### PR TITLE
fix(runtime): complete __try_call_val builtin (eval + native impl)

### DIFF
--- a/lib/eval/eval.ml
+++ b/lib/eval/eval.ml
@@ -2478,6 +2478,23 @@ let base_env : env =
            | Invalid_argument m -> VCon ("Err", [VString ("invalid argument: " ^ m)])
            | exn                -> VCon ("Err", [VString (Printexc.to_string exn)]))
         | _ -> eval_error "__try_call: expected one thunk argument"))
+    (* Value-carrying try — same semantics as __try_call but the Ok payload is
+       the thunk's actual (possibly heap) result rather than a Bool.  The
+       interpreter already wraps an arbitrary value, so the body is identical;
+       the two differ only in the native runtime + typechecker signature. *)
+  ; ("__try_call_val", VBuiltin ("__try_call_val", function
+        | [thunk] ->
+          (try VCon ("Ok", [!apply_hook thunk [VBool true]])
+           with
+           | Assert_failure msg -> VCon ("Err", [VString msg])
+           | Match_failure msg  -> VCon ("Err", [VString ("match failure: " ^ msg)])
+           | Eval_error msg     -> VCon ("Err", [VString msg])
+           | Failure msg        -> VCon ("Err", [VString msg])
+           | Division_by_zero   -> VCon ("Err", [VString "division by zero"])
+           | Stack_overflow     -> VCon ("Err", [VString "stack overflow"])
+           | Invalid_argument m -> VCon ("Err", [VString ("invalid argument: " ^ m)])
+           | exn                -> VCon ("Err", [VString (Printexc.to_string exn)]))
+        | _ -> eval_error "__try_call_val: expected one thunk argument"))
     (* Conversions *)
   ; ("bool_to_string", VBuiltin ("bool_to_string", function
         | [VBool b] -> VString (string_of_bool b)

--- a/runtime/march_runtime.c
+++ b/runtime/march_runtime.c
@@ -884,6 +884,75 @@ void *__try_call(void *thunk) {
     return result;
 }
 
+/* ── __try_call_val ──────────────────────────────────────────────────────── */
+/*
+ * __try_call_val : (Bool -> a) -> Result(a, String)
+ *
+ * Value-carrying sibling of __try_call.  The thunk's March return type is the
+ * type variable `a`, so the compiled thunk returns its result in the *uniform*
+ * representation (heap pointers raw, immediates low-bit-tagged).  We therefore
+ * store ok_result into the Ok field VERBATIM — no `<<1 | 1` retag — exactly as
+ * the Err path below stores the heap march_string raw.  This lets a heap result
+ * (e.g. a nested Result(v, String)) round-trip without the pointer corruption
+ * that the Bool-only __try_call guards against.
+ *
+ * Ownership: the thunk transfers ownership of its result to us (Perceus return
+ * convention); storing it raw into the Ok field forwards that ownership to the
+ * returned Result, which the caller then owns.  No extra incrc/decrc is needed.
+ * On the panic path the thunk did not return, so there is no value to manage
+ * (any heap captured before the panic may leak — acceptable, as for __try_call).
+ *
+ * RC contract, closure layout, and Result layout are identical to __try_call.
+ */
+void *__try_call_val(void *thunk) {
+    typedef int64_t (*apply_fn_t)(void *, int64_t);
+    apply_fn_t apply = *(apply_fn_t *)((char *)thunk + 16);
+
+    jmp_buf saved_jmp;
+    char    saved_fail[sizeof(march_test_fail_buf)];
+    int     saved_in_test = march_test_in_test;
+    memcpy(&saved_jmp, &march_test_jmp_buf, sizeof(jmp_buf));
+    memcpy(saved_fail, march_test_fail_buf, sizeof(march_test_fail_buf));
+
+    march_test_fail_buf[0] = '\0';
+    march_test_in_test     = 1;
+
+    int64_t ok_result = 0;
+    int     panicked  = 0;
+
+    if (setjmp(march_test_jmp_buf) == 0) {
+        ok_result = apply(thunk, 1);   /* 1 = dummy Bool argument */
+    } else {
+        panicked = 1;
+    }
+
+    void *err_str = NULL;
+    if (panicked) {
+        const char *msg = march_test_fail_buf[0]
+            ? march_test_fail_buf : "call panicked";
+        err_str = march_string_lit(msg, (int64_t)strlen(msg));
+    }
+
+    memcpy(&march_test_jmp_buf, &saved_jmp, sizeof(jmp_buf));
+    memcpy(march_test_fail_buf, saved_fail, sizeof(march_test_fail_buf));
+    march_test_in_test = saved_in_test;
+
+    march_decrc(thunk);
+
+    char      *result = (char *)march_alloc(24);
+    march_hdr *hdr    = (march_hdr *)result;
+    void     **field  = (void **)(result + 16);
+    if (!panicked) {
+        hdr->tag = 0;                              /* Ok */
+        /* Uniform-repr value stored verbatim — see header comment. */
+        *field   = (void *)ok_result;
+    } else {
+        hdr->tag = 1;                              /* Err */
+        *field   = err_str;
+    }
+    return result;
+}
+
 /* ── Actor runtime — green thread based ──────────────────────────────────── */
 /*
  * Design overview


### PR DESCRIPTION
## Problem

`main` is in a half-applied state for the `__try_call_val` builtin: the **typechecker signature** (`(Bool -> a) -> Result(a, String)`) and the **compiled regression test** (`adversarial-regressions` → `__try_call_val: heap Ok payload round-trips + panic caught`) are on `main`, but the **eval interpreter builtin** and the **native C runtime implementation** are not.

Result: anything calling `__try_call_val` fails to link natively (missing `__try_call_val` symbol), the interpreter has no `VBuiltin` entry, and the existing compiled test fails — i.e. `main` CI is red.

## Fix

Add the two missing pieces:

- **`lib/eval/eval.ml`** — `VBuiltin` mirroring `__try_call`. The interpreter already wraps an arbitrary `Ok` payload, so the body is identical.
- **`runtime/march_runtime.c`** — `__try_call_val` stores the thunk's **uniform-repr** result into the `Ok` field *verbatim* (no `<<1 | 1` retag), exactly as `__try_call` already stores its heap `march_string` in the `Err` field. The thunk's return type is a type variable `a`, so the compiled thunk returns uniform repr (heap pointers raw, immediates tagged) — storing it raw is correct for both. Ownership transfers thunk → `Ok` field → caller, so no extra inc/dec.

## Why a sibling and not a change to `__try_call`

`__try_call` is intentionally `Bool`-only (its `Ok` field is an immediate) and drives the property runner. `__try_call_val` is the value-carrying variant for callers that must preserve a heap result (e.g. a transaction wrapper guarding a `Result(v, String)`-returning callback).

## Test

Existing compiled test now passes (verified off `origin/main`):
```
[OK] adversarial-regressions  14  __try_call tags Bool result ...
[OK] adversarial-regressions  15  __try_call_val: heap Ok payload round-trips + panic caught (compiled)
Test Successful in 8.07s. 19 tests run.
```