### PR TITLE
docs: document Linux cross-compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ end
 
 **Backend**
 - Compiles to LLVM IR, linked to native binaries via `clang` — or to `.wasm` via `--target wasm64-wasi`
+- Cross-compiles Linux binaries (`linux/amd64`, `linux/arm64`) from any host via `zig cc`, Go's `GOOS=linux` style
 - Perceus reference counting — deterministic memory management, no GC pauses
 - **FBIP (Functional But In-Place)** — when the reference count on a pattern-matched value is 1, destructured nodes are reused in-place rather than freed and reallocated (see below)
 - Escape analysis promotes allocations to the stack where possible
@@ -114,6 +115,10 @@ march file.march
 # Compile to a native binary
 march --compile file.march        # produces ./file
 march --compile -o hello file.march
+
+# Cross-compile a Linux binary from any host (requires zig — see Cross-compilation below)
+march --compile --target linux/amd64 file.march -o app   # x86-64 Linux ELF
+march --compile --target linux/arm64 file.march -o app   # aarch64 Linux ELF
 
 # Compile to WebAssembly (requires wasi-sdk + wasmtime — see below)
 march --compile --target wasm64-wasi file.march   # produces file.wasm
@@ -260,7 +265,21 @@ export WASI_SDK_PATH=/path/to/wasi-sdk
 march --compile --target wasm64-wasi file.march
 ```
 
-Available targets: `native` (default), `wasm64-wasi`, `wasm32-wasi`, `wasm32-unknown-unknown`.
+Available targets: `native` (default), `linux/amd64`, `linux/arm64`, `wasm64-wasi`, `wasm32-wasi`, `wasm32-unknown-unknown`, `js`.
+
+## Cross-compilation to Linux
+
+Build a Linux binary from any host — including macOS — the way Go's `GOOS=linux go build` does, using [`zig cc`](https://ziglang.org) as the C cross-compiler:
+
+```bash
+brew install zig          # macOS; or download from https://ziglang.org/download/
+
+march --compile --target linux/amd64 file.march -o app   # x86-64 Linux ELF
+march --compile --target linux/arm64 file.march -o app   # aarch64 Linux ELF
+forge build --target linux/amd64                          # via forge (per-target output dir)
+```
+
+You get a dynamically-linked **glibc** binary (min glibc 2.31) that runs on mainstream distributions and in glibc containers (`debian:*-slim`, `ubuntu:*`, distroless-cc). Cross builds currently cover **compute and CLI workloads**; TLS/HTTPS, compression, hot code reload, and Rust FFI are not yet included. See the [cross-compilation guide](docs/tooling.md#cross-compiling-to-linux) for details.
 
 ## Running the tests
 

--- a/docs/hot-code-reload.md
+++ b/docs/hot-code-reload.md
@@ -78,6 +78,13 @@ forge deploy hot
 forge deploy hot --so /path/to/my_app.so
 ```
 
+> **Cross-host note.** `forge deploy hot` (no `--so`) builds the reload
+> `.so` for your **host** platform, so deploying from macOS to a Linux server
+> needs a Linux-built artifact passed via `--so`. Native cross-compilation of
+> reload units (`--compile-so --target linux/…`) is planned; today, cross builds
+> cover the initial binary — see
+> [Cross-compiling to Linux](tooling.md#cross-compiling-to-linux).
+
 On a successful deploy you see:
 
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -168,6 +168,7 @@ end
 - **LLVM backend** — whole-program monomorphization, defunctionalization, native binaries
 - **Work-stealing scheduler** — cooperative + preemptive, scales across cores
 - **WebAssembly target** — compile to `.wasm` via `--target wasm64-wasi`
+- **Linux cross-compilation** — build `linux/amd64` + `linux/arm64` binaries from any host via `zig cc`, Go's `GOOS=linux` style ([guide](tooling.md#cross-compiling-to-linux))
 
 ### Language
 - **Algebraic data types** — `type Shape = Circle(Float) | Rect(Float, Float)`

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -175,6 +175,75 @@ react  = "^18.3.0"
 
 The generated `package.json` sets `"type": "module"` so your `.mjs` output loads cleanly. For Deno or Bun, use their native specifiers (`npm:lodash`, `jsr:@std/path`) directly in the `extern` lib name — no `[js_deps]` needed since those runtimes fetch packages on demand.
 
+### Cross-compiling to Linux
+
+March can build a **Linux** binary from any host — including macOS — the way Go's
+`GOOS=linux go build` does. Pass a `linux/*` target and you get a native Linux
+ELF without a Linux box, VM, or Docker build step:
+
+```sh
+march --compile --target linux/amd64 app.march -o app   # x86-64 Linux
+march --compile --target linux/arm64 app.march -o app   # aarch64 Linux
+
+forge build --target linux/amd64                          # via forge
+forge build --target linux/arm64
+```
+
+Accepted aliases: `linux/amd64` (= `linux/x86_64`) and `linux/arm64`
+(= `linux/aarch64`).
+
+**Prerequisite — `zig`.** Cross-compilation uses [`zig cc`](https://ziglang.org)
+as the C cross-compiler (it bundles a clang plus the Linux sysroots, so there's
+nothing else to install). Put `zig` on your `PATH`:
+
+```sh
+brew install zig          # macOS
+# or download from https://ziglang.org/download/
+```
+
+`forge build --target linux/…` checks for `zig` up front and tells you if it's
+missing; a bare `march --compile --target linux/…` will fail at the link step
+without it.
+
+**Output.** `forge` writes cross builds to a per-target directory so they never
+clobber your host binary:
+
+```
+.march/build/linux-amd64/debug/<name>
+.march/build/linux-arm64/release/<name>
+```
+
+**What you get.** A **dynamically-linked glibc** binary (minimum glibc 2.31 —
+Ubuntu 20.04 / Debian 11 and newer). It runs on mainstream distributions and in
+glibc-based containers (`debian:*-slim`, `ubuntu:*`, distroless-cc), e.g.:
+
+```dockerfile
+FROM debian:bookworm-slim
+COPY app /usr/local/bin/app
+CMD ["app"]
+```
+
+```sh
+# Smoke-test a cross build locally, without deploying:
+march --compile --target linux/amd64 app.march -o app
+docker run --rm --platform linux/amd64 -v "$PWD/app":/app:ro debian:bookworm-slim /app
+```
+
+**Scope (current).** Cross-compilation currently targets **compute and CLI
+workloads**. Not yet included in a cross build:
+
+- **TLS/HTTPS** and **compression** (zstd/brotli/zlib) — these runtime modules are
+  omitted from cross builds for now.
+- **Hot code reload** — the reload `.so` path is host-only today; deploy a
+  pre-built artifact instead (see [Hot Code Reload](hot-code-reload.md)).
+- **Rust FFI** (`[ffi.rust]`) — `forge build --target linux/…` fails with a clear
+  message rather than mislinking a host-architecture static library.
+- **Concurrency/actor programs** are not yet validated on cross targets.
+
+Correctness is guarded by a differential test that cross-compiles a corpus and
+checks each program's output against the native build byte-for-byte, so a
+codegen regression on a cross target is caught in CI.
+
 ### Checking Types
 
 `forge check` typechecks every `.march` file in the project without producing a binary. It's fast — use it for pre-commit checks or continuous editor feedback:


### PR DESCRIPTION
## Document Linux cross-compilation

Follows up #12 (Go-style Linux cross-compilation) with user-facing docs for the new `--target linux/amd64|arm64` capability.

- **`docs/tooling.md`** — new **Cross-compiling to Linux** section: `march`/`forge` usage, the `zig` prerequisite, per-target output dirs, a Docker smoke-test + Dockerfile snippet, and an honest **scope** list (TLS/HTTPS, compression, hot-reload, Rust FFI not yet in cross builds; concurrency not yet validated).
- **`README.md`** — cross-compile bullet under Backend, a usage example, an updated "Available targets" line, and a short **Cross-compilation to Linux** section beside the WebAssembly one.
- **`docs/index.md`** — feature bullet linking to the guide.
- **`docs/hot-code-reload.md`** — cross-host note clarifying reload `.so`s are host-built today (use `--so` for Linux) while cross-compile covers the initial binary.

`scripts/check-docs.sh` passes (no dead source pointers, no stale stdlib counts).
