### PR TITLE
fix(eval): interface default methods clobbering type-dispatched impl_tbl entry

### DIFF
--- a/lib/eval/eval.ml
+++ b/lib/eval/eval.ml
@@ -272,6 +272,22 @@ let is_type_dispatched_method iface meth =
   | "Show", "show" | "Eq", "eq" | "Ord", "compare" | "Hash", "hash" -> true
   | _ -> false
 
+(** Whether [iface] is a built-in interface whose value-level dispatch reads
+    [impl_tbl] under the shared (iface, type) key (see [is_type_dispatched_method]).
+
+    Such an interface has exactly ONE dispatch method (Eq→eq, Ord→compare,
+    Show→show, Hash→hash), but a user may declare it with the built-in name and
+    give it EXTRA methods — e.g. [Eq]'s default [neq], or [Ord]'s [lt]/[gt]/
+    [le]/[ge].  Those extra methods must NOT be written into [impl_tbl], or they
+    clobber the dispatch method under the same key: the builtin then invokes the
+    wrong method and [neq → eq → neq] recurses forever (stack overflow).
+    Non-dispatched interfaces (Json, Drop, user interfaces) are unaffected —
+    nothing reads their (iface, type) entry by value, so they keep their
+    existing per-method registration. *)
+let is_type_dispatched_iface = function
+  | "Show" | "Eq" | "Ord" | "Hash" -> true
+  | _ -> false
+
 (** Constructor → type name mapping.
     Maps each data constructor name (e.g. "Red") to its declaring type (e.g. "Color").
     Populated when [eval_decl] processes [DType] nodes.
@@ -8300,7 +8316,12 @@ let rec eval_decl (env : env) (d : decl) : env =
         if type_name <> "" then begin
           match List.assoc_opt mname.txt new_env with
           | Some fn_val ->
-            Hashtbl.replace impl_tbl (idef.impl_iface.txt, type_name) fn_val;
+            (* For a type-dispatched interface, only its single dispatch method
+               may claim the shared (iface, type) key; extra methods (e.g. Eq's
+               default `neq`) must not clobber it, or builtin dispatch invokes
+               the wrong method and recurses forever (neq → eq → neq). *)
+            if (not (is_type_dispatched_iface idef.impl_iface.txt)) || is_dispatched then
+              Hashtbl.replace impl_tbl (idef.impl_iface.txt, type_name) fn_val;
             let iface_qualified = idef.impl_iface.txt ^ "." ^ mname.txt in
             Hashtbl.replace module_registry iface_qualified fn_val
           | None -> ()
@@ -8611,7 +8632,12 @@ let eval_module_env (m : module_) : env =
           if type_name <> "" then begin
             match List.assoc_opt mname.txt new_acc with
             | Some fn_val ->
-              Hashtbl.replace impl_tbl (idef.impl_iface.txt, type_name) fn_val;
+              (* For a type-dispatched interface, only its single dispatch method
+                 may claim the shared (iface, type) key; extra methods (e.g. Eq's
+                 default `neq`) must not clobber it, or builtin dispatch invokes
+                 the wrong method and recurses forever (neq → eq → neq). *)
+              if (not (is_type_dispatched_iface idef.impl_iface.txt)) || is_dispatched then
+                Hashtbl.replace impl_tbl (idef.impl_iface.txt, type_name) fn_val;
               let iface_qualified = idef.impl_iface.txt ^ "." ^ mname.txt in
               Hashtbl.replace module_registry iface_qualified fn_val
             | None -> ()

--- a/test/test_eval.ml
+++ b/test/test_eval.ml
@@ -1490,6 +1490,53 @@ let test_default_method_eval () =
   Alcotest.(check bool) "neq default returns true for 1 neq 2" true
     (vbool result)
 
+let test_default_method_user_type () =
+  (* Regression: a user-declared `interface Eq(a)` (name collides with the
+     built-in Eq) with a default `neq` calling `eq`, implemented for a USER
+     type, must terminate and return the correct answer.
+
+     The builtin `eq`/`==` dispatcher resolves the impl from
+     `impl_tbl[("Eq", type)]`.  The DImpl eval used to write EVERY method of the
+     impl under that single (iface, type) key, so the injected default `neq`
+     (processed after `eq`) clobbered the `eq` entry.  A builtin `eq` on a
+     Widget then invoked `neq`, whose body called `eq`, which dispatched to
+     `neq` again → unbounded recursion (stack overflow / hang).  This mirrors
+     the "Default Implementations" example in docs/interfaces.md.
+
+     NOTE: the existing `test_default_method_eval` uses `impl Eq(Int)`, which
+     never triggered the bug: the builtin `eq` short-circuits primitives
+     (`[VInt a; VInt b] -> VBool (a = b)`) BEFORE consulting `impl_tbl`.  A user
+     ADT is required to exercise the corrupted table. *)
+  let src = {|mod Test do
+    interface Eq(a) do
+      fn eq  : a -> a -> Bool
+      fn neq : a -> a -> Bool do fn (x, y) -> !eq(x, y) end
+    end
+    type Widget = Widget(Int)
+    impl Eq(Widget) do
+      fn eq(a, b) do
+        match (a, b) do
+          (Widget(x), Widget(y)) -> x == y
+        end
+      end
+    end
+    fn neq_diff() do neq(Widget(1), Widget(2)) end
+    fn neq_same() do neq(Widget(7), Widget(7)) end
+    fn eq_diff()  do eq(Widget(1), Widget(2)) end
+    fn eq_same()  do eq(Widget(5), Widget(5)) end
+  end|} in
+  let env = eval_module src in
+  Alcotest.(check bool) "neq(Widget 1, Widget 2) = true"  true
+    (vbool (call_fn env "neq_diff" []));
+  Alcotest.(check bool) "neq(Widget 7, Widget 7) = false" false
+    (vbool (call_fn env "neq_same" []));
+  (* A direct `eq` call must also terminate: the corrupted table made even this
+     path loop, since bare `eq` on an ADT routes through the builtin dispatcher. *)
+  Alcotest.(check bool) "eq(Widget 1, Widget 2) = false"  false
+    (vbool (call_fn env "eq_diff" []));
+  Alcotest.(check bool) "eq(Widget 5, Widget 5) = true"   true
+    (vbool (call_fn env "eq_same" []))
+
 let test_missing_required_method () =
   (* Impl omits a non-default method — should error *)
   let ctx = typecheck {|mod Test do
@@ -4261,6 +4308,7 @@ let eval_suites =
           Alcotest.test_case "superclass missing"     `Quick test_superclass_missing;
           Alcotest.test_case "default method tc"      `Quick test_default_method_inherited;
           Alcotest.test_case "default method eval"    `Quick test_default_method_eval;
+          Alcotest.test_case "default method user type"`Quick test_default_method_user_type;
           Alcotest.test_case "missing required method"`Quick test_missing_required_method;
           Alcotest.test_case "unknown ctor suggests"  `Quick test_unknown_ctor_suggests_similar;
           Alcotest.test_case "ambiguous ctor warns"   `Quick test_ambiguous_ctor_warns;


### PR DESCRIPTION
## Problem

A user-declared interface whose name collides with a built-in (`Eq`/`Ord`/`Show`/`Hash`) and whose impl carries **extra** methods — e.g. `Eq`'s injected default `neq`, or `Ord`'s default `lt`/`gt`/`le`/`ge` — hangs / stack-overflows at runtime in the interpreter when a default method is called on a **user ADT**.

Minimal repro (the canonical "Default Implementations" example from `docs/interfaces.md`):

```march
mod Test do
  interface Eq(a) do
    fn eq  : a -> a -> Bool
    fn neq : a -> a -> Bool do fn (x, y) -> !eq(x, y) end
  end
  type Widget = Widget(Int)
  impl Eq(Widget) do
    fn eq(a, b) do match (a, b) do (Widget(x), Widget(y)) -> x == y end end
  end
  fn main() do println(bool_to_string(neq(Widget(1), Widget(2)))) end  -- hangs
end
```

## Root cause

`impl_tbl` in `lib/eval/eval.ml` is keyed by `(iface_name, type_name)` and is read only by the type-directed builtin dispatchers, each expecting the single dispatch method per interface (`Eq→eq`, `Ord→compare`, `Show→show`, `Hash→hash`). The `DImpl` eval fold wrote **every** impl method under that one key, so the non-dispatch method (`neq`, processed after `eq`) **overwrote** the `eq` entry. The builtin `eq` on a `Widget` then invoked `neq` → whose body calls `eq` → dispatches to `neq` again → unbounded recursion.

Primitives were unaffected because the builtins short-circuit them (`[VInt a; VInt b] -> VBool (a = b)`) **before** the `impl_tbl` lookup — which is why the existing `impl Eq(Int)` test never surfaced it. A user ADT is required to hit the corrupted table.

## Fix

Add an `is_type_dispatched_iface` helper next to `is_type_dispatched_method`, and guard **both** `DImpl` fold sites so only the dispatch method claims the `(iface, type)` key for `Eq`/`Ord`/`Show`/`Hash`. Non-dispatch methods stay reachable via their env binding and the `"Iface.method"` module_registry entry — nothing reads them from `impl_tbl`. Derived impls (single-method) and Json/Drop/user interfaces are untouched. Compiled path is unaffected (compile-time dispatch, no `impl_tbl`).

## Tests

- New regression test `test_default_method_user_type` in `test/test_eval.ml` — user `interface Eq(a)` + default `neq` + `impl Eq(Widget)`, asserting both `neq` and a direct `eq` on the ADT terminate with correct booleans. Uses an ADT (not `Int`) so it actually exercises the dispatch table. Fail-first verified: neutralizing the guard makes it hang.
- `run_eval` (231), `run_compiler` (408) green on this base. `run_codegen` (389) and `run_stdlib` (804) were green on the local base; both are unaffected by this interpreter-only change (CI covers them here).
- Also fixes the invalid `fn x y ->` lambda syntax (missing parens on multi-param lambdas) in `docs/interfaces.md`'s interface examples so the canonical examples parse and run.