### PR TITLE
fix(typecheck): seed bare type names when loading a module from the compiled registry

### DIFF
--- a/lib/typecheck/typecheck.ml
+++ b/lib/typecheck/typecheck.ml
@@ -895,13 +895,35 @@ let load_module_into_env (mod_name : string) (exports : March_modules.Module_reg
       else if StrMap.mem qname env.vars then env
       else { env with vars = StrMap.add qname (Mono (fresh_var 0)) env.vars }
     | ExType arity ->
-      if StrMap.mem qname env.types then env
-      else { env with types = StrMap.add qname arity env.types }
+      (* Register the qualified name AND the BARE type name.  March uses a single
+         global type namespace (see [surface_ty]'s [canon_name]): a type's bare
+         name is its canonical identity, and a sibling module resolves a peer
+         type UNQUALIFIED (`scope : UniqueScope`, no `use`/`import`).  When the
+         defining module is PREBOUND FROM SOURCE, [prebind_mod_members] (:8931)
+         seeds the bare name; when it is loaded from the compiled Module_registry
+         instead (e.g. a dependency in the `--compile`/`--test` unit), only the
+         qualified key was seeded — so expanding a registry-loaded RECORD whose
+         field references a bare sibling type failed with a bogus "I cannot find
+         `UniqueScope`" pointing at the definer's field span.  Seed the bare name
+         too, first-wins (don't clobber a name a source module already bound),
+         mirroring the source-prebind path. *)
+      let env = if StrMap.mem qname env.types then env
+                else { env with types = StrMap.add qname arity env.types } in
+      if StrMap.mem entry.ex_name env.types then env
+      else { env with types = StrMap.add entry.ex_name arity env.types }
     | ExRecord (arity, field_decls) ->
+      let param_names = List.init arity (fun i -> Printf.sprintf "$t%d" i) in
       let env1 = if StrMap.mem qname env.types then env
                  else { env with types = StrMap.add qname arity env.types } in
-      let param_names = List.init arity (fun i -> Printf.sprintf "$t%d" i) in
-      { env1 with records = StrMap.add qname (param_names, field_decls) env1.records }
+      (* Bare type name too — see the [ExType] arm's rationale. *)
+      let env1 = if StrMap.mem entry.ex_name env1.types then env1
+                 else { env1 with types = StrMap.add entry.ex_name arity env1.types } in
+      (* Register the record's fields under BOTH the qualified and bare keys so a
+         bare cross-module reference (or a peer module's bare field type) expands
+         structurally instead of staying an opaque TCon. *)
+      let env1 = { env1 with records = StrMap.add qname (param_names, field_decls) env1.records } in
+      if StrMap.mem entry.ex_name env1.records then env1
+      else { env1 with records = StrMap.add entry.ex_name (param_names, field_decls) env1.records }
     | ExCtor (parent_type, _ctor_arity) ->
       begin
         (* Find the parent type's param names from the module's type exports *)
@@ -2660,17 +2682,28 @@ let rec surface_ty env ~(tvars : (string * ty) list ref) (s : Ast.ty) : ty =
                    | ExRecord (arity, fields) when entry.ex_name = member ->
                      let params = List.init arity
                        (fun i -> Printf.sprintf "$t%d" i) in
-                     Some (params, fields)
+                     (* Thread an env enriched with the DEFINING module's exports
+                        so the record's field types — stored as UNRESOLVED surface
+                        types that name sibling types by their BARE name (`scope :
+                        UniqueScope`) — resolve against those siblings' bare names.
+                        Without this the fields would be expanded in the referrer's
+                        env, which has only the qualified sibling names, failing
+                        with a bogus "I cannot find `UniqueScope`" pointing at the
+                        definer's field span.  [load_module_into_env] seeds both
+                        the qualified and bare forms (first-wins), so this cannot
+                        clobber a name the referrer already bound. *)
+                     let fenv = load_module_into_env mod_name exports env in
+                     Some (params, fields, fenv)
                    | _ -> None)
               ) None exports.me_entries)
        in
        (match registry_record with
-        | Some (params, field_decls)
+        | Some (params, field_decls, fenv)
           when List.length params = List.length args'
                && not (name_is_variant env name.txt) ->
           let saved = !tvars in
           List.iter2 (fun pname arg -> tvars := (pname, arg) :: !tvars) params args';
-          let flds = List.map (fun (fn, fty) -> (fn, surface_ty env ~tvars fty)) field_decls in
+          let flds = List.map (fun (fn, fty) -> (fn, surface_ty fenv ~tvars fty)) field_decls in
           tvars := saved;
           TRecord (List.sort (fun (a, _) (b, _) -> String.compare a b) flds)
         | _ ->

--- a/test/test_codegen.ml
+++ b/test/test_codegen.ml
@@ -1141,6 +1141,60 @@ let test_entry_bulk_import_resolves_partial_qualified () =
   Alcotest.(check bool) "no unresolved bare @Sub.greet call" false
     (Test_helpers.contains "@Sub.greet(" ir)
 
+(* A record type loaded from the COMPILED module registry (a dependency in the
+   `--compile`/`--test` unit, not prebound from source) stores its field types as
+   UNRESOLVED surface types that name sibling types by their BARE name (e.g.
+   `mod Conduit`'s `type UniqueConstraint = { scope : UniqueScope }` — both types
+   in one module, `UniqueScope` referenced unqualified).  When a referring module
+   annotates against `Conduit.UniqueConstraint`, [surface_ty] must expand that
+   record's fields; before the fix it expanded them in the REFERRER's env, which
+   held only the QUALIFIED sibling name (`Conduit.UniqueScope`) — [load_module_
+   into_env]/registry loading never seeded the bare `UniqueScope`.  Result: a
+   bogus "I cannot find `UniqueScope`" pointing at the definer's field span,
+   reproduced ~16x (once per test file importing the dep) under `forge test`
+   while `forge check` (which prebinds the dep FROM SOURCE, seeding bare names)
+   stayed clean.  Fix: registry type/record loading seeds the bare name too, and
+   registry-record field expansion threads the defining module's env.  This test
+   drives the exact registry path: register a module with a bare-named sibling
+   type referenced by a record field, then resolve the qualified record in a
+   separate module — pre-fix errors, post-fix clean. *)
+let test_registry_record_field_bare_sibling_type_resolves () =
+  let open March_modules.Module_registry in
+  reset ();
+  let dummy = March_ast.Ast.dummy_span in
+  let bare_ty n = March_ast.Ast.TyCon ({ March_ast.Ast.txt = n; span = dummy }, []) in
+  register "Widgets" {
+    me_name = "Widgets";
+    me_entries = [
+      (* A variant sibling type, referenced BARE by the record field below. *)
+      { ex_name = "Scope"; ex_kind = ExType 0; ex_public = true };
+      (* The record whose stored field type names `Scope` by its bare name —
+         exactly how the compiler serialises a same-module sibling reference. *)
+      { ex_name = "Constraint";
+        ex_kind = ExRecord (0, [("scope", bare_ty "Scope")]);
+        ex_public = true };
+    ];
+  };
+  (* A DIFFERENT module references the qualified record type; expanding it must
+     resolve the bare `Scope` field type. *)
+  let src = {|mod Client do
+    fn describe(c : Widgets.Constraint) : Int do 0 end
+  end|} in
+  let m = Test_helpers.parse_and_desugar src in
+  let (errors, _tm) = March_typecheck.Typecheck.check_module m in
+  reset ();
+  let msgs = List.map (fun (d : March_errors.Errors.diagnostic) -> d.message)
+      errors.March_errors.Errors.diagnostics in
+  let mentions_scope =
+    List.exists (fun s -> Test_helpers.contains "Scope" s
+                          && Test_helpers.contains "cannot find" s) msgs in
+  Alcotest.(check bool)
+    "no 'cannot find Scope' when expanding a registry record's bare-named field"
+    false mentions_scope;
+  Alcotest.(check bool)
+    "referrer typechecks cleanly against the registry record type"
+    false (March_errors.Errors.has_errors errors)
+
 (* --- multiline tests --- *)
 
 let test_multiline_depth_zero () =
@@ -8647,6 +8701,8 @@ let codegen_suites =
             test_qualified_alias_no_cross_module_hijack;
           Alcotest.test_case "entry-file bulk import resolves partial-qualified call" `Quick
             test_entry_bulk_import_resolves_partial_qualified;
+          Alcotest.test_case "registry record's bare-named sibling field type resolves" `Quick
+            test_registry_record_field_bare_sibling_type_resolves;
         ] );
       ( "js_pipeline", [
           Alcotest.test_case "simple program compiles"      `Quick test_js_pipeline_simple_program_compiles;


### PR DESCRIPTION
## Summary

Fixes a name-resolution bug specific to loading dependency modules from the compiled `Module_registry` — the path `forge test`/`--compile` take for dependencies (as opposed to `forge check`, which prebinds deps from source).

## The bug

`load_module_into_env` registered only the **qualified** type name (e.g. `Conduit.UniqueScope`) into `env.types` when loading a dependency from the registry. But a record type's field types are stored as unresolved surface types that name sibling types by their **bare** name — March has a single global type namespace. So a record like conduit's `UniqueConstraint = { scope: UniqueScope }` failed to resolve `scope`'s field type when the referring module's env only had the qualified `Conduit.UniqueScope`, not the bare `UniqueScope`.

Symptom: `I cannot find UniqueScope` reported at the *definer's own field span* — a package's own type failing to resolve inside its own record definition, purely because it was loaded from the registry rather than from source.

This is the same bug class as the two lowering fixes in #25 (`6bfbadfb`/`958e3ef2` — global vs. per-module alias-table scoping), but for type names in the typechecker's registry-load path, discovered while migrating a downstream project's toolchain onto main after #25 merged.

## Fix

`load_module_into_env` now also seeds the bare type/record name (first-wins, mirroring the existing `prebind_mod_members` seeding used for source-loaded modules), and `surface_ty`'s `registry_record` branch expands a record's fields using an env enriched via `load_module_into_env`. Enrichment is transient — scoped to that field-expansion call, never leaking into the referrer's persistent env.

Qualified references are untouched (their seeding path is unchanged), and the first-wins collision semantics for the bare name exactly match the already-accepted behavior on the source-prebind path — this makes registry-load consistent with source-load rather than introducing a new hazard class.

## Testing

- New regression test drives the actual `Module_registry` path (a type registered directly into the registry, referenced from a separate compilation unit) with the exact bug shape — fails pre-fix, passes post-fix.
- `run_codegen`: 408/408 (includes the new test). `run_eval`: unchanged (1 pre-existing baseline failure).
- End-to-end: a large downstream multi-package project (forgepm + conduit + bastion + depot) went from 235 `forge test` compile errors to 0 — all 548 tests now run.
