### PR TITLE
Open-items plan: Phase 2 float-boxing — Stage 1 (runtime box API) + plan

### DIFF
--- a/docs/value-representation.md
+++ b/docs/value-representation.md
@@ -164,6 +164,23 @@ the `record_put`-uniform-handoff bug families (§7). A NATURAL-repr even `Int`
 type (record shape) disambiguates it. A UNIFORM slot resolves the same
 ambiguity dynamically via the odd/even tag.
 
+**Floats in UNIFORM slots — the open exception.** A `Float` in a UNIFORM
+slot is *today* stored as its raw IEEE-754 bits bitcast into the `ptr`
+slot, untagged, and decoded by the reader's static type. This is **unsound
+against generic code**: the raw bits are even and in the canonical range,
+so `IS_HEAP_PTR` accepts them — a generic RC op writes into `*(3.5)`
+(SIGSEGV) and a generic `<=` integer-compares the bits (correct for
+positive floats by IEEE coincidence, backwards for negatives). The fix
+(`specs/plans/2026-07-13-float-boxing-design.md`) is to **box** a Float
+crossing an erasure boundary in a `MARCH_FLOAT_TAG` (-3) heap cell — making
+a UNIFORM slot uniformly heap-or-tagged and `needs_rc (TVar _)` genuinely
+sound. The runtime box API (`march_alloc_float`/`march_unbox_float`,
+value-aware `march_poly_eq`/`march_poly_compare`) landed additively as
+stage 1; the codegen flip that populates UNIFORM slots with boxes is
+staged (decision-gated). Until it lands, the monomorphism restriction
+keeps unannotated let-bound lambdas monomorphic so generic float
+comparators never reach a UNIFORM Float slot.
+
 **Claim 4 — verified (IR), Probe A (UNIFORM).** `let t = (n+40, n+1)` (tuple,
 runtime-derived so the constant-folder cannot eliminate it) allocates a
 2-field cell and stores **both** fields tagged, as `ptr`:

--- a/runtime/march_message.c
+++ b/runtime/march_message.c
@@ -27,6 +27,13 @@ typedef struct { int64_t rc; int32_t tag; int32_t pad; int64_t len; char data[];
 /* Tag value used to mark string objects (must match march_runtime.h).
  * Strings use tag = -1 (0xFFFFFFFF as int32_t) as a sentinel. */
 #define MARCH_STRING_TAG  (-1)
+/* Boxed-Float sentinel (must match march_runtime.h MARCH_FLOAT_TAG). A float
+ * box is [rc][tag][pad][double val@16] = 24 bytes; its payload word is raw
+ * IEEE-754 bits, NOT a pointer, so copy_value must copy it opaquely rather
+ * than sniffing the field with IS_HEAP_PTR. Kept in sync manually (same
+ * circular-include avoidance as MARCH_STRING_TAG above). */
+#define MARCH_FLOAT_TAG   (-3)
+#define MARCH_FLOAT_BOX_SIZE  24u
 
 /* Values below one OS page are unboxed scalars (inttoptr-encoded integers). */
 #define IS_HEAP_PTR(p)  ((uintptr_t)(p) >= 4096u)
@@ -150,6 +157,18 @@ static void *copy_value(march_heap_t *dst_heap, void *value, fwd_table *fwd) {
         void *ns = copy_string(dst_heap, value);
         fwd_insert(fwd, value, ns);
         return ns;
+    }
+
+    /* Boxed float (float-boxing design): the payload at offset 16 is raw
+     * IEEE-754 bits, NOT a pointer — the generic field loop below would sniff
+     * it with IS_HEAP_PTR and try to recurse into *(3.5). Copy the 24-byte
+     * cell opaquely, like the string arm. */
+    if (h->tag == MARCH_FLOAT_TAG) {
+        void *nf = march_process_alloc(dst_heap, MARCH_FLOAT_BOX_SIZE);
+        memcpy(nf, value, MARCH_FLOAT_BOX_SIZE);
+        ((msg_hdr *)nf)->rc = 1;
+        fwd_insert(fwd, value, nf);
+        return nf;
     }
 
     /* Recover field count from alloc_meta. */

--- a/runtime/march_runtime.c
+++ b/runtime/march_runtime.c
@@ -455,6 +455,24 @@ int64_t march_compare_float(double x, double y) {
     return (x > y) - (x < y);
 }
 
+/* ── Boxed Float (float-boxing design, stage 1 — additive) ─────────────── */
+
+/* Heap-box a Float for storage in a type-erased (ptr) slot: a 24-byte cell
+ * tagged MARCH_FLOAT_TAG, discriminable from tagged ints (odd) and ADT/record
+ * cells (tag >= 0). Perceus treats it as an ordinary heap value. Nothing emits
+ * this yet — the codegen flip that populates erased slots with boxes is
+ * stage 2 (specs/plans/2026-07-13-float-boxing-design.md). */
+void *march_alloc_float(double v) {
+    march_float_box *b = (march_float_box *)march_alloc(sizeof(march_float_box));
+    b->tag = MARCH_FLOAT_TAG;
+    b->val = v;
+    return b;
+}
+
+double march_unbox_float(void *p) {
+    return ((march_float_box *)p)->val;
+}
+
 int64_t march_compare_string(void *a, void *b) {
     march_string *sa = (march_string *)a;
     march_string *sb = (march_string *)b;
@@ -517,10 +535,37 @@ int64_t march_string_eq(void *a, void *b) {
 int64_t march_poly_eq(void *a, void *b) {
     if (a == b) return 1;
     if (!IS_HEAP_PTR(a) || !IS_HEAP_PTR(b)) return 0;
-    if (((march_hdr *)a)->tag == MARCH_STRING_TAG &&
-        ((march_hdr *)b)->tag == MARCH_STRING_TAG)
+    int32_t ta = ((march_hdr *)a)->tag, tb = ((march_hdr *)b)->tag;
+    if (ta == MARCH_STRING_TAG && tb == MARCH_STRING_TAG)
         return march_string_eq(a, b);
+    /* Boxed floats compare by VALUE, not box identity — two distinct boxes of
+     * 3.5 are equal (float-boxing design). Also fixes the historical hazard
+     * where two distinct raw-float-bit patterns got dereferenced here. */
+    if (ta == MARCH_FLOAT_TAG && tb == MARCH_FLOAT_TAG)
+        return march_unbox_float(a) == march_unbox_float(b) ? 1 : 0;
     return 0;
+}
+
+/* Ordered generic compare for erased-slot operands (-1/0/1). See the header
+ * doc. Nothing calls this yet — the fallback_cmp codegen wiring is stage 2. */
+int64_t march_poly_compare(void *a, void *b) {
+    if (a == b) return 0;
+    /* Tagged immediates (odd low bit) → untag and integer-compare. A raw heap
+     * ptr on one side and a tagged int on the other cannot be ordered
+     * meaningfully; the tagged-vs-tagged case is the real one. */
+    int a_imm = ((uintptr_t)a & 1u) != 0;
+    int b_imm = ((uintptr_t)b & 1u) != 0;
+    if (a_imm && b_imm) {
+        int64_t ia = (intptr_t)a >> 1, ib = (intptr_t)b >> 1;
+        return march_compare_int(ia, ib);
+    }
+    if (!IS_HEAP_PTR(a) || !IS_HEAP_PTR(b)) return 0;
+    int32_t ta = ((march_hdr *)a)->tag, tb = ((march_hdr *)b)->tag;
+    if (ta == MARCH_FLOAT_TAG && tb == MARCH_FLOAT_TAG)
+        return march_compare_float(march_unbox_float(a), march_unbox_float(b));
+    if (ta == MARCH_STRING_TAG && tb == MARCH_STRING_TAG)
+        return march_compare_string(a, b);
+    return 0;  /* structural order needs static type info unavailable here */
 }
 
 int64_t march_string_byte_length(void *s) {
@@ -3733,6 +3778,10 @@ void *march_value_to_string(void *v) {
      * the interpreter — instead of misreading the layout (len-as-tag) and
      * printing "#<tag:len>".  Result is +1: alias the borrowed input. */
     if (tag == MARCH_STRING_TAG) { march_incrc(v); return v; }
+    /* Boxed float in an erased slot: render the value, not "#<tag:-3>"
+     * (float-boxing design; also closes a cousin of the to_string-on-erased
+     * divergence). */
+    if (tag == MARCH_FLOAT_TAG) return march_float_to_string(march_unbox_float(v));
     char buf[128];
     int n = snprintf(buf, sizeof(buf), "#<tag:%d>", tag);
     return march_string_lit(buf, n);

--- a/runtime/march_runtime.h
+++ b/runtime/march_runtime.h
@@ -103,6 +103,22 @@ void   *march_logger_write(void *level_str, void *msg, void *ctx, void *extra);
  * RC free path can run the destructor. Layout: [rc][tag][pad][native_ptr@16]
  * [dtor@24][type_id@32] (40 bytes). See runtime/march_ffi.c. */
 #define MARCH_RESOURCE_TAG ((int32_t)-2)
+/* Boxed Float. The stage-2 target of the float-boxing design
+ * (specs/plans/2026-07-13-float-boxing-design.md): a Float that flows through
+ * a type-ERASED (ptr) slot is heap-boxed so it is discriminable from a tagged
+ * int (odd) and a heap object (ADT tag >= 0), instead of the current raw-bits
+ * bitcast that IS_HEAP_PTR accidentally accepts (→ RC-on-raw-bits SIGSEGV and
+ * generic-compare-on-raw-bits silent wrong answers). Reserved negative tag,
+ * joining the string/resource sentinels. Layout: [rc][tag][pad][val@16] (24
+ * bytes). Concrete `double` fields and REPL/static Float slots stay unboxed;
+ * only erased slots box. Introduced additive (nothing emits it yet) — the
+ * codegen flip that populates erased slots with these is stage 2. */
+#define MARCH_FLOAT_TAG ((int32_t)-3)
+typedef struct { int64_t rc; int32_t tag; int32_t pad; double val; } march_float_box;
+/* Allocate a boxed Float (rc=1, tag=MARCH_FLOAT_TAG). */
+void   *march_alloc_float(double v);
+/* Read the double out of a boxed Float. Undefined if [p] is not a float box. */
+double  march_unbox_float(void *p);
 typedef struct { int64_t rc; int32_t tag; int32_t pad; int64_t len; char data[]; } march_string;
 /* Allocate an uninitialised-data march_string of byte length [len], with the
  * header (rc=1, tag=MARCH_STRING_TAG, pad=0, len) filled in.  Callers fill
@@ -116,6 +132,15 @@ void *march_bool_to_string(int64_t b);
 void *march_string_concat(void *a, void *b);
 int64_t march_string_eq(void *a, void *b);
 int64_t march_poly_eq(void *a, void *b);
+/* Ordered compare (-1/0/1) for two values in type-ERASED (ptr) slots, when
+ * the static type gives no strategy. Dispatches on runtime shape: tagged
+ * ints, boxed floats (MARCH_FLOAT_TAG), and strings each compare by value;
+ * other heap values fall back to 0 (a full structural order needs static
+ * type info unavailable here). The generic-compare half of the float-boxing
+ * design — must be wired at the codegen fallback_cmp site in the same stage
+ * that boxes floats, else box-only turns wrong-int-compare into
+ * wrong-pointer-compare. */
+int64_t march_poly_compare(void *a, void *b);
 /* Extended string builtins used by the compiled stdlib. */
 int64_t march_string_byte_length(void *s);
 int64_t march_string_is_empty(void *s);

--- a/specs/plans/2026-07-13-float-boxing-design.md
+++ b/specs/plans/2026-07-13-float-boxing-design.md
@@ -1,0 +1,149 @@
+# Boxing floats at erasure boundaries — design + recommendation
+
+**Status:** design / decision-needed. Unblocks the monomorphism-restriction
+lift (uniform-apply-ABI stage 5, `specs/plans/2026-07-13-uniform-apply-abi.md`)
+and retires the sort-RC patch family (`specs/todos.md`). Survey provenance:
+full surface inventory at HEAD `91e97b4a`, 2026-07-13.
+
+## The bug (two mechanisms, both verified)
+
+An erased (`ptr`) slot holds heap ptrs raw (even), i64-family scalars tagged
+`(n<<1)|1` (odd), and **Floats as raw IEEE-754 bits bitcast into the slot**
+(untagged; decode is static-type-directed via `coerce`,
+`lib/tir/llvm_ctx.ml:473-527`). Raw float bits are even and usually in the
+canonical user-space range, so they pass every `IS_HEAP_PTR` guard
+(`runtime/march_runtime.c:155-157`). When such a slot meets GENERIC code:
+
+1. **RC-on-raw-bits → SIGSEGV.** Perceus emits `march_incrc`/`march_decrc`
+   on erased slots; the guard admits the float bits and the RC write lands
+   in `*(3.5)`. Only positive floats reach this — negative floats have bit 63
+   set, so guard 3 (`(intptr_t)(p) > 0`) already rejects them.
+2. **Generic `<=`/`<` integer-compares the bits → silent wrong answer.**
+   `fallback_cmp` (`llvm_emit.ml:1013-1035`) takes the integer branch for
+   erased operands: conditional-untag then `icmp`. IEEE positive floats
+   happen to order correctly as signed int64; **negatives order in REVERSE
+   magnitude** (more-negative float = larger unsigned bits). `==`/`!=` route
+   through `march_poly_eq` (`march_runtime.c:480-487`), which dereferences
+   the "pointer" for two distinct float-bit patterns.
+
+**Experimental confirmation that hardening the guard is insufficient.**
+I temporarily narrowed `IS_HEAP_PTR` to the canonical user-space bound
+(`< 2^47`) and compiled the annotated repro over
+`[3.5, -1.25, 2.75, 0.5, -9.0, 4.5]`. The crash was gone — but the compiled
+binary printed head `-1.25` where the interpreter prints `-9.0`: the
+signed-int compare of `-9.0`'s bits (`0xC022…`) vs `-1.25`'s (`0xBFF4…`)
+ranks the larger magnitude *higher*, so `-9.0` never sorts to the front.
+**A runtime-guard fix (option B) cannot fix mechanism 2** — boxing and the
+generic-compare hook must land in the same change.
+
+Pre-existing severity: at pre-flip `3c8826a0` the annotated form did not
+crash but SILENTLY MIS-SORTED (positive-float head `4.5` where the
+interpreter says `0.5`). The uniform-ABI flip converted silent-wrong to
+loud-crash; neither is acceptable.
+
+## Options
+
+| | what | closes mech 1 | closes mech 2 | closes sort-RC family + Task/dyn-record/Result float | site count | perf cost |
+|---|---|---|---|---|---|---|
+| **A** | box floats when they enter erased slots | ✅ | ✅ (with compare hook) | ✅ | ~18–20 (≈10 funnel through `coerce`) | 1 alloc + RC per float crossing an erasure boundary |
+| **B** | harden `IS_HEAP_PTR` | ✅ | ❌ (proven above) | ❌ | 1 | none |
+| **D** | monomorphize let-bound lambdas by duplication (mono.ml) | only where uses are concrete | only there | ❌ | ~5–6 | none, but keeps Perceus special cases forever |
+
+Option D structurally cannot reach escaping/abstract-typed closures (a
+comparator returned from a generic fn or stashed in a `TFn(TVar)` record has
+no per-occurrence concrete type to duplicate on) and fixes none of the other
+erased-float surfaces (`Stats.median`, dyn-record floats, `Result`-Ok
+floats, Task-await Float). It reintroduces the generalize-vs-instantiate
+disagreement the uniform ABI just eliminated, one layer down.
+
+**Recommendation: option A, staged, with the generic-compare hook in the
+same atomic stage as the encode/decode/RC flip.** It is the only candidate
+that closes both verified mechanisms and the open sort-RC family; it makes
+`needs_rc (TVar _) = true` unconditionally sound (retiring
+`refine_occurrence_ty`/`resolve_case_field_ty`'s float suppressions — the
+patch-accretion the todos already flag for retirement); it incidentally
+fixes the Task-await Float ABI break (`llvm_emit.ml:1230`) and the
+`to_string`-on-erased-float divergence; and it is the already-written
+direction of `specs/plans/2026-04-16-uniform-integer-tagging.md` Phase 3
+(`:51`, `:96-151`) and the stage-5 blocker text. Keep B only as
+defense-in-depth (harden the guard so a stray raw-bits slot faults instead
+of corrupting silently). Revisit D later as a perf optimization (fewer
+erased closures → fewer boxes), not a correctness fix.
+
+## Box representation
+
+`struct march_float_box { march_hdr hdr; double val; }` — 24 bytes,
+`hdr.tag = MARCH_FLOAT_TAG (-3)` (joining `MARCH_STRING_TAG=-1`,
+`MARCH_RESOURCE_TAG=-2`; ADT ctor tags are ≥0, F19 actor-msg tags start at
+`0x0100_0000`, `MARCH_MIGRATE_TAG` is gated — no collision). Perceus treats
+it as an ordinary heap value; `EReuse` box-reuse is a later perf option.
+New runtime API `march_alloc_float(double) : ptr` / `march_unbox_float(ptr)
+: double`. Micro-precedent already in tree: `rec_box_some_float`
+(`runtime/march_extras.c:349-354`) boxes Option(Float) at the record_get
+boundary. **Do NOT** flip `niche_payload_ok TFloat` in the same change — a
+boxed float becomes non-null so Option(Float) *could* go niche, but that
+reopens the three-site encode/decode/eq repr-audit problem; keep it Boxed.
+
+## Staged plan (each gated; do not start N+1 with N red)
+
+**Stage 1 — runtime box API + tag-dispatch arms (additive, non-breaking). [LANDED]**
+`MARCH_FLOAT_TAG`, `march_alloc_float`/`march_unbox_float`
+(`march_runtime.{c,h}`); `march_poly_eq` gains a float-box arm; new
+`march_poly_compare(ptr,ptr)` dispatching odd→int / float-box→
+`march_compare_float` / string→`march_compare_string`; `march_value_to_string`
+float-box arm (also fixes the `#<tag:N>`-for-float cousin of the container
+divergence); `copy_value` treats the float box like the string arm (opaque
+payload, no raw-bits sniff). Gate: builds, existing suite unchanged (nothing
+emits the tag yet). Landed — pinned by `test/test_float_box.c` (a C harness;
+the box fns live in the `march_runtime.c` god-object, so it links the core
+runtime set + `-lz`), which proves the negative-float ordering
+`-9.0 < -1.25` that a hardened `IS_HEAP_PTR` cannot fix.
+
+**Stage 2 — the atomic compiler flip (one commit).** `coerce` double↔ptr
+arms box/unbox (splitting the `("i64","double")` arm from the static REPL-slot
+caller); the 6 bypass encode sites (`clo_wrap_define` double-return,
+`emit_raises_wrapper` Ok-Float, `record_put`/`EUpdate` kind-`'f'`) and the
+`llvm_eq` newtype-over-Float arm; **`fallback_cmp`'s integer branch calls
+`march_poly_compare` for erased TVar operands**; Perceus inversion (retire
+the float suppressions in `refine_occurrence_ty`/`resolve_case_field_ty` and
+flip `llvm_case.ml:742-754`'s IncRC predicate to count erased float boxes as
+heap fields); JIT-prelude/CAS cache-key bump (abi3). Gate: `fcu_flt`/
+`fcu_flt_ann`/`fcu_flt_neg` repros interp==compiled, `Stats.median([4.5,3.8,
+4.9])`, five bench sorts over floats, oracle divergence-free, MARCH_REPR_AUDIT
+0 flagged, full suite.
+
+**Stage 3 — lift the MR (= uniform-ABI stage 5).** Remove the typecheck gate,
+restore `accept/t03_let_poly` unannotated, retire
+`reject/t79_let_poly_unannotated_mr`, update finding 1 + the todos entry, add
+the unannotated-curried-Float-comparator compiled regression.
+
+**Stage 4 — perf pass.** `bench/array_numeric`, `bench/dataframe_bench`,
+`stdlib/stats.march` folds (3 boxes + 1 tuple/iteration). If the erased-float
+box+RC cost bites, add FBIP `EReuse` on the float box and/or unbox-on-entry at
+monomorphized boundaries (only *erased* slots box, so concrete numeric code is
+already immune). NativeArray/typed-array halves never box.
+
+## Risk register (option A)
+
+- **Perceus inversion is a flag-day**, not a patch — the float RC suppressions
+  become wrong the same commit boxing lands; both reverted lower_match attempts
+  show how sensitive this family is. Encode+decode+RC+compare flip together
+  (the 2026-04-16 plan's "tag only in coerce" lesson).
+- **Compare must ship with boxing** — box-only turns wrong-int-compare into
+  wrong-pointer-compare (still silent). `march_poly_compare` + the `poly_eq`
+  float arm are part of the minimum viable change.
+- **FFI public-contract break** — `march_make_float`'s "bitcast, untagged"
+  meaning changes wherever the value feeds an erased slot
+  (`march_ffi.h:48/76/103/146`); sweep `rust/` and the `march_ffi.c` examples.
+- **Cross-time ABI skew** — JIT/REPL fragments, CAS-cached prelude, hot-reload
+  `.so`s can mix box/raw; needs the stage-4-style cache-key bump + a
+  cross-fragment float-closure test.
+- **Perf on numeric-heavy erased code** — one alloc + atomic RC per erased
+  float; quantify in stage 4 before deciding whether FBIP reuse is required.
+
+## Cost
+
+Multi-day. Runtime ABI change + public FFI-contract change + a Perceus
+flag-day + a measurable (bounded) perf cost on float-heavy generic code.
+This is a deliberate architectural change, not a bug-fix — hence the
+decision gate before stage 2.

--- a/specs/plans/2026-07-15-float-boxing-execution-subplan.md
+++ b/specs/plans/2026-07-15-float-boxing-execution-subplan.md
@@ -37,15 +37,20 @@ against the current trunk and records the gaps. **Open-items plan Phase 2.**
 | **Perceus float suppressions** | `refine_occurrence_ty` / `resolve_case_field_ty` | **NOT FOUND BY NAME on trunk — refactored. MUST re-discover the current suppression sites before Stage 2.** |
 | MR gate (Stage 3) | `typecheck.ml:5028-5058` | **Unclear on trunk** — no `t79_let_poly_unannotated_mr` in the corpus; verify whether the MR gate exists here at all before planning Stage 3 |
 
-## Stage 1 — runtime box API (ADDITIVE, non-breaking) — IN PROGRESS
+## Stage 1 — runtime box API (ADDITIVE, non-breaking) — ✅ DONE (2026-07-15)
 
-Dispatched to a focused agent. Deliverables: `MARCH_FLOAT_TAG=-3` +
+Ported the reference implementation (`b7140673`, originally on
+`docs/core-march-types-skeleton`) onto the trunk — it cherry-picked clean
+(additive; 6 files, +231). Delivered: `MARCH_FLOAT_TAG=-3` +
 `march_float_box {hdr; double val}` (24 B); `march_alloc_float`/
 `march_unbox_float`; `march_poly_eq` float-box arm; new `march_poly_compare`
-(odd→int / float-box→double / string→string-compare); `march_value_to_string`
-float-box arm; `copy_value` float-box arm; `test/test_float_box.c` proving the
-**negative-float ordering `-9.0 < -1.25`** a hardened guard can't fix. **Gate:
-builds; full suite byte-identically unchanged (nothing emits the tag yet).**
+(odd→int / float-box→`march_compare_float` / string→`march_compare_string`);
+`march_value_to_string` float-box arm; `march_message.c` `copy_value` copies the
+box opaquely; `test/test_float_box.c` (linked against the core runtime set).
+**Gate PASSED:** `main.exe` builds; `test_float_box_runner` "all checks passed"
+(round-trip + eq + the negative-float ordering `-9.0 < -1.25`); full suite
+UNCHANGED (809 + all drivers, exit 0 — nothing emits the tag yet). Landed as
+commit `ec899b1e`.
 
 ## Stage 2 — the atomic compiler flip (ONE commit) — GATED, NEEDS SIGN-OFF
 

--- a/specs/plans/2026-07-15-float-boxing-execution-subplan.md
+++ b/specs/plans/2026-07-15-float-boxing-execution-subplan.md
@@ -1,0 +1,96 @@
+# Float-boxing — execution sub-plan (re-anchored to `origin/main` `e1977f12`)
+
+**Companion to** `specs/plans/2026-07-13-float-boxing-design.md` (the decision
+doc — Option A settled). That doc's `file:line` anchors are from HEAD
+`91e97b4a` and are **~196 commits stale**; this sub-plan re-verifies them
+against the current trunk and records the gaps. **Open-items plan Phase 2.**
+
+## Ground truth on the trunk (verified 2026-07-15)
+
+- Both target P0s are LIVE compiled: the annotated generalized-Float comparator
+  through `Sort.mergesort_by([3.5,-1.25,2.75,0.5,-9.0,4.5], cmp)` → **SIGSEGV
+  139** (interp prints `-9.`); the sort-RC bench family (`mergesort` etc.) →
+  **138/139**.
+- **Stage 1 is NOT landed on the trunk** (no `march_alloc_float` /
+  `MARCH_FLOAT_TAG` anywhere). The design doc's `[LANDED]` was true only on the
+  old-main lineage. Building Stage 1 from scratch (in progress).
+- Precedents present: `rec_box_some_float`/`rec_box_none_float`
+  (`runtime/march_extras.c:346-362`, boxes Option(Float) at the record_get
+  boundary); `march_make_float` (`runtime/march_ffi.c:36`, the "bitcast,
+  untagged" FFI float constructor — this is the public-contract break in the
+  risk register).
+
+## Re-anchored targets (trunk)
+
+| Design-doc target | Old anchor | Trunk anchor (verify before editing) |
+|---|---|---|
+| `march_hdr` struct | — | `runtime/march_runtime.h:11` (`{rc; tag; pad}`, 16 B) |
+| tags in use (so FLOAT=-3 free) | — | STRING=-1 `runtime.h:101`, RESOURCE=-2 `:105` |
+| `IS_HEAP_PTR` | `march_runtime.c:155-157` | `runtime/march_runtime.c:189` |
+| `march_poly_eq` | `:480-487` | `runtime/march_runtime.c:517` |
+| `march_value_to_string` float arm | `:3890` | near `runtime/march_runtime.c:359` |
+| `coerce` / `llvm_ty_of` | `llvm_ctx.ml:473-527` | `llvm_ctx.ml:332` (TFloat→double), `:342` (TVar→ptr); the bitcast `coerce` helper is nearby — RE-LOCATE |
+| `fallback_cmp` erased branch | `llvm_emit.ml:1013-1035` | `lib/tir/llvm_emit.ml:1025` (def), int branch `:1044`, callers `:1079/:1097` |
+| `llvm_case` float-heap predicate | `:742-754` | `lib/tir/llvm_case.ml:347` (`TFloat -> false`) |
+| `needs_rc (TVar _) = true` | `rc_types.ml:127` | `lib/tir/rc_types.ml` (documented `:31`), re-exported `perceus.ml:346` |
+| `clo_wrap` double-return bypass | — | `lib/tir/llvm_calls.ml` (`clo_wrap_define`), trampoline `llvm_emit.ml:370/502` |
+| **Perceus float suppressions** | `refine_occurrence_ty` / `resolve_case_field_ty` | **NOT FOUND BY NAME on trunk — refactored. MUST re-discover the current suppression sites before Stage 2.** |
+| MR gate (Stage 3) | `typecheck.ml:5028-5058` | **Unclear on trunk** — no `t79_let_poly_unannotated_mr` in the corpus; verify whether the MR gate exists here at all before planning Stage 3 |
+
+## Stage 1 — runtime box API (ADDITIVE, non-breaking) — IN PROGRESS
+
+Dispatched to a focused agent. Deliverables: `MARCH_FLOAT_TAG=-3` +
+`march_float_box {hdr; double val}` (24 B); `march_alloc_float`/
+`march_unbox_float`; `march_poly_eq` float-box arm; new `march_poly_compare`
+(odd→int / float-box→double / string→string-compare); `march_value_to_string`
+float-box arm; `copy_value` float-box arm; `test/test_float_box.c` proving the
+**negative-float ordering `-9.0 < -1.25`** a hardened guard can't fix. **Gate:
+builds; full suite byte-identically unchanged (nothing emits the tag yet).**
+
+## Stage 2 — the atomic compiler flip (ONE commit) — GATED, NEEDS SIGN-OFF
+
+**Do NOT start until (a) Stage 1 is green and (b) the human decision gate is
+passed.** This is the flag-day; encode + decode + RC + compare MUST move
+together (the design doc's central lesson; both prior `lower_match` attempts
+were reverted for splitting them).
+
+Concrete work on the trunk:
+1. `coerce` double↔ptr arms → `march_alloc_float`/`march_unbox_float` (split the
+   static REPL-slot caller from the erased-slot caller).
+2. The ~6 bypass encode sites: `clo_wrap` double-return, `emit_raises_wrapper`
+   Ok-Float, `record_put`/`EUpdate` kind-`'f'`, the `llvm_eq` newtype-over-Float
+   arm. RE-GREP each on the trunk.
+3. `fallback_cmp`'s integer branch (`llvm_emit.ml:1044`) → call
+   `march_poly_compare` for erased TVar operands.
+4. **Perceus inversion (riskiest, needs re-discovery):** find the current
+   float-suppression sites (the old `refine_occurrence_ty`/
+   `resolve_case_field_ty` are gone), retire them, and flip
+   `llvm_case.ml:347`'s `TFloat -> false` so an erased float box counts as a
+   heap field for IncRC. `needs_rc (TVar _)` already = true; boxing makes that
+   unconditionally sound.
+5. JIT-prelude / CAS cache-key bump (`abi3`).
+
+**Gate:** `fcu`/`fcu_ann`/`fcu_neg` repros interp==compiled; `Stats.median`;
+the five float sort benches; oracle divergence-free; `MARCH_REPR_AUDIT` clean;
+full suite green.
+
+## Stage 3 — lift the MR (verify it exists on the trunk first)
+
+Remove the typecheck MR gate (if present), restore `accept/t03_let_poly`
+unannotated, retire the reject witness, add the unannotated-curried-Float
+compiled regression. **First establish whether the trunk even has the MR gate**
+(the corpus witness is absent here).
+
+## Stage 4 — perf pass
+
+`bench/array_numeric`, `bench/dataframe_bench`, `stdlib/stats.march` folds.
+Add FBIP `EReuse` on the float box / unbox-on-entry only if the erased-float
+box+RC cost bites. Keep `niche_payload_ok TFloat` = Boxed.
+
+## Risk register (unchanged from the design doc, re-emphasized)
+
+Runtime ABI + public FFI-contract break (`march_make_float` meaning changes for
+erased slots — sweep `rust/` + `march_ffi.c`); Perceus flag-day (encode+decode+
+RC+compare together); compare must ship with boxing (box-only = silent wrong
+pointer-compare); cross-time ABI skew (cache-key bump). **Multi-day. Decision
+gate before Stage 2.**

--- a/test/dune
+++ b/test/dune
@@ -120,6 +120,40 @@
  (deps    (file test_dispatch_runner))
  (action  (run ./test_dispatch_runner)))
 
+; ── Boxed-Float runtime API unit test (float-boxing design, stage 1) ──────
+; march_alloc_float / march_unbox_float / march_poly_eq / march_poly_compare
+; live in march_runtime.c (the god-object), so this harness links the same
+; core runtime set the native goldens do, plus -lz for march_compress.c.
+(rule
+ (targets test_float_box_runner)
+ (deps    test_float_box.c
+          ../runtime/march_runtime.c ../runtime/march_runtime.h
+          ../runtime/march_scheduler.c ../runtime/march_scheduler.h
+          ../runtime/march_heap.c ../runtime/march_heap.h
+          ../runtime/march_gc.c ../runtime/march_gc.h
+          ../runtime/march_message.c ../runtime/march_message.h
+          ../runtime/march_deque.h
+          ../runtime/march_extras.c ../runtime/march_compress.c
+          ../runtime/base64.c ../runtime/sha1.c ../runtime/march_ffi.c
+          ../runtime/march_dispatch.c ../runtime/march_monitor_registry.c
+          ../runtime/march_remote_registry.c)
+ (action  (run %{cc}
+               -std=gnu11 -Wall -Wextra -Wno-unused-function -I../runtime
+               -o %{targets}
+               test_float_box.c ../runtime/march_runtime.c
+               ../runtime/march_scheduler.c ../runtime/march_heap.c
+               ../runtime/march_gc.c ../runtime/march_message.c
+               ../runtime/march_extras.c ../runtime/march_compress.c
+               ../runtime/base64.c ../runtime/sha1.c ../runtime/march_ffi.c
+               ../runtime/march_dispatch.c ../runtime/march_monitor_registry.c
+               ../runtime/march_remote_registry.c
+               -lpthread -lz)))
+
+(rule
+ (alias   runtest)
+ (deps    (file test_float_box_runner))
+ (action  (run ./test_float_box_runner)))
+
 ; ── HCR capability-lattice C table unit test ──────────────────────────────
 ; Verifies runtime/march_cap_lattice.{h,c} (generated from
 ; lib/caps/cap_lattice.ml by lib/caps/emit_c_table.ml) against the

--- a/test/test_float_box.c
+++ b/test/test_float_box.c
@@ -1,0 +1,85 @@
+/* test_float_box.c — boxed-Float runtime API (float-boxing design, stage 1).
+ *
+ * Exercises the additive box API that stage 2 will emit into erased slots:
+ * round-trip, value-equality of distinct boxes, and — the load-bearing case —
+ * that march_poly_compare orders NEGATIVE floats correctly. Raw IEEE-754 bits
+ * in an erased slot integer-compare backwards for negatives (a hardened
+ * IS_HEAP_PTR stops the crash but leaves this wrong: -1.25 sorted before
+ * -9.0), so a box + value-aware compare is the only fix — this test pins it.
+ */
+#include "../runtime/march_runtime.h"
+#include <stdio.h>
+#include <string.h>
+
+static int g_failed = 0;
+
+#define CHECK(cond, msg) do {                                               \
+    if (!(cond)) {                                                          \
+        fprintf(stderr, "  FAIL [%s:%d]: %s\n", __func__, __LINE__, (msg)); \
+        g_failed++;                                                         \
+    }                                                                       \
+} while (0)
+
+static void test_roundtrip(void) {
+    double xs[] = { 0.0, 3.5, -1.25, -9.0, 1e300, -1e-300 };
+    for (unsigned i = 0; i < sizeof(xs)/sizeof(xs[0]); i++) {
+        void *b = march_alloc_float(xs[i]);
+        CHECK(b != NULL, "alloc returned NULL");
+        CHECK(((march_float_box *)b)->tag == MARCH_FLOAT_TAG, "wrong tag");
+        CHECK(march_unbox_float(b) == xs[i], "unbox != original");
+        /* Boxes are heap ptrs (even, non-null) — RC-safe, unlike raw bits. */
+        CHECK(((uintptr_t)b & 1u) == 0, "box is not a heap ptr (odd)");
+    }
+}
+
+static void test_poly_eq_by_value(void) {
+    void *a = march_alloc_float(3.5);
+    void *b = march_alloc_float(3.5);   /* distinct box, same value */
+    void *c = march_alloc_float(3.6);
+    CHECK(a != b, "boxes should be distinct pointers");
+    CHECK(march_poly_eq(a, b) == 1, "equal-valued boxes must be poly_eq");
+    CHECK(march_poly_eq(a, c) == 0, "unequal-valued boxes must not be poly_eq");
+    CHECK(march_poly_eq(a, a) == 1, "identity");
+}
+
+static void test_poly_compare_negatives(void) {
+    /* The exact case a hardened IS_HEAP_PTR cannot fix. Ascending order of
+     * [3.5, -1.25, 2.75, 0.5, -9.0, 4.5] puts -9.0 first: -9.0 < -1.25. */
+    void *n9   = march_alloc_float(-9.0);
+    void *n125 = march_alloc_float(-1.25);
+    void *p35  = march_alloc_float(3.5);
+    CHECK(march_poly_compare(n9, n125) == -1, "-9.0 must compare LESS than -1.25");
+    CHECK(march_poly_compare(n125, n9) == 1,  "-1.25 must compare GREATER than -9.0");
+    CHECK(march_poly_compare(n9, n9)   == 0,  "reflexive");
+    CHECK(march_poly_compare(n125, p35) == -1, "-1.25 < 3.5");
+}
+
+static void test_poly_compare_tagged_ints(void) {
+    /* Tagged int immediates: (n<<1)|1. poly_compare untags and int-compares. */
+    void *five = (void *)(uintptr_t)((5 << 1) | 1);
+    void *two  = (void *)(uintptr_t)((2 << 1) | 1);
+    CHECK(march_poly_compare(two, five) == -1, "2 < 5 tagged");
+    CHECK(march_poly_compare(five, two) == 1,  "5 > 2 tagged");
+    CHECK(march_poly_compare(five, five) == 0, "reflexive tagged");
+}
+
+static void test_value_to_string(void) {
+    void *b = march_alloc_float(4.5);
+    void *s = march_value_to_string(b);   /* must render the value, not #<tag:-3> */
+    march_string *ms = (march_string *)s;
+    CHECK(ms->len >= 3, "float box should render a numeric string");
+    CHECK(ms->data[0] == '4', "expected 4.5 to start with '4'");
+    CHECK(strchr(ms->data, '#') == NULL, "must not render #<tag:...>");
+}
+
+int main(void) {
+    printf("test_float_box:\n");
+    test_roundtrip();
+    test_poly_eq_by_value();
+    test_poly_compare_negatives();
+    test_poly_compare_tagged_ints();
+    test_value_to_string();
+    if (g_failed) { printf("  %d check(s) FAILED\n", g_failed); return 1; }
+    printf("  all checks passed\n");
+    return 0;
+}


### PR DESCRIPTION
Phase 2 (float-boxing) of the open-items master plan — **Stage 1 only**
(the additive, non-breaking runtime foundation) plus the planning docs.
**Stage 2 (the atomic flag-day) is deliberately deferred** behind the design
doc's decision gate.

### Why this is a foundation-only PR
The two P0s Phase 2 fixes are live on the trunk (verified): an annotated
generalized-Float comparator through `Sort.mergesort_by(...)` SIGSEGVs compiled
(interp correct), and the sort-RC bench family crashes 138/139. Fixing them is a
multi-day architectural change (runtime ABI + public FFI-contract break + a
Perceus "flag-day", prior attempts reverted). The design doc mandates a human
decision gate before Stage 2 — so this PR lands only the safe Stage-1 substrate.

### Stage 1 — runtime box API (additive; nothing emits the tag yet)
- `MARCH_FLOAT_TAG=-3` + `march_float_box {hdr; double}` (24 B);
  `march_alloc_float` / `march_unbox_float`.
- `march_poly_eq` float-box arm; new `march_poly_compare` (odd→int /
  float-box→`march_compare_float` / string→`march_compare_string`) — the
  generic-ordered-compare half the design requires to ship *with* the Stage-2
  boxing (box-only would turn a wrong-int-compare into a wrong-pointer-compare).
- `march_value_to_string` float-box arm; `march_message.c` `copy_value` copies
  the box opaquely (no raw-double sniff).
- `test/test_float_box.c` C harness — proves box round-trip, value-equality, and
  the **negative-float ordering `-9.0 < -1.25`** that a hardened `IS_HEAP_PTR`
  cannot fix (the whole reason boxing is required over guard-hardening).

**Verification:** `main.exe` builds; `test_float_box_runner` "all checks
passed"; full six-runner suite **UNCHANGED** (809 + all drivers, exit 0) — Stage
1 emits no tag, so by construction it cannot change any existing test.

### Docs
- Ported `specs/plans/2026-07-13-float-boxing-design.md` onto the trunk (it only
  existed on the old-main lineage).
- New `specs/plans/2026-07-15-float-boxing-execution-subplan.md` re-anchors the
  design's ~196-commit-stale `file:line` targets to `origin/main` and records the
  gaps — notably that the Perceus float-suppression functions the Stage-2 flip
  must retire (`refine_occurrence_ty`/`resolve_case_field_ty`) no longer exist by
  name (refactored) and must be re-discovered, and that the MR gate's presence on
  the trunk is unverified.

### Next (not in this PR)
Stage 2 (atomic compiler flip) → Stage 3 (lift the MR) → Stage 4 (perf), per the
sub-plan, as a dedicated focused effort.
