### PR TITLE
fix(eval): general-interface methods dispatch by argument type (Layer 1)

### DIFF
--- a/lib/eval/eval.ml
+++ b/lib/eval/eval.ml
@@ -261,6 +261,15 @@ let doc_registry : (string, string) Hashtbl.t = Hashtbl.create 32
     Reset per module eval via [reset_scheduler_state]. *)
 let impl_tbl : (string * string, value) Hashtbl.t = Hashtbl.create 8
 
+(** General-interface method dispatch table — maps (iface_name, method_name,
+    type_name) to the concrete method value, so a call to a general (non
+    type-dispatched-builtin) interface method routes by the FIRST argument's
+    runtime type instead of the last-bound name. Keyed by method too (unlike
+    [impl_tbl]'s single (iface,type) slot) so a MULTI-method interface's methods
+    don't overwrite each other. [type_name] is the declaring-module-qualified
+    identity for a colliding short name, else the bare name (see DImpl eval). *)
+let iface_method_tbl : (string * string * string, value) Hashtbl.t = Hashtbl.create 8
+
 (** Interface methods that are dispatched by the argument's type through a
     type-directed builtin ([show], [eq], [compare], [hash]) rather than by name.
 
@@ -7951,6 +7960,7 @@ let reset_scheduler_state () : unit =
   Hashtbl.clear actor_registry;
   Hashtbl.clear actor_defs_tbl;
   Hashtbl.reset impl_tbl;
+  Hashtbl.reset iface_method_tbl;
   Hashtbl.reset ctor_type_tbl;
   (* Pre-register builtin constructor → type mappings so Show dispatch works *)
   List.iter (fun (ctor, ty) -> Hashtbl.replace ctor_type_tbl ctor ty)
@@ -8895,6 +8905,13 @@ let rec eval_decl (env : env) (d : decl) : env =
                the wrong method and recurses forever (neq → eq → neq). *)
             if (not (is_type_dispatched_iface idef.impl_iface.txt)) || is_dispatched then
               Hashtbl.replace impl_tbl (idef.impl_iface.txt, type_name) fn_val;
+            (* General (non-builtin, non-Json) interface methods also go in the
+               per-method dispatch table so a call routes by the first arg's
+               runtime type, not the last-bound name (fixes multi-impl dispatch,
+               e.g. Speak(Dog) + Speak(Cat)). *)
+            if not (is_type_dispatched_iface idef.impl_iface.txt) && not is_json_iface then
+              Hashtbl.replace iface_method_tbl
+                (idef.impl_iface.txt, mname.txt, type_name) fn_val;
             let iface_qualified = idef.impl_iface.txt ^ "." ^ mname.txt in
             Hashtbl.replace module_registry iface_qualified fn_val
           | None -> ()
@@ -8906,7 +8923,38 @@ let rec eval_decl (env : env) (d : decl) : env =
            dispatches through impl_tbl, so binding the bare name in the env
            would shadow the builtin and break dispatch when 2+ impls exist. *)
         if (is_json_iface && mname.txt = "to_json") || is_dispatched then env
-        else new_env
+        else if is_json_iface then new_env  (* from_json &c.: name-bound (dispatch is on return type) *)
+        else if is_type_dispatched_iface idef.impl_iface.txt then new_env
+          (* A NON-dispatch method (e.g. a user `interface Eq`'s default `neq`)
+             of a builtin-named interface: bind the concrete method by name. *)
+        else begin
+          (* General interface method: bind a TYPE-DISPATCHER (routes by arg0's
+             runtime type via iface_method_tbl) instead of the concrete method,
+             so 2+ impls dispatch by type rather than last-binding-wins. Bound
+             once per method name (idempotent across sibling impls). *)
+          let iface = idef.impl_iface.txt in
+          let disp_tag = "$dispatch$" ^ iface ^ "$" ^ mname.txt in
+          let already = match List.assoc_opt mname.txt env with
+            | Some (VBuiltin (n, _)) -> n = disp_tag
+            | _ -> false in
+          if already then env
+          else
+            let disp = VBuiltin (disp_tag, fun args ->
+              match args with
+              | arg0 :: _ ->
+                (match type_name_of_value arg0 with
+                 | Some tname ->
+                   (match Hashtbl.find_opt iface_method_tbl (iface, mname.txt, tname) with
+                    | Some m -> !iface_dispatch_hook m args
+                    | None -> eval_error
+                        "no implementation of interface `%s` for type `%s`" iface tname)
+                 | None -> eval_error
+                     "cannot dispatch interface method `%s`: argument has no dispatchable type" mname.txt)
+              | [] -> eval_error
+                  "interface method `%s` called with no arguments" mname.txt)
+            in
+            (mname.txt, disp) :: env
+        end
       ) env idef.impl_methods
 
   | DProtocol (name, pdef, _sp) ->
@@ -9052,6 +9100,7 @@ let eval_module_env (m : module_) : env =
   dyn_sup_next_vpid := (-1);
   (* Pre-register builtin constructor → type mappings so Show/impl dispatch works *)
   Hashtbl.reset impl_tbl;
+  Hashtbl.reset iface_method_tbl;
   Hashtbl.reset ctor_type_tbl;
   List.iter (fun (ctor, ty) -> Hashtbl.replace ctor_type_tbl ctor ty)
     [ "Ok", "Result"; "Err", "Result"
@@ -9216,6 +9265,12 @@ let eval_module_env (m : module_) : env =
                  the wrong method and recurses forever (neq → eq → neq). *)
               if (not (is_type_dispatched_iface idef.impl_iface.txt)) || is_dispatched then
                 Hashtbl.replace impl_tbl (idef.impl_iface.txt, type_name) fn_val;
+              (* General (non-builtin, non-Json) interface methods also go in the
+                 per-method dispatch table so a call routes by the first arg's
+                 runtime type, not the last-bound name. *)
+              if not (is_type_dispatched_iface idef.impl_iface.txt) && not is_json_iface then
+                Hashtbl.replace iface_method_tbl
+                  (idef.impl_iface.txt, mname.txt, type_name) fn_val;
               let iface_qualified = idef.impl_iface.txt ^ "." ^ mname.txt in
               Hashtbl.replace module_registry iface_qualified fn_val
             | None -> ()
@@ -9226,7 +9281,38 @@ let eval_module_env (m : module_) : env =
              above, don't rebind the bare name globally — it would shadow the
              builtin and break dispatch when 2+ impls of the iface exist. *)
           if is_json_iface || is_dispatched then acc_env
-          else new_acc
+          else if is_type_dispatched_iface idef.impl_iface.txt then new_acc
+            (* A NON-dispatch method (e.g. a user `interface Eq`'s default `neq`)
+               of a builtin-named interface: bind the concrete method by name, as
+               before — it's not in iface_method_tbl and is called directly. *)
+          else begin
+            (* General interface method: bind a TYPE-DISPATCHER (routes by arg0's
+               runtime type via iface_method_tbl) instead of the concrete method,
+               so 2+ impls dispatch by type rather than last-binding-wins.
+               Idempotent across sibling impls. *)
+            let iface = idef.impl_iface.txt in
+            let disp_tag = "$dispatch$" ^ iface ^ "$" ^ mname.txt in
+            let already = match List.assoc_opt mname.txt acc_env with
+              | Some (VBuiltin (n, _)) -> n = disp_tag
+              | _ -> false in
+            if already then acc_env
+            else
+              let disp = VBuiltin (disp_tag, fun args ->
+                match args with
+                | arg0 :: _ ->
+                  (match type_name_of_value arg0 with
+                   | Some tname ->
+                     (match Hashtbl.find_opt iface_method_tbl (iface, mname.txt, tname) with
+                      | Some m -> !iface_dispatch_hook m args
+                      | None -> eval_error
+                          "no implementation of interface `%s` for type `%s`" iface tname)
+                   | None -> eval_error
+                       "cannot dispatch interface method `%s`: argument has no dispatchable type" mname.txt)
+                | [] -> eval_error
+                    "interface method `%s` called with no arguments" mname.txt)
+              in
+              (mname.txt, disp) :: acc_env
+          end
         ) env idef.impl_methods in
       env_ref := env';
       make_recursive_env rest env'

--- a/specs/plans/2026-07-20-fqn-impl-dispatch-identity.md
+++ b/specs/plans/2026-07-20-fqn-impl-dispatch-identity.md
@@ -315,6 +315,90 @@ Layer 1b (interp same-name) rides alongside: qualify the `iface_method_tbl` key 
 the `iface_native_type_dispatched` gate; flip `reject/t82` → accept + add a
 compiled+interp `from-A`/`from-B` runtime witness.
 
+### Layer 2 — the value-representation solution + dispatch codegen (execution-ready)
+
+**The blocking sub-problem (found while implementing step 2).** A runtime tag
+switch needs every colliding value to carry a readable, module-unique
+discriminator. But two representation optimisations defeat a naive tag change:
+- **Single-ctor / nullary types** (e.g. `Thing = TA`) may be lowered to an
+  immediate or an unallocated constant with **no stored tag word** — nothing to
+  switch on at runtime.
+- **Niche-repr types** (Option-shaped: one nullary + one payload ctor, `None`
+  encoded as a null pointer) special-case small tags; blindly bumping a niche
+  type's ctor tag to `0x0100_0000` corrupts the niche encode/decode.
+
+So the tag can't just be reassigned globally — the colliding type's whole
+representation has to guarantee a readable discriminator.
+
+**Solution — uniform tagged representation for colliding types (collision-
+conditional).** For any type in the collision set, the value-representation
+classifier (the `niche_repr_of_concrete` / boxed-vs-immediate decision in
+`llvm_data.ml` / `llvm_case.ml`) must emit the **uniform heap-boxed, tag-word
+representation** — never niche, never single-ctor-immediate. Then:
+- every colliding value stores an `i32` tag (`emit_store_tag`, `llvm_data.ml:25`)
+  that `emit_load_tag` (`:18`) can read at a dispatch site;
+- the tag is the **global** tag from step 2, so it is module-unique;
+- `EAlloc` and `match` for the colliding type already resolve via the
+  module-qualified `ctor_info` key, so they store/read the same global tag —
+  self-consistent.
+Because it is gated on the collision set, single-declaration types keep niche/
+immediate reprs → their emitted IR, CAS keys, and `.expected` snapshots are
+byte-identical. Verify with `git status test/snapshots/` + a CAS value-reveal on
+a niche-heavy single-declaration program (e.g. an `Option`-returning bench).
+
+**Dispatch codegen — one generated dispatch function per `(iface, method,
+colliding-short-name)`** (mirrors `ensure_adt_eq_fn`, `llvm_eq.ml:51`, not an
+inline switch at every call site):
+- Name: `__march_ifdispatch_<Iface>_<method>_<Short>`; generated lazily the first
+  time a call to that method on a colliding-short-name static type is emitted.
+- Body: `load tag from arg0; switch (tag) { <each colliding type T's ctor tags>
+  -> tail-call <T's qualified impl symbol>(args); default -> unreachable }`. The
+  `(type → its ctor tags → its qualified impl symbol)` rows come from the mono
+  dispatch table once it is keyed by module-qualified type (step 3) + `ctor_info`.
+- At the call site (`mono.ml` first-arg-type dispatch, `:318/375/521/632`): if the
+  static arg type's short name is in the collision set, emit a call to the
+  generated dispatch function instead of `resolve_impl_by_type`'s single static
+  symbol. Non-colliding calls are unchanged (byte-identical).
+
+**Collision set — computed once, threaded to three consumers.** Derive it from
+the module-qualified `TDVariant`/`TDRecord` names in the TIR module
+(`m.Tir.tm_types`; short = last `.` segment, module = prefix; short names under
+≥2 distinct module prefixes). Consumers: (a) `build_ctor_info` (global tags +
+repr force), (b) the repr classifier (force uniform tagged), (c) `mono` dispatch
+(emit the dispatch function / route). Compute in one place (a `Llvm_ctx` field
+populated at `build_ctor_info`, or a pre-pass) so all three agree.
+
+**Ctor-name collisions within the set.** For the target case (`NA.Thing = TA`,
+`NB.Thing = TB`) the ctor NAMES differ, so the `TypeName.CtorName` `ctor_info`
+keys already distinguish them. When two colliding types ALSO share ctor names
+(e.g. two `AeDir` both with `AeNorth`), the `ctor_info` key must become
+**module-qualified** (`ci_module.Type.Ctor`) and `EAlloc`/`match` must embed the
+same — this is the umbrella doc's Stage-4 ctor-identity carry. Do it
+collision-conditionally too; it is only reachable for same-ctor-name colliders.
+
+**Layer 3 finalisation + witnesses.** Drop the `iface_native_type_dispatched`
+gate (remove the `MARCH_DEV_RELAX_COHERENCE` dev bypass) so the coherence
+relaxation covers all interfaces; flip `reject/t82` → `accept/t82` (or a new
+accept) and delete the `run_compiler` "general-iface err" case added in Stage 1;
+add a runtime witness under `test/imports/` that RUNS both interpreted and
+compiled and asserts `from-A`/`from-B` (the first cross-backend runtime witness
+for same-name general dispatch). Update the `adt_eq_native`-style native golden
+set if any colliding fixture's IR intentionally changes.
+
+**Validation gate (all must pass):** full suite (`scripts/run-tests.sh`, not -q);
+`dune build @runtest @oracle` (native rules + parity); `git status
+test/snapshots/` empty (or reviewed + regenerated deliberately); a CAS
+value-reveal on a single-declaration niche program (byte-identity proof); the
+new `from-A`/`from-B` runtime witness green on BOTH backends. If any mangled
+symbol / tag changes for a single-declaration type, the collision-conditional
+gate has a leak — fix it, do not re-baseline goldens.
+
+**Estimated shape:** 3–4 focused sub-tasks (collision-set + repr force; global
+tags; dispatch-function codegen + mono routing; Layer 1b + Layer 3 + witnesses),
+each independently buildable, with byte-identity checked at every step. This is
+the compiler's highest miscompile-risk surface (value representation + tags);
+keep every intermediate green and collision-conditional.
+
 ## Test & validation strategy
 - Reuse the `specs/lang/types/{accept,reject}/` witness harness (t79/t80/t83/t85
   already exist; add t86-style two-module accept + an interp/native runtime

--- a/specs/plans/2026-07-20-fqn-impl-dispatch-identity.md
+++ b/specs/plans/2026-07-20-fqn-impl-dispatch-identity.md
@@ -215,6 +215,58 @@ first** (release-relevant, byte-identical goldens); 2–3 complete A-full.
 - Note the residual: `TCon` type-references remain bare (no type-reference
   qualification); that full carry stays the deferred umbrella-doc flag-day.
 
+## Stages 2+3 combined — refined approach (2026-07-20, general-interface case)
+
+Building the FULL general-user-interface same-short-name case (chosen: land
+interp + native + typecheck-relax together). Two empirical findings reshape the
+plan beyond the clean stage split above:
+
+**Finding A — the interpreter's general-interface dispatch is ALREADY broken for
+multiple impls, by NAME not type.** `eval.ml`'s `DImpl` arm binds each general
+interface method under its BARE method name in `env` (`:8877`
+`(mname.txt, clo) :: env`); a second `impl Speak(_)` shadows the first, so
+`speak(x)` resolves to the last-bound method regardless of `x`. Verified:
+`impl Speak(Dog)` + `impl Speak(Cat)` (DISTINCT short names) prints `meow`/`meow`
+interpreted (should be `woof`/`meow`) while native is correct — a pre-existing,
+uncovered interp-vs-native divergence (the `accept/t83` Dog/Cat witness is
+`--check`-only, never run). Only the type-dispatched builtins (Eq/Ord/Show/Hash)
+dispatch by value type today, via `impl_tbl[(iface, type_name_of_value)]`.
+→ **Layer 1 (interp):** generalize that mechanism — bind every interface method
+to a first-arg **type dispatcher** that looks up `impl_tbl[(iface,
+type_name_of_value arg0)]`, instead of name-binding the concrete method.
+`impl_tbl` is already populated for general interfaces (`:8897`). Methods that
+can't dispatch on arg0 (e.g. `from_json : JsonValue -> a`) keep today's
+name-binding (already special-cased). Same-short-name types then need
+`impl_tbl` keys + `type_name_of_value` qualified by declaring module
+(collision-conditional, from `module_stack`) so `NA.Thing` vs `NB.Thing` don't
+collide — the original Stage-2 work.
+
+**Finding B — regular ADT ctor tags are PER-TYPE 0-based, so a runtime tag
+switch cannot identify the module.** `llvm_toplevel.ml:488` assigns
+`ce_tag = tag_idx` (0,1,2… within each type), so `NA.Thing.TA` and `NB.Thing.TB`
+BOTH get tag 0. The design's "runtime ctor-tag → declaring-module" step assumed
+tags identify the module; they do not. Actor-msg ctors already get
+globally-unique tags (`:437` `actor_msg_tag` base `0x0100_0000`) — the model.
+→ **Layer 2 (native):** collision-conditionally give a colliding type's ctors
+**globally-unique tags** (reuse the actor-msg scheme) AND key `ctor_info` by a
+**module-qualified** ctor identity (`ci_module`, threaded into lowering — the
+umbrella doc's Stage 4), so `EAlloc`/`match`/dispatch all resolve the same tag.
+Qualify the generated impl symbol by declaring module (`lower.ml:1081`). Then a
+call `speak(x)` whose static type is a colliding short name emits a switch on
+`x`'s (now module-unique) tag → the right impl symbol. Single-declaration types
+keep per-type tags + bare identity → CAS keys + goldens byte-identical.
+
+**Layer 3 (typecheck):** once both backends dispatch correctly for colliding
+general interfaces, drop the `iface_native_type_dispatched` gate in
+`register_impl_shape` so the relaxation covers ALL interfaces, and flip
+`reject/t82` → an accept + a compiled + interp cross-backend runtime witness
+(`from-A`/`from-B`).
+
+**Sequencing:** build Layer 1 (interp, most tractable, fixes the Dog/Cat
+divergence), then Layer 2 (native, the flag-day), then Layer 3 (relax) — all on
+`claude/fqn-impl-coherence-stage2-636503`, landed together. Gate at each layer;
+final oracle + full-suite + snapshot review; CAS value-reveal check for Layer 2.
+
 ## Test & validation strategy
 - Reuse the `specs/lang/types/{accept,reject}/` witness harness (t79/t80/t83/t85
   already exist; add t86-style two-module accept + an interp/native runtime

--- a/specs/plans/2026-07-20-fqn-impl-dispatch-identity.md
+++ b/specs/plans/2026-07-20-fqn-impl-dispatch-identity.md
@@ -267,6 +267,54 @@ divergence), then Layer 2 (native, the flag-day), then Layer 3 (relax) — all o
 `claude/fqn-impl-coherence-stage2-636503`, landed together. Gate at each layer;
 final oracle + full-suite + snapshot review; CAS value-reveal check for Layer 2.
 
+### Layer 2 — concrete implementation steps (native flag-day), verified harness
+
+DEV HARNESS: `MARCH_DEV_RELAX_COHERENCE=1` env-var bypass in `register_impl_shape`
+(TEMPORARY — remove when Layer 3 lands) lets a same-short-name general-interface
+program compile. Baseline confirmed: `mod Top { mod NA{type Thing=TA;
+impl Speak(Thing)->"from-A"} mod NB{type Thing=TB; impl Speak(Thing)->"from-B"} }`
+compiles and MISCOMPILES natively `from-A`/`from-A` today (interp is correct after
+Layer 1). Fixture at `scratchpad/spike/spike.march`.
+
+Root cause (grep-verified): (1) two `impl Speak(Thing)` mangle to ONE symbol
+`Speak$Thing.speak` (`lower.ml:1069-1082`, bare type_name), last-write-wins;
+(2) the mono dispatch table maps `speak → [("Thing", sym)]` with both impls under
+bare "Thing" (`resolve_impl_by_type` first-wins); (3) ADT ctor tags are PER-TYPE
+0-based (`llvm_toplevel.ml:488`) so `NA.Thing.TA` and `NB.Thing.TB` both = tag 0
+→ no runtime discriminator.
+
+The four coordinated changes (collision-conditional — a short type name declared
+by ≥2 modules; single-declaration types stay byte-identical):
+1. **Collision set** at `build_ctor_info` (`llvm_toplevel.ml:424`): scan the
+   `TDVariant` names (module-qualified at `lower.ml:1267/1269`, e.g. `NA.Thing`)
+   → the set of short names (last `.` segment) appearing under ≥2 module prefixes.
+2. **Global tags for colliding types**: in `build_ctor_info`, a colliding type's
+   ctors get globally-unique tags (reuse the actor-msg counter scheme at `:437`,
+   base `0x0100_0000`) instead of `ce_tag = tag_idx`. Keep the module-qualified
+   `ctor_info` key (`ci_module`) so `NA.Thing.TA`/`NB.Thing.TB` are distinct
+   entries and `EAlloc`/`match` (which resolve via the same key) get the new tag.
+3. **Qualified impl symbol + dispatch entry** (`lower.ml:1069-1082/1109-1117`):
+   qualify `type_name` by the impl's declaring module (`mod_prefix`) for colliding
+   types → distinct symbols (`Speak$NA.Thing.speak`) + distinct dispatch entries.
+4. **Runtime tag-switch at the call site** (`mono.ml` dispatch, `:318/375/521/632`
+   + `resolve_impl_by_type`): when the call's static arg type is a colliding short
+   name, emit `switch(tag(arg0))` over the colliding types' (now module-unique)
+   tags → the matching qualified impl symbol, instead of a single static call.
+   Model: `ensure_adt_eq_fn` (`llvm_eq.ml:51`) reads per-tag layouts from
+   module-qualified ctor_info keys.
+
+CAS/golden: the TCon-name/tag change flows through `mangle_ty` + `write_ty`
+(`cas/serialize.ml:126`); collision-conditional keeps single-declaration output
+byte-identical (verify with `git status test/snapshots/` + a CAS value-reveal).
+If any mangled symbol changes, add the flag to `cas_flags` (bin/main.ml, 2 sites).
+
+Layer 1b (interp same-name) rides alongside: qualify the `iface_method_tbl` key +
+`type_name_of_value` (`eval.ml`) by declaring module for colliding short names
+(collision set from the same ≥2-modules scan, computed at DType eval via
+`module_stack`), else bare. Layer 3: replace the dev bypass with the real drop of
+the `iface_native_type_dispatched` gate; flip `reject/t82` → accept + add a
+compiled+interp `from-A`/`from-B` runtime witness.
+
 ## Test & validation strategy
 - Reuse the `specs/lang/types/{accept,reject}/` witness harness (t79/t80/t83/t85
   already exist; add t86-style two-module accept + an interp/native runtime

--- a/test/test_eval.ml
+++ b/test/test_eval.ml
@@ -1490,6 +1490,30 @@ let test_default_method_eval () =
   Alcotest.(check bool) "neq default returns true for 1 neq 2" true
     (vbool result)
 
+let test_general_iface_multi_impl_dispatch () =
+  (* Two impls of ONE general interface for DISTINCT types must each dispatch to
+     their own body by the argument's runtime type, not the last-bound name.
+     Regression: the interp used to name-bind general-interface methods (last
+     impl wins), so speak(Dog) wrongly ran Cat's body (meow/meow). Now routed
+     through iface_method_tbl by type. *)
+  let src = {|mod Test do
+    interface Speak(a) do
+      fn speak : a -> String
+    end
+    type Dog = Dog
+    type Cat = Cat
+    impl Speak(Dog) do fn speak(_x) do "woof" end end
+    impl Speak(Cat) do fn speak(_x) do "meow" end end
+    fn say_dog() do speak(Dog) end
+    fn say_cat() do speak(Cat) end
+  end|} in
+  let env = eval_module src in
+  let vstr v = match v with March_eval.Eval.VString s -> s | _ -> failwith "expected VString" in
+  Alcotest.(check string) "speak(Dog) dispatches to Dog's body"
+    "woof" (vstr (call_fn env "say_dog" []));
+  Alcotest.(check string) "speak(Cat) dispatches to Cat's body"
+    "meow" (vstr (call_fn env "say_cat" []))
+
 let test_default_method_user_type () =
   (* Regression: a user-declared `interface Eq(a)` (name collides with the
      built-in Eq) with a default `neq` calling `eq`, implemented for a USER
@@ -4391,6 +4415,7 @@ let eval_suites =
           Alcotest.test_case "superclass missing"     `Quick test_superclass_missing;
           Alcotest.test_case "default method tc"      `Quick test_default_method_inherited;
           Alcotest.test_case "default method eval"    `Quick test_default_method_eval;
+          Alcotest.test_case "general iface multi-impl dispatch" `Quick test_general_iface_multi_impl_dispatch;
           Alcotest.test_case "default method user type"`Quick test_default_method_user_type;
           Alcotest.test_case "missing required method"`Quick test_missing_required_method;
           Alcotest.test_case "unknown ctor suggests"  `Quick test_unknown_ctor_suggests_similar;


### PR DESCRIPTION
## Summary

**Layer 1 of the general-interface FQN dispatch work — a standalone interpreter bugfix.** Stacked on #49 (Stage 1).

The interpreter dispatched **general** (non-builtin) interface methods by **name** in the environment (`eval.ml` DImpl), last-impl-wins — so multiple impls of one interface, *even for distinct types*, mis-dispatched. Verified pre-existing, uncovered divergence:

```
impl Speak(Dog) + impl Speak(Cat):   speak(Dog)   speak(Cat)
  interpreted (before):                meow ✗        meow
  native:                              woof ✓        meow ✓
  interpreted (after this PR):          woof ✓        meow ✓
```

(The `accept/t83` Dog/Cat witness is `--check`-only, so it never ran — the divergence was latent.)

## Fix

Every general-interface method now binds a **type-dispatcher** (`VBuiltin`) that routes by the first argument's runtime type through a new `iface_method_tbl : (iface, method, type) → value` — keyed by **method** (unlike `impl_tbl`'s single `(iface,type)` slot) so a multi-method interface's methods don't overwrite each other. Applied to **both** DImpl eval paths (`eval_decl` and `make_recursive_env` — the latter is the active top-level path). Builtins (`Eq`/`Ord`/`Show`/`Hash`) and their non-dispatch defaults (e.g. a user `interface Eq`'s `neq`) keep their existing binding.

## Tests
- New `run_eval` witness: two-impl `Speak(Dog)`/`Speak(Cat)` dispatch by type.
- run_eval **234**, run_stdlib **810** (exercises the one general stdlib impl, `Iterable`, + all interface machinery), run_compiler **520** — no regressions.

## Also included
- `specs/plans/2026-07-20-fqn-impl-dispatch-identity.md`: the refined 3-layer design for the full same-short-name general case (Layer 2 = the native ctor-tag flag-day, with the niche/single-ctor **value-representation risk** documented; Layer 3 = typecheck relaxation). Layer 1 here is the independently-valuable, independently-testable slice.

## Base
Targets `claude/fqn-impl-coherence-636503` (#49). Same-short-name general dispatch stays correctly rejected until Layers 2+3.
