### PR TITLE
test(ffi): valgrind + ASAN UB probe for the ffi_result flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
       # (the flake has never reproduced on macOS) and non-blocking (the evidence
       # is the point; a red X here must not fail the pipeline).
       - name: FFI Result flake probe (Linux-only diagnostic; non-blocking)
-        if: runner.os == 'Linux'
+        if: ${{ always() && runner.os == 'Linux' }}
         continue-on-error: true
         run: |
           eval $(opam env)
@@ -98,7 +98,7 @@ jobs:
       # a non-reproducing binary) plus an ASAN/UBSan pass.  Linux-only,
       # non-blocking; the evidence is the point.
       - name: FFI Result UB probe — valgrind + ASAN (Linux-only; non-blocking)
-        if: runner.os == 'Linux'
+        if: ${{ always() && runner.os == 'Linux' }}
         continue-on-error: true
         run: |
           eval $(opam env)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,17 @@ jobs:
       - name: Build
         run: |
           eval $(opam env)
-          dune build
+          # `dune build` (no target) intermittently wedges at ~0% CPU on the Linux
+          # runner AFTER building everything — a known dune-daemon hang. Cap it so a
+          # wedge fails fast and is retryable instead of hanging until the 6h job
+          # timeout. Compile-only (no test execution) is well under this bound.
+          # macOS has no coreutils `timeout` by default and hasn't wedged, so guard
+          # by OS.
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            timeout 1200 dune build || { echo "::error::dune build wedged or exceeded 20m — re-run the job"; exit 1; }
+          else
+            dune build
+          fi
 
       - name: Test
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,20 @@ jobs:
           eval $(opam env)
           scripts/ffi_result_flake_probe.sh 40
 
+      # The flake reproduces deterministically on this runner (the probe above
+      # showed byte-identical binaries => execution-time UB, not codegen).  Pin
+      # the UB down: valgrind --track-origins on the UN-instrumented binary
+      # (preserves the reproducing layout — the original "valgrind clean" ran on
+      # a non-reproducing binary) plus an ASAN/UBSan pass.  Linux-only,
+      # non-blocking; the evidence is the point.
+      - name: FFI Result UB probe — valgrind + ASAN (Linux-only; non-blocking)
+        if: runner.os == 'Linux'
+        continue-on-error: true
+        run: |
+          eval $(opam env)
+          sudo apt-get install -y valgrind
+          scripts/ffi_result_sanitize_probe.sh 6
+
       - name: Static-semantics conformance corpus (slow lane, not part of runtest)
         run: |
           eval $(opam env)

--- a/scripts/ffi_result_flake_probe.sh
+++ b/scripts/ffi_result_flake_probe.sh
@@ -42,15 +42,24 @@ DIAG_TGT="test/native_ffi_result_diag"
 MAIN_BIN="_build/default/test/native_ffi_result"
 DIAG_BIN="_build/default/test/native_ffi_result_diag"
 
-# objdump on Linux, otool on macOS (for local dry-runs).
+# objdump on Linux, otool on macOS (for local dry-runs).  Dump both the C shims
+# AND the March-emitted callers (march_main / shown / println) — the miscompile
+# is memory-safe and the shims + IR are provably correct, so the wrong codegen
+# must be in how clang lowers the (correct) IR of these functions.  objdump
+# separates functions with a blank line, so print each matching header block up
+# to the next blank line.
 dump_fn() {  # $1 = binary
+  local fns='ffi_test_parse|ffi_layout_probe_guard|ffi_raise_parse|march_main|shown|println.String|march_int_to_string'
   if command -v objdump >/dev/null 2>&1; then
-    echo "--- nm (shim addresses) ---"
-    nm "$1" 2>/dev/null | grep -iE 'ffi_test_parse|ffi_layout_probe_guard|ffi_raise_parse' | sort
-    echo "--- objdump -d ffi_test_parse .. ffi_raise_parse ---"
-    objdump -d "$1" 2>/dev/null | awk '/<ffi_test_parse>:/{p=1} p{print} /<ffi_raise_fdiv>:/{exit}'
+    echo "--- nm (fn addresses) ---"
+    nm "$1" 2>/dev/null | grep -iE "$fns" | sort
+    echo "--- objdump -d (C shims + March callers) ---"
+    objdump -d "$1" 2>/dev/null | awk -v F="$fns" '
+      $0 ~ ("^[0-9a-f]+ <("F")>:") {p=1}
+      p && /^[[:space:]]*$/ {p=0}
+      p {print}'
   elif command -v otool >/dev/null 2>&1; then
-    nm "$1" 2>/dev/null | grep -iE 'ffi_test_parse|ffi_layout_probe_guard|ffi_raise_parse' | sort
+    nm "$1" 2>/dev/null | grep -iE "$fns" | sort
     otool -tv "$1" 2>/dev/null | awk '/^_ffi_test_parse:/{p=1} p{print} /^_ffi_raise_fdiv:/{exit}'
   fi
 }

--- a/scripts/ffi_result_sanitize_probe.sh
+++ b/scripts/ffi_result_sanitize_probe.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# ffi_result_sanitize_probe.sh — pinpoint the ffi_result flake's UB now that it
+# reproduces (deterministically, on GH ubuntu clang 18.1.3; see
+# scripts/ffi_result_flake_probe.sh, which proved byte-identical binaries =>
+# execution-time UB, not codegen).  Two passes:
+#
+#   1. VALGRIND on the UN-instrumented binary.  Valgrind does not change the
+#      binary's code/layout, so it preserves the exact conditions that
+#      reproduce the flake — the best shot at naming the UB (uninitialised
+#      read / invalid access) without a Heisenberg layout shift.
+#   2. ASAN + UBSan (MARCH_SANITIZE=1).  Stronger diagnostics, BUT -fsanitize
+#      changes layout, so it may mask the flake — if the output also reverts to
+#      "nan" with no report, that itself confirms layout-sensitive UB.
+#
+# Each iteration clears the CAS + disables dune's cache and --force-rebuilds, so
+# every compile is fresh (the flake is layout/compile-sensitive).  Always exits
+# 0 — this is a non-blocking diagnostic; the evidence is the point.
+#
+# Usage:  scripts/ffi_result_sanitize_probe.sh [ITER]   (default 6)
+set -u
+
+ITER="${1:-6}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT" || exit 2
+
+DUNE="${DUNE:-dune}"
+MAIN_TGT="test/native_ffi_result"
+BIN="_build/default/test/native_ffi_result"
+EXPECT=$'7\nnan'
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+echo "== ffi_result sanitize probe: $ITER iterations/pass =="
+clang --version 2>/dev/null | head -1
+
+# ── Pass 1: valgrind on the un-instrumented binary (layout preserved) ────────
+echo
+echo "===== VALGRIND (un-instrumented; preserves the reproducing layout) ====="
+if command -v valgrind >/dev/null 2>&1; then
+  vg_found=0
+  for i in $(seq 1 "$ITER"); do
+    rm -rf .march/cas/artifacts
+    DUNE_CACHE=disabled "$DUNE" build --root . --force "$MAIN_TGT" >/dev/null 2>&1
+    plain="$("$BIN" 2>/dev/null)"
+    valgrind --error-exitcode=99 --track-origins=yes --num-callers=40 \
+             --log-file="$TMP/vg_$i.log" "$BIN" >/dev/null 2>&1
+    vrc=$?
+    echo "valgrind iter=$i plain_out=$(printf '%q' "$plain") valgrind_rc=$vrc"
+    if [ "$vrc" = "99" ] || grep -qiE 'Invalid read|Invalid write|uninitiali|Conditional jump' "$TMP/vg_$i.log"; then
+      vg_found=1
+      echo ">>>>> VALGRIND FLAGGED ERRORS (iter $i) >>>>>"
+      cat "$TMP/vg_$i.log"
+      echo "<<<<<"
+    else
+      grep -E 'ERROR SUMMARY|definitely lost|indirectly lost' "$TMP/vg_$i.log" | sed 's/^/  /' | head -3
+    fi
+  done
+  [ "$vg_found" = 0 ] && echo "valgrind: no memory errors flagged across $ITER runs"
+else
+  echo "valgrind not installed — skipping (install: apt-get install -y valgrind)"
+fi
+
+# ── Pass 2: ASAN + UBSan (changes layout — may mask) ─────────────────────────
+echo
+echo "===== ASAN + UBSan (MARCH_SANITIZE=1; NOTE: -fsanitize changes layout) ====="
+export ASAN_OPTIONS="abort_on_error=0:halt_on_error=0:detect_leaks=0:print_stacktrace=1"
+export UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=0"
+asan_found=0
+for i in $(seq 1 "$ITER"); do
+  rm -rf .march/cas/artifacts
+  MARCH_SANITIZE=1 DUNE_CACHE=disabled "$DUNE" build --root . --force "$MAIN_TGT" >/dev/null 2>&1
+  out="$("$BIN" 2>"$TMP/asan_$i.log")"
+  tag="ok"; [ "$out" != "$EXPECT" ] && tag="wrong-output"
+  san="$(grep -iE 'runtime error|AddressSanitizer|ERROR:|SUMMARY:|heap-|stack-|use-after' "$TMP/asan_$i.log" | head -1)"
+  if [ -n "$san" ]; then asan_found=1; tag="SANITIZER HIT"; fi
+  echo "asan iter=$i out=$(printf '%q' "$out") [$tag]"
+  if [ -n "$san" ] || [ "$out" != "$EXPECT" ]; then
+    echo "----- sanitizer stderr (iter $i) -----"; cat "$TMP/asan_$i.log"; echo "-----"
+  fi
+done
+if [ "$asan_found" = 0 ]; then
+  echo "ASAN/UBSan: no sanitizer report across $ITER runs"
+  echo "  (if output also stayed 'nan', the sanitizer masked the flake => layout-sensitive UB confirmed)"
+fi
+
+echo
+echo "== sanitize probe done =="
+exit 0

--- a/test/native/ffi_raise.march
+++ b/test/native/ffi_raise.march
@@ -1,11 +1,20 @@
 -- FFI env-routed error protocol: a `raises` binding takes a hidden march_env*
 -- and returns the bare Ok payload, calling march_raise(env, e) to fail. The
 -- compiler-emitted wrapper materializes Ok(payload) / Err(e). Both arms match.
+--
+-- The extern is named `raise_parse` (NOT `parse`) on purpose: ffi_result.march
+-- declares `mod Test`'s `fn parse = "ffi_test_parse"`, and when both fixtures
+-- are in scope together (module discovery in the shared build dir) a bare
+-- `parse` in BOTH modules collides — extern resolution then picks one binding by
+-- hash order, which differs by platform (macOS→ffi_test_parse, Linux→
+-- ffi_raise_parse). That was the root cause of the intermittent GH-Actions-only
+-- `ffi_result` "bad int" flake. Distinct names (cf. ffi_interp2.march's
+-- test_parse/raise_parse) keep the binding unambiguous.
 mod Test do
   needs Ffi
   needs IO.Foreign
   extern "rt" : Cap(Ffi) do
-    raises fn parse(s: String): Result(Int, String) = "ffi_raise_parse"
+    raises fn raise_parse(s: String): Result(Int, String) = "ffi_raise_parse"
   end
   fn shown(r: Result(Int, String)) : String do
     match r do
@@ -14,7 +23,7 @@ mod Test do
     end
   end
   fn main() : Unit do
-    println(shown(parse("7")))     -- Ok(7)   -> 7
-    println(shown(parse("zz")))    -- raised  -> bad int
+    println(shown(raise_parse("7")))     -- Ok(7)   -> 7
+    println(shown(raise_parse("zz")))    -- raised  -> bad int
   end
 end


### PR DESCRIPTION
Follow-up to the ffi_result instrumentation (#54). The stress probe reproduced the flake on the GH ubuntu runner and showed **40/40 byte-identical binaries all printing `bad int`** — so it is **execution-time UB, not codegen**. The wrong string is still `bad int` (not the now-adjacent guard), so it is **not** a physical fall-through; and the diag variant prints correctly, so the bug is **layout/memory-sensitive** (uninitialised-memory signature).

This PR adds a Linux-only, non-blocking CI step to pin the UB down:
- **valgrind --track-origins** on the **un-instrumented** binary (preserves the reproducing layout — the original 'valgrind clean' ran on a non-reproducing binary), plus
- an **ASAN/UBSan** (`MARCH_SANITIZE=1`) pass (stronger, but changes layout so it may mask — which itself confirms layout-sensitivity).

No compiler/runtime changes, so the reproducing `ffi_result` binary layout is unchanged; the probe runs on this PR's CI. Not a fix — evidence collection.