### PR TITLE
docs: fix fabricated homepage syntax, add Sigils chapter, close visitor-journey gaps

### DIFF
--- a/docs/_layouts/landing.html
+++ b/docs/_layouts/landing.html
@@ -163,6 +163,12 @@
       font-family: 'JetBrains Mono', monospace; font-size: 13.5px; line-height: 1.72; tab-size: 2;
       color: var(--text);
     }
+    .m-hero-learn {
+      padding: 10px 24px; border-top: 1px solid var(--border);
+      font-family: 'JetBrains Mono', monospace; font-size: 12px; color: var(--text-faint);
+    }
+    .m-hero-learn a { color: var(--accent); text-decoration: none; }
+    .m-hero-learn a:hover { text-decoration: underline; }
 
     /* FEATURES */
     .m-features { padding: 80px 32px; border-top: 1px solid var(--border); }
@@ -474,6 +480,7 @@
         <div class="m-code-tabs" id="hero-tabs"></div>
       </div>
       <pre class="m-hero-pre"><code id="hero-code"></code></pre>
+      <p class="m-hero-learn" id="hero-learn"></p>
     </div>
   </div>
 </section>
@@ -698,7 +705,7 @@ function syntaxHL(code, dark) {
 
 // ─── Code content ─────────────────────────────────────────────────────────────
 const HERO_EXAMPLES = [
-  { label: 'Actors', code: `actor Counter do
+  { label: 'Actors', learn: '/docs/actors/', code: `actor Counter do
   state { count : Int }
   init  { count: 0 }
 
@@ -706,16 +713,20 @@ const HERO_EXAMPLES = [
     { state with count: state.count + n }
   end
 
-  on Get() -> reply state.count
+  on Get() do
+    println("count: " ++ int_to_string(state.count))
+    state
+  end
 end
 
 fn main() : Unit do
   let c = spawn(Counter)
   send(c, Increment(10))
   send(c, Increment(5))
-  send(c, Get())      -- prints 15
+  send(c, Get())      -- prints "count: 15"
+  run_until_idle()
 end` },
-  { label: 'Linear Types', code: `linear type DbConn = DbConn(Int)
+  { label: 'Linear Types', learn: '/docs/linear-types/', code: `always_linear type DbConn = DbConn(Int)
 
 fn query_users(conn : DbConn)
     : (List(String), DbConn) do
@@ -728,55 +739,55 @@ fn with_db(path : String) : List(String) do
   Db.close(conn2)                -- consumed
   rows
 end` },
-  { label: 'Capabilities', code: `-- Capabilities are proof tokens tracked by the type system
-fn read_config(path : String) : String
-  needs [IO, FileSystem]
-do
-  File.read(path)
-end
+  { label: 'Capabilities', learn: '/docs/capabilities/', code: `-- Capabilities are proof tokens tracked by the type system
+mod Config do
+  needs IO.FileSystem
 
--- No capabilities needed: always safe, even in pure tests
-fn transform(s : String) : String do
-  s |> String.trim |> String.to_upper
-end
+  fn read_config(path : String) : String do
+    File.read(path)
+  end
 
-fn main() : Unit needs [IO, FileSystem] do
-  read_config("/etc/march/config.toml")
-  |> transform |> println
+  -- No capabilities needed: always safe, even in pure tests
+  fn transform(s : String) : String do
+    s |> String.trim |> String.to_upper
+  end
+
+  fn main() : Unit do
+    read_config("/etc/march/config.toml")
+    |> transform |> println
+  end
 end` },
-  { label: 'Property Tests', code: `-- Checked with 100s of randomly generated inputs
-property reverse_involutive(lst : List(Int)) do
-  List.reverse(List.reverse(lst)) == lst
+  { label: 'Property Tests', learn: '/docs/property-testing/', code: `-- Checked with 100s of randomly generated inputs
+test "reverse is involutive" do
+  Check.all(Gen.list(Gen.int(-50, 50)), fn xs ->
+    List.reverse(List.reverse(xs)) == xs
+  )
 end
 
-property sort_idempotent(lst : List(Int)) do
-  let s = List.sort(lst)
-  List.sort(s) == s
-end
-
-property map_preserves_length(
-  lst : List(Int), f : Int -> Int
-) do
-  List.length(List.map(lst, f))
-    == List.length(lst)
+test "sort is idempotent" do
+  Check.all(Gen.list(Gen.int(-50, 50)), fn xs ->
+    let s = List.sort(xs)
+    List.sort(s) == s
+  )
 end` },
-  { label: '~H Sigil', code: `-- ~H validates and compiles HTML templates at compile time
-fn dashboard(user : User, msgs : List(Msg)) : Html do
+  { label: '~H Sigil', learn: '/docs/sigils/', code: `-- ~H compiles HTML templates; interpolations are auto-escaped
+fn render_user(u : User) : IOList do
   ~H"""
-  <div class="dashboard">
-    <header>
-      <h1>Hello, {user.name}</h1>
-      <span class="badge">{List.length(msgs)}</span>
-    </header>
-    <ul>
-      {for msg <- msgs}
-        <li>{msg.body}</li>
-      {/for}
-    </ul>
-  </div>
+  <li class="user-row">
+    <strong>\${u.name}</strong>
+    <span class="email">\${u.email}</span>
+  </li>
+  """
+end
+
+fn dashboard(users : List(User)) : IOList do
+  let items = Html.list(users, render_user)
+  ~H"""
+  <h1>Users (\${int_to_string(List.length(users))})</h1>
+  <ul class="user-list">\${items}</ul>
   """
 end` },
-  { label: 'Error Handling', code: `-- let? chains Results; each Err short-circuits
+  { label: 'Error Handling', learn: '/docs/tour/#result-propagation-with-let', code: `-- let? chains Results; each Err short-circuits
 fn load(path : String) : Result(Config, String) do
   let? src  = File.read(path)
   let? toml = Toml.parse(src)
@@ -862,7 +873,7 @@ end
 
 (area(Circle(5.0)), area(Rect(3.0, 4.0)))`;
 
-const LINEAR = `linear type FileHandle = FileHandle(Int)
+const LINEAR = `always_linear type FileHandle = FileHandle(Int)
 
 fn write_and_close(
   f : FileHandle, s : String
@@ -917,7 +928,10 @@ function renderHeroTabs() {
 }
 
 function renderHeroCode() {
-  document.getElementById('hero-code').innerHTML = hl(HERO_EXAMPLES[heroTab].code);
+  const ex = HERO_EXAMPLES[heroTab];
+  document.getElementById('hero-code').innerHTML = hl(ex.code);
+  document.getElementById('hero-learn').innerHTML =
+    `Learn more about <a href="${ex.learn}">${ex.label}</a> →`;
 }
 
 function renderInstall() {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,7 +7,7 @@ permalink: /docs/getting-started/
 
 # Getting Started
 
-This guide walks you from zero to a working March program. See [Installation](installation.md) first if you haven't built the compiler yet.
+This guide walks you from zero to a working March program. See [Installation](installation.md) first if you haven't installed March yet.
 
 ---
 
@@ -28,8 +28,10 @@ end
 Run it:
 
 ```sh
-dune exec march -- hello.march
+march hello.march
 ```
+
+(Building from source instead of using an installed binary? Use `dune exec march -- hello.march`.)
 
 Output:
 ```
@@ -64,8 +66,10 @@ end
 
 Run it:
 ```sh
-dune exec march -- greet.march
+march greet.march
 ```
+
+(Source build: `dune exec march -- greet.march`.)
 
 Output:
 ```
@@ -88,9 +92,11 @@ Key things to notice:
 To produce a standalone native binary, use `--compile`:
 
 ```sh
-dune exec march -- --compile -o greet greet.march
+march --compile -o greet greet.march
 ./greet
 ```
+
+(Source build: `dune exec march -- --compile -o greet greet.march`.)
 
 The compiler runs LLVM, links the C runtime, and produces a native executable.
 
@@ -101,15 +107,18 @@ The compiler runs LLVM, links the C runtime, and produces a native executable.
 Start an interactive session:
 
 ```sh
-dune exec march -- repl
+march repl
 ```
 
-(With an installed binary, just run `march repl`, or `march` with no arguments.)
+(`march` with no arguments also drops you into the REPL. Building from source:
+`dune exec march -- repl`.)
 
 Or via forge:
 ```sh
-dune exec forge -- interactive
+forge interactive
 ```
+
+(Source build: `dune exec forge -- interactive`.)
 
 The REPL loads the standard library and drops you into a numbered prompt:
 
@@ -153,9 +162,11 @@ back off) — see the [REPL guide](repl.md) for the full command list.
 
 Create a new project:
 ```sh
-dune exec forge -- new my_app
+forge new my_app
 cd my_app
 ```
+
+(Source build: `dune exec forge -- new my_app`.)
 
 This scaffolds:
 ```
@@ -169,14 +180,16 @@ my_app/
 
 Build and run:
 ```sh
-dune exec forge -- build
-dune exec forge -- run
+forge build
+forge run
 ```
 
 Run tests:
 ```sh
-dune exec forge -- test
+forge test
 ```
+
+(Source build: prefix each with `dune exec forge --`, e.g. `dune exec forge -- build`.)
 
 ---
 
@@ -242,6 +255,15 @@ Learn the language:
 - [Language Tour](tour.md) — a comprehensive walkthrough of all syntax
 - [Type System](types.md) — algebraic data types, generics, Option/Result
 - [Pattern Matching](pattern-matching.md) — destructuring and exhaustiveness checking
-- [Actors](actors.md) — concurrent programming with the actor model
+- [Actors](actors.md) — concurrent programming with the actor model, and the jumping-off point for supervision, clustering, and hot code reload
+
+Curious about March's compile-time safety guarantees? These go beyond a standard ML-family type system:
+
+- [Interfaces](interfaces.md) — ad-hoc polymorphism with `interface`/`impl`
+- [Linear Types](linear-types.md) — resources the compiler proves are used exactly once, at zero runtime cost
+- [Refinement Types](refinement-types.md) — value predicates (`{Int | _ >= 0}`) checked by an SMT solver
+- [Capabilities](capabilities.md) — IO permissions tracked in the type system
+- [Safety by Construction](safety-by-construction.md) — how these layers compose on one function
+- [Memory Model](memory-model.md) — why March has no garbage collector or pauses
 
 Coming from another language? [Python](coming-from-python.md) · [TypeScript](coming-from-typescript.md) · [Haskell/Elixir/OCaml](coming-from-fp.md).

--- a/docs/sigils.md
+++ b/docs/sigils.md
@@ -1,0 +1,158 @@
+---
+layout: docs
+title: Sigils & Templating
+nav_order: 5.9
+permalink: /docs/sigils/
+---
+
+# Sigils & Templating
+
+Some kinds of text aren't really "just a string" — a chunk of TOML, an HTML template, an
+XML document. March's **sigils** let you write that text as a literal, right in your
+source, and have the compiler hand it to a parser or template builder instead of
+treating it as a plain `String`. The most-used one, `~H`, builds safe, auto-escaping
+HTML templates — the rest of this page starts with the general mechanism, then goes deep
+on `~H` specifically.
+
+---
+
+## The general mechanism
+
+A sigil is written `~Name"..."` (or `~Name"""...multi-line..."""` for longer content).
+The uppercase (or lowercase-word) name right after the `~` selects which handler runs:
+
+```march
+~toml"""
+port = 8080
+host = "localhost"
+"""
+```
+
+Under the hood, `~Name"content"` is sugar for a plain function call: `~toml"..."`
+becomes `Sigil.toml("...")`, `~xml"..."` becomes `Sigil.xml("...")`, and so on — a
+sigil is just a call with unusual syntax around the argument, not a separate kind of
+value. That means you can always see exactly what a sigil does by looking up
+`Sigil.<name>` in the stdlib.
+
+March ships three general-purpose sigils out of the box:
+
+| Sigil | Calls | Returns |
+|---|---|---|
+| `~toml"..."` | `Toml.parse_exn` | a `TomlValue` |
+| `~xml"..."` | `Xml.parse_exn` | a parsed XML document |
+| `~yaml"..."` | `Yaml.parse_exn` | a parsed YAML document |
+
+All three **panic if the content doesn't parse** — they're meant for literals you
+control (embedding a known-good config as source, not parsing untrusted input at
+runtime). If you need to handle a malformed document gracefully, parse a runtime string
+with the ordinary `Toml.parse`/`Xml.parse`/`Yaml.parse` functions instead, which return
+a `Result` rather than panicking.
+
+```march
+let config = ~toml"""
+port = 8080
+host = "localhost"
+"""
+-- config : TomlValue, built at the call site — a typo here panics immediately,
+-- which is exactly what you want for a literal baked into your source
+```
+
+---
+
+## The `~H` sigil: HTML templates
+
+`~H` is the one sigil with genuinely special treatment: instead of calling a
+`Sigil.h` function at runtime, the compiler builds the HTML directly into an efficient
+multi-segment structure (an `IOList`) at compile time — there's no intermediate string
+concatenation, even for a template with many interpolated pieces.
+
+```march
+let name = "<script>alert(1)</script>"
+let html = ~H"<p>Hello, ${name}!</p>"
+-- renders: <p>Hello, &lt;script&gt;alert(1)&lt;/script&gt;!</p>
+```
+
+**Interpolation is `${expr}`, and it's auto-escaped.** Any value you interpolate is run
+through `Html.escape` before it lands in the output — the string above is safe to render
+even though it contains `<script>`, because `~H` escaped it for you. This is the
+headline reason to use `~H` instead of building HTML with plain string concatenation:
+you'd have to remember to escape every interpolated value yourself, and forgetting even
+once is exactly how HTML injection bugs happen.
+
+Multi-line templates use triple quotes, exactly like triple-quoted strings elsewhere in
+March:
+
+```march
+fn render_card(title : String, body : String) : IOList do
+  ~H"""
+  <div class="card">
+    <h2>${title}</h2>
+    <p>${body}</p>
+  </div>
+  """
+end
+```
+
+### Trusted content: `Html.raw`
+
+Sometimes you *want* to interpolate real markup — an icon's `<svg>`, or HTML you already
+sanitized elsewhere. `Html.raw` marks a string as pre-trusted, so `~H` skips escaping it:
+
+```march
+let icon = Html.raw("<svg>...</svg>")
+let html = ~H"<button>${icon} Click me</button>"
+```
+
+Only reach for `Html.raw` on content you generated or verified yourself — never on user
+input, since that's exactly the escaping `~H` exists to give you automatically.
+
+### Composing templates
+
+A `~H` template returns an `IOList`, and an `IOList` interpolates cleanly into another
+`~H` template without being re-escaped or double-wrapped — so partials compose the way
+you'd expect:
+
+```march
+fn render_user(u : User) : IOList do
+  ~H"""
+  <li class="user-row">
+    <strong>${u.name}</strong>
+    <span class="email">${u.email}</span>
+  </li>
+  """
+end
+
+fn render_list(users : List(User)) : IOList do
+  let items = Html.list(users, render_user)   -- IOList of all the rendered rows
+  ~H"""
+  <ul class="user-list">${items}</ul>
+  """
+end
+```
+
+There's no template-level `for` loop inside `~H` itself — `Html.list` (map a render
+function over a list, producing one combined `IOList`) is the idiomatic way to render a
+collection, and ordinary recursion works too for anything more custom. See [HTML
+cookbook]({{ site.baseurl }}/docs/cookbook/html/) for a complete worked example
+(layouts, partials, a full user-list page) built entirely from these pieces.
+
+### A gotcha worth knowing: CSRF injection
+
+If you're building a web app with March's HTTP framework, `~H` automatically injects a
+CSRF protection tag into `<form method="post|put|patch|delete">` tags it emits — but
+**only when a `conn` binding is lexically in scope** at that `~H` call site. If you're
+rendering a form outside of a request-handling context (no `conn` in scope), the tag
+isn't injected and you won't get a compile error about it — so if you rely on this
+protection, make sure the form-rendering function actually has `conn` available, rather
+than assuming every `~H` form is automatically protected.
+
+---
+
+## Next Steps
+
+- [HTML cookbook]({{ site.baseurl }}/docs/cookbook/html/) — this page covers the
+  mechanism; the cookbook shows you how to build a full page with it (layouts, partials,
+  a complete example).
+- [Type System](types.md) — what `TomlValue` and friends look like as ordinary ADTs.
+- [Capabilities]({{ site.baseurl }}/docs/capabilities/) — the permission system that
+  guards the file/network access templating code often sits next to.

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -563,6 +563,16 @@ Go deeper:
 - [Type System](types.md) — algebraic data types and generics in depth
 - [Pattern Matching](pattern-matching.md) — exhaustiveness, guards, nested patterns
 - [Modules](modules.md) — organizing code across files
-- [Actors](actors.md) — concurrent programming
+- [Actors](actors.md) — concurrent programming, and the jumping-off point for supervision, clustering, and hot code reload
+
+March's compile-time safety goes further than a standard ML-family type system:
+
+- [Interfaces](interfaces.md) — ad-hoc polymorphism with `interface`/`impl`
+- [Linear Types](linear-types.md) — resources the compiler proves are used exactly once, at zero runtime cost
+- [Refinement Types](refinement-types.md) — value predicates (`{Int | _ >= 0}`) checked by an SMT solver
+- [Capabilities](capabilities.md) — IO permissions tracked in the type system
+- [Safety by Construction](safety-by-construction.md) — how these layers compose on one function
+- [Memory Model](memory-model.md) — why March has no garbage collector or pauses
+- [Sigils & Templating](sigils.md) — `~H` HTML templates and the general `~Name"..."` mechanism
 
 Coming from another language? [Python](coming-from-python.md) · [TypeScript](coming-from-typescript.md) · [Haskell/Elixir/OCaml](coming-from-fp.md).


### PR DESCRIPTION
## Summary

Walking the actual visitor journey (Home → Docs → Getting Started → Tour) on the live site surfaced a correctness bug bigger than expected: **5 of the homepage's 6 interactive code-tab teasers contained syntax that doesn't exist in the real language**, verified directly against `lib/parser/parser.mly`/`lib/lexer/lexer.mll`:

| Tab | Was | Now |
|---|---|---|
| Actors | `on Get() -> reply state.count` (no such form; `reply` isn't a keyword) | `on Get() do println(...) state end` |
| Linear Types | `linear type DbConn = ...` | `always_linear type DbConn = ...` |
| Capabilities | `fn f(...) needs [IO, FileSystem] do` (no `needs` slot on `fn` at all) | `mod Config do needs IO.FileSystem ... end` |
| Property Tests | `property name(...) do ... end` (no such keyword) | `test "..." do Check.all(gen, fn v -> ...) end` |
| ~H Sigil | `{user.name}`, `{for msg <- msgs}...{/for}` | real `${expr}` interpolation, `Html.list` for collections |

The same `linear type` bug also existed in the lower features-grid `LINEAR` const — fixed there too.

Also:
- Added a "Learn more →" link under the hero code panel that updates with the active tab, so the homepage's highest-intent moment (a visitor picking what interests them) actually leads to the docs page for it.
- New `docs/sigils.md` ("Sigils & Templating"): the general `~Name"..."` mechanism (`~toml`/`~xml`/`~yaml`) plus a deep dive on `~H` (interpolation, auto-escaping, `Html.raw`, composing partials, the CSRF-injection scope gotcha) — cross-linked to the existing `docs/cookbook/html.md` rather than duplicating it.
- Expanded Getting Started's and the Tour's "Next Steps" to route readers to the safety/ownership cluster (Interfaces, Linear Types, Refinement Types, Capabilities, Safety by Construction, Memory Model) that was previously only reachable by browsing the sidebar directly.
- Getting Started's commands led with `dune exec march --`/`dune exec forge --` (from-source contributor commands) even though `docs/installation.md` recommends the prebuilt-binary install as the primary path. Flipped primary/aside in all 5 spots so the installed-binary command is what a visitor sees first.

## Test plan

- [x] `scripts/check-docs.sh` passes
- [x] Full local Jekyll build succeeds with no errors
- [x] Clicked through all 6 homepage tabs in a local preview — confirmed each code sample matches the real grammar and each "Learn more" link (including the anchored Error Handling → Tour link) resolves correctly
- [x] Verified `/docs/sigils/` renders with correct sidebar placement, and its outbound links resolve
- [x] Verified Getting Started's and the Tour's expanded Next Steps links all resolve
- [x] No browser console errors from the hand-rolled homepage JS after all the tab-switching