### PR TITLE
perf(tir): preserve acyclic inliner candidates

### DIFF
--- a/docs/superpowers/plans/2026-07-26-scc-aware-inliner.md
+++ b/docs/superpowers/plans/2026-07-26-scc-aware-inliner.md
@@ -1,0 +1,356 @@
+# SCC-Aware Inliner Candidate Selection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce residual direct calls in emitted LLVM by retaining small, pure functions in acyclic candidate chains while excluding recursive strongly connected components.
+
+**Architecture:** `Inline.run` will build its existing purity/size/HCR candidate pool, derive a direct `EApp` graph over that pool, and use Tarjan SCC detection to remove only recursive components. The existing alpha-renaming, ANF substitution, one-level traversal, fixed-point coordinator, and DCE remain unchanged.
+
+**Tech Stack:** OCaml, March TIR, Alcotest, LLVM text emission, Dune.
+
+## Global Constraints
+
+- Do not add a new IR node or annotation.
+- Do not change March language semantics.
+- Do not change ownership, Perceus, or RC behavior.
+- Keep `inline_size_threshold = 50`.
+- Preserve hot-reload boundary exclusions.
+- Keep `inline_expr`, `alpha_rename`, and `subst_args` behavior unchanged.
+- Build graph edges only from direct `EApp` calls; `ECallPtr` remains the responsibility of `Known_call`.
+- Runtime speed is not a merge criterion; the named residual LLVM call and definition are.
+
+---
+
+### Task 1: Preserve acyclic candidates and reject recursive SCCs
+
+**Files:**
+- Modify: `lib/tir/inline.ml:20-205`
+- Test: `test/test_codegen.ml:3360-3440`
+
+**Interfaces:**
+- Consumes: `(string, Tir.fn_def) Hashtbl.t`, the initial purity/size/HCR candidate pool.
+- Produces: `recursive_candidate_names : (string, Tir.fn_def) Hashtbl.t -> SSet.t`.
+- Produces: an `fn_env` containing every initial candidate not returned by `recursive_candidate_names`.
+
+- [ ] **Step 1: Add a failing acyclic-chain unit test**
+
+Add this helper near the existing inliner tests:
+
+```ocaml
+let direct_call_to name =
+  March_tir.Tir.EApp
+    (mk_var name
+       (March_tir.Tir.TFn ([March_tir.Tir.TInt], March_tir.Tir.TInt)),
+     [ilit 1])
+```
+
+Add a test that constructs `leaf`, `wrapper`, and `main`, where `wrapper`
+directly calls `leaf` and `main` directly calls `wrapper`:
+
+```ocaml
+let test_inline_acyclic_candidate_chain () =
+  let changed = ref false in
+  let x = mk_var "x" March_tir.Tir.TInt in
+  let leaf =
+    { March_tir.Tir.fn_name = "leaf";
+      fn_params = [x];
+      fn_ret_ty = March_tir.Tir.TInt;
+      fn_body = app "+" [March_tir.Tir.AVar x; ilit 1];
+      fn_kind = March_tir.Tir.FnNormal }
+  in
+  let wrapper =
+    { March_tir.Tir.fn_name = "wrapper";
+      fn_params = [x];
+      fn_ret_ty = March_tir.Tir.TInt;
+      fn_body =
+        March_tir.Tir.EApp
+          (mk_var "leaf"
+             (March_tir.Tir.TFn
+                ([March_tir.Tir.TInt], March_tir.Tir.TInt)),
+           [March_tir.Tir.AVar x]);
+      fn_kind = March_tir.Tir.FnNormal }
+  in
+  let main =
+    { March_tir.Tir.fn_name = "main";
+      fn_params = [];
+      fn_ret_ty = March_tir.Tir.TInt;
+      fn_body = direct_call_to "wrapper";
+      fn_kind = March_tir.Tir.FnNormal }
+  in
+  let result =
+    March_tir.Inline.run ~changed (mk_module [leaf; wrapper; main])
+  in
+  let main_body =
+    result.March_tir.Tir.tm_fns
+    |> List.find (fun fn -> String.equal fn.March_tir.Tir.fn_name "main")
+    |> fun fn -> fn.March_tir.Tir.fn_body
+  in
+  match main_body with
+  | March_tir.Tir.EApp (fn, _)
+    when String.equal fn.March_tir.Tir.v_name "wrapper" ->
+    Alcotest.fail "acyclic wrapper remained excluded from candidates"
+  | _ -> ()
+```
+
+Register it in the `"inline"` test group as `"acyclic_candidate_chain"`.
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run:
+
+```bash
+dune exec test/run_codegen.exe -- test inline -e --color=never
+```
+
+Expected: `acyclic_candidate_chain` fails because `main` remains an `EApp` to
+`wrapper`. The four existing tests remain green.
+
+- [ ] **Step 3: Add graph collection and Tarjan SCC detection**
+
+In `lib/tir/inline.ml`, define:
+
+```ocaml
+module SSet = Set.Make (String)
+```
+
+Add `direct_candidate_calls` with the same recursive expression coverage as
+the old `calls_other` closure:
+
+```ocaml
+let direct_candidate_calls candidates expr =
+  let rec collect acc = function
+    | Tir.EApp (fn, _) when Hashtbl.mem candidates fn.Tir.v_name ->
+      SSet.add fn.Tir.v_name acc
+    | Tir.ELet (_, rhs, body) ->
+      collect (collect acc rhs) body
+    | Tir.ELetRec (fns, body) ->
+      let acc =
+        List.fold_left
+          (fun calls fn -> collect calls fn.Tir.fn_body)
+          acc fns
+      in
+      collect acc body
+    | Tir.ECase (_, branches, default) ->
+      let acc =
+        List.fold_left
+          (fun calls branch -> collect calls branch.Tir.br_body)
+          acc branches
+      in
+      Option.fold ~none:acc ~some:(collect acc) default
+    | Tir.ESeq (e1, e2) ->
+      collect (collect acc e1) e2
+    | _ -> acc
+  in
+  collect SSet.empty expr
+```
+
+Add `recursive_candidate_names`. It must:
+
+- precompute each candidate’s `SSet.t` successors;
+- assign Tarjan `index` and `lowlink` values;
+- maintain a stack and `on_stack` set;
+- mark every component of size greater than one recursive; and
+- mark a singleton recursive only when its successor set contains itself.
+
+Use function names as graph identities and return one `SSet.t`; do not mutate
+`fn_env` while Tarjan is traversing it.
+
+- [ ] **Step 4: Replace conservative filtering**
+
+Change `Inline.run` so the initial pool uses only purity, size, and HCR checks.
+Remove the `calls_self` eligibility check and the entire “calls another
+candidate” loop.
+
+Then filter once:
+
+```ocaml
+let recursive = recursive_candidate_names fn_env in
+SSet.iter (Hashtbl.remove fn_env) recursive;
+```
+
+Leave the final `inline_expr` mapping unchanged.
+
+- [ ] **Step 5: Run unit tests and verify GREEN**
+
+Run:
+
+```bash
+dune exec test/run_codegen.exe -- test inline -e --color=never
+dune exec test/test_hot_reload.exe -- --color=never
+```
+
+Expected:
+
+- five inliner tests pass;
+- self-recursion remains un-inlined;
+- mutual recursion remains un-inlined; and
+- all hot-reload tests pass.
+
+- [ ] **Step 6: Commit Task 1**
+
+```bash
+git add lib/tir/inline.ml test/test_codegen.ml
+git commit -m "perf(tir): preserve acyclic inliner candidates"
+```
+
+---
+
+### Task 2: Pin the emitted-LLVM residual-call reduction
+
+**Files:**
+- Test: `test/test_codegen.ml` in the inliner test section
+
+**Interfaces:**
+- Consumes: `March_tir.Opt.run` and `March_tir.Llvm_emit.emit_module`.
+- Produces: a deterministic regression proving `@outer_growth` has neither a residual call nor a retained definition.
+
+- [ ] **Step 1: Add a live wrapper-body builder**
+
+Add a test-local builder whose arithmetic depends on its parameter so Fold,
+Simplify, and DCE cannot collapse it:
+
+```ocaml
+let live_add_chain param count tail =
+  let rec build index current =
+    if index = count then tail current
+    else
+      let next = mk_var (Printf.sprintf "grow_%d" index) March_tir.Tir.TInt in
+      March_tir.Tir.ELet
+        (next,
+         app "+" [March_tir.Tir.AVar current; March_tir.Tir.AVar param],
+         build (index + 1) next)
+  in
+  build 0 param
+```
+
+Call `live_add_chain` with `count = 11`. Make `inner_growth` a nine-node body:
+two live arithmetic `ELet` bindings followed by `EAtom`. The outer body is
+then 46 nodes before inlining and 55 nodes after the inner call is replaced.
+Assert `node_count inner_growth.fn_body = 9` and
+`node_count outer_growth.fn_body = 46` so fixture drift fails loudly.
+
+- [ ] **Step 2: Add the LLVM regression**
+
+Construct:
+
+- `inner_growth(x)`, a small pure arithmetic body;
+- `outer_growth(x)`, the live addition chain ending in a call to
+  `inner_growth`; and
+- `main()`, which calls `outer_growth(1)`.
+
+Run:
+
+```ocaml
+let optimized = March_tir.Opt.run module_ in
+let ir = March_tir.Llvm_emit.emit_module optimized in
+```
+
+Add a local substring helper and assert:
+
+```ocaml
+Alcotest.(check bool)
+  "no residual call to outer_growth" false
+  (contains ir "call i64 @outer_growth(");
+Alcotest.(check bool)
+  "DCE removes outer_growth definition" false
+  (contains ir "define i64 @outer_growth(")
+```
+
+Also count occurrences of `" call "` and record `String.length ir` before and
+after optimization in the assertion labels or failure message. Do not gate on
+an exact total-call count or exact IR byte size.
+
+- [ ] **Step 3: Prove the regression detects the old behavior**
+
+Temporarily restore the old “calls another candidate” filter or invert the new
+acyclic-retention condition, then run:
+
+```bash
+dune exec test/run_codegen.exe -- test inline -e --color=never
+```
+
+Expected: the emitted-LLVM regression fails because `main` contains a call to
+`@outer_growth` and its definition remains.
+
+Restore the SCC-aware implementation immediately.
+
+- [ ] **Step 4: Verify the regression passes**
+
+Run:
+
+```bash
+dune exec test/run_codegen.exe -- test inline -e --color=never
+```
+
+Expected: all six inliner tests pass.
+
+- [ ] **Step 5: Commit Task 2**
+
+```bash
+git add test/test_codegen.ml
+git commit -m "test(codegen): pin acyclic wrapper call elimination"
+```
+
+---
+
+### Task 3: Document and verify the optimization
+
+**Files:**
+- Modify: `specs/progress.md`
+
+**Interfaces:**
+- Consumes: the completed SCC-aware implementation and LLVM regression.
+- Produces: source-grounded release notes and final verification evidence.
+
+- [ ] **Step 1: Document the result**
+
+Add a concise dated entry to `specs/progress.md` covering:
+
+- the old conservative candidate filter;
+- SCC-only recursive exclusion;
+- the body-growth fixture;
+- the named LLVM call and definition removed; and
+- the measured before/after call count, LLVM byte size, and repeated fixture
+  compile time.
+
+Do not claim a runtime speedup.
+
+- [ ] **Step 2: Run focused verification**
+
+```bash
+dune exec test/run_codegen.exe -- test inline -e --color=never
+dune exec test/test_hot_reload.exe -- --color=never
+dune exec test/run_eval.exe -- test tir -e --color=never
+QCHECK_SEED=230208339 dune exec test/test_properties.exe -- test 'tir pipeline|tir passes|tir pass invariants' -e --color=never
+QCHECK_SEED=446158617 dune exec test/test_properties.exe -- test 'tir pipeline|tir passes|tir pass invariants' -e --color=never
+```
+
+Expected: every command exits zero.
+
+- [ ] **Step 3: Run full codegen verification**
+
+```bash
+dune exec test/run_codegen.exe -- test -e --color=never
+git diff --check
+```
+
+Expected: 449 or more codegen tests pass, with zero failures, and
+`git diff --check` emits no output.
+
+- [ ] **Step 4: Commit documentation**
+
+```bash
+git add specs/progress.md
+git commit -m "docs: record SCC-aware inliner selection"
+```
+
+- [ ] **Step 5: Review final branch**
+
+```bash
+git status --short
+git log --oneline origin/main..HEAD
+git diff --stat origin/main...HEAD
+```
+
+Expected: the worktree is clean and the branch contains the design, focused
+implementation, regression, and documentation commits only.

--- a/docs/superpowers/specs/2026-07-26-scc-aware-inliner-design.md
+++ b/docs/superpowers/specs/2026-07-26-scc-aware-inliner-design.md
@@ -1,0 +1,134 @@
+# SCC-Aware Inliner Candidate Selection
+
+## Goal
+
+Reduce residual direct calls in emitted LLVM by allowing small, pure functions
+in an acyclic caller/callee chain to remain inliner candidates at the same
+time.
+
+The change must not alter March semantics, TIR representation, ownership/RC
+rules, hot-reload boundaries, or the mechanics of expression substitution.
+
+## Current Behavior
+
+`lib/tir/inline.ml` first selects functions that are:
+
+- pure,
+- at most `inline_size_threshold` TIR nodes,
+- not directly self-recursive, and
+- not hot-reload boundaries.
+
+It then removes every candidate that calls any other candidate. This prevents
+mutually recursive functions from expanding forever, but also rejects acyclic
+callers.
+
+The fixed-point optimizer can recover some acyclic chains over later
+iterations. It cannot recover a caller whose callee is inlined first and makes
+the caller exceed the size threshold. That caller remains as a residual LLVM
+call even though it was small enough to inline before the callee expansion.
+
+## Chosen Design
+
+Replace the “calls another candidate” filter with cycle-aware filtering.
+
+1. Build an initial pool using purity, size, and hot-reload checks; recursion is
+   handled by the graph instead of the existing `calls_self` prefilter.
+2. Build a direct-call graph over that initial pool.
+3. Add an edge `f -> g` for each `EApp` to another pooled function.
+4. Compute strongly connected components over that graph.
+5. Remove:
+   - any component containing more than one function; and
+   - any singleton component with a self-edge.
+6. Keep every function in the acyclic remainder in `fn_env`.
+7. Run the existing `inline_expr` traversal unchanged.
+
+Graph traversal follows the same expression coverage as the existing filter,
+including `ELet`, `ELetRec`, `ECase`, and `ESeq`. `ECallPtr` does not create an
+edge; `Known_call` remains responsible for converting statically known closure
+calls before the inliner runs.
+
+## Correctness Boundaries
+
+- Purity and the 50-node threshold remain unchanged.
+- Hot-reload boundary functions remain excluded before graph construction.
+- Recursive SCCs are excluded as a unit, preventing fixed-point code growth.
+- Alpha-renaming and ANF argument binding remain unchanged.
+- Inlining still performs one substitution level per optimizer iteration.
+- No new IR node, annotation, ownership rule, or RC transformation is added.
+- Calls to functions outside the candidate set do not affect cycle detection.
+
+## Alternatives Rejected
+
+### Bottom-up topological inlining
+
+Inlining callees into callers in graph order could reduce optimizer iterations,
+but it changes when size is measured and makes code-growth policy part of this
+PR. That is broader than necessary.
+
+### Raising the fixed-point iteration limit
+
+More iterations do not fix the body-growth case: once a caller grows beyond the
+threshold, it remains ineligible. It also adds compile-time cost without a
+structural bound.
+
+## Tests
+
+### Unit tests in `test/test_codegen.ml`
+
+- An acyclic candidate caller remains eligible even when it calls another
+  candidate.
+- A self-recursive function is not inlined.
+- Both members of a mutually recursive pair are not inlined.
+- A hot-reload boundary call remains intact.
+
+### Emitted-LLVM regression
+
+Compile a fixture with:
+
+- an outer pure wrapper initially below 50 nodes;
+- a small pure callee used inside the wrapper;
+- enough wrapper body nodes that inlining the callee pushes the wrapper above
+  50 nodes; and
+- `main` calling the outer wrapper.
+
+Before the change, the emitted LLVM contains a direct call to the outer
+wrapper. After the change:
+
+- no call to the outer wrapper remains; and
+- DCE removes its unused definition.
+
+The assertion targets the named call/definition rather than total LLVM call
+count, which would be noisy because runtime and allocation calls are expected.
+
+### Regression suites
+
+Run:
+
+- the inliner unit-test group;
+- hot-reload inliner tests;
+- TIR tests;
+- the two known monomorphization property seeds;
+- the full codegen suite; and
+- `git diff --check`.
+
+## Measurement
+
+The PR is successful when the deterministic fixture loses the named residual
+LLVM call and definition.
+
+Also report, without making them merge gates:
+
+- total direct-call count in the fixture before and after;
+- emitted LLVM byte size before and after; and
+- compile time for repeated fixture compilation.
+
+Runtime performance is explicitly not a success criterion for this PR.
+
+## Non-Goals
+
+- Single-use impure-function inlining.
+- A larger inlining threshold or profile-guided threshold.
+- Recursive-function partial inlining.
+- Bottom-up/topological body rewriting.
+- Capture-free closure allocation elimination.
+- Changes to LLVM’s own inliner configuration.

--- a/lib/tir/inline.ml
+++ b/lib/tir/inline.ml
@@ -10,6 +10,8 @@
     of this threshold — they are handled by the size check implicitly. *)
 let inline_size_threshold = 50
 
+module SSet = Set.Make (String)
+
 (** Hot Code Reload boundary config, set by [Opt.run] for the duration of a
     run. When [Some], reloadable (boundary) functions are excluded from the
     inline-candidate set so a boundary→boundary call survives to codegen as a
@@ -34,18 +36,85 @@ let rec node_count : Tir.expr -> int = function
     + Option.fold ~none:0 ~some:node_count default
   | Tir.ESeq (e1, e2) -> 1 + node_count e1 + node_count e2
 
-(** Check if a function calls itself (recursion detection). *)
-let rec calls_self name : Tir.expr -> bool = function
-  | Tir.EApp (f, _) when f.Tir.v_name = name -> true
-  | Tir.ELet (_, rhs, body) -> calls_self name rhs || calls_self name body
-  | Tir.ELetRec (fns, body) ->
-    List.exists (fun fd -> calls_self name fd.Tir.fn_body) fns
-    || calls_self name body
-  | Tir.ECase (_, branches, default) ->
-    List.exists (fun b -> calls_self name b.Tir.br_body) branches
-    || Option.fold ~none:false ~some:(calls_self name) default
-  | Tir.ESeq (e1, e2) -> calls_self name e1 || calls_self name e2
-  | _ -> false
+(** Collect direct calls to functions in the current candidate pool. *)
+let direct_candidate_calls candidates expr =
+  let rec collect acc = function
+    | Tir.EApp (fn, _) when Hashtbl.mem candidates fn.Tir.v_name ->
+      SSet.add fn.Tir.v_name acc
+    | Tir.ELet (_, rhs, body) ->
+      collect (collect acc rhs) body
+    | Tir.ELetRec (fns, body) ->
+      let acc =
+        List.fold_left
+          (fun calls fn -> collect calls fn.Tir.fn_body)
+          acc fns
+      in
+      collect acc body
+    | Tir.ECase (_, branches, default) ->
+      let acc =
+        List.fold_left
+          (fun calls branch -> collect calls branch.Tir.br_body)
+          acc branches
+      in
+      Option.fold ~none:acc ~some:(collect acc) default
+    | Tir.ESeq (e1, e2) ->
+      collect (collect acc e1) e2
+    | _ -> acc
+  in
+  collect SSet.empty expr
+
+(** Return candidates that participate in recursive call-graph SCCs. *)
+let recursive_candidate_names (candidates : (string, Tir.fn_def) Hashtbl.t)
+    : SSet.t =
+  let successors : (string, SSet.t) Hashtbl.t = Hashtbl.create 16 in
+  Hashtbl.iter (fun name fn ->
+    Hashtbl.add successors name (direct_candidate_calls candidates fn.Tir.fn_body)
+  ) candidates;
+  let indices : (string, int) Hashtbl.t = Hashtbl.create 16 in
+  let lowlinks : (string, int) Hashtbl.t = Hashtbl.create 16 in
+  let index = ref 0 in
+  let stack = ref [] in
+  let on_stack = ref SSet.empty in
+  let recursive = ref SSet.empty in
+  let rec strongconnect name =
+    Hashtbl.add indices name !index;
+    Hashtbl.add lowlinks name !index;
+    incr index;
+    stack := name :: !stack;
+    on_stack := SSet.add name !on_stack;
+    SSet.iter (fun successor ->
+      if not (Hashtbl.mem indices successor) then begin
+        strongconnect successor;
+        let lowlink = min (Hashtbl.find lowlinks name)
+            (Hashtbl.find lowlinks successor) in
+        Hashtbl.replace lowlinks name lowlink
+      end else if SSet.mem successor !on_stack then begin
+        let lowlink = min (Hashtbl.find lowlinks name)
+            (Hashtbl.find indices successor) in
+        Hashtbl.replace lowlinks name lowlink
+      end
+    ) (Hashtbl.find successors name);
+    if Hashtbl.find lowlinks name = Hashtbl.find indices name then begin
+      let rec pop_component component =
+        match !stack with
+        | member :: rest ->
+          stack := rest;
+          on_stack := SSet.remove member !on_stack;
+          let component = SSet.add member component in
+          if String.equal member name then component
+          else pop_component component
+        | [] -> assert false
+      in
+      let component = pop_component SSet.empty in
+      if SSet.cardinal component > 1
+         || SSet.mem name (Hashtbl.find successors name) then
+        recursive := SSet.union !recursive component
+    end
+  in
+  Hashtbl.iter (fun name _ ->
+    if not (Hashtbl.mem indices name) then strongconnect name
+  ) successors;
+  !recursive
 
 (** Alpha-rename: give each parameter and let-bound variable a fresh name. *)
 let gensym =
@@ -163,41 +232,16 @@ let run ~changed (m : Tir.tir_module) : Tir.tir_module =
   List.iter (fun fd ->
     let is_pure     = Purity.is_pure fd.Tir.fn_body in
     let is_small    = node_count fd.Tir.fn_body <= inline_size_threshold in
-    let is_nonrec   = not (calls_self fd.Tir.fn_name fd.Tir.fn_body) in
     (* Hot Code Reload: a reloadable (boundary) function must never be inlined,
        or its call sites would be fixed into callers and could not be swapped. *)
     let is_reloadable = match !boundary_config with
       | Some cfg -> Hot_reload.is_reloadable cfg (Hot_reload.module_of_name fd.Tir.fn_name)
       | None     -> false in
-    if is_pure && is_small && is_nonrec && not is_reloadable then
+    if is_pure && is_small && not is_reloadable then
       Hashtbl.add fn_env fd.Tir.fn_name fd
   ) m.Tir.tm_fns;
-  (* Conservative mutual-recursion filter:
-     Remove any candidate that calls another candidate to prevent infinite
-     fixed-point loops. Chains (f→g→h non-circular) still work correctly:
-     only g/h are inlined in this pass; f gains their bodies and becomes
-     eligible in subsequent fixed-point iterations. *)
-  let candidate_names = Hashtbl.fold (fun k _ acc -> k :: acc) fn_env [] in
-  List.iter (fun name ->
-    match Hashtbl.find_opt fn_env name with
-    | None -> ()  (* already removed *)
-    | Some fd ->
-      let calls_other =
-        let rec check = function
-          | Tir.EApp (f, _) -> List.mem f.Tir.v_name candidate_names && f.Tir.v_name <> name
-          | Tir.ELet (_, rhs, body) -> check rhs || check body
-          | Tir.ELetRec (fns, body) ->
-            List.exists (fun nfd -> check nfd.Tir.fn_body) fns || check body
-          | Tir.ECase (_, branches, default) ->
-            List.exists (fun b -> check b.Tir.br_body) branches
-            || Option.fold ~none:false ~some:check default
-          | Tir.ESeq (e1, e2) -> check e1 || check e2
-          | _ -> false
-        in
-        check fd.Tir.fn_body
-      in
-      if calls_other then Hashtbl.remove fn_env name
-  ) candidate_names;
+  let recursive = recursive_candidate_names fn_env in
+  SSet.iter (Hashtbl.remove fn_env) recursive;
   { m with Tir.tm_fns = List.map (fun fd ->
       { fd with Tir.fn_body = inline_expr ~changed fn_env fd.Tir.fn_body }
     ) m.Tir.tm_fns }

--- a/specs/progress.md
+++ b/specs/progress.md
@@ -24,6 +24,22 @@ The stdlib HAMT remains out of reach behind three stacked obstacles, the first
 of which is the built-in `List`'s opaque element sort — see the Limitations
 section of `specs/lang/refinement-types.md`.
 
+## 2026-07-26 — SCC-aware inliner candidate selection
+
+The inliner formerly applied a conservative second candidate filter that
+discarded every small, pure candidate that directly called another candidate;
+that avoided recursive expansion but also excluded acyclic callers.  It now
+builds the same purity/size/hot-reload candidate pool, computes direct-call
+SCCs, and excludes only recursive components (including singleton self-edges).
+The emitted-LLVM regression uses a live body-growth fixture: a 9-node
+`inner_growth` inside a 46-node `outer_growth` (an 11-binding addition chain,
+55 nodes after inner expansion).  After optimization, LLVM has neither the
+named `call i64 @outer_growth(...)` nor its `define i64 @outer_growth(...)`:
+the fixture's direct-call count is 4 → 2 and its LLVM size is 22,633 → 22,215
+bytes.  Five warm repeated compile-and-emit fixture runs took 215–324 ms
+(median 232 ms).  These are regression and compiler-work measurements, not a
+runtime-speedup claim.
+
 ## Current State (as of 2026-07-25, verified LLVM allocation and closure-trampoline attributes)
 
 LLVM output now declares `march_alloc` with the conservative facts proven by

--- a/specs/progress.md
+++ b/specs/progress.md
@@ -36,9 +36,9 @@ The emitted-LLVM regression uses a live body-growth fixture: a 9-node
 55 nodes after inner expansion).  After optimization, LLVM has neither the
 named `call i64 @outer_growth(...)` nor its `define i64 @outer_growth(...)`:
 the fixture's direct-call count is 4 → 2 and its LLVM size is 22,633 → 22,215
-bytes.  Five warm repeated compile-and-emit fixture runs took 215–324 ms
-(median 232 ms).  These are regression and compiler-work measurements, not a
-runtime-speedup claim.
+bytes.  Five warm runs of the focused Dune/Alcotest command took 215–324 ms
+(median 232 ms), including process and test-runner startup.  These are
+regression-suite wall-time measurements, not a runtime-speedup claim.
 
 ## Current State (as of 2026-07-25, verified LLVM allocation and closure-trampoline attributes)
 

--- a/test/test_codegen.ml
+++ b/test/test_codegen.ml
@@ -3483,6 +3483,98 @@ let test_inline_acyclic_candidate_chain () =
     Alcotest.fail "acyclic wrapper remained excluded from candidates"
   | _ -> ()
 
+let live_add_chain param count tail =
+  let rec build index current =
+    if index = count then tail current
+    else
+      let next =
+        mk_var (Printf.sprintf "grow_%d" index) March_tir.Tir.TInt
+      in
+      March_tir.Tir.ELet
+        (next,
+         app "+" [March_tir.Tir.AVar current; March_tir.Tir.AVar param],
+         build (index + 1) next)
+  in
+  build 0 param
+
+let test_inline_acyclic_growth_removes_outer_from_llvm () =
+  let int_fn_ty =
+    March_tir.Tir.TFn ([March_tir.Tir.TInt], March_tir.Tir.TInt)
+  in
+  let x = mk_var "x" March_tir.Tir.TInt in
+  let inner_first = mk_var "inner_first" March_tir.Tir.TInt in
+  let inner_second = mk_var "inner_second" March_tir.Tir.TInt in
+  let inner_growth =
+    { March_tir.Tir.fn_name = "inner_growth";
+      fn_params = [x];
+      fn_ret_ty = March_tir.Tir.TInt;
+      fn_body =
+        March_tir.Tir.ELet
+          (inner_first,
+           app "+" [March_tir.Tir.AVar x; March_tir.Tir.AVar x],
+           March_tir.Tir.ELet
+             (inner_second,
+              app "+" [March_tir.Tir.AVar inner_first; March_tir.Tir.AVar x],
+              March_tir.Tir.EAtom (March_tir.Tir.AVar inner_second)));
+      fn_kind = March_tir.Tir.FnNormal }
+  in
+  let outer_x = mk_var "outer_x" March_tir.Tir.TInt in
+  let outer_growth =
+    { March_tir.Tir.fn_name = "outer_growth";
+      fn_params = [outer_x];
+      fn_ret_ty = March_tir.Tir.TInt;
+      fn_body =
+        live_add_chain outer_x 11 (fun current ->
+          March_tir.Tir.EApp
+            (mk_var "inner_growth" int_fn_ty, [March_tir.Tir.AVar current]));
+      fn_kind = March_tir.Tir.FnNormal }
+  in
+  let main =
+    { March_tir.Tir.fn_name = "main";
+      fn_params = [];
+      fn_ret_ty = March_tir.Tir.TInt;
+      fn_body = March_tir.Tir.EApp (mk_var "outer_growth" int_fn_ty, [ilit 1]);
+      fn_kind = March_tir.Tir.FnNormal }
+  in
+  Alcotest.(check int) "inner_growth fixture node count" 9
+    (March_tir.Inline.node_count inner_growth.March_tir.Tir.fn_body);
+  Alcotest.(check int) "outer_growth fixture node count" 46
+    (March_tir.Inline.node_count outer_growth.March_tir.Tir.fn_body);
+  let module_ = mk_module [inner_growth; outer_growth; main] in
+  let contains haystack needle =
+    let needle_len = String.length needle in
+    let rec search index =
+      index + needle_len <= String.length haystack
+      && (String.sub haystack index needle_len = needle || search (index + 1))
+    in
+    search 0
+  in
+  let count_substring haystack needle =
+    let needle_len = String.length needle in
+    let rec count index total =
+      if index + needle_len > String.length haystack then total
+      else if String.sub haystack index needle_len = needle then
+        count (index + needle_len) (total + 1)
+      else count (index + 1) total
+    in
+    count 0 0
+  in
+  let ir_before = March_tir.Llvm_emit.emit_module module_ in
+  let optimized = March_tir.Opt.run module_ in
+  let ir = March_tir.Llvm_emit.emit_module optimized in
+  let metrics =
+    Printf.sprintf " (calls before=%d after=%d; ir bytes before=%d after=%d)"
+      (count_substring ir_before " call ")
+      (count_substring ir " call ")
+      (String.length ir_before) (String.length ir)
+  in
+  Alcotest.(check bool)
+    ("no residual call to outer_growth" ^ metrics) false
+    (contains ir "call i64 @outer_growth(");
+  Alcotest.(check bool)
+    ("DCE removes outer_growth definition" ^ metrics) false
+    (contains ir "define i64 @outer_growth(")
+
 (* ── Known-call optimization ─────────────────────────────────────── *)
 
 (** Helper: build an EAlloc for a Defun-style closure struct.
@@ -9957,6 +10049,8 @@ let codegen_suites =
         Alcotest.test_case "recursive_not_inlined" `Quick test_inline_recursive_not_inlined;
         Alcotest.test_case "mutual_recursion_not_inlined" `Quick test_inline_mutual_recursion_not_inlined;
         Alcotest.test_case "acyclic_candidate_chain" `Quick test_inline_acyclic_candidate_chain;
+        Alcotest.test_case "acyclic_growth_removes_outer_from_llvm" `Quick
+          test_inline_acyclic_growth_removes_outer_from_llvm;
       ]);
       ("known_call", [
         Alcotest.test_case "direct"          `Quick test_known_call_direct;

--- a/test/test_codegen.ml
+++ b/test/test_codegen.ml
@@ -3360,6 +3360,12 @@ let test_simplify_not_false () =
 
 (* ── Function inlining ───────────────────────────────────────────── *)
 
+let direct_call_to name =
+  March_tir.Tir.EApp
+    (mk_var name
+       (March_tir.Tir.TFn ([March_tir.Tir.TInt], March_tir.Tir.TInt)),
+     [ilit 1])
+
 let test_inline_pure_small () =
   (* fn double(x) = x + x; fn main() = double(5) → call gets inlined *)
   let changed = ref false in
@@ -3433,6 +3439,49 @@ let test_inline_mutual_recursion_not_inlined () =
   let m = mk_module [f_fn; g_fn; main_fn] in
   let _ = March_tir.Inline.run ~changed m in
   Alcotest.(check bool) "not changed (mutually recursive)" false !changed
+
+let test_inline_acyclic_candidate_chain () =
+  let changed = ref false in
+  let x = mk_var "x" March_tir.Tir.TInt in
+  let leaf =
+    { March_tir.Tir.fn_name = "leaf";
+      fn_params = [x];
+      fn_ret_ty = March_tir.Tir.TInt;
+      fn_body = app "+" [March_tir.Tir.AVar x; ilit 1];
+      fn_kind = March_tir.Tir.FnNormal }
+  in
+  let wrapper =
+    { March_tir.Tir.fn_name = "wrapper";
+      fn_params = [x];
+      fn_ret_ty = March_tir.Tir.TInt;
+      fn_body =
+        March_tir.Tir.EApp
+          (mk_var "leaf"
+             (March_tir.Tir.TFn
+                ([March_tir.Tir.TInt], March_tir.Tir.TInt)),
+           [March_tir.Tir.AVar x]);
+      fn_kind = March_tir.Tir.FnNormal }
+  in
+  let main =
+    { March_tir.Tir.fn_name = "main";
+      fn_params = [];
+      fn_ret_ty = March_tir.Tir.TInt;
+      fn_body = direct_call_to "wrapper";
+      fn_kind = March_tir.Tir.FnNormal }
+  in
+  let result =
+    March_tir.Inline.run ~changed (mk_module [leaf; wrapper; main])
+  in
+  let main_body =
+    result.March_tir.Tir.tm_fns
+    |> List.find (fun fn -> String.equal fn.March_tir.Tir.fn_name "main")
+    |> fun fn -> fn.March_tir.Tir.fn_body
+  in
+  match main_body with
+  | March_tir.Tir.EApp (fn, _)
+    when String.equal fn.March_tir.Tir.v_name "wrapper" ->
+    Alcotest.fail "acyclic wrapper remained excluded from candidates"
+  | _ -> ()
 
 (* ── Known-call optimization ─────────────────────────────────────── *)
 
@@ -9907,6 +9956,7 @@ let codegen_suites =
         Alcotest.test_case "impure_not_inlined"    `Quick test_inline_impure_not_inlined;
         Alcotest.test_case "recursive_not_inlined" `Quick test_inline_recursive_not_inlined;
         Alcotest.test_case "mutual_recursion_not_inlined" `Quick test_inline_mutual_recursion_not_inlined;
+        Alcotest.test_case "acyclic_candidate_chain" `Quick test_inline_acyclic_candidate_chain;
       ]);
       ("known_call", [
         Alcotest.test_case "direct"          `Quick test_known_call_direct;
@@ -10380,4 +10430,3 @@ let codegen_suites =
   @ Test_ir_verify.suites (* W2.1: LLVM IR validity gate over test/native/*.march *)
   @ Test_collision_set.suites (* Task 0: same-short-name type collision-set computation *)
   @ Test_ctor_tags.suites (* Task 1: globally-unique ctor tags for colliding types *)
-


### PR DESCRIPTION
## Summary

- replace the inliner's blanket candidate-dependency rejection with direct-call SCC analysis
- retain pure, size-eligible acyclic caller chains while excluding recursive SCCs and singleton self-edges
- add an emitted-LLVM regression proving the named `outer_growth` call and dead private definition are removed
- preserve the existing size threshold, hot-reload exclusions, IR, ownership, and RC behavior

## Verification

- `dune exec test/run_codegen.exe -- test inline -e --color=never` — 6/6 passed
- `dune exec test/test_hot_reload.exe -- --color=never` — 30/30 passed
- `dune exec test/run_codegen.exe -- test -e --color=never` — 451/451 passed (one expected cross-tool skip: target sysroot unavailable)
- `dune build @install`
- `git diff --check origin/main...HEAD`

## Scope

No new IR and no language-semantics, Perceus, ownership, RC, or hot-reload-boundary changes.