### PR TITLE
stdlib: first real refinement contracts (unwrap/expect + numeric ranges)

### DIFF
--- a/stdlib/option.march
+++ b/stdlib/option.march
@@ -44,7 +44,7 @@ mod Option do
   The panic message is prefixed with the module name and `on None` so
   it is clearly attributable when it shows up in a stack trace.
   """
-  fn expect(opt : Option(a), msg : String) : a do
+  fn expect(opt : {Option(a) | is_Some(_)}, msg : String) : a do
     match opt do
     Some(x) -> x
     None    -> panic("Option.expect on None: " ++ msg)
@@ -60,7 +60,7 @@ mod Option do
       march> Option.unwrap(None)
       ** panic: Option.unwrap called on None
   """
-  fn unwrap(opt : Option(a)) : a do
+  fn unwrap(opt : {Option(a) | is_Some(_)}) : a do
     match opt do
     Some(x) -> x
     None    -> panic("Option.unwrap called on None")

--- a/stdlib/prelude.march
+++ b/stdlib/prelude.march
@@ -56,7 +56,7 @@ mod Prelude do
   -- ---- Option helpers ----
 
   doc "Extracts the value from Some(x), panicking if None."
-  fn unwrap(opt : Option(a)) : a do
+  fn unwrap(opt : {Option(a) | is_Some(_)}) : a do
     match opt do
     Some(x) -> x
     None    -> panic("unwrap called on None")

--- a/stdlib/random.march
+++ b/stdlib/random.march
@@ -216,7 +216,7 @@ mod Random do
   Sample from the normal distribution N(mu, sigma^2).
   Panics if sigma < 0.  sigma=0 returns mu.
   """
-  fn normal(rng : Rng, mu : Float, sigma : Float) : (Float, Rng) do
+  fn normal(rng : Rng, mu : Float, sigma : {Float | _ >= 0.0}) : (Float, Rng) do
     if sigma < 0.0 do panic("Random.normal: sigma must be non-negative")
     else if sigma == 0.0 do (mu, rng)
     else do
@@ -231,7 +231,7 @@ mod Random do
   X = -ln(U) / lambda is Exp(lambda).
   Panics if lambda <= 0.
   """
-  fn exponential(rng : Rng, lambda : Float) : (Float, Rng) do
+  fn exponential(rng : Rng, lambda : {Float | _ > 0.0}) : (Float, Rng) do
     if lambda <= 0.0 do panic("Random.exponential: lambda must be positive")
     else do
       let (u, rng2) = next_float_open(rng)
@@ -243,7 +243,7 @@ mod Random do
   Sample from a Bernoulli distribution with success probability p.
   p must be in [0.0, 1.0]; panics otherwise.
   """
-  fn bernoulli(rng : Rng, p : Float) : (Bool, Rng) do
+  fn bernoulli(rng : Rng, p : {Float | _ >= 0.0 && _ <= 1.0}) : (Bool, Rng) do
     if p < 0.0 || p > 1.0 do panic("Random.bernoulli: p must be in [0, 1]")
     else do
       let (u, rng2) = next_float(rng)

--- a/stdlib/result.march
+++ b/stdlib/result.march
@@ -29,7 +29,7 @@ mod Result do
   The panic message includes the underlying Err value so callers can
   see *why* the assumption was violated, not just that it was.
   """
-  fn expect(res : Result(a, e), msg : String) : a do
+  fn expect(res : {Result(a, e) | is_Ok(_)}, msg : String) : a do
     match res do
     Ok(x)  -> x
     Err(e) -> panic("Result.expect on Err(" ++ to_string(e) ++ "): " ++ msg)
@@ -37,7 +37,7 @@ mod Result do
   end
 
   doc "Extracts the Ok value, panicking if Err."
-  fn unwrap(res : Result(a, e)) : a do
+  fn unwrap(res : {Result(a, e) | is_Ok(_)}) : a do
     match res do
     Ok(x)  -> x
     Err(e) -> panic("Result.unwrap called on Err: " ++ to_string(e))
@@ -45,7 +45,7 @@ mod Result do
   end
 
   doc "Extracts the Err value, panicking if Ok."
-  fn unwrap_err(res : Result(a, e)) : e do
+  fn unwrap_err(res : {Result(a, e) | is_Err(_)}) : e do
     match res do
     Err(e) -> e
     Ok(_)  -> panic("Result.unwrap_err called on Ok")

--- a/stdlib/stats.march
+++ b/stdlib/stats.march
@@ -64,7 +64,7 @@ mod Stats do
   Percentile using linear interpolation.
   p must be in [0.0, 100.0]. Panics on empty list or out-of-range p.
   """
-  fn percentile(xs : List(Float), p : Float) : Float do
+  fn percentile(xs : List(Float), p : {Float | _ >= 0.0 && _ <= 100.0}) : Float do
     match xs do
     Nil -> panic("Stats.percentile: empty list")
     _ -> do
@@ -248,7 +248,7 @@ mod Stats do
   existing `percentile(xs, p)` is equivalent to
   `quantile(xs, p / 100.0, Linear)`.
   """
-  fn quantile(xs : List(Float), q : Float, method : QuantileMethod) : Float do
+  fn quantile(xs : List(Float), q : {Float | _ >= 0.0 && _ <= 1.0}, method : QuantileMethod) : Float do
     match xs do
     Nil -> panic("Stats.quantile: empty list")
     _ -> do


### PR DESCRIPTION
Adds 10 refinement contracts to the standard library, turning a class of runtime panic into a compile error.

## Why

The refinement checker had almost no users: **11 contracts across 111 modules**, all simple `{Int | _ >= 0}` shapes, none using anything added recently. Meanwhile there are **111 `panic(` sites**, many guarding preconditions the checker can now express — including `List.nth`, which is the motivating example in our own documentation and still panics.

This is the first slice: the two categories with near-zero internal blast radius.

## What

```march
fn unwrap(opt : {Option(a) | is_Some(_)}) : a
fn expect(opt : {Option(a) | is_Some(_)}, msg : String) : a
fn unwrap(res : {Result(a, e) | is_Ok(_)}) : a
fn unwrap_err(res : {Result(a, e) | is_Err(_)}) : e

fn bernoulli(rng : Rng, p : {Float | _ >= 0.0 && _ <= 1.0})
fn exponential(rng : Rng, lambda : {Float | _ > 0.0})
fn normal(rng : Rng, mu : Float, sigma : {Float | _ >= 0.0})
fn percentile(xs : List(Float), p : {Float | _ >= 0.0 && _ <= 100.0})
fn quantile(xs : List(Float), q : {Float | _ >= 0.0 && _ <= 1.0}, ...)
```

**Every contract is derived from that function's own panic message**, so none is stronger than the check the code already performs — a stronger precondition would reject calls the function handles fine, which in the stdlib breaks everyone's build.

**The `panic` calls stay.** The refinement is a compile-time gate for statically-known arguments; the runtime check still covers everything the checker skips. Removing them would be a behaviour change dressed as a type improvement.

## Verification

- **9/9 violating literal calls** are now compile errors
- **0 false positives**: unknown values correctly skipped, and a guard (`if p >= 0.0 && p <= 1.0`) discharges the precondition
- `test_refinecheck`, `run_compiler`, `run_eval`, `check-docs.sh` all exit 0
- A real stdlib-using program compiles with zero diagnostics; 9/10 sampled `examples/` pass (the tenth has a pre-existing `fold_left` argument-order **type** error, zero refinement violations)

## Deliberately not in this PR

- **Non-empty-collection contracts** (`List.head`, `Stats.mean`, ~15 sites — the largest category). These need `len(xs) > 0`, a spelling coupled to the parameter's *name*: rename the parameter and the contract is silently unenforced, with no refinement diagnostic. The documented `len(_)` idiom does not work in measure position. Blocked on that fix.
- **`List.nth` and index bounds.** 26 internal stdlib call sites — its own project.