### PR TITLE
fix(resolver): resolve modules by declared name; stop silently dropping test modules

### DIFF
--- a/lib/resolver/resolver.ml
+++ b/lib/resolver/resolver.ml
@@ -111,7 +111,9 @@ let rec has_global_effect_decl decls =
   List.exists (function
     | March_ast.Ast.DImpl _ | March_ast.Ast.DInterface _
     | March_ast.Ast.DDeriving _ | March_ast.Ast.DTransitions _
-    | March_ast.Ast.DProtocol _ | March_ast.Ast.DExtern _ -> true
+    | March_ast.Ast.DProtocol _ | March_ast.Ast.DExtern _
+    | March_ast.Ast.DDescribe _ | March_ast.Ast.DTest _
+    | March_ast.Ast.DSetup _ | March_ast.Ast.DSetupAll _ -> true
     | March_ast.Ast.DMod (_, _, inner, _) -> has_global_effect_decl inner
     | _ -> false) decls
 
@@ -469,7 +471,7 @@ let resolve_imports ?(extra_lib_paths = []) ?(auto_discover = true)
       (* Phase 1: parse + desugar every un-loaded discovered file across ALL
          lib dirs, keeping its source text for reachability analysis. *)
       let all_parsed =
-        List.concat_map (fun lib_dir ->
+        List.concat_map (fun (dir_idx, lib_dir) ->
             let files = collect_lib_files lib_dir in
             List.filter_map (fun file_path ->
                 let canon_fp =
@@ -483,11 +485,11 @@ let resolve_imports ?(extra_lib_paths = []) ?(auto_discover = true)
                     | Error msg ->
                       Printf.eprintf "[lib] %s\n%!" msg; None
                     | Ok ast ->
-                      Some (canon_fp, file_path,
+                      Some (dir_idx, canon_fp, file_path,
                             March_desugar.Desugar.desugar_module ~is_entry:false ast,
                             src)
               ) files
-          ) all_lib_paths
+          ) (List.mapi (fun i d -> (i, d)) all_lib_paths)
       in
       (* Reachability pruning.  An auto-discovered library module is only
          built when the entry can actually reach it — directly or transitively,
@@ -514,7 +516,7 @@ let resolve_imports ?(extra_lib_paths = []) ?(auto_discover = true)
            anchors that keep it (module name + provided type/ctor names), and
            the module-name tokens its own source references (transitive spread). *)
         let discovered =
-          List.map (fun (_, _, ast, src) ->
+          List.map (fun (_, _, _, ast, src) ->
               let mn = mod_name_of ast in
               let anchors = mn :: provided_anchor_names ast.March_ast.Ast.mod_decls in
               (mn, anchors, referenced_name_tokens src))
@@ -540,12 +542,25 @@ let resolve_imports ?(extra_lib_paths = []) ?(auto_discover = true)
         || Hashtbl.mem reachable (mod_name_of ast)
         || has_global_effect_decl ast.March_ast.Ast.mod_decls
       in
-      (* Sort: more dot-segments in mod name → load first (namespace leaves).
-         Alphabetical tiebreak keeps things deterministic. *)
-      let sorted = List.sort (fun (_, _, a, _) (_, _, b, _) ->
-          let da = dot_count (mod_name_of a) and db = dot_count (mod_name_of b) in
-          if db <> da then compare db da
-          else compare (mod_name_of a) (mod_name_of b)
+      (* Sort: SEARCH-PATH ORDER first, then more dot-segments in mod name
+         (namespace leaves), then alphabetically for determinism.
+
+         The search-path key is what keeps the caller's ordering intent
+         intact.  `forge test` places lib/ before test/ on MARCH_LIB_PATH
+         precisely because test modules call into lib modules and never the
+         reverse: a lib function still bound to its pass-1 Mono placeholder,
+         pinned first by a TEST call site, makes every later call site with
+         a different record shape fail to unify.  Sorting on the module name
+         alone silently undid that — `Forgepm.Test.*` and `Forgepm.Web.*`
+         have equal dot-counts, so "Test" sorted ahead of "Web" and the test
+         modules were checked first, yielding a wall of `expected () but got
+         Unit`.  Within one directory the dot-count rule still applies. *)
+      let sorted = List.sort (fun (ia, _, _, a, _) (ib, _, _, b, _) ->
+          if ia <> ib then compare ia ib
+          else
+            let da = dot_count (mod_name_of a) and db = dot_count (mod_name_of b) in
+            if db <> da then compare db da
+            else compare (mod_name_of a) (mod_name_of b)
         ) all_parsed in
       (* Phase 2: build DMods in sorted order for KEPT modules only.  Emit
          transitive imports as top-level siblings (not nested) to avoid
@@ -553,7 +568,7 @@ let resolve_imports ?(extra_lib_paths = []) ?(auto_discover = true)
          the string the file was parsed under (= what its spans carry),
          recorded for user_files.  A pruned module is skipped entirely — never
          noted as a user file, never emitted, never typechecked. *)
-      List.concat_map (fun (canon_fp, orig_path, ast, _src) ->
+      List.concat_map (fun (_dir_idx, canon_fp, orig_path, ast, _src) ->
           if Hashtbl.mem loaded_paths canon_fp then []
           else if not (keep ast) then []
           else begin

--- a/lib/resolver/resolver.ml
+++ b/lib/resolver/resolver.ml
@@ -34,7 +34,15 @@ let module_name_to_filename name =
 (** Stdlib module names — used only to SUPPRESS "module not found" errors
     for imports that resolve from the bundled stdlib.  A user file with the
     same conventional filename always wins (it is found first), so listing
-    a name here never shadows user code. *)
+    a name here never shadows user code.
+
+    Every entry must name a module that [stdlib/] actually declares.  Nine
+    Depot* names (Depot, Depot.Gate, DepotForm, DepotGate, DepotSchema,
+    DepotRepo, DepotQuery, DepotMigration, DepotTest) were listed but ship
+    in the third-party `depot` package, not here, so they only suppressed
+    genuine diagnostics for depot's own modules.  "URI" was likewise never
+    a module — [stdlib/uri.march] declares `mod Uri`, and the mismatched
+    casing meant a plain `import Uri` reported "not found". *)
 let stdlib_module_names =
   [ "List"; "Map"; "Set"; "Array"; "Queue"; "String"; "Option"; "Result"
   ; "Math"; "Enum"; "BigInt"; "Decimal"; "DateTime"; "Duration"; "Bytes"; "Json"
@@ -42,12 +50,9 @@ let stdlib_module_names =
   ; "HttpServer"; "HttpTransport"; "WebSocket"; "Process"; "Logger"
   ; "Flow"; "Actor"; "Sort"; "Hamt"; "Seq"; "Iterable"; "IOList"
   ; "Random"; "Stats"; "Plot"; "Prelude"; "DataFrame"; "Test"
-  ; "Vault"; "URI"
-  ; "Depot"; "Depot.Gate"
+  ; "Vault"; "Uri"
   ; "Config"; "Crypto"; "Env"; "Channel"; "PubSub"
   ; "ChannelServer"; "ChannelSocket"; "Presence"; "Tls"; "Uuid"
-  ; "DepotForm"; "DepotGate"; "DepotSchema"; "DepotRepo"
-  ; "DepotQuery"; "DepotMigration"; "DepotTest"
   ; "Tuple"; "Char"; "OrderedMap"; "SortedSet"; "Range" ]
 
 (** All non-empty dotted prefixes of [names], LONGEST first, down to the
@@ -283,12 +288,56 @@ let resolve_imports ?(extra_lib_paths = []) ?(auto_discover = true)
   Hashtbl.add loaded_paths canonical_source ();
   note_user_file source_file canonical_source;
 
+  (* Does [path] declare `mod [mod_name]` at the start of a line?  A cheap
+     textual check — enough to locate the file, which is then parsed
+     properly by [load]. *)
+  let file_declares path mod_name =
+    match (try Some (read_file path) with Sys_error _ -> None) with
+    | None -> false
+    | Some src ->
+      let needle = "mod " ^ mod_name in
+      let nlen = String.length needle in
+      let slen = String.length src in
+      let rec scan i =
+        if i + nlen > slen then false
+        else if (i = 0 || src.[i - 1] = '\n')
+                && String.sub src i nlen = needle
+                && (i + nlen = slen
+                    || (match src.[i + nlen] with
+                        | ' ' | '\t' | '\n' | '\r' -> true
+                        | _ -> false))
+        then true
+        else scan (i + 1)
+      in
+      scan 0
+  in
+
+  (* The conventional dotted->path mapping first ("MyApp.Router" ->
+     "my_app/router.march"), then a scan for the file that actually DECLARES
+     the module.  The scan matters because a module's file need not follow
+     the convention: step 2's auto-discovery keys off the `mod` declaration,
+     not the path, so such a module was always reachable — just not by
+     explicit `import`.  depot declares `mod Depot.Query` in
+     lib/api/depot_query.march, and until [import_refs] began yielding
+     dotted candidates that import resolved only because "Depot" sat
+     (wrongly) in [stdlib_module_names] and suppressed the lookup entirely.
+     Scanning only on a miss keeps the common path a single [Sys.file_exists]
+     and preserves the precise "looked for <path>" diagnostic for a module
+     that genuinely is not there. *)
   let find_file mod_name =
     let fname = module_name_to_filename mod_name in
-    List.find_map (fun dir ->
-        let p = Filename.concat dir fname in
-        if Sys.file_exists p then Some p else None
-      ) search_path
+    match
+      List.find_map (fun dir ->
+          let p = Filename.concat dir fname in
+          if Sys.file_exists p then Some p else None
+        ) search_path
+    with
+    | Some p -> Some p
+    | None ->
+      List.find_map (fun dir ->
+          List.find_opt (fun p -> file_declares p mod_name)
+            (collect_lib_files dir)
+        ) search_path
   in
 
   let rec load mod_name ~from_span =

--- a/test/test_compiler.ml
+++ b/test/test_compiler.ml
@@ -5409,6 +5409,34 @@ end
     "unrelated-named sibling dotted module still resolves (regression control)"
     false errored
 
+(* A user module whose dotted name's LEADING SEGMENT collides with a stdlib
+   module ("Depot" is in [stdlib_module_names], as is "Env", "Ast", …) must
+   still resolve from the search path.  Before dotted candidates existed
+   [import_refs] yielded only the first segment, so `use Depot.Query` was
+   skipped as stdlib and step 2's auto-discovery picked the user file up;
+   once candidates were filtered against the stdlib list, the bare "Depot"
+   was dropped and the surviving "Depot.Query" — a real user module, but not
+   at `depot/query.march` — became a hard "Module not found".  That broke
+   depot itself, whose own Depot.Query / Depot.Url / Depot.Transaction /
+   Depot.Migration live at lib/api/depot_*.march. *)
+let test_stdlib_prefixed_user_module_resolves () =
+  let sibling_src = {|mod Depot.Query do
+  fn answer() : Int do 42 end
+end
+|} in
+  let entry_src = {|mod App do
+  import Depot.Query
+
+  fn main() : Int do
+    Depot.Query.answer()
+  end
+end
+|} in
+  let errored = check_entry_with_lib_dir [("depot_query.march", sibling_src)] entry_src in
+  Alcotest.(check bool)
+    "user module under a stdlib-named prefix resolves from the search path"
+    false errored
+
 let test_self_prefix_nested_submodule_still_strips () =
   (* Control for the [strip_entry_self_qual] fix itself: a GENUINE nested
      submodule (declared directly inside the entry, not a separate sibling
@@ -9894,6 +9922,9 @@ let compiler_suites =
           Alcotest.test_case
             "genuine nested submodule self-qualification still strips"
             `Quick test_self_prefix_nested_submodule_still_strips;
+          Alcotest.test_case
+            "user module under a stdlib-named dotted prefix resolves"
+            `Quick test_stdlib_prefixed_user_module_resolves;
         ] );
       ( "diagnostic dedup",
         [

--- a/test/test_compiler.ml
+++ b/test/test_compiler.ml
@@ -5419,6 +5419,64 @@ end
    at `depot/query.march` — became a hard "Module not found".  That broke
    depot itself, whose own Depot.Query / Depot.Url / Depot.Transaction /
    Depot.Migration live at lib/api/depot_*.march. *)
+(* `forge test` compiles ONE test file as the entry and lets auto-discovery
+   pull in the siblings.  Reachability pruning (48cf9263) keeps a discovered
+   module only when the entry references it or it carries a global-effect
+   decl — and nothing references a test module by name, which is what a test
+   module IS.  Every sibling was therefore dropped, [collect_tests] never saw
+   its bodies, and the run reported a PASS over whatever survived: forgepm
+   went from 544 tests to 21, exit 0.  Silent test loss is the worst
+   available failure mode, so pin it. *)
+let test_sibling_test_module_is_not_pruned () =
+  let sibling_src = {|mod T.Sibling do
+  import Test
+
+describe "sibling" do
+  test "runs" do
+    Test.assert_true(true, "holds")
+  end
+end
+end
+|} in
+  let entry_src = {|mod T.Entry do
+  import Test
+
+describe "entry" do
+  test "runs" do
+    Test.assert_true(true, "holds")
+  end
+end
+end
+|} in
+  let dir = Filename.temp_file "march_test_prune_" "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  Fun.protect ~finally:(fun () ->
+      try ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir)))
+      with _ -> ())
+    (fun () ->
+      let oc = open_out (Filename.concat dir "sibling_test.march") in
+      output_string oc sibling_src; close_out oc;
+      (* The entry must be a REAL file: [resolve_imports] disables pruning
+         entirely when it cannot read [source_file], so a synthetic path
+         would make this test vacuous (it passes either way). *)
+      let entry_path = Filename.concat dir "entry_test.march" in
+      let oc = open_out entry_path in
+      output_string oc entry_src; close_out oc;
+      Unix.putenv "MARCH_LIB_PATH" dir;
+      Fun.protect ~finally:(fun () -> Unix.putenv "MARCH_LIB_PATH" "") (fun () ->
+        let m = parse_and_desugar entry_src in
+        let (_errs, extra_decls, _files) =
+          March_resolver.Resolver.resolve_imports ~source_file:entry_path m in
+        let mentions_sibling =
+          List.exists (function
+            | March_ast.Ast.DMod (n, _, _, _) -> n.March_ast.Ast.txt = "T.Sibling"
+            | _ -> false) extra_decls
+        in
+        Alcotest.(check bool)
+          "an unreferenced sibling test module survives reachability pruning"
+          true mentions_sibling))
+
 let test_stdlib_prefixed_user_module_resolves () =
   let sibling_src = {|mod Depot.Query do
   fn answer() : Int do 42 end
@@ -9925,6 +9983,9 @@ let compiler_suites =
           Alcotest.test_case
             "user module under a stdlib-named dotted prefix resolves"
             `Quick test_stdlib_prefixed_user_module_resolves;
+          Alcotest.test_case
+            "unreferenced sibling test module is not pruned"
+            `Quick test_sibling_test_module_is_not_pruned;
         ] );
       ( "diagnostic dedup",
         [


### PR DESCRIPTION
Three resolver bugs found while moving forgepm onto current `main`. Each is independently verified and has a regression test that fails with only its own fix reverted.

## 1. A module was importable only at its conventional path

`import Depot.Query` failed with ``Module `Depot.Query` not found (looked for `depot/query.march`)`` for depot's own modules, which live at `lib/api/depot_query.march`. `forge check` passed and `forge build` did not, so the two disagreed about what resolves.

Nine `Depot*` names sat in `stdlib_module_names`, whose documented job is suppressing "not found" for modules that ship in `stdlib/`. None of them do — depot is a third-party package. While `import_refs` yielded only a path's first segment that bogus entry was accidentally load-bearing: `use Depot.Query` was skipped as stdlib and auto-discovery supplied the module. Once 7849f0da made candidates dotted, the stdlib filter dropped the bare `Depot` and the surviving `Depot.Query` became a hard error. (`URI` was listed too, but `stdlib/uri.march` declares `mod Uri`, so the casing mismatch meant a plain `import Uri` reported "not found".)

Deleting those entries alone leaves the real gap: `find_file` resolved **only** by the conventional dotted→path mapping, while auto-discovery indexes by the `mod` declaration — so a module whose file doesn't follow the convention was reachable by reference but not by explicit `import`. `find_file` now falls back to scanning for the file that declares the name, only when the conventional path misses, so a genuinely-absent module keeps its precise `looked for <path>` diagnostic.

This is not Depot-specific: `mod Config.Test` hit the identical failure, and `Config` genuinely does ship in stdlib.

## 2. `forge test` silently ran a fraction of the suite

`forge test` compiles ONE test file as the entry and relies on auto-discovery for the siblings. Reachability pruning (48cf9263) keeps a discovered module only when the entry references it or it carries a global-effect decl — and nothing references a test module by name, which is what a test module *is*. Every sibling was dropped, `collect_tests` never saw its bodies, and the run reported a PASS over whatever survived.

**forgepm went from 544 tests to 21, exit 0.** Silent test loss with a green exit is the worst available failure mode.

`DDescribe`/`DTest`/`DSetup`/`DSetupAll` now count as global-effect. `DDescribe` is the one that matters — a test file's top-level decls are `describe` blocks, and adding only `DTest` changes nothing.

## 3. Checking order discarded the search path

Fixing (2) then produced **552** `expected () but got Unit` errors. Phase 2 sorted discovered modules by NAME (dot-count, then alphabetical), discarding the order the search path was given in. forge deliberately puts `lib/` before `test/` on `MARCH_LIB_PATH`, and its own comment explains why: a lib function still bound to its pass-1 Mono placeholder gets pinned by whichever call site is checked first. `Forgepm.Test.*` and `Forgepm.Web.*` have equal dot-counts, so `Test` sorted ahead of `Web` and pinned every shared helper from a test call site. Search-path index is now the primary sort key; the dot-count rule still orders within a directory.

## Verification

- `run_compiler` 607/607, `run_eval` 256/256
- Both new tests verified to fail with only their own fix reverted. The pruning test writes a **real** entry file — `resolve_imports` disables pruning outright when it cannot read `source_file`, so a synthetic path makes such a test vacuous (my first version passed either way)
- End to end: depot, bastion and forgepm all build against this. forgepm goes from *21 tests, 0 failures* (unfixed main) to **544 tests, 0 failures**, matching the pre-regression count on the old pin

## Related

Needs march-language/depot#1 and march-language/bastion#5 to build those two against current main; neither is required for this PR.