### PR TITLE
fix(tir): purity oracle now recognizes monomorphized builtin names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,18 @@ git log is authoritative for exact commits.
 
 ### Fixed
 
+- **The optimizer's purity oracle no longer misjudges a monomorphized builtin
+  call as pure.** Monomorphization rewrites calls to specialized names before
+  optimization runs (e.g. `println` becomes `println$String`), and the purity
+  check (used by `Inline`/`single_use_inline`/DCE/fusion) matched callee names
+  with exact string equality against a bare-name impure-builtin list, so a
+  specialized impure builtin like `println$String` was silently treated as
+  pure. Fixed by stripping the specialization suffix before matching. No live
+  miscompile was found or is claimed by this fix — it closes a latent
+  correctness gap in the oracle (and a companion test-integrity gap where a
+  native regression test passed regardless of whether the pass it targeted
+  ran at all).
+
 - **`cap no_panic`: an unreflectable divisor refinement is no longer accepted as
   a proof.** The division-safety check treated "this predicate is outside the
   checkable fragment" as a discharged obligation, which made a *meaningless*

--- a/lib/tir/purity.ml
+++ b/lib/tir/purity.ml
@@ -73,8 +73,15 @@ let rec is_pure_ext (impure_fns : StringSet.t) : Tir.expr -> bool = function
   | Tir.EIncRC _ | Tir.EDecRC _ | Tir.EFree _ | Tir.EReuse _
   | Tir.EAtomicIncRC _ | Tir.EAtomicDecRC _ -> false
   | Tir.EApp (f, _)            ->
-    not (List.mem f.Tir.v_name impure_builtins)
+    (* Monomorphization rewrites builtin/stdlib calls to specialized names
+       (e.g. "println" -> "println$String" via Tir_names.specialize_mangle),
+       so match against the specialization-stripped base name, not the raw
+       call-site name — an exact match here would silently reclassify every
+       specialized impure builtin as pure. *)
+    let base = Tir_names.strip_specialization_suffix f.Tir.v_name in
+    not (List.mem base impure_builtins)
     && not (StringSet.mem f.Tir.v_name impure_fns)
+    && not (StringSet.mem base impure_fns)
   | Tir.ECallPtr _             -> false  (* indirect call — unknown target *)
   | Tir.ELet (_, rhs, body)    -> is_pure_ext impure_fns rhs && is_pure_ext impure_fns body
   | Tir.ELetRec (fns, body)    ->

--- a/lib/tir/tir_names.ml
+++ b/lib/tir/tir_names.ml
@@ -251,6 +251,49 @@ let iface_mangle ~(iface : string) ~(ty : string) ~(meth : string) : string =
 let specialize_mangle (base : string) (mangled_ty : string) : string =
   base ^ "$" ^ mangled_ty
 
+(** [strip_specialization_suffix name] inverts [specialize_mangle]/
+    [mangle_name]'s "$"-suffix convention: it strips the specialization
+    suffix (and any interface-impl second-order suffix appended the same
+    way) to recover the base name a purity/effect table would have an
+    entry for.
+
+    Rule, mirroring [is_iface_mangled]'s own last-'.' scan: find the LAST
+    ['.'] in [name] (or the start of the string if there is none); the
+    specialization separator is the FIRST ['$'] at-or-after that position.
+    Truncate there. A ['$'] that lands BEFORE the last '.' is part of an
+    interface-impl mangle (e.g. "Show$List.show") and is therefore part of
+    the base name, not a specialization suffix — left untouched.
+
+      - ["println$String"]        -> ["println"]           (no '.'; first
+        '$' at position 0 is the separator)
+      - ["List.map$Int"]          -> ["List.map"]           ('$' after the
+        last '.')
+      - ["Show$List.show$Int"]    -> ["Show$List.show"]     (the FIRST '$'
+        is before the last '.', so it is skipped; the SECOND '$', after
+        the last '.', is the separator)
+      - ["map"] (no '$' at all)   -> ["map"]                (unchanged)
+
+    This is a total, deterministic string operation — every input has a
+    well-defined answer under this rule, so there is no "ambiguous" case
+    to reject. Conservatism belongs to the CALLER (e.g. [Purity]): match
+    against the stripped base, and if the base is not recognised, treat
+    the name as impure rather than assuming purity. *)
+let strip_specialization_suffix (name : string) : string =
+  let len = String.length name in
+  let search_start =
+    match String.rindex_opt name '.' with
+    | Some i -> i + 1
+    | None -> 0
+  in
+  let rec find_dollar i =
+    if i >= len then None
+    else if name.[i] = '$' then Some i
+    else find_dollar (i + 1)
+  in
+  match find_dollar search_start with
+  | Some j -> String.sub name 0 j
+  | None -> name
+
 (* ── Default-argument mangling: "base$N" ────────────────────────────────
    Producer: lib/desugar/desugar.ml's [expand_defaults_decl] mints, for a
    fn with default params, a full-arity mangled decl ["%s$%d" name

--- a/specs/progress.md
+++ b/specs/progress.md
@@ -1,5 +1,56 @@
 # March — Progress Summary
 
+## Current State (as of 2026-07-28, purity oracle: monomorphized builtin names)
+
+**Fixed a latent purity-oracle defect and the vacuous test it caused.**
+`lib/tir/purity.ml`'s `is_pure_ext` matched an `EApp` callee's `v_name` against
+`impure_builtins` (bare names like `"println"`) with exact string equality, but
+monomorphization rewrites calls to specialized names before `Opt.run` (the
+consumer of this oracle) runs — `println` becomes `println$String` via
+`lib/tir/mono.ml`'s `mangle_name`/`Tir_names.specialize_mangle`. The exact match
+silently missed every specialized impure builtin, classifying it PURE.
+
+New `Tir_names.strip_specialization_suffix` (`lib/tir/tir_names.ml`, next to
+`specialize_mangle`) is the single home for inverting that mangling: find the
+last `.` (or string start), take the first `$` at-or-after it, truncate there —
+this correctly distinguishes an interface-impl mangle's own `.`-preceding `$`
+(`"Show$List.show"`, left as base) from a specialization suffix appended after
+the last `.` (`"List.map$Int"` -> `"List.map"`, `"Show$List.show$Int"` ->
+`"Show$List.show"`, `"println$String"` -> `"println"`). `purity.ml` now matches
+the stripped base. Unit tests in `test/test_codegen.ml`'s `tir_names` group.
+
+No live miscompile was found (DCE does not drop impure-looking dead bindings;
+impure-inlining output parity held across the corpus) — this closes a latent
+soundness gap in the oracle, not an observed wrong-output bug. The main
+practical consequence was test-integrity: `test/native/single_use_inline_rc.march`
+(alias `single_use_inline_rc` in `test/dune`) passed regardless of whether
+`lib/tir/single_use_inline.ml` ran at all, because its `helper` (calls
+`println` twice, zero RC ops — borrowed `List(Int)` param, string literals,
+scalar return) was eliminated by the ordinary `Inline` pass under the buggy
+oracle. Verified de-vacuumed: disabling `single_use_inline`'s eligibility
+predicate and recompiling with `--emit-llvm` leaves `@helper` (`define` and
+`call`) in the emitted IR — the test's grep guard would now catch that.
+Restoring the predicate eliminates `@helper` again.
+
+Behavior-shift measurement: because `Opt.run` runs after Perceus RC-insertion,
+most bodies already contained RC ops and were already impure under the
+pre-existing (independent) RC-op check — the builtin-name gap only flips
+classification for the zero-RC-op shape above. No TIR golden snapshot changed
+(`run_snapshots`' corpus stops at post-Perceus, before `Opt.run` and the
+affected passes — `Inline`/`single_use_inline`/`dce`/`fusion` — ever run), and
+no other test's pass/fail status moved.
+
+**Test counts:** `run_compiler` 612, `run_eval` 256, `run_codegen` 509 (all
+`-e`, all exit 0). `run_stdlib -q` 780 (exit 0). `run_snapshots` 33/33.
+`dune build @runtest`: 4179/4179 plus one pre-existing unrelated failure,
+`adversarial-regressions` #39 (`MARCH_SANITIZE` sanitized-binary 30s timeout
+under machine load) — reproduces byte-for-byte on unmodified `HEAD` (confirmed
+by temporarily reverting the fix, rebuilding, and rerunning that one test
+before restoring the fix), consistent with the machine-wide ASAN hazard
+already on record in this file (2026-07-18 entry).
+
+---
+
 ## Current State (as of 2026-07-28, refinement legibility: `--refine-report`, measure aliases, `cap verified`)
 
 **A refinement obligation now leaves a record, so the checked fraction is a

--- a/specs/todos.md
+++ b/specs/todos.md
@@ -8,6 +8,63 @@ This file tracks everything that still needs to get done. Organized by priority 
 
 ---
 
+## Purity oracle mismatched monomorphized builtin names (FIXED 2026-07-28)
+
+**Symptom.** `lib/tir/purity.ml`'s `is_pure_ext` matched an `EApp` callee's name
+against `impure_builtins` (bare names like `"println"`) with exact `List.mem`
+equality. Monomorphization (`lib/tir/mono.ml`'s `mangle_name`, via
+`Tir_names.specialize_mangle`) rewrites calls to specialized names before
+`Opt.run` (which consumes the purity oracle) ever sees them — `println` becomes
+`println$String`. The exact match failed, so `println$String` (and every other
+specialized impure builtin) was silently classified PURE.
+
+**Consequence.** `test/native/single_use_inline_rc.march` (wired at `test/dune`,
+alias `single_use_inline_rc`) was vacuous: its `helper` (calls `println` twice,
+zero RC ops in its body — a borrowed `List(Int)` param, string literals, scalar
+return) was eliminated by the ordinary `Inline` pass regardless of whether
+`single_use_inline.ml` ran at all, because `Inline` requires purity and the
+buggy oracle said `helper` was pure. No live miscompile was found or is claimed
+— DCE does not drop dead impure-looking bindings, and impure-inlining output
+parity held across the corpus — this was a latent correctness defect in the
+oracle plus a real test-integrity gap.
+
+**Fix.** Added `Tir_names.strip_specialization_suffix` (next to
+`specialize_mangle`, `lib/tir/tir_names.ml`) as the single home for inverting
+the "$"-suffix mangling convention: find the last `.` (or start of string),
+take the first `$` at-or-after that position, truncate there. This correctly
+leaves an interface-impl mangle's own `.`-preceding `$` (e.g.
+`"Show$List.show"`) untouched while stripping only the specialization suffix
+(`"Show$List.show$Int"` -> `"Show$List.show"`; `"println$String"` -> `"println"`;
+`"List.map$Int"` -> `"List.map"`). `purity.ml`'s `EApp` case now matches the
+stripped base name against `impure_builtins` (and the transitive impure-fn set),
+so a specialized impure builtin is no longer misclassified. Unit tests added in
+`test/test_codegen.ml`'s `tir_names` group covering all three shapes plus the
+no-`$`-at-all case and round-trips through `specialize_mangle`/`iface_mangle`.
+
+**Verified non-vacuous.** With the fix applied, disabling
+`single_use_inline.ml`'s eligibility predicate (`if false && ...` at line 309)
+and recompiling `single_use_inline_rc.march` with `--emit-llvm` leaves `@helper`
+in the emitted LLVM (both `define` and `call`) — the native test's grep guard
+would now fail. Restoring the predicate eliminates `@helper` again. The test
+genuinely exercises `single_use_inline` now.
+
+**Behavior shift measured, smaller than initially anticipated.** Because
+`Opt.run` runs after Perceus RC-insertion, most function bodies already contain
+`EIncRC`/`EDecRC`/etc. and were already classified impure by the pre-existing
+RC-op check, independent of this bug. The builtin-name gap only flips
+classification for bodies with zero RC ops that call a specialized impure
+builtin — the `single_use_inline_rc.march` shape is the paradigm case. No TIR
+golden snapshot changed (`test/run_snapshots.exe`'s corpus stops at
+post-Perceus, before `Opt.run`/the affected passes ever execute) and no other
+test's pass/fail status changed. Full suite results: `run_codegen` 509/509,
+`run_compiler` 612/612, `run_eval` 256/256, `run_stdlib -q` clean (Slow tests
+skipped), `run_snapshots` 33/33, `dune build @runtest` 4179/4179 plus one
+pre-existing unrelated failure (`adversarial-regressions` #39, an ASAN-binary
+30s-timeout under machine load — reproduces identically on unmodified `HEAD`,
+confirmed by reverting the fix and rerunning before restoring it).
+
+---
+
 ## A measure over the refined value only worked under one spelling (FIXED 2026-07-27)
 
 **Symptom.** `{List(a) | len(_) > 0}` and `{v : List(a) | len(v) > 0}` parsed,

--- a/test/test_codegen.ml
+++ b/test/test_codegen.ml
@@ -229,6 +229,29 @@ let test_tir_names_specialize_mangle () =
     (March_tir.Tir_names.is_iface_mangled
        (March_tir.Tir_names.specialize_mangle "map" "Int"))
 
+let test_tir_names_strip_specialization_suffix () =
+  (* No '.' at all: first '$' is the specialization separator. *)
+  Alcotest.(check string) "println$String -> println" "println"
+    (March_tir.Tir_names.strip_specialization_suffix "println$String");
+  (* '$' after the last '.': ordinary specialized generic fn. *)
+  Alcotest.(check string) "List.map$Int -> List.map" "List.map"
+    (March_tir.Tir_names.strip_specialization_suffix "List.map$Int");
+  (* '$' before the last '.' is part of an interface-impl mangle (base);
+     only the '$' AFTER the last '.' is the specialization separator. *)
+  Alcotest.(check string) "Show$List.show$Int -> Show$List.show" "Show$List.show"
+    (March_tir.Tir_names.strip_specialization_suffix "Show$List.show$Int");
+  (* No '$' at all: unchanged. *)
+  Alcotest.(check string) "map (no $) -> map" "map"
+    (March_tir.Tir_names.strip_specialization_suffix "map");
+  (* Round-trips against the actual producer, specialize_mangle. *)
+  Alcotest.(check string) "round-trip through specialize_mangle" "println"
+    (March_tir.Tir_names.strip_specialization_suffix
+       (March_tir.Tir_names.specialize_mangle "println" "String"));
+  let iface_base = March_tir.Tir_names.iface_mangle ~iface:"Show" ~ty:"List" ~meth:"show" in
+  Alcotest.(check string) "round-trip through iface + specialize mangle" iface_base
+    (March_tir.Tir_names.strip_specialization_suffix
+       (March_tir.Tir_names.specialize_mangle iface_base "List_Int"))
+
 let test_tir_names_bool_tags () =
   Alcotest.(check string) "synthetic_true_tag" "True" March_tir.Tir_names.synthetic_true_tag;
   Alcotest.(check string) "synthetic_false_tag" "False" March_tir.Tir_names.synthetic_false_tag;
@@ -11709,6 +11732,7 @@ let codegen_suites =
           Alcotest.test_case "is_try_call"                 `Quick test_tir_names_try_call;
           Alcotest.test_case "test/setup fn names"         `Quick test_tir_names_test_and_setup_fn_names;
           Alcotest.test_case "specialize_mangle"           `Quick test_tir_names_specialize_mangle;
+          Alcotest.test_case "strip_specialization_suffix" `Quick test_tir_names_strip_specialization_suffix;
           Alcotest.test_case "bool tags"                   `Quick test_tir_names_bool_tags;
         ] );
       ( "fnfused_coverage", [


### PR DESCRIPTION
## Summary

`lib/tir/purity.ml` decided impurity with an **exact** string match against a list of **bare** builtin names:

```ocaml
not (List.mem f.Tir.v_name impure_builtins)   (* impure_builtins holds "println", … *)
```

But monomorphization rewrites calls through `Tir_names.specialize_mangle` (`base ^ "$" ^ mangled_ty`), so by the time `Opt.run` executes the TIR contains **`println$String`**, not `println`. The match failed and a known-impure builtin was classified **pure**.

Verified directly: `--dump-tir --opt 2` shows `println$String`, and a function whose body calls `println` gets inlined by the purity-gated ordinary `Inline` pass.

## What this actually broke

**A real test-integrity defect.** `test/native/single_use_inline_rc.march` — the only compiled end-to-end regression for single-use inlining — was **vacuous**. Its `helper` was eliminated by the ordinary `Inline` pass regardless, so the test passed even with `single_use_inline.ml` fully disabled. It would have passed with that file deleted.

**Honest scoping: I could not produce a miscompile.** I probed the obvious candidates — `dce.ml:140` uses the same oracle to decide whether a dead binding can be *dropped*, which would delete a side effect; and effect duplication across multiple call sites and loops. The side effect survives, and compiled/interpreted output matched exactly in every shape tried. So this is a **latent correctness defect plus a real test defect**, not a known live miscompile. The oracle feeds four passes (`inline.ml`, `single_use_inline.ml`, `dce.ml`, and 8 sites in `fusion.ml`), all of which were getting an over-permissive answer.

## The fix

`Tir_names.strip_specialization_suffix` — placed in `tir_names.ml`, the repo's designated single home for name contracts, specifically to avoid the "same predicate re-derived at two sites, one goes stale" pattern this repo has hit before. It respects the existing scheme:

| Name | Base |
| --- | --- |
| `println$String` | `println` |
| `List.map$Int` | `List.map` |
| `Show$List.show$Int` | `Show$List.show` |

(find the last `.`; take the first `$` at-or-after it). Conservatism is left to the **caller**: `Purity` matches the stripped base and treats an unrecognized name as impure — the safe direction, losing optimization rather than risking a miscompile.

## The test is now provably non-vacuous

Disabling `single_use_inline`'s eligibility predicate leaves `@helper` in the emitted LLVM (test fails); restoring it eliminates `@helper` again (test passes). That's the check the old test could never make.

## Why the behavior shift is small

Worth knowing for reviewers: `purity.ml` already returns *impure* for anything containing `EIncRC`/`EDecRC`/`EFree`/`EReuse` or an `ECallPtr`. Since `Opt.run` executes **after** Perceus, essentially every non-trivial body already carries RC ops — so most functions were already classified impure regardless of builtin-name matching. This fix only changes classification for bodies with **no RC ops at all**, which is exactly the shape of the affected test fixture.

Consequently: **no snapshot changes and no other test flipped.**

## Test plan

- [x] Unit tests for the helper: all three name shapes above, plus a name with no `$`
- [x] `run_codegen` 509, `run_compiler` 612, `run_eval` 256, `run_stdlib -q` 780, `run_snapshots` 33 — all exit 0
- [x] `dune build @runtest` 4179/4179 (reaches the `test/dune`-rule tests the alcotest binaries don't), plus 1 pre-existing unrelated ASAN timeout confirmed reproducing identically on unmodified HEAD
- [x] doc-lint clean