### PR TITLE
refactor(tir): share the SCC helper; document single-use-inline's invariants

### DIFF
--- a/lib/tir/inline.ml
+++ b/lib/tir/inline.ml
@@ -70,13 +70,20 @@ let direct_candidate_calls candidates expr =
   in
   collect SSet.empty expr
 
-(** Return candidates that participate in recursive call-graph SCCs. *)
-let recursive_candidate_names (candidates : (string, Tir.fn_def) Hashtbl.t)
+(** Tarjan's SCC algorithm, generic over any [name -> successor names] graph.
+    Returns the subset of graph nodes that participate in a call-graph cycle:
+    an SCC with more than one member, or a singleton with a direct self-edge.
+    Both inliner passes (this module's [recursive_candidate_names], keyed off
+    [direct_candidate_calls], and [Single_use_inline.run], keyed off its own
+    reference-counting scan) need exactly this "which candidates are
+    recursive, so exclude them from inlining" computation — only the way the
+    [successors] table gets built differs between them. Keep this the single
+    implementation: a subtle SCC bug (an off-by-one in [lowlinks], a missed
+    self-loop) is easy to introduce and hard to notice in either caller, and
+    having two hand-rolled copies is exactly the "same predicate re-derived
+    twice, one goes stale" trap this codebase has been bitten by before. *)
+let recursive_names_in_graph (successors : (string, SSet.t) Hashtbl.t)
     : SSet.t =
-  let successors : (string, SSet.t) Hashtbl.t = Hashtbl.create 16 in
-  Hashtbl.iter (fun name fn ->
-    Hashtbl.add successors name (direct_candidate_calls candidates fn.Tir.fn_body)
-  ) candidates;
   let indices : (string, int) Hashtbl.t = Hashtbl.create 16 in
   let lowlinks : (string, int) Hashtbl.t = Hashtbl.create 16 in
   let index = ref 0 in
@@ -122,6 +129,15 @@ let recursive_candidate_names (candidates : (string, Tir.fn_def) Hashtbl.t)
     if not (Hashtbl.mem indices name) then strongconnect name
   ) successors;
   !recursive
+
+(** Return candidates that participate in recursive call-graph SCCs. *)
+let recursive_candidate_names (candidates : (string, Tir.fn_def) Hashtbl.t)
+    : SSet.t =
+  let successors : (string, SSet.t) Hashtbl.t = Hashtbl.create 16 in
+  Hashtbl.iter (fun name fn ->
+    Hashtbl.add successors name (direct_candidate_calls candidates fn.Tir.fn_body)
+  ) candidates;
+  recursive_names_in_graph successors
 
 (** Alpha-rename: give each parameter and let-bound variable a fresh name. *)
 let gensym =

--- a/lib/tir/opt.ml
+++ b/lib/tir/opt.ml
@@ -19,6 +19,17 @@
     a label of the form ["tir-opt-{iter}-{pass}"] and the post-pass module.
     When [~snap] is omitted (or is a no-op) behaviour is identical to before. *)
 
+(* NOTE — [Beta_adt] is deliberately NOT in this list.  It runs once,
+   PRE-Perceus (bin/main.ml, "tir-beta-adt-pre").  That placement is
+   load-bearing for [Single_use_inline]'s capture guard: pre-Perceus a
+   collapsed case-branch binder is still a plain copy that Cprop/Dce
+   erase, whereas post-Perceus it becomes "let f = inc_rc $fN; $fN" and
+   would survive — depositing a plain, user-chosen name into a scope that
+   is lexically dead but still live in codegen's flat-per-function
+   [var_slot].  Moving Beta_adt into this loop (or adding any other
+   post-Perceus case-of-known-constructor reduction) would make a
+   currently-unreachable variable-capture bug reachable.  See the guard
+   comment in lib/tir/single_use_inline.ml before changing this. *)
 let named_passes = [
   "join-points", Join_points.run;
   "known-call",  Known_call.run;

--- a/lib/tir/single_use_inline.ml
+++ b/lib/tir/single_use_inline.ml
@@ -86,7 +86,41 @@ let rewrite_expr ~changed candidates candidate_free_names resolve_name ~bound =
          the callee's bound variables cannot repair that provenance
          loss, so conservatively retain this one call when scopes
          collide. This keeps the rejection local to the one-use pass
-         instead of alpha-renaming unrelated caller bindings. *)
+         instead of alpha-renaming unrelated caller bindings.
+
+         WHY A *LEXICAL* [bound] IS SUFFICIENT, EVEN THOUGH THE THING IT
+         DEFENDS AGAINST IS NOT LEXICAL.  Codegen's shadowing map,
+         [Llvm_ctx.ctx.var_slot], is FLAT PER FUNCTION: cleared at entry
+         and snapshotted/restored only across [ECase] branches, never at
+         an [ELet]/[ESeq] scope end.  So a caller binder in an EARLIER
+         [ESeq] component is "dead" lexically (absent from [bound]) yet
+         still live in [var_slot] when the relocated body is emitted, and
+         a callee free [AVar] naming a global would then load that stale
+         local instead.  This was reproduced synthetically (hand-built
+         TIR: a body returning global [G] returned the caller's local 7
+         instead of 41), so the hazard is real in principle.
+
+         It is nevertheless unreachable from March source today, and the
+         block rests on three separate invariants — instrumenting this
+         pass over 73 programs found 10,941 inlines, 1,221 distinct names
+         in such dead scopes, and ZERO plain user-chosen ones among them:
+           (a) [Inline.alpha_rename] freshens every binder it relocates to
+               "name_i<N>" (checked unique), so anything an inline drops
+               into a dead scope can never equal a global's name;
+           (b) [llvm_case] snapshots/restores [var_slot] per branch, so
+               branch binders — the one place plain user names survive
+               post-Perceus, as "let f = inc_rc $fN; $fN" — stay contained;
+           (c) [Beta_adt], the only pass that could lift such a branch
+               binder OUT of its [ECase], runs PRE-Perceus, where the
+               binder is still a plain copy that Cprop/Dce erase.
+         Break any of those and this becomes live.  In particular, moving
+         [Beta_adt] into [Opt.named_passes] (or adding any post-Perceus
+         case-of-known-constructor reduction) would start depositing
+         plain, RC-carrying user names into [ELet]-RHS dead scopes.
+
+         For scale: [Inline.run] has NO capture guard at all — it relies
+         purely on [alpha_rename] — so this guard is already strictly
+         stronger than the pipeline's general inliner. *)
       if not (SSet.is_empty (SSet.inter bound free_names)) then call
       else
         match Inline.expand_call fn args with
@@ -209,6 +243,17 @@ let run ~changed (module_ : Tir.tir_module) : Tir.tir_module =
     | Tir.AVar var when not (SSet.mem var.Tir.v_name bound) ->
       record_free caller var.Tir.v_name;
       record_resolved occurrence (resolve_name var.Tir.v_name)
+    (* Deliberate asymmetry with the [AVar] arm above: this records the
+       occurrence (so the single-use COUNT stays correct) but does NOT
+       call [record_free], so an [ADefRef]-only reference never enters
+       [free_names] and is invisible to the capture guard.  That is safe,
+       not an oversight: [ADefRef] is emitted at exactly one site,
+       llvm_emit.ml's ("ptr", "@" ^ llvm_name (mangle_extern …)) arm,
+       unconditionally and with no [var_slot] consultation — capture can
+       only happen through the var_slot-sensitive [AVar] paths.  (For
+       belt and braces, [Inline.alpha_rename] also folds ADefRef names
+       into its used-name set, so freshening can never mint a local equal
+       to an ADefRef target.) *)
     | Tir.ADefRef def
       when SSet.mem def.Tir.did_name top_names ->
       record def.Tir.did_name occurrence

--- a/lib/tir/single_use_inline.ml
+++ b/lib/tir/single_use_inline.ml
@@ -1,3 +1,65 @@
+(** Single-use, impure-body inlining pass.
+
+    Relocates a top-level function's body to its single call site — the
+    complement of [Inline], which only handles syntactically *pure*
+    candidates. Scope:
+    - Impure-only: candidacy is gated on
+      [not (Purity.is_pure fn.Tir.fn_body)] below. A syntactically pure
+      function stays [Inline]'s responsibility (it can be duplicated freely
+      across several call sites, so it doesn't need this pass's
+      single-reference restriction). This pass exists because an impure body
+      may only ever be relocated, never duplicated: duplicating it would
+      duplicate its observable side effects, so it is only sound when there
+      is exactly one call site to move it to.
+    - Exhaustive reference counting: the eligibility test is "exactly one
+      *total* free top-level reference in the whole artifact, and that
+      occurrence is an arity-correct direct [EApp]". [scan_atom]/[scan_expr]
+      below must visit every atom position in every body with no gaps —
+      that's why [ADefRef], closure-stored atoms, [ECallPtr] targets, etc.
+      all count via [NonDirect] rather than being skipped. A future new
+      [Tir.expr]/[Tir.atom] constructor MUST be added to these scan
+      functions too, or a real (uncounted) second reference would make the
+      function wrongly look single-use.
+    - This pass never deletes a function definition: [run] below rebuilds
+      [tm_fns] with every [fn_def] intact and only rewrites [fn_body] at call
+      sites, leaving deletion to DCE's independent reachability analysis.
+      That is why an under-count in the reference scan above degrades to a
+      *code-size* hazard rather than a soundness one: the original
+      definition survives, so a missed second caller still reaches a whole,
+      correct copy of the body — it just also gets a duplicate relocated
+      into the (wrongly-believed) sole call site. Each dynamic call still
+      executes exactly one copy of the body; nothing dangles and no
+      side effect fires an extra time. This is the main reason the pass is
+      forgiving of its own edge cases — but it is not a license to be sloppy
+      in the scan, since silent code bloat is still a real defect.
+    - Post-Perceus, "impure" is a very wide net. [Purity.is_pure] (used
+      unparameterized here, i.e. with no known-impure user functions) treats
+      any body containing [EIncRC]/[EDecRC]/[EFree]/[EReuse]/atomic-RC or an
+      [ECallPtr] as impure — see `lib/tir/purity.ml`. Because this pass runs
+      inside [Opt.run] strictly after Perceus (see below), essentially every
+      non-trivial function body already carries RC ops by construction, so
+      almost every candidate is "impure" in this sense and falls to this
+      pass rather than to [Inline.run] (which requires purity). In practice
+      this pass, not [Inline.run], does most of the single-call-site
+      inlining once Perceus has run — despite the "impure-only" framing
+      above sounding like a narrow carve-out. Keep that in mind when judging
+      the blast radius of a change here: it is not a rarely-hit corner case.
+    - Perceus must already have run. Ownership operations ([EIncRC],
+      [EDecRC], [EFree], [EReuse], the atomic RC variants) are relocated
+      verbatim, in their original order, alongside the body they annotate —
+      soundness depends on those ops already being explicit in the TIR by
+      the time this pass runs. Nothing here asserts that; the ordering is
+      enforced only by [Opt.named_passes] running after
+      [March_tir.Perceus.perceus] in the driver (see `bin/main.ml`, and the
+      pass-order comment atop `lib/tir/opt.ml`). If that invocation order
+      is ever changed — e.g. `Opt.run` moved ahead of `Perceus.perceus`, or
+      a caller runs `Opt.run` standalone on pre-Perceus TIR — this pass
+      would silently relocate a pre-RC body as if it carried real RC ops,
+      miscompiling with no error at any stage. There is no cheap way to
+      assert this locally (the pass has no reliable, zero-cost signal that
+      RC insertion has or hasn't happened yet), so watch this ordering by
+      hand when touching the pass list. *)
+
 module SSet = Set.Make (String)
 
 type occurrence =
@@ -8,54 +70,6 @@ type summary = {
   mutable count : int;
   mutable sole : occurrence option;
 }
-
-let recursive_names successors =
-  let indices : (string, int) Hashtbl.t = Hashtbl.create 16 in
-  let lowlinks : (string, int) Hashtbl.t = Hashtbl.create 16 in
-  let index = ref 0 in
-  let stack = ref [] in
-  let on_stack = ref SSet.empty in
-  let recursive = ref SSet.empty in
-  let rec strongconnect name =
-    Hashtbl.add indices name !index;
-    Hashtbl.add lowlinks name !index;
-    incr index;
-    stack := name :: !stack;
-    on_stack := SSet.add name !on_stack;
-    SSet.iter
-      (fun successor ->
-        if not (Hashtbl.mem indices successor) then begin
-          strongconnect successor;
-          Hashtbl.replace lowlinks name
-            (min (Hashtbl.find lowlinks name)
-               (Hashtbl.find lowlinks successor))
-        end else if SSet.mem successor !on_stack then
-          Hashtbl.replace lowlinks name
-            (min (Hashtbl.find lowlinks name)
-               (Hashtbl.find indices successor)))
-      (Hashtbl.find successors name);
-    if Hashtbl.find lowlinks name = Hashtbl.find indices name then begin
-      let rec pop_component component =
-        match !stack with
-        | member :: rest ->
-          stack := rest;
-          on_stack := SSet.remove member !on_stack;
-          let component = SSet.add member component in
-          if String.equal member name then component
-          else pop_component component
-        | [] -> assert false
-      in
-      let component = pop_component SSet.empty in
-      if SSet.cardinal component > 1
-         || SSet.mem name (Hashtbl.find successors name) then
-        recursive := SSet.union component !recursive
-    end
-  in
-  Hashtbl.iter
-    (fun name _ ->
-      if not (Hashtbl.mem indices name) then strongconnect name)
-    successors;
-  !recursive
 
 let rewrite_expr ~changed candidates candidate_free_names resolve_name ~bound =
   let try_inline_call ~bound ~args ~call candidate_name =
@@ -295,7 +309,7 @@ let run ~changed (module_ : Tir.tir_module) : Tir.tir_module =
       scan_expr ~caller:fn.Tir.fn_name ~bound fn.Tir.fn_body)
     module_.Tir.tm_fns;
   let roots = SSet.of_list (Dce.root_names module_) in
-  let recursive = recursive_names successors in
+  let recursive = Inline.recursive_names_in_graph successors in
   let candidates : (string, Tir.fn_def) Hashtbl.t = Hashtbl.create 16 in
   List.iter
     (fun fn ->


### PR DESCRIPTION
## Summary

Maintainability findings from a broad three-reviewer code review of single-use inlining. **No behavior change** — a pure refactor plus documentation.

The review found no confirmed miscompiles in the pass. What it did find is that the reasoning keeping it correct lives mostly outside the code.

## 1. Duplicated Tarjan SCC

`inline.ml` and `single_use_inline.ml` each carried a near-identical hand-rolled Tarjan SCC — differing only in formatting and one commutative `SSet.union` argument order. Both answer "which candidate names participate in a cycle" so recursive functions are excluded from inlining. A correctness fix to one had nothing forcing it into the other, and SCC bugs are subtle and rarely exercised, so a missed twin fix could sit unnoticed indefinitely.

Now one shared `Inline.recursive_names_in_graph`, parameterized by the successors graph its two callers build differently.

**Proof it's behavior-preserving:** TIR golden snapshots are **byte-identical with no regeneration**, and all suite counts are unchanged.

## 2. `single_use_inline.ml` had no module documentation

Its load-bearing invariants lived only in `specs/optimizations.md`. The new header records five, each verified against the code:

- **Impure-only** — pure functions stay the ordinary inliner's responsibility.
- **Exhaustive reference scanning** — a new `Tir.expr`/`Tir.atom` constructor *must* be added to the scan, or a real second reference goes uncounted.
- **The pass never deletes a definition.** `run` rebuilds `tm_fns` intact; deletion is DCE's independent call. This is why an under-count degrades to *code bloat* rather than a dangling reference — the main reason the pass is forgiving of its own edge cases.
- **Post-Perceus, "impure" is a very wide net.** Since `purity.ml` treats any body with RC ops as impure, and Opt runs after Perceus, almost everything qualifies. **In practice this pass — not `Inline.run` — does most of the single-call-site inlining at `-O2`**, despite the "impure-only" framing sounding like a narrow carve-out. That matters when judging the blast radius of any change here.
- **Perceus must already have run,** and *nothing asserts it*. If `Opt.run` were ever moved ahead of `Perceus.perceus`, this pass would relocate a pre-RC body as though it carried real RC ops and **silently miscompile**.

## 3. Why the capture guard's lexical scope is sufficient

The most valuable finding. The guard's `bound` is **lexical**, but the mechanism it defends against — codegen's `var_slot` — is **flat per function**, restored only across `ECase` branches. A reviewer *reproduced* the resulting capture with hand-built TIR: a relocated body returning global `G` instead returned the caller's local (`7` rather than `41`).

It is **unreachable from March source**. Instrumenting the pass across 73 programs: **10,941 inlines, 1,221 distinct names in such dead scopes, and zero plain user-chosen ones** — every one was a lowering gensym or alpha-rename residue.

Three invariants hold that line:
1. `Inline.alpha_rename` freshens every relocated binder to `name_i<N>`, so it can never equal a global.
2. `llvm_case` snapshots/restores `var_slot` per branch, containing the one place plain user names survive post-Perceus.
3. **`Beta_adt` — the only pass that could lift such a binder out of its `ECase` — runs pre-Perceus**, where it's still a plain copy that Cprop/Dce erase.

**That third one is the fragile edge and had no marker anywhere.** Moving `Beta_adt` into `Opt.named_passes` (or adding any post-Perceus case-of-known-constructor reduction) would make this bug live. Now noted at both the guard and the pass list.

Also recorded: the `ADefRef`/`AVar` asymmetry in `scan_atom` is deliberate, not an oversight — `ADefRef` is emitted unconditionally with no `var_slot` lookup, so it cannot be captured.

For scale, worth knowing: **`Inline.run` has no capture guard at all**, relying purely on `alpha_rename`. This pass's guard is already strictly stronger than the pipeline's general inliner.

## Test plan

- [x] `run_codegen`, `run_compiler`, `run_eval`, `run_stdlib -q` — all exit 0, counts identical before and after the refactor
- [x] `run_snapshots` 33/33 **byte-identical, no regeneration** — the real proof the SCC extraction changed nothing
- [x] Comments-only changes verified to build with snapshots unchanged