### PR TITLE
fix(forge): make the embedded registry client compile

### DIFF
--- a/forge/tasks/forge_registry.march
+++ b/forge/tasks/forge_registry.march
@@ -275,7 +275,7 @@ pfn make_tarball(pkg_dir, out_path) do
   Err(e)  -> Err("tar failed: " ++ e)
   Ok(res) ->
     match res do
-    ProcessResult(code, _, stderr) ->
+    Process.ProcessResult(code, _, stderr) ->
       if code == 0 do Ok(out_path) else Err("tar exit " ++ int_to_string(code) ++ ": " ++ stderr) end
     end
   end
@@ -390,7 +390,7 @@ pfn run_fetch() do
     Ok((st, bd)) ->
       if st >= 200 && st < 300 do
         match File.write(out, bd) do
-        Err(e) -> do println("write failed: " ++ e) Process.exit(2) end
+        Err(e) -> do println("write failed: " ++ to_string(e)) Process.exit(2) end
         Ok(_)  -> do println("ok " ++ int_to_string(st) ++ " " ++ int_to_string(String.byte_size(bd))) Process.exit(0) end
         end
       else


### PR DESCRIPTION
Follow-up to #106 — this commit was on that branch but the squash-merge landed an earlier state, so the fix is missing from `main`.

`forge deps` compiles `forge/tasks/forge_registry.march` on the fly, so this breaks dependency resolution for **every project with a registry dependency**. It surfaces as `registry client failed to compile` during `forge deps`, nowhere near the file at fault:

```
-- ERROR --------------- /tmp/forge_registry_2e5103.march
Constructor `ProcessResult` is ambiguous between multiple modules:
  • `System.ProcessResult`  • `Process.ProcessResult`
279 |     ProcessResult(code, _, stderr) ->

-- ERROR --------------- /tmp/forge_registry_2e5103.march
expected `String` but got `FileError`.
394 |         Err(e) -> do println("write failed: " ++ e) Process.exit(2) end
```

Two adaptations, the same ones every consumer needs:

- `ProcessResult` is ambiguous between `System` and `Process`; the tar call here means `Process.ProcessResult`.
- `File.write` now fails with a `FileError`, not a `String`, so the error path goes through `to_string`.

Verified: `march --check forge/tasks/forge_registry.march` is clean on top of current `main`. This is the sole remaining blocker for ForgePM/forgepm#2, whose CI fails at `forge deps` before reaching any of its own code.