### PR TITLE
fix(docs): mobile navbar crowding hamburger menu

### DIFF
--- a/docs/_includes/search.html
+++ b/docs/_includes/search.html
@@ -350,8 +350,13 @@
   var debounce   = null;
   var queryToken = 0;      // guards against an older query resolving after a newer one
 
-  Array.prototype.forEach.call(document.querySelectorAll('[data-ms-open]'), function (el) {
-    el.addEventListener('click', open);
+  // Delegated rather than bound per-element: this script runs synchronously at its
+  // position in the document, so a static querySelectorAll would miss any trigger
+  // markup a layout places LATER in the DOM (e.g. a mobile drawer nested in a sidebar
+  // that comes after this include). Delegation binds once and matches triggers
+  // regardless of where — or when — they appear.
+  document.addEventListener('click', function (e) {
+    if (e.target.closest('[data-ms-open]')) open();
   });
 
   // Show the platform-correct hint rather than always claiming ⌘.

--- a/docs/_layouts/cookbook.html
+++ b/docs/_layouts/cookbook.html
@@ -91,6 +91,20 @@
       color: var(--text-muted); padding: 6px; line-height: 0;
     }
 
+    /* Search/Docs/GitHub/theme move here on narrow screens — see the
+       .d-mobile-extra rules under the 900px media query below. */
+    .d-mobile-extra { display: none; }
+    .d-mobile-search-btn {
+      display: flex; align-items: center; gap: 8px; width: 100%;
+      background: none; border: 1px solid var(--border); color: var(--text-muted);
+      cursor: pointer; padding: 8px 12px; border-radius: 6px; font-size: 13px;
+      font-family: 'JetBrains Mono', monospace;
+    }
+    .d-mobile-search-btn kbd {
+      margin-left: auto; font-size: 10px; padding: 1px 5px; border-radius: 4px;
+      border: 1px solid var(--border); color: inherit;
+    }
+
     /* ── LAYOUT ──────────────────────────────────────────────────────────── */
     .d-layout {
       display: flex; padding-top: 60px; min-height: 100vh;
@@ -311,6 +325,15 @@
       .d-hamburger { display: block; }
       .d-main { padding: 32px 24px; max-width: 100%; }
       .ck-repl-panel { width: min(var(--ck-panel-w), 100vw); }
+
+      /* Crowd relief: search/Docs/GitHub/theme move into the sidebar drawer so
+         the nav row never has to fit more than the logo + hamburger. */
+      .d-nav-right > *:not(#d-hamburger) { display: none; }
+      .d-mobile-extra {
+        display: flex; flex-direction: column; gap: 8px;
+        padding: 4px 12px 16px; margin-bottom: 12px; border-bottom: 1px solid var(--border);
+      }
+      .d-mobile-extra .d-theme-btn { align-self: flex-start; }
       .d-layout.repl-open { padding-right: 0; }
     }
     @media (max-width: 600px) {
@@ -348,6 +371,18 @@
 
   <aside class="d-sidebar" id="d-sidebar">
     <div class="d-sidebar-inner">
+      <div class="d-mobile-extra">
+        <button type="button" class="d-mobile-search-btn" data-ms-open aria-label="Search docs (Command K)">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/>
+          </svg>
+          <span>Search</span>
+          <kbd>⌘K</kbd>
+        </button>
+        <a href="{{ site.baseurl }}/docs/getting-started/" class="d-sidebar-link" onclick="closeSidebar()">Docs</a>
+        <a href="https://github.com/march-language/march" target="_blank" rel="noopener" class="d-sidebar-link" onclick="closeSidebar()">GitHub</a>
+        <button class="d-theme-btn" id="d-theme-btn-mobile">☀ Light</button>
+      </div>
       <p class="d-sidebar-section">Orientation</p>
       <a href="{{ site.baseurl }}/docs/coming-from-python/" class="d-sidebar-link{% if page.url contains 'coming-from-python' %} active{% endif %}">Coming from Python</a>
       <a href="{{ site.baseurl }}/docs/coming-from-typescript/" class="d-sidebar-link{% if page.url contains 'coming-from-typescript' %} active{% endif %}">Coming from TypeScript</a>
@@ -415,15 +450,21 @@ function initTheme() {
 
 function applyTheme() {
   document.documentElement.classList.toggle('light', !dark);
+  const label = dark ? '☀ Light' : '☾ Dark';
   const btn = document.getElementById('d-theme-btn');
-  if (btn) btn.textContent = dark ? '☀ Light' : '☾ Dark';
+  const btnMobile = document.getElementById('d-theme-btn-mobile');
+  if (btn) btn.textContent = label;
+  if (btnMobile) btnMobile.textContent = label;
 }
 
-document.getElementById('d-theme-btn').addEventListener('click', () => {
+function toggleTheme() {
   dark = !dark;
   localStorage.setItem('march-theme', dark ? 'dark' : 'light');
   applyTheme();
-});
+}
+
+document.getElementById('d-theme-btn').addEventListener('click', toggleTheme);
+document.getElementById('d-theme-btn-mobile').addEventListener('click', toggleTheme);
 
 const sidebar   = document.getElementById('d-sidebar');
 const overlay   = document.getElementById('d-overlay');

--- a/docs/_layouts/docs.html
+++ b/docs/_layouts/docs.html
@@ -90,6 +90,20 @@
       color: var(--text-muted); padding: 6px; line-height: 0;
     }
 
+    /* Search/Home/GitHub/theme move here on narrow screens — see the
+       .d-mobile-extra rules under the 900px media query below. */
+    .d-mobile-extra { display: none; }
+    .d-mobile-search-btn {
+      display: flex; align-items: center; gap: 8px; width: 100%;
+      background: none; border: 1px solid var(--border); color: var(--text-muted);
+      cursor: pointer; padding: 8px 12px; border-radius: 6px; font-size: 13px;
+      font-family: 'JetBrains Mono', monospace;
+    }
+    .d-mobile-search-btn kbd {
+      margin-left: auto; font-size: 10px; padding: 1px 5px; border-radius: 4px;
+      border: 1px solid var(--border); color: inherit;
+    }
+
     /* ── LAYOUT ──────────────────────────────────────────────────────────── */
     .d-layout { display: flex; padding-top: 60px; min-height: 100vh; }
 
@@ -221,6 +235,15 @@
       .d-sidebar.open { transform: translateX(0); }
       .d-hamburger { display: block; }
       .d-main { padding: 32px 24px; max-width: 100%; }
+
+      /* Crowd relief: search/Home/GitHub/theme move into the sidebar drawer so
+         the nav row never has to fit more than the logo + hamburger. */
+      .d-nav-right > *:not(#d-hamburger) { display: none; }
+      .d-mobile-extra {
+        display: flex; flex-direction: column; gap: 8px;
+        padding: 4px 12px 16px; margin-bottom: 12px; border-bottom: 1px solid var(--border);
+      }
+      .d-mobile-extra .d-theme-btn { align-self: flex-start; }
     }
     @media (max-width: 600px) {
       .d-nav-inner { padding: 0 16px; }
@@ -260,6 +283,18 @@
   <!-- SIDEBAR -->
   <aside class="d-sidebar" id="d-sidebar">
     <div class="d-sidebar-inner">
+      <div class="d-mobile-extra">
+        <button type="button" class="d-mobile-search-btn" data-ms-open aria-label="Search docs (Command K)">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/>
+          </svg>
+          <span>Search</span>
+          <kbd>⌘K</kbd>
+        </button>
+        <a href="{{ site.baseurl }}/" class="d-sidebar-link" onclick="closeSidebar()">Home</a>
+        <a href="https://github.com/march-language/march" target="_blank" rel="noopener" class="d-sidebar-link" onclick="closeSidebar()">GitHub</a>
+        <button class="d-theme-btn" id="d-theme-btn-mobile">☀ Light</button>
+      </div>
       {% assign nav_pages = site.pages | sort: 'nav_order' %}
 
       <p class="d-sidebar-section">Start Here</p>
@@ -328,15 +363,21 @@ function initTheme() {
 
 function applyTheme() {
   document.documentElement.classList.toggle('light', !dark);
+  const label = dark ? '☀ Light' : '☾ Dark';
   const btn = document.getElementById('d-theme-btn');
-  if (btn) btn.textContent = dark ? '☀ Light' : '☾ Dark';
+  const btnMobile = document.getElementById('d-theme-btn-mobile');
+  if (btn) btn.textContent = label;
+  if (btnMobile) btnMobile.textContent = label;
 }
 
-document.getElementById('d-theme-btn').addEventListener('click', () => {
+function toggleTheme() {
   dark = !dark;
   localStorage.setItem('march-theme', dark ? 'dark' : 'light');
   applyTheme();
-});
+}
+
+document.getElementById('d-theme-btn').addEventListener('click', toggleTheme);
+document.getElementById('d-theme-btn-mobile').addEventListener('click', toggleTheme);
 
 const sidebar  = document.getElementById('d-sidebar');
 const overlay  = document.getElementById('d-overlay');


### PR DESCRIPTION
## Summary
- Search, Home/Docs, GitHub, and the theme toggle were crammed into the same row as the hamburger with no wrapping, so on small phones the row overflowed and pushed the hamburger off-screen entirely (reported: navbar broken on https://march-lang.org/docs/getting-started/ on small phones).
- Those controls now move to the top of the sidebar drawer below 900px in both `docs.html` and `cookbook.html`, matching the pattern already used on the landing page.
- Fixed a latent bug in the shared `search.html` component: it bound click listeners via a one-time `querySelectorAll` at parse time, so a trigger placed later in the DOM (the new drawer button) was never wired up. Switched to event delegation.

## Test plan
- [x] Built the site locally with `scripts/serve-docs.sh` and verified at 375px width: hamburger no longer clipped off-screen, drawer opens with search/Home/GitHub/theme at top, search modal opens and works, theme toggle syncs both buttons.
- [x] Verified desktop (1280px) layout is unchanged.
- [x] Repeated for `/docs/cookbook/`.