### PR TITLE
fix(forge): resolve ambiguous ProcessResult and FileError-to-String bug in forge_registry.march

### DIFF
--- a/forge/tasks/forge_registry.march
+++ b/forge/tasks/forge_registry.march
@@ -275,7 +275,7 @@ pfn make_tarball(pkg_dir, out_path) do
   Err(e)  -> Err("tar failed: " ++ e)
   Ok(res) ->
     match res do
-    ProcessResult(code, _, stderr) ->
+    Process.ProcessResult(code, _, stderr) ->
       if code == 0 do Ok(out_path) else Err("tar exit " ++ int_to_string(code) ++ ": " ++ stderr) end
     end
   end
@@ -390,7 +390,7 @@ pfn run_fetch() do
     Ok((st, bd)) ->
       if st >= 200 && st < 300 do
         match File.write(out, bd) do
-        Err(e) -> do println("write failed: " ++ e) Process.exit(2) end
+        Err(e) -> do println("write failed: " ++ to_string(e)) Process.exit(2) end
         Ok(_)  -> do println("ok " ++ int_to_string(st) ++ " " ++ int_to_string(String.byte_size(bd))) Process.exit(0) end
         end
       else


### PR DESCRIPTION
## Summary
Two rounds of fixes, both discovered while running `forge publish` for conduit 0.1.1 — the first two bugs are in forge's own bundled registry-publish client, the third is a stdlib type-collision bug that broke it more fundamentally.

1. `make_tarball` matched a bare `ProcessResult(code, _, stderr)`, ambiguous between `System.ProcessResult` and `Process.ProcessResult` (both declare a type of that name). Qualified as `Process.ProcessResult`.
2. The `FORGE_ACTION=fetch` path concatenated a `FileError` from `File.write` directly as a `String` instead of converting with `to_string(e)`.
3. **The real blocker**: `System` declared its own `type ProcessResult = ProcessResult(Int, String, String)`, documented as "mirrors Process.ProcessResult for symmetry" — a second nominal type sharing Process's bare constructor name. `process_spawn_sync`'s return type is generic (`Result('a, String)`); with two same-named types in scope, every caller that pattern-matched its Ok payload as `ProcessResult(...)` — bare (ambiguous, compile error) or qualified either way (both type-check) — hit a **compiled-backend-only** `panic: non-exhaustive pattern match` at runtime, even though the match is provably exhaustive and the interpreter always took it correctly. Confirmed with a ~10-line standalone repro. Fixed by having `System` `import Process` and reuse `Process.ProcessResult` instead of declaring its own copy.

That fix resolves the isolated repro and `System.cmd` cleanly, but `forge_registry.march`'s own `do_publish` still panicked afterward with no code-shape difference from the now-passing isolated repros — narrowed to a **compiled-backend register-allocation/RC-timing sensitivity to the surrounding function's size/shape** (the same flavor of bug as several other compiled-only issues tracked in `specs/todos.md`). A `println` progress message immediately before the `Process.run` call reliably avoids it (verified over multiple fresh compiles, no flakes). Left in as a genuine progress indicator with a comment explaining it's load-bearing, pending the actual codegen fix — flagged clearly so it isn't accidentally removed as a "cleanup."

## Test plan
- [x] Isolated ~10-line `Process.run` + `Process.ProcessResult(...)` match repro: was a deterministic panic compiled, now passes
- [x] `System.cmd` + `System.exit_code`/`stdout`/`stderr` repro: was a deterministic panic compiled, now passes
- [x] `forge publish` against forgepm.org (real conduit 0.1.1 package, invalid token to avoid actually publishing): full pipeline runs — tar, checksum, multipart upload, TLS request — normal 401 rejection instead of a panic, across 3 consecutive fresh compiles
- [ ] Real `forge publish` with a valid token (conduit maintainer to confirm)