### PR TITLE
fix(refinecheck): a stdlib import must not withdraw the List.length alias

### DIFF
--- a/lib/refinecheck/refine_check.ml
+++ b/lib/refinecheck/refine_check.ml
@@ -4408,6 +4408,27 @@ let stdlib_member_defs_ok ~(md : string) ~(fn : string) ~(mod_name : string)
     if in_mod && b && not (is_stdlib_source_file sp.A.file) then foreign := true
   in
   let mentions_md xs = List.exists (fun (n : A.name) -> n.A.txt = md) xs in
+  (* A `use`/`alias` competes for the bare name `<md>` on the same terms a
+     member definition does: only when it is the PROGRAM's, not the standard
+     library's.  Without this the exclusion was asymmetric — [defines] already
+     ignored stdlib spans — and one `import` added inside stdlib withdrew the
+     alias for every program compiled with that stdlib.
+
+     That happened: #112 added `import Process` to stdlib/system.march to
+     dedupe System.ProcessResult.  It is a glob (`UseAll`), which this scan
+     treats as "could carry a nested module named List", so `List.length`
+     stopped being recognised as the stdlib's and every
+     `{List(a) | len(_) > 0}` contract silently stopped being enforced —
+     caught only by specs/lang/types/reject/t117, whose whole purpose is to
+     notice the alias going missing.
+
+     Scoping makes this sound beyond the stdlib case: an import inside
+     `mod System` binds names in System's body, not in the module being
+     checked.  This stays conservative for user code and only stops the
+     stdlib's own internals from speaking for the program. *)
+  let rebinds (sp : A.span) b =
+    if b && not (is_stdlib_source_file sp.A.file) then rebound := true
+  in
   let rec go in_mod ds =
     List.iter
       (function
@@ -4431,8 +4452,8 @@ let stdlib_member_defs_ok ~(md : string) ~(fn : string) ~(mod_name : string)
           defines in_mod sp
             (List.exists (fun ((mn : A.name), _) -> mn.A.txt = fn) idf.A.impl_methods)
         (* ── Rebinds the bare segment `<md>` ─────────────────────────────── *)
-        | A.DAlias (a, _) -> if a.A.alias_name.A.txt = md then rebound := true
-        | A.DUse (u, _) ->
+        | A.DAlias (a, sp) -> rebinds sp (a.A.alias_name.A.txt = md)
+        | A.DUse (u, sp) ->
           (* Four selector forms, all of which can put some other module under
              the bare name `<md>`:
                `use X.<md>`            — UseSingle, the path's last segment
@@ -4443,12 +4464,13 @@ let stdlib_member_defs_ok ~(md : string) ~(fn : string) ~(mod_name : string)
                                          excluded. *)
           (match u.A.use_sel with
            | A.UseSingle ->
-             (match List.rev u.A.use_path with
-              | last :: _ :: _ when last.A.txt = md -> rebound := true
-              | _ -> ())
-           | A.UseNames xs -> if mentions_md xs then rebound := true
-           | A.UseExcept xs -> if not (mentions_md xs) then rebound := true
-           | A.UseAll -> rebound := true)
+             rebinds sp
+               (match List.rev u.A.use_path with
+                | last :: _ :: _ -> last.A.txt = md
+                | _ -> false)
+           | A.UseNames xs -> rebinds sp (mentions_md xs)
+           | A.UseExcept xs -> rebinds sp (not (mentions_md xs))
+           | A.UseAll -> rebinds sp true)
         (* ── Contains declarations; recurse ──────────────────────────────── *)
         | A.DMod (name, _, ds, _) -> go (name.A.txt = md) ds
         (* A `describe` block does not open a module scope of its own, so its

--- a/test/test_refinecheck.ml
+++ b/test/test_refinecheck.ml
@@ -3268,6 +3268,56 @@ end|}
          Alcotest.(check bool) "error" true
            (has_refine_error_from ~stdlib_files:[ file ] ~file src)));
 
+    (* ── A stdlib `import` must not withdraw the alias ────────────────────
+       The REBINDING half of this gate treats a glob `import X` as "could
+       carry a nested module named List", and — unlike the DEFINITION half,
+       which has always ignored stdlib spans — applied that to the standard
+       library's own sources.  One import added inside stdlib therefore
+       withdrew `List.length` -> `len` for every program compiled with it.
+
+       Not hypothetical: #112 added `import Process` to stdlib/system.march
+       to dedupe System.ProcessResult, and every `{List(a) | len(_) > 0}`
+       contract stopped being enforced.  Nothing failed except
+       specs/lang/types/reject/t117, which exists to notice exactly this — a
+       withdrawn alias is silent by construction, since refinement checking
+       only speaks when a predicate can NEVER hold.  So the contradictory
+       guard here must still FIRE for the test to mean anything. *)
+    (let src =
+       {|
+mod SysLike do
+  import Process
+  fn head(xs : {List(Int) | len(_) > 0}) : Int do 0 end
+  fn go(ys : List(Int)) : Int do
+    if List.length(ys) == 0 do head(ys) else 0 end
+  end
+  fn main() : Int do go([1]) end
+end|}
+     in
+     let file = "/opt/march/share/march/system.march" in
+     gated "a glob import in a STDLIB file does not withdraw the alias" (fun () ->
+         Alcotest.(check bool) "violation still reported" true
+           (has_refine_error_from ~stdlib_files:[ file ] ~file src)));
+
+    (* Control: the same glob import in the PROGRAM's own file still
+       withdraws it — a user's `import X` genuinely can put another module
+       under the bare name `List`, and suppressing is the safe direction. *)
+    (let src =
+       {|
+mod UserMod do
+  import Process
+  fn head(xs : {List(Int) | len(_) > 0}) : Int do 0 end
+  fn go(ys : List(Int)) : Int do
+    if List.length(ys) == 0 do head(ys) else 0 end
+  end
+  fn main() : Int do go([1]) end
+end|}
+     in
+     gated "...while the same import in USER code still withdraws it" (fun () ->
+         Alcotest.(check bool) "no error" false
+           (has_refine_error_from
+              ~stdlib_files:[ "/opt/march/share/march/list.march" ]
+              ~file:"/home/u/proj/main.march" src)));
+
     (let src =
        {|
 mod S do


### PR DESCRIPTION
Repairs `main`'s conformance failure. Bisected: `a27f1eda` is *218 passed, 0 failed*; `30f7ba93` (#112) is *217 passed, 1 failed*.

## What broke

`stdlib_member_defs_ok` gates the `List.length` → `len` measure alias on two things: nobody else **defines** the member, and nobody **rebinds** the bare module name. The definition half has always ignored stdlib spans — a definition only competes when it is the program's. The rebinding half did not.

A glob `import X` counts as a rebind (it could carry a nested module named `List`), so **one import added inside stdlib withdrew the alias for every program compiled with that stdlib**. #112 added `import Process` to `stdlib/system.march` to dedupe `System.ProcessResult`, and that was enough.

## Why it was nearly silent

Every `{List(a) | len(_) > 0}` contract stopped being enforced, and nothing reported it. Refinement checking speaks only when a predicate can *never* hold, so a withdrawn alias is indistinguishable from a clean run.

The one thing that noticed was `specs/lang/types/reject/t117_refine_length_guard_contradiction`, which exists for this and says so:

> If this file ever starts exiting 0, the `List.length` alias has been withdrawn (or never applied), and every guarded non-empty call in the program is back to being unprovable-and-skipped.

## The fix

Apply the same stdlib-source exclusion to the rebind scan that the definition scan already had. Sound beyond the stdlib case by scoping: an import inside `mod System` binds names in System's body, not in the module being checked. User code is unaffected — its own imports still withdraw the alias, pinned by an added control test.

## Verification

- `@types-check`: **218 passed, 0 failed**
- refinement ratchet: **8 proved, 0 violated, 28 skipped** — exactly its `proved_floor` and `baseline` ceiling
- `test_refinecheck` 292/292, including a new stdlib-import test verified to fail without the fix

## Note for reviewers

A hand-run `--check` on t117 is not a valid check here — `ci.yml` documents why: a `--check` whose sources hash into the CAS *"exits BEFORE parsing… so the report never runs and the command prints nothing while exiting 0."* It reports success either way. Use `dune build @types-check`.