### PR TITLE
fix(interp): an idle WebSocket no longer blocks every other connection

### DIFF
--- a/js/dune
+++ b/js/dune
@@ -21,6 +21,16 @@
   march_typecheck
   march_eval
   js_of_ocaml)
+ ; Effects are left at jsoo's default (disabled), which emits a
+ ; [missing-effects-backend] warning because march_eval contains effect
+ ; handlers (the WS fiber parking in run_http_event_loop — see eval.ml's
+ ; [ws_wait_ready]). That handler is unreachable here by construction: it
+ ; only runs under the HTTP server's accept loop, which needs Unix sockets
+ ; that do not exist in a browser. Enabling --effects=double-translation to
+ ; silence the warning costs ~3.3MB (+16%) on this bundle for a code path
+ ; that can never execute, so the warning is accepted deliberately. If a
+ ; future change makes the browser REPL reach an effect handler, switch to
+ ; --effects=double-translation (NOT cps, which slows all code).
  (js_of_ocaml (flags (:standard)))
  (modes js))
 
@@ -40,5 +50,15 @@
   march_tir
   march_driver
   js_of_ocaml)
+ ; Effects are left at jsoo's default (disabled), which emits a
+ ; [missing-effects-backend] warning because march_eval contains effect
+ ; handlers (the WS fiber parking in run_http_event_loop — see eval.ml's
+ ; [ws_wait_ready]). That handler is unreachable here by construction: it
+ ; only runs under the HTTP server's accept loop, which needs Unix sockets
+ ; that do not exist in a browser. Enabling --effects=double-translation to
+ ; silence the warning costs ~3.3MB (+16%) on this bundle for a code path
+ ; that can never execute, so the warning is accepted deliberately. If a
+ ; future change makes the browser REPL reach an effect handler, switch to
+ ; --effects=double-translation (NOT cps, which slows all code).
  (js_of_ocaml (flags (:standard)))
  (modes js))

--- a/lib/eval/eval.ml
+++ b/lib/eval/eval.ml
@@ -2635,16 +2635,61 @@ let rec march_headers_to_string = function
     n ^ ": " ^ v ^ "\r\n" ^ march_headers_to_string rest
   | _ -> ""
 
-(** Send all bytes in [data] to [sock], ignoring short writes. *)
+(* ── Cooperative blocking for WebSocket-owned sockets ───────────────── *)
+(* A WebSocket connection's March handler (e.g. a `ws_loop` that calls
+   WebSocket.recv in a loop) is written in ordinary blocking style: recv
+   must not return until a frame arrives. Running that inline on the
+   single-threaded HTTP event loop would stall EVERY other connection for
+   the WS connection's entire lifetime — one idle browser tab holding a
+   socket open would block all further page loads.
+
+   So a WS-owned socket stays non-blocking, and every recv/send that would
+   block performs [Ws_block] instead. [run_http_event_loop] installs an
+   effect handler that captures the continuation, parks it against the fd,
+   and resumes it once select reports that fd ready. That's the same
+   cooperative discipline the HTTP request/response phases already use —
+   but here the suspension point is deep inside the *interpreted* handler,
+   which is precisely what an effect continuation can capture and a
+   hand-rolled state machine cannot (we do not control the shape of the
+   user's ws_loop).
+
+   Callers with no handler installed — the blocking spawn_n accept loop,
+   or any genuinely blocking socket — get [Effect.Unhandled] and fall back
+   to a blocking select, preserving the previous behavior exactly. *)
+type ws_wait_dir = Ws_wait_read | Ws_wait_write
+
+type _ Effect.t +=
+  Ws_block : (Unix.file_descr * ws_wait_dir) -> unit Effect.t
+
+let ws_wait_ready (sock : Unix.file_descr) (dir : ws_wait_dir) : unit =
+  try Effect.perform (Ws_block (sock, dir))
+  with Effect.Unhandled _ ->
+    (* No event loop driving us: wait synchronously, as before. *)
+    (try
+       match dir with
+       | Ws_wait_read  -> ignore (Unix.select [sock] [] [] (-1.0))
+       | Ws_wait_write -> ignore (Unix.select [] [sock] [] (-1.0))
+     with _ -> ())
+
+(** Send all bytes in [data] to [sock], ignoring short writes.
+    On a non-blocking socket an EAGAIN is a "not yet", never an error:
+    yield until writable and resume, or the response would be silently
+    truncated (the pre-existing [with Unix_error _ -> ()] below would
+    otherwise swallow it). *)
 let tcp_send_all sock data =
   let buf   = Bytes.of_string data in
   let total = Bytes.length buf in
   let off   = ref 0 in
   (try
      while !off < total do
-       let n = Unix.send sock buf !off (total - !off) [] in
-       if n = 0 then off := total
-       else off := !off + n
+       match
+         (try `Sent (Unix.send sock buf !off (total - !off) [])
+          with Unix.Unix_error
+                 ((Unix.EAGAIN | Unix.EWOULDBLOCK | Unix.EINTR), _, _) -> `Again)
+       with
+       | `Again  -> ws_wait_ready sock Ws_wait_write
+       | `Sent 0 -> off := total
+       | `Sent n -> off := !off + n
      done
    with Unix.Unix_error _ -> ())
 
@@ -2872,9 +2917,19 @@ let ws_recv_exact sock (buf : bytes) off n =
   let got = ref 0 in
   let ok  = ref true in
   while !ok && !got < n do
-    let r = Unix.recv sock buf (off + !got) (n - !got) [] in
-    if r = 0 then ok := false
-    else got := !got + r
+    (* EAGAIN on a WS-owned (non-blocking) socket means "no bytes yet", not
+       end-of-stream: yield to the event loop and resume mid-frame. [got]
+       is captured by the continuation, so a frame split across several
+       readiness events reassembles correctly. Without this the caller's
+       catch-all would misread EAGAIN as the peer hanging up. *)
+    match
+      (try `Got (Unix.recv sock buf (off + !got) (n - !got) [])
+       with Unix.Unix_error
+              ((Unix.EAGAIN | Unix.EWOULDBLOCK | Unix.EINTR), _, _) -> `Again)
+    with
+    | `Again -> ws_wait_ready sock Ws_wait_read
+    | `Got 0 -> ok := false
+    | `Got r -> got := !got + r
   done;
   !ok
 
@@ -3181,19 +3236,27 @@ let http_try_parse_request (raw : string) :
     if available_body < content_length then None  (* body not fully arrived yet *)
     else Some (meth, full_path, headers_raw, String.sub raw header_end content_length)
 
-(** Run the pipeline for a fully-received request and produce the response
-    bytes to write (or detect a WebSocket upgrade, returning [None] since
-    there is no ordinary HTTP response to queue in that case). This part is
-    pure in-memory computation (no blocking I/O) except for the WS handshake
-    write and handoff, which — like the prior blocking implementation —
-    intentionally takes over the socket for the lifetime of the WS
-    connection (matching the documented, unchanged semantics of
-    WebSocketUpgrade / handler_fn: once upgraded, this one connection is
-    WS-owned and blocking, exactly as before this fix). *)
+(** What the event loop should do with a connection once its request has
+    been run through the pipeline. *)
+type http_outcome =
+  | HttpRespond of string  (* queue these response bytes for writing *)
+  | HttpWsUpgrade of value (* 101 sent; [value] is the WS handler closure *)
+  | HttpDrop               (* nothing to send — close the connection *)
+
+(** Run the pipeline for a fully-received request and decide the outcome.
+    This is pure in-memory computation (no blocking I/O) apart from the WS
+    handshake write.
+
+    On a WebSocket upgrade the socket is NOT taken over here. The 101 is
+    written and the handler closure is handed back to the event loop, which
+    runs it as a cooperative fiber ([Ws_block] / [ws_wait_ready]) so the WS
+    connection cannot stall the other connections. It also deliberately
+    leaves the socket in non-blocking mode: the fiber depends on recv/send
+    reporting EAGAIN in order to yield. *)
 let http_run_pipeline_and_respond
     (sock : Unix.file_descr) (pipeline_fn : value)
     (meth : string) (full_path : string)
-    (headers_raw : (string * string) list) (body : string) : string option =
+    (headers_raw : (string * string) list) (body : string) : http_outcome =
   let conn_val = build_conn_value
       ~fd:(Obj.magic sock : int)
       ~method_str:meth ~full_path ~headers_raw ~body () in
@@ -3210,7 +3273,7 @@ let http_run_pipeline_and_respond
     in
     (match ws_key_opt with
      | None ->
-       Some "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n"
+       HttpRespond "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n"
      | Some (_, key) ->
        let accept = ws_accept_key (String.trim key) in
        let handshake =
@@ -3219,22 +3282,10 @@ let http_run_pipeline_and_respond
          "Connection: Upgrade\r\n" ^
          "Sec-WebSocket-Accept: " ^ accept ^ "\r\n\r\n"
        in
-       (* The handshake + subsequent WS frames are written/read with the
-          same blocking helpers the old implementation used: this one
-          connection becomes WS-owned for its lifetime, same as before.
-          The accept loop above put this socket in non-blocking mode for
-          its own multiplexed select() bookkeeping; that flag is still set
-          here and must be cleared before handing off, or ws_recv_frame's
-          blocking-style Unix.recv calls raise EAGAIN/EWOULDBLOCK the
-          moment the client goes idle (even on the very first read, if it
-          races ahead of the client's next frame), which ws_recv_frame's
-          catch-all then misreports as the peer closing the connection. *)
-       (try Unix.clear_nonblock sock with _ -> ());
+       (* Socket stays non-blocking (the accept loop set that): the WS fiber
+          needs EAGAIN to know when to yield. *)
        tcp_send_all sock handshake;
-       let fd_int = (Obj.magic sock : int) in
-       let ws_sock = VCon ("WsSocket", [VInt fd_int]) in
-       (try ignore (!apply_hook handler_fn [ws_sock]) with _ -> ());
-       None)
+       HttpWsUpgrade handler_fn)
   | _ ->
     let (status, resp_headers, resp_body) = extract_conn_response result_conn in
     let effective_status = if status = 0 then 200 else status in
@@ -3247,14 +3298,19 @@ let http_run_pipeline_and_respond
         (String.length resp_body)
         resp_body
     in
-    Some response
+    HttpRespond response
 
 (** Non-blocking multiplexed HTTP accept/serve loop.
     Tracks every open connection (not just the listening socket) and
     [Unix.select]s across all of them each iteration, so a connection that
     is idle/slow/partially-written never blocks progress on any other
     connection. Each connection is driven forward only when [select]
-    reports it ready for the operation it is currently waiting on. *)
+    reports it ready for the operation it is currently waiting on.
+
+    Upgraded WebSocket connections are multiplexed the same way: each runs
+    as an effect-handler fiber that parks on [Ws_block] whenever its recv/
+    send would block, so a long-lived (usually idle) WS connection costs one
+    parked continuation rather than the whole loop. See [ws_wait_ready]. *)
 let run_http_event_loop (server_sock : Unix.file_descr) (pipeline_fn : value) : unit =
   let open Unix in
   set_nonblock server_sock;
@@ -3263,6 +3319,48 @@ let run_http_event_loop (server_sock : Unix.file_descr) (pipeline_fn : value) : 
   let close_conn (c : http_conn_state) =
     Hashtbl.remove conns c.hc_sock;
     (try close c.hc_sock with _ -> ())
+  in
+  (* Upgraded WS connections, parked mid-handler waiting on readiness.
+     A fiber is present here only while suspended; while it runs it owns
+     the (single) thread of control, exactly like an HTTP phase callback. *)
+  let ws_parked :
+    (Unix.file_descr,
+     (unit, unit) Effect.Deep.continuation * ws_wait_dir) Hashtbl.t =
+    Hashtbl.create 8
+  in
+  let close_ws (fd : Unix.file_descr) =
+    Hashtbl.remove ws_parked fd;
+    (try close fd with _ -> ())
+  in
+  (* Deep handler: persists across every [continue], so the fiber can park
+     and resume any number of times over the connection's lifetime. *)
+  let ws_fiber_handler fd : (unit, unit) Effect.Deep.handler =
+    { Effect.Deep.retc = (fun () -> close_ws fd)
+    ; Effect.Deep.exnc = (fun _ -> close_ws fd)
+    ; Effect.Deep.effc =
+        (fun (type a) (eff : a Effect.t) ->
+           match eff with
+           | Ws_block (bfd, dir) ->
+             Some (fun (k : (a, unit) Effect.Deep.continuation) ->
+                 Hashtbl.replace ws_parked bfd (k, dir))
+           | _ -> None)
+    }
+  in
+  let start_ws_fiber fd handler_fn =
+    let ws_sock = VCon ("WsSocket", [VInt (Obj.magic fd : int)]) in
+    Effect.Deep.match_with
+      (fun () -> ignore (!apply_hook handler_fn [ws_sock]))
+      ()
+      (ws_fiber_handler fd)
+  in
+  let resume_ws fd =
+    match Hashtbl.find_opt ws_parked fd with
+    | None -> ()
+    | Some (k, _dir) ->
+      (* Remove before resuming: the fiber will re-park itself (fresh
+         continuation) if it blocks again. *)
+      Hashtbl.remove ws_parked fd;
+      Effect.Deep.continue k ()
   in
   (* Try to make forward progress reading a request on [c]. Called only
      after select reports the socket readable. *)
@@ -3283,26 +3381,31 @@ let run_http_event_loop (server_sock : Unix.file_descr) (pipeline_fn : value) : 
       (match http_try_parse_request (Buffer.contents c.hc_in_buf) with
        | None -> ()  (* need more bytes; keep waiting on this socket *)
        | Some (meth, full_path, headers_raw, body) ->
-         (* Run the (in-memory, non-blocking) pipeline now. This may take
-            over the socket for a WebSocket upgrade — matching the prior
-            blocking implementation's semantics exactly — in which case
-            there is no HTTP response to queue and the connection is
-            simply closed out from the event loop's perspective. *)
+         (* Run the (in-memory, non-blocking) pipeline now. A WebSocket
+            upgrade hands the socket to a cooperative fiber instead of
+            queueing a response. *)
          (match
             (try http_run_pipeline_and_respond c.hc_sock pipeline_fn
                    meth full_path headers_raw body
              with
              | Eval_error msg ->
                Printf.eprintf "[http handler error] %s\n%!" msg;
-               Some "HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\n\r\n"
-             | Unix.Unix_error _ -> None
-             | _ -> None)
+               HttpRespond
+                 "HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\n\r\n"
+             | Unix.Unix_error _ -> HttpDrop
+             | _ -> HttpDrop)
           with
-          | None -> close_conn c
-          | Some response ->
+          | HttpDrop -> close_conn c
+          | HttpRespond response ->
             c.hc_out_buf <- response;
             c.hc_out_off <- 0;
-            c.hc_phase <- HCWriting))
+            c.hc_phase <- HCWriting
+          | HttpWsUpgrade handler_fn ->
+            (* No longer an HTTP connection: the fiber owns the fd (and
+               closes it via the handler's retc/exnc). Drop it from [conns]
+               WITHOUT closing, then run until it first parks. *)
+            Hashtbl.remove conns c.hc_sock;
+            start_ws_fiber c.hc_sock handler_fn))
   in
   (* Try to make forward progress writing the queued response on [c].
      Called only after select reports the socket writable. *)
@@ -3328,14 +3431,20 @@ let run_http_event_loop (server_sock : Unix.file_descr) (pipeline_fn : value) : 
      while not !shutdown_requested do
        let read_fds =
          server_sock ::
-         Hashtbl.fold (fun _ c acc ->
-             if c.hc_phase = HCReadingRequest then c.hc_sock :: acc else acc)
-           conns []
+         Hashtbl.fold (fun fd (_, dir) acc ->
+             if dir = Ws_wait_read then fd :: acc else acc)
+           ws_parked
+           (Hashtbl.fold (fun _ c acc ->
+                if c.hc_phase = HCReadingRequest then c.hc_sock :: acc else acc)
+              conns [])
        in
        let write_fds =
-         Hashtbl.fold (fun _ c acc ->
-             if c.hc_phase = HCWriting then c.hc_sock :: acc else acc)
-           conns []
+         Hashtbl.fold (fun fd (_, dir) acc ->
+             if dir = Ws_wait_write then fd :: acc else acc)
+           ws_parked
+           (Hashtbl.fold (fun _ c acc ->
+                if c.hc_phase = HCWriting then c.hc_sock :: acc else acc)
+              conns [])
        in
        let (readable, writable, _) =
          try select read_fds write_fds [] 1.0
@@ -3364,24 +3473,30 @@ let run_http_event_loop (server_sock : Unix.file_descr) (pipeline_fn : value) : 
            done
          end;
          (* Drive every connection ready for its current phase. Snapshot
-            first since advance_read/advance_write may remove entries. *)
+            first since advance_read/advance_write may remove entries.
+            A parked WS fiber and an HTTP conn can never share an fd, so
+            the [conns] lookup failing means "try the WS table". *)
          List.iter (fun fd ->
              match Hashtbl.find_opt conns fd with
              | Some c when c.hc_phase = HCReadingRequest -> advance_read c
-             | _ -> ())
+             | Some _ -> ()
+             | None -> resume_ws fd)
            readable;
          List.iter (fun fd ->
              match Hashtbl.find_opt conns fd with
              | Some c when c.hc_phase = HCWriting -> advance_write c
-             | _ -> ())
+             | Some _ -> ()
+             | None -> resume_ws fd)
            writable
        end
      done;
      Printf.eprintf "march: Shutting down...\n%!"
    with exn ->
      Hashtbl.iter (fun _ c -> try close c.hc_sock with _ -> ()) conns;
+     Hashtbl.iter (fun fd _ -> try close fd with _ -> ()) ws_parked;
      raise exn);
-  Hashtbl.iter (fun _ c -> try close c.hc_sock with _ -> ()) conns
+  Hashtbl.iter (fun _ c -> try close c.hc_sock with _ -> ()) conns;
+  Hashtbl.iter (fun fd _ -> try close fd with _ -> ()) ws_parked
 
 (* ------------------------------------------------------------------ *)
 (* Session-typed channel runtime                                       *)

--- a/test/test_stdlib_suite.ml
+++ b/test/test_stdlib_suite.ml
@@ -12096,6 +12096,232 @@ let test_interp_http_server_idle_client_does_not_block_others () =
         true (elapsed < 1.0))
   end
 
+(* Regression (sibling of the idle-HTTP-client test above, one layer deeper):
+   the interpreter's event loop multiplexed *HTTP* phases correctly, but an
+   UPGRADED WebSocket connection was then run inline to completion —
+   [http_run_pipeline_and_respond] called the March handler synchronously and
+   only returned once the WS connection closed. Since the event loop is
+   single-threaded, one established-and-idle WebSocket (i.e. any open browser
+   tab sitting on a notebook) blocked every other connection on the server for
+   its entire lifetime: no page load, no asset, no second tab.
+
+   Fixed by running each upgraded connection as an effect-handler fiber that
+   parks on [Ws_block] whenever its recv/send would block, and is resumed by
+   the same select() loop that drives the HTTP phases (see [ws_wait_ready] and
+   [run_http_event_loop] in lib/eval/eval.ml).
+
+   Interpreter-only, like the test above: the compiled/LLVM path already
+   spawns a real thread per WS connection (runtime/march_http_evloop.c).
+
+   Shape: complete a real WS handshake, leave that socket ESTABLISHED and
+   silent, then assert an ordinary GET is still served promptly. Pre-fix, the
+   GET gets no response at all (the loop is parked inside the WS handler's
+   blocking recv); post-fix it returns in milliseconds. *)
+let test_interp_http_server_idle_websocket_does_not_block_others () =
+  let exe_dir  = Filename.dirname Sys.executable_name in
+  let main_exe = Filename.concat exe_dir "../bin/main.exe" in
+  if not (Sys.file_exists main_exe) then ()  (* skip: no interpreter binary *)
+  else begin
+    let tmp = Filename.temp_file "march_ws_evloop" "" in
+    Sys.remove tmp;
+    Unix.mkdir tmp 0o755;
+    let port = 25000 + (Unix.getpid () mod 4000) in
+    let src = Filename.concat tmp "srv.march" in
+    let oc = open_out src in
+    output_string oc (Printf.sprintf
+      "mod Srv do\n\
+      \  fn ws_loop(sock) do\n\
+      \    match WebSocket.recv(sock) do\n\
+      \    TextFrame(m) -> do\n\
+      \      WebSocket.send_frame(sock, TextFrame(m))\n\
+      \      ws_loop(sock)\n\
+      \    end\n\
+      \    _ -> ()\n\
+      \    end\n\
+      \  end\n\
+      \  fn router(conn) do\n\
+      \    if HttpServer.path(conn) == \"/ws\" do\n\
+      \      WebSocket.upgrade(conn, fn s -> ws_loop(s))\n\
+      \    else\n\
+      \      conn |> HttpServer.text(200, \"hello\")\n\
+      \    end\n\
+      \  end\n\
+      \  fn main() do\n\
+      \    HttpServer.new(%d)\n\
+      \    |> HttpServer.plug(router)\n\
+      \    |> HttpServer.listen()\n\
+      \  end\n\
+       end\n" port);
+    close_out oc;
+    let log_path = Filename.concat tmp "srv.log" in
+    let log_fd = Unix.openfile log_path [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC] 0o644 in
+    let child_pid =
+      Unix.create_process main_exe [| main_exe; src |] Unix.stdin log_fd log_fd
+    in
+    Unix.close log_fd;
+    let cleanup () =
+      (try Unix.kill child_pid Sys.sigkill with _ -> ());
+      (try ignore (Unix.waitpid [] child_pid) with _ -> ())
+    in
+    Fun.protect ~finally:cleanup (fun () ->
+      let connect_addr = Unix.ADDR_INET (Unix.inet_addr_loopback, port) in
+      let rec wait_for_listen attempts =
+        if attempts <= 0 then
+          Alcotest.fail "interpreted HTTP server never started listening"
+        else
+          let probe = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+          match (try Unix.connect probe connect_addr; `Ok
+                 with Unix.Unix_error _ -> `NotYet)
+          with
+          | `Ok -> (try Unix.close probe with _ -> ())
+          | `NotYet ->
+            (try Unix.close probe with _ -> ());
+            Unix.sleepf 0.1;
+            wait_for_listen (attempts - 1)
+      in
+      wait_for_listen 50;  (* up to ~5s *)
+
+      (* 1. Establish a real WebSocket, then go silent. The handshake must
+            actually complete — an unupgraded socket would only re-test the
+            HTTP-phase multiplexing the sibling test already covers. *)
+      let ws_sock = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+      Unix.connect ws_sock connect_addr;
+      let upgrade_req =
+        "GET /ws HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         Upgrade: websocket\r\n\
+         Connection: Upgrade\r\n\
+         Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\
+         Sec-WebSocket-Version: 13\r\n\r\n"
+      in
+      ignore (Unix.write_substring ws_sock upgrade_req 0 (String.length upgrade_req));
+      let ws_reply = Buffer.create 256 in
+      let rec read_handshake deadline =
+        if Unix.gettimeofday () > deadline then ()
+        else match Unix.select [ws_sock] [] [] (deadline -. Unix.gettimeofday ()) with
+          | ([], _, _) -> ()
+          | _ ->
+            let chunk = Bytes.create 1024 in
+            let n = try Unix.read ws_sock chunk 0 1024 with _ -> 0 in
+            if n > 0 then begin
+              Buffer.add_subbytes ws_reply chunk 0 n;
+              (* stop as soon as the header block is complete *)
+              let s = Buffer.contents ws_reply in
+              let len = String.length s in
+              let has_end =
+                let rec scan i =
+                  if i + 3 >= len then false
+                  else if s.[i]='\r' && s.[i+1]='\n' && s.[i+2]='\r' && s.[i+3]='\n'
+                  then true else scan (i+1)
+                in scan 0
+              in
+              if not has_end then read_handshake deadline
+            end
+      in
+      read_handshake (Unix.gettimeofday () +. 2.0);
+      let handshake_resp = Buffer.contents ws_reply in
+      Alcotest.(check bool)
+        "WS handshake returned 101 Switching Protocols"
+        true
+        (String.length handshake_resp >= 12
+         && String.sub handshake_resp 0 12 = "HTTP/1.1 101");
+
+      (* The connection is now an established, idle WebSocket. Give the server
+         a moment to settle into waiting on it — on pre-fix code that means
+         parked inside the handler's blocking recv, which is what must NOT
+         block the request below. *)
+      Unix.sleepf 0.3;
+
+      (* 2. Ordinary HTTP request on a separate connection: must be served
+            promptly despite the idle WS connection still being open. *)
+      let start_time = Unix.gettimeofday () in
+      let client_sock = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+      Unix.connect client_sock connect_addr;
+      let request = "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n" in
+      ignore (Unix.write_substring client_sock request 0 (String.length request));
+      let deadline = 2.0 in
+      let buf = Buffer.create 256 in
+      let rec read_until_closed_or_deadline () =
+        let elapsed = Unix.gettimeofday () -. start_time in
+        let remaining = deadline -. elapsed in
+        if remaining <= 0.0 then ()
+        else
+          match Unix.select [client_sock] [] [] remaining with
+          | ([], _, _) -> ()
+          | (_, _, _) ->
+            let chunk = Bytes.create 4096 in
+            let n = try Unix.read client_sock chunk 0 4096 with _ -> 0 in
+            if n > 0 then begin
+              Buffer.add_subbytes buf chunk 0 n;
+              read_until_closed_or_deadline ()
+            end
+      in
+      read_until_closed_or_deadline ();
+      let elapsed = Unix.gettimeofday () -. start_time in
+      let response = Buffer.contents buf in
+
+      (* 3. And the WS connection must still be live and functional afterwards
+            — proving the fiber was parked/resumed, not dropped. Send a masked
+            text frame ("hi") and expect the echo back. *)
+      let ws_still_works =
+        let frame = Bytes.create 8 in
+        Bytes.set frame 0 '\x81';                       (* FIN + text *)
+        Bytes.set frame 1 '\x82';                       (* masked, len 2 *)
+        Bytes.set frame 2 '\x00'; Bytes.set frame 3 '\x00';
+        Bytes.set frame 4 '\x00'; Bytes.set frame 5 '\x00';  (* zero mask *)
+        Bytes.set frame 6 'h';   Bytes.set frame 7 'i';
+        match (try ignore (Unix.write ws_sock frame 0 8); true with _ -> false) with
+        | false -> false
+        | true ->
+          (* [ws_send_frame] writes the header and the payload as two separate
+             sends, so the 4 bytes we expect can arrive in more than one read —
+             accumulate rather than assuming a single read sees the whole
+             frame. *)
+          let echo = Buffer.create 16 in
+          let echo_deadline = Unix.gettimeofday () +. 2.0 in
+          let rec read_echo () =
+            if Buffer.length echo >= 4 then ()
+            else
+              let remaining = echo_deadline -. Unix.gettimeofday () in
+              if remaining <= 0.0 then ()
+              else match Unix.select [ws_sock] [] [] remaining with
+                | ([], _, _) -> ()
+                | _ ->
+                  let chunk = Bytes.create 64 in
+                  let n = try Unix.read ws_sock chunk 0 64 with _ -> 0 in
+                  if n > 0 then begin
+                    Buffer.add_subbytes echo chunk 0 n;
+                    read_echo ()
+                  end
+          in
+          read_echo ();
+          let s = Buffer.contents echo in
+          (* server->client frames are never masked: 0x81, len=2, 'h', 'i' *)
+          String.length s >= 4 && s.[0] = '\x81' && String.sub s 2 2 = "hi"
+      in
+
+      (try Unix.close client_sock with _ -> ());
+      (try Unix.close ws_sock with _ -> ());
+
+      Alcotest.(check bool)
+        "HTTP client got a response while a WebSocket was open and idle"
+        true (String.length response > 0);
+      Alcotest.(check bool)
+        "response is 200 OK"
+        true
+        (String.length response >= 15 && String.sub response 0 15 = "HTTP/1.1 200 OK");
+      Alcotest.(check bool)
+        (Printf.sprintf
+           "HTTP client served promptly (%.3fs) despite an open idle WebSocket \
+            — must be well under the %.1fs deadline"
+           elapsed deadline)
+        true (elapsed < 1.0);
+      Alcotest.(check bool)
+        "the parked WebSocket still echoes after the HTTP request \
+         (fiber resumed, not dropped)"
+        true ws_still_works)
+  end
+
 (* Regression: a dangling symlink in a scanned lib dir used to crash the whole
    compiler — [Sys.is_directory] stats through the link and raises Sys_error.
    [collect_lib_files] must skip it and still find sibling .march modules. *)
@@ -13155,5 +13381,7 @@ let stdlib_suites =
           test_concat_chain_values;
         Alcotest.test_case "interp http_server_listen: idle client does not block second client (event-loop fix)" `Slow
           test_interp_http_server_idle_client_does_not_block_others;
+        Alcotest.test_case "interp http_server_listen: idle upgraded WebSocket does not block other connections (WS fiber fix)" `Slow
+          test_interp_http_server_idle_websocket_does_not_block_others;
       ]);
     ]


### PR DESCRIPTION
## Summary

The interpreter's HTTP event loop multiplexes HTTP request/response phases correctly, but an **upgraded WebSocket** was then run inline to completion: `http_run_pipeline_and_respond` called the March handler synchronously and only returned once the connection closed. The loop is single-threaded, so **one established-and-idle WebSocket — i.e. any open browser tab — blocked every other connection on the server for its entire lifetime.** No page loads, no assets, no second tab.

The prior code documented this as intentional (*"this one connection becomes WS-owned for its lifetime"*), but it makes any WebSocket app unusable under `forge <task>` / interpreter dev mode. Found while running [scroll](https://github.com/march-language/scroll) (a notebook UI): opening the notebook made the server stop responding to everything else, including its own asset requests.

## Approach

Run each upgraded connection as an **effect-handler fiber**:

- The WS socket stays non-blocking. `ws_recv_exact` / `tcp_send_all` treat `EAGAIN` as "not yet" and perform `Ws_block`, which parks the continuation against the fd.
- The same `select()` loop that drives the HTTP phases resumes it once that fd is ready.
- This is the cooperative discipline the HTTP phases already use — but the suspension point here is deep inside the *interpreted* handler, which is exactly what an effect continuation captures and a hand-rolled state machine cannot, since we don't control the shape of the user's `ws_loop`.
- A frame split across several readiness events reassembles correctly because `ws_recv_exact`'s byte counter is captured by the continuation.
- Callers with **no** handler installed (the blocking `spawn_n` accept loop, any genuinely blocking socket) get `Effect.Unhandled` and fall back to a blocking `select` — previous behavior preserved exactly.

Also fixes `tcp_send_all` **silently truncating** on a non-blocking socket: its pre-existing catch-all swallowed the `EAGAIN` as if the write had completed.

The compiled/LLVM path is unaffected — `runtime/march_http_evloop.c` already spawns a thread per WS connection.

## Test plan

New regression test in `test/test_stdlib_suite.ml`, sibling of the existing idle-HTTP-client test: completes a real WS handshake, leaves the socket silent, asserts a plain `GET` is still served promptly, and that the WS **still echoes afterwards** (proving the fiber was parked and resumed, not dropped).

- [x] **Verified RED on the pre-fix compiler** — the handshake succeeds but the `GET` gets *no response at all*; GREEN after the fix
- [x] `test/run_eval.exe` — 256/256
- [x] `test/run_compiler.exe` — 615/615
- [x] `test/run_snapshots.exe` — 33/33
- [x] `test/run_stdlib.exe` — 826 run, 1 failure: the pre-existing `MARCH_SANITIZE` case. Per that test's own message I ran the prescribed check — a trivial unrelated `clang -fsanitize=address` binary hangs identically on this machine, so it's a machine-wide ASAN environment issue, not a regression (it also fails on the pre-fix build).
- [x] End-to-end against scroll: 2 idle WebSockets + a third executing a cell + concurrent HTTP — all served in <20ms, cell output correct, idle sockets still live afterwards. Previously the HTTP requests hung indefinitely.

### Note on `js/dune`

`march_eval` now contains effect handlers, so jsoo emits a `missing-effects-backend` warning. Left at the default (`disabled`) with a comment explaining why: the handler is unreachable in-browser by construction (it only runs under the HTTP accept loop, which needs Unix sockets), and `--effects=double-translation` would add ~3.3MB (+16%) to the playground bundle for dead code.