### PR TITLE
fix(forge): `forge test` now resolves transitive dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,15 @@ git log is authoritative for exact commits.
 
 ### Fixed
 
+- **`forge test` now resolves transitive dependencies.** `forge build` and
+  `forge check` walk the dependency graph transitively — if your project depends
+  on `B` and `B` depends on `C`, then `C`'s `lib/` is on `MARCH_LIB_PATH`.
+  `forge test` built its own path from the *direct* deps only, so a test calling
+  into a transitive dependency's module failed with "Unknown module ..." even
+  though the identical call in `lib/` typechecked. `forge test` now uses the same
+  transitive walk (with the same nearest-wins shadowing for same-named deps),
+  applied to the test scope: `deps` + `dev-deps` + `test-deps`.
+
 - **A refinement whose predicate measures the refined value itself is now
   enforced for user ADTs.** A contract like `{Tree | size(_) > 0}`, where `size`
   is a user `@[measure]` over `Tree`, checked *nothing*: the argument being

--- a/forge/lib/cmd_test.ml
+++ b/forge/lib/cmd_test.ml
@@ -107,8 +107,16 @@ let project_env proj =
   let config_dir = Filename.concat proj.Project.root "config" in
   let test_scope_deps =
     proj.Project.deps @ proj.Project.dev_deps @ proj.Project.test_deps in
+  (* Walk the graph transitively, exactly as [Cmd_build.lib_path_env] does:
+     a dep's own prod deps must be on MARCH_LIB_PATH too, or a test calling
+     into a transitive dep's module fails with "Unknown module ..." while the
+     identical call in lib/ typechecks under `forge build`/`forge check`. *)
+  let visited = Hashtbl.create 16 in
+  let transitive_deps =
+    Cmd_build.collect_transitive_deps visited (proj.Project.root, test_scope_deps) in
   let dep_lib_paths = List.concat_map
-    (Cmd_build.dep_to_lib_paths ~root:proj.Project.root) test_scope_deps in
+    (fun (root, dep_name, dep) -> Cmd_build.dep_to_lib_paths ~root (dep_name, dep))
+    transitive_deps in
   let gen_dir = Filename.concat proj.Project.root ".forge/generated" in
   let all_lib_paths =
     dep_lib_paths @ Cmd_build.collect_lib_dirs lib_dir

--- a/forge/test/test_build_check.ml
+++ b/forge/test/test_build_check.ml
@@ -469,6 +469,41 @@ let test_project_env_honors_toolchain_pin () =
             Alcotest.(check bool) "lib_path_env is prefixed with the toolchain PATH override"
               true (contains lib_path_env "versions/0.6.0/bin")))
 
+(** Regression test: `forge test`'s [Cmd_test.project_env] must walk the
+    dependency graph TRANSITIVELY, exactly as [Cmd_build.lib_path_env] does.
+
+    [project_env] used to map [dep_to_lib_paths] over the DIRECT test-scope
+    deps only, so a project depending on B (which itself depends on C) got
+    C's lib/ on MARCH_LIB_PATH under `forge build`/`forge check` but NOT
+    under `forge test` — tests calling a transitive dep's module failed with
+    "Unknown module ..." even though the same call typechecked in lib/. *)
+let test_project_env_walks_transitive_path_deps () =
+  let c_root = make_path_dep_project ~name:"leafc" ~deps:[] in
+  Fun.protect ~finally:(fun () ->
+      let _ = Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote c_root)) in ())
+    (fun () ->
+      write_file (Filename.concat c_root (Filename.concat "lib" "leaf.march"))
+        "mod Leaf do\n\n  fn value() : Int do\n    99\n  end\n\nend\n";
+      let b_root = make_path_dep_project ~name:"midb" ~deps:["leafc", c_root] in
+      Fun.protect ~finally:(fun () ->
+          let _ = Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote b_root)) in ())
+        (fun () ->
+          write_file (Filename.concat b_root (Filename.concat "lib" "mid.march"))
+            "mod Mid do\n\n  fn value() : Int do\n    1\n  end\n\nend\n";
+          with_project ~project_type:Project.Lib (fun _name root ->
+              let toml_path = Filename.concat root "forge.toml" in
+              let oc = open_out_gen [Open_append] 0o644 toml_path in
+              Printf.fprintf oc "\n[deps.midb]\npath = %S\n" b_root;
+              close_out oc;
+              match Project.load () with
+              | Error m -> Alcotest.fail ("expected project to load: " ^ m)
+              | Ok proj ->
+                let (_env, _output, all_lib_paths, _pfx) = Cmd_test.project_env proj in
+                let c_lib = Filename.concat c_root "lib" in
+                Alcotest.(check bool)
+                  "transitive dep leafc's lib/ is on the test MARCH_LIB_PATH"
+                  true (List.mem c_lib all_lib_paths))))
+
 (* -------------------------------------------------------------------- suite *)
 
 let () =
@@ -501,5 +536,7 @@ let () =
     "forge test", [
       Alcotest.test_case "project_env honors .march-version toolchain pin" `Quick
         test_project_env_honors_toolchain_pin;
+      Alcotest.test_case "project_env walks transitive path deps" `Quick
+        test_project_env_walks_transitive_path_deps;
     ];
   ]

--- a/specs/progress.md
+++ b/specs/progress.md
@@ -1,5 +1,33 @@
 # March — Progress Summary
 
+## Current State (as of 2026-07-30, `forge test` resolves transitive deps)
+
+**`forge test` built `MARCH_LIB_PATH` from DIRECT deps only**, while
+`forge build`/`forge check` walk the graph transitively. `Cmd_build.lib_path_env`
+(`forge/lib/cmd_build.ml:244`) calls `collect_transitive_deps` — a breadth-first,
+nearest-wins walk that pulls in each dep's own prod `deps` recursively —
+but `Cmd_test.project_env` (`forge/lib/cmd_test.ml:105`) mapped
+`dep_to_lib_paths` straight over `deps @ dev_deps @ test_deps`. Consequence: a
+project depending on `B`, where `B` depends on `C`, saw `C`'s modules from
+`lib/` under `forge check` and NOT from `test/` under `forge test` — the test
+compile failed with "Unknown module ..." for a call that typechecks two
+directories away. This is the same class of bug as the earlier
+`scroll`→`bastion`→`depot` failure, just on the one code path that never got
+the fix.
+
+`project_env` now uses `Cmd_build.collect_transitive_deps` over the test scope
+(`deps` + `dev-deps` + `test-deps`, still excluding `dev-only-deps`), so it
+inherits the same breadth-first nearest-wins shadowing — a project's own direct
+path dep still beats a same-named dep reached through a sibling.
+
+Pinned by a new unit regression in `forge/test/test_build_check.ml`
+("project_env walks transitive path deps"): A path-deps `midb`, `midb`
+path-deps `leafc`, assert `leafc/lib` is in `project_env`'s returned lib paths.
+Fails on the old code, passes on the new. All seven other forge suites green
+(242 tests); `test_build_check` has one PRE-EXISTING unrelated failure
+("check: stdlib shadow does not corrupt an unrelated module"), confirmed by
+reverting the change and reproducing it.
+
 ## Current State (as of 2026-07-30, REPL variable slots now RC-correct)
 
 **A real, independent bug found while chasing the still-open REPL


### PR DESCRIPTION
## The bug

`forge build` and `forge check` walk the dependency graph transitively via `Cmd_build.collect_transitive_deps` — a breadth-first, nearest-wins walk that pulls in each dep's own prod `deps` recursively. `Cmd_test.project_env` built its `MARCH_LIB_PATH` independently, mapping `dep_to_lib_paths` straight over the **direct** test-scope deps.

So for `A → B → C`: `C`'s `lib/` was on `MARCH_LIB_PATH` under `forge build`/`forge check`, but not under `forge test`. A test calling into a transitive dependency's module failed with `Unknown module ...` — for a call that typechecks one directory over in `lib/`.

Same bug class as the earlier `scroll` → `bastion` → `depot` failure; `cmd_test.ml` was just the one code path that never got the fix.

## The fix

`project_env` now routes the test scope (`deps` + `dev-deps` + `test-deps`, still excluding `dev-only-deps`) through `Cmd_build.collect_transitive_deps`, inheriting the same breadth-first nearest-wins shadowing — a project's own direct path dep still beats a same-named dep reached through a sibling.

## Verification

- New unit regression in `forge/test/test_build_check.ml` ("project_env walks transitive path deps"): A path-deps `midb`, `midb` path-deps `leafc`, assert `leafc/lib` is in `project_env`'s returned lib paths. Confirmed **red** before the fix (`Expected: true / Received: false`), green after.
- All seven other forge suites pass (242 tests).
- `test_build_check` has one failure, "check: stdlib shadow does not corrupt an unrelated module" — **pre-existing and unrelated**, reproduced with this change reverted.
- `scripts/check-docs.sh` passes.

`CHANGELOG.md` and `specs/progress.md` updated in the same commit per CLAUDE.md.