### PR TITLE
fix(jit): a capture-free closure no longer leaks per materialization under the REPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,16 @@ git log is authoritative for exact commits.
 
 ### Fixed
 
+- **A capture-free closure used repeatedly in the REPL no longer leaks an
+  allocation per use.** Passing a lambda that captures nothing — or a
+  top-level function used as a value — to something that calls it (a
+  higher-order function, `task_spawn`) allocated a fresh closure object on
+  every materialization and never freed any of them, so a loop at the REPL
+  prompt grew the live-object count in lockstep with its iteration count.
+  Compiled programs were never affected: there, such a closure is a single
+  immortal object shared by the whole program. Both capture-free shapes are
+  now released, and compiled output is byte-for-byte unchanged.
+
 - **`forge test` now resolves transitive dependencies.** `forge build` and
   `forge check` walk the dependency graph transitively — if your project depends
   on `B` and `B` depends on `C`, then `C`'s `lib/` is on `MARCH_LIB_PATH`.

--- a/lib/jit/repl_jit.ml
+++ b/lib/jit/repl_jit.ml
@@ -292,7 +292,12 @@ let lower_module ~type_map ?(stdlib_context : March_ast.Ast.decl list = []) ?(re
     Printf.eprintf "Error: %s\n\n" msg
   ) violations;
   let tir = March_tir.Defun.defunctionalize tir in
-  let tir = March_tir.Perceus.perceus ~repl_vars tir in
+  (* [~repl:true] must track [Llvm_emit]'s [ctx.repl] exactly (every emission
+     path in this file passes [~repl:true]): it is what tells Perceus that a
+     capture-free closure is a real per-materialization [march_alloc] here
+     rather than the immortal static global [static_closure_ok] gives the
+     native build, and therefore needs a callee-side release. *)
+  let tir = March_tir.Perceus.perceus ~repl:true ~repl_vars tir in
   let tir = March_tir.Escape.escape_analysis tir in
   tir
 

--- a/lib/tir/llvm_calls.ml
+++ b/lib/tir/llvm_calls.ml
@@ -135,8 +135,22 @@ let fail_if_unresolved_iface_method ctx (bare_name : string) : unit =
     misread a concrete `i64`/`double` return (e.g. a Bool-returning predicate
     passed to List.filter, read back tagged and inverted).  Scalars are tagged
     `(n<<1)|1` and floats bitcast into the ptr slot; the consumer untags via the
-    usual ptr->scalar coerce.  void wrappers carry no value (ret ptr null). *)
-let clo_wrap_define wrap_name (param_ltys : string list) target_ret fn_name =
+    usual ptr->scalar coerce.  void wrappers carry no value (ret ptr null).
+
+    [~drop_clo:true] adds the callee-side release of the closure the caller
+    transferred in — the same ownership contract every TIR apply fn follows via
+    [Perceus.insert_apply_fn_clo_drop] and the param-0 pin in
+    [Borrow.infer_module].  A `$clo_wrap` is NOT a TIR function (it is
+    synthesized here, at emission), so Perceus can never reach it and the drop
+    has to be emitted by hand.  Set only under the REPL/JIT: natively
+    [Llvm_emit.static_closure_ok] routes a top-level function value to one
+    immortal global that must never be released, whereas under [ctx.repl] each
+    materialization is a real [march_alloc] that otherwise leaks (measured at
+    exactly one leaked object per materialization).  Dropping at entry is safe
+    because the wrapper never reads [%_clo] again — it captures nothing, and
+    the dispatch already loaded the code pointer before the call. *)
+let clo_wrap_define ?(drop_clo = false) wrap_name (param_ltys : string list)
+    target_ret fn_name =
   let arg_names = List.mapi (fun i _ -> Printf.sprintf "%%a%d" i) param_ltys in
   (* Closure dispatch uses a uniform ptr ABI (see is_apply_fn / the ECallPtr
      call site).  A `double` param would land in an FP register while the
@@ -173,7 +187,10 @@ let clo_wrap_define wrap_name (param_ltys : string list) target_ret fn_name =
         end else target_ty ^ " " ^ name)
       param_ltys arg_names in
   let call_args = String.concat ", " call_arg_strs in
-  let pro = Buffer.contents prologue in
+  let pro =
+    (if drop_clo then "  call void @march_decrc(ptr %_clo)\n" else "")
+    ^ Buffer.contents prologue
+  in
   if target_ret = "void" then
     Printf.sprintf
       "define ptr @%s(%s) alwaysinline {\nentry:\n%s  call void @%s(%s)\n  ret ptr null\n}\n\n"

--- a/lib/tir/llvm_emit.ml
+++ b/lib/tir/llvm_emit.ml
@@ -413,7 +413,7 @@ let emit_atom ctx (atom : Tir.atom) : string * string =
          concrete forwarding call (boxing/unboxing Float params + return). *)
       let param_tys = List.map llvm_ty ps_tirs in
       Buffer.add_string ctx.extra_fns
-        (clo_wrap_define wrap_name param_tys target_ret fn_name)
+        (clo_wrap_define ~drop_clo:ctx.repl wrap_name param_tys target_ret fn_name)
     end;
     (* Allocate closure: header(16) + fn_ptr(8) = 24 bytes *)
     if static_closure_ok ctx v.Tir.v_name then
@@ -532,7 +532,7 @@ let emit_atom ctx (atom : Tir.atom) : string * string =
          let target_ret  = llvm_ret_ty ret_tir in
          let param_tys   = List.map llvm_ty ps in
          Buffer.add_string ctx.extra_fns
-           (clo_wrap_define wrap_name param_tys target_ret fn_name)
+           (clo_wrap_define ~drop_clo:ctx.repl wrap_name param_tys target_ret fn_name)
        end;
        if static_closure_ok ctx resolved then
          ("ptr", Llvm_ctx.intern_static_closure ctx fn_name wrap_name)

--- a/lib/tir/llvm_repl.ml
+++ b/lib/tir/llvm_repl.ml
@@ -373,7 +373,8 @@ let emit_repl_fn_with_closure_slot ~emit_expr ?(fast_math=false) ~(n : int)
   if not (Hashtbl.mem ctx.Llvm_ctx.emitted_wraps wrap_name) then begin
     Hashtbl.add ctx.Llvm_ctx.emitted_wraps wrap_name ();
     Buffer.add_string ctx.Llvm_ctx.extra_fns
-      (Llvm_calls.clo_wrap_define wrap_name param_tys target_ret fn_llvm_name)
+      (Llvm_calls.clo_wrap_define ~drop_clo:ctx.Llvm_ctx.repl wrap_name param_tys
+         target_ret fn_llvm_name)
   end;
   (* Init function: allocate closure {header(16), fn_ptr} and store in the slot *)
   let init_name = Printf.sprintf "repl_%d_init" n in

--- a/lib/tir/perceus.ml
+++ b/lib/tir/perceus.ml
@@ -1474,7 +1474,7 @@ let rec dup_field_results (e : Tir.expr) : Tir.expr =
     dead-binding cleanup does.  One wrinkle: a prefix binding's RHS may be
     wrapped in a protective [EIncRC]/[EAtomicIncRC], so [is_clo_source] must
     see through that wrap. *)
-let insert_apply_fn_clo_drop (body : Tir.expr) : Tir.expr =
+let insert_apply_fn_clo_drop ~(repl : bool) (body : Tir.expr) : Tir.expr =
   let clo = Tir_names.clo_param_name in
   let clo_var =
     { Tir.v_name = clo; Tir.v_ty = Tir.TPtr Tir.TUnit; Tir.v_lin = Tir.Unr }
@@ -1601,18 +1601,48 @@ let insert_apply_fn_clo_drop (body : Tir.expr) : Tir.expr =
         (verified: `fn x -> x + 1` in a 100,000-iteration loop went from
         obj_allocs 0 to obj_allocs 100000 without a guard here).
 
-     2. A capture-FREE apply fn that does mention $clo (a recursive one, whose
-        only $clo use is the self-binding) has no captured ownership unit to
-        release, and dropping it is unsound under the JIT.  [static_closure_ok]
-        is [not ctx.repl && ...]: natively such a closure is the immortal
-        global, where a decrement is a no-op by construction, but in the
-        REPL/JIT it is a REAL [march_alloc] with rc = 1.  The drop then frees
-        it on the first call and the next dispatch jumps through the zeroed
-        apply-fn slot — observed as EXC_BAD_ACCESS at address 0x0, frame #0 =
-        0x0, in run_codegen's "stdlib List.length via precompile" (a jump to a
-        null code pointer, NOT a data use-after-free).  Native stayed green
-        throughout precisely because the immortal global masked it, so this
-        guard cannot be justified from native measurements alone. *)
+     2. A capture-FREE apply fn that DOES mention $clo — a self-recursive one,
+        whose only $clo use is [lift_lambda]'s `let go = $clo` self-binding —
+        must NOT get a drop here, and this is a hard correctness constraint,
+        not a conservatism.  Ordinary RC insertion already releases that
+        reference through the alias: the self-binding is an ordinary owned
+        local, so [insert_rc_expr] emits `dec_rc go` on every path where the
+        alias is dead and transfers it into the recursive `call_ptr go(..)` on
+        the paths where it is live.  Confirmed in the emitted TIR for
+        List.length's inner `go`:
+
+          fn go$apply($clo, lst, acc) =
+            let go = $clo in
+            case lst of
+              Nil()          -> dec_rc go; dec_rc lst; acc
+              Cons($f, $t)   -> ... call_ptr go(t, $t2)
+
+        Adding an unconditional drop on top of that is a SECOND release of the
+        same reference: rc reaches 0 on the first call, the closure is freed,
+        and the recursive dispatch reads a zeroed apply-fn slot.  That is the
+        exact crash two prior attempts at this hit — EXC_BAD_ACCESS at address
+        0x0, frame #0 = 0x0, in run_codegen's "stdlib List.length via
+        precompile", whose stack is `List.length$List_Int -> go$apply$218 ->
+        0x0` (a jump through a null code pointer, NOT a data use-after-free).
+        Native stayed green throughout because [static_closure_ok] routes the
+        native build to the immortal global, where the over-release is a no-op
+        by construction; only the JIT (where it is a real [march_alloc] with
+        rc = 1) exposes it.
+
+     3. A capture-free apply fn that mentions $clo NOWHERE — a non-recursive
+        capture-free lambda, the case in (1) — is the one that genuinely
+        leaks, and only under the REPL/JIT.  Nothing in its body ever names
+        $clo, so ordinary RC insertion has nothing to release, while the
+        apply-fn param-0 pin in [Borrow.infer_module] means every caller
+        transfers a reference in.  Natively that is fine (the immortal global
+        absorbs it); under [ctx.repl] it is a fresh [march_alloc] per
+        materialization that nobody frees — one leaked allocation per use,
+        measured at exactly 2,000 over a 2,000-iteration REPL fragment.  Hence
+        the [repl]-gated arm at the bottom of this function: it fires for
+        exactly this shape, which is also why it cannot regress (1) — a body
+        that never mentions $clo cannot acquire a $clo reference that would
+        defeat the static-closure optimization, and the arm is off natively
+        regardless. *)
   (* Mirrors [is_clo_source]'s unwrapping: a prefix binding's RHS may be
      wrapped in a protective EIncRC, so a bare [EField] match would miss it
      and misclassify a capturing apply fn as capture-free. *)
@@ -1633,7 +1663,15 @@ let insert_apply_fn_clo_drop (body : Tir.expr) : Tir.expr =
   match body with
   | Tir.ELet (_, e1, _) when is_clo_source e1 && prefix_has_fv_extraction body ->
     splice None body
-  | _ -> body
+  | _ ->
+    (* Case (3) above: under the REPL/JIT only, and only for an apply fn whose
+       body never mentions $clo at all.  The [not (mem clo ..)] test is what
+       separates this from case (2): a self-recursive capture-free apply fn
+       DOES mention $clo (its self-binding alias) and already releases the
+       reference through that alias, so it must fall through untouched. *)
+    if repl && not (StringSet.mem clo (Dce.free_vars body)) then
+      Tir.ESeq (Tir.EDecRC (Tir.AVar clo_var), body)
+    else body
 
 (** [insert_rc ~module_env ~borrowed fn] runs Phase 2 (RC insertion) over one
     function.  [module_env] carries the module-scoped fields (borrow_map,
@@ -1646,7 +1684,7 @@ let insert_apply_fn_clo_drop (body : Tir.expr) : Tir.expr =
     value here (rather than mutating shared refs), no restore step is needed
     afterward: the caller ([perceus]'s [List.map]) never sees this function's
     env — it only sees the returned [fn_def]. *)
-let insert_rc ~(module_env : env) ?(borrowed = StringSet.empty)
+let insert_rc ~(module_env : env) ?(repl = false) ?(borrowed = StringSet.empty)
     (fn : Tir.fn_def) : Tir.fn_def =
   (* Rename ELet/ECase-bound variables that shadow borrowed parameters before
      RC insertion.  See [rename_borrowed_shadows] for the full rationale. *)
@@ -1693,7 +1731,7 @@ let insert_rc ~(module_env : env) ?(borrowed = StringSet.empty)
   let body'' =
     if Tir_names.is_apply_fn fn.Tir.fn_name
        && not (Borrow.is_borrowed module_env.borrow_map fn.Tir.fn_name 0)
-    then insert_apply_fn_clo_drop body'
+    then insert_apply_fn_clo_drop ~repl body'
     else body'
   in
   { fn' with Tir.fn_body = body'' }
@@ -1809,7 +1847,8 @@ let print_perceus_stats ~(label : string) ~(before : rc_counts) ~(after : rc_cou
     - Caller: EIncRC is skipped for args at borrowed positions that are still
       live after the call; a post-call EDecRC is emitted instead when the arg
       is the caller's last use. *)
-let perceus ?(repl_vars : string list = []) (m : Tir.tir_module) : Tir.tir_module =
+let perceus ?(repl : bool = false) ?(repl_vars : string list = [])
+    (m : Tir.tir_module) : Tir.tir_module =
   (* Reset the fresh-name counter per module so that compiling the same module
      twice produces identical IR.  A monotonic counter that survives across
      modules makes IR diffs unstable and causes spurious churn in test
@@ -1849,7 +1888,7 @@ let perceus ?(repl_vars : string list = []) (m : Tir.tir_module) : Tir.tir_modul
              else s
            ) base (List.mapi (fun i p -> (i, p)) fn.Tir.fn_params)
          in
-         insert_rc ~module_env ~borrowed fn)
+         insert_rc ~module_env ~repl ~borrowed fn)
   in
   let fns' =
     fns_after_insert

--- a/specs/progress.md
+++ b/specs/progress.md
@@ -1,5 +1,52 @@
 # March — Progress Summary
 
+## Current State (as of 2026-07-30, the REPL capture-free closure leak is closed)
+
+**Counts:** `run_codegen` 518 tests (was 517 — one new
+`repl_jit_cross_line` regression), `run_eval` / `run_compiler` /
+`run_stdlib` unchanged. Known failure: `adversarial-regressions` 39
+(`MARCH_SANITIZE` 30s timeout) — pre-existing and environmental, reproduced
+on a base tree with these changes reverted.
+
+**A capture-free closure materialized under the REPL/JIT no longer leaks one
+allocation per materialization.** Natively such a closure is a single
+immortal global (`Llvm_ctx.intern_static_closure`), so nothing needs to
+release it; `Llvm_emit.static_closure_ok` is `not ctx.repl && ..`, so under
+the REPL the very same closure falls back to a fresh `march_alloc` per
+materialization — and nothing ever released THAT.
+
+Two prior attempts at this both crashed with `EXC_BAD_ACCESS` at `0x0`,
+frame #0 = `0x0`, in `repl_jit_cross_line`'s "stdlib List.length via
+precompile", and both diagnosed the crash by pattern-matching rather than by
+looking. An actual `lldb` backtrace named it immediately:
+`List.length$List_Int -> go$apply$218 -> 0x0`. `go` is `List.length`'s inner
+**self-recursive** helper — capture-free, hence caught by a blanket
+"drop capture-free apply fns" rule, but it already releases its own
+reference through `lift_lambda`'s self-binding alias under completely
+ordinary RC insertion (`let go = $clo in case .. of Nil -> dec_rc go; ..`).
+The added drop was a second release of the same reference: freed on call 1,
+the recursive dispatch then read a zeroed apply-fn slot.
+
+**Fixed in two places, one per capture-free shape** — the second found by
+measurement after the first was already green, and independent of it:
+
+- `Perceus.insert_apply_fn_clo_drop ~repl` (threaded via `insert_rc` ←
+  `perceus ~repl` ← `Repl_jit.lower_module`, which passes `~repl:true` so
+  the flag tracks `ctx.repl` exactly) drops `$clo` for an apply fn whose
+  body mentions `$clo` **nowhere**. That test is what excludes the
+  self-recursive case above. Covers capture-free lambdas.
+- `Llvm_calls.clo_wrap_define ~drop_clo` (`~drop_clo:ctx.repl` at all three
+  emission sites) covers capture-free top-level function values, whose
+  `@<fn>$clo_wrap` trampoline is synthesized at LLVM emission and has no TIR
+  apply fn for Perceus to reach. Sound alongside the slot-read `incrc` from
+  the "REPL variable slots now RC-correct" entry below.
+
+Measured over 2,000 materializations in a REPL fragment: `march_live_allocs`
+grew by exactly 2,000 before and 0 after, for each shape independently.
+Native output is unchanged and provably so — a program exercising both
+shapes plus `List.length` emits byte-identical `--emit-llvm --opt 2` IR
+before and after. `repl_jit_cross_line` green 20/20 consecutive runs.
+
 ## Current State (as of 2026-07-30, `forge test` resolves transitive deps)
 
 **`forge test` built `MARCH_LIB_PATH` from DIRECT deps only**, while

--- a/specs/todos.md
+++ b/specs/todos.md
@@ -607,12 +607,13 @@ on the first attempt). Two new regression tests in `test/test_codegen.ml`'s
 double-recursive-call correctness check (compiled vs. interpreted parity) to
 catch an over-eager drop as a wrong value or crash rather than growth.
 
-Investigated as a related follow-up but NOT fixed: extending this same
-capture-free-under-REPL gap (the note above) by threading an `is_repl` flag
-into `insert_apply_fn_clo_drop` reintroduced the EXACT SIGSEGV the guard
-exists to prevent (`repl_jit_cross_line` test 7, "stdlib List.length via
-precompile") — reverted. `task_spawn`-ing a genuinely capture-free closure
-from a REPL fragment still leaks one allocation per materialization.
+Investigated as a related follow-up but NOT fixed at the time (since FIXED —
+see "Third attempt" below): extending this same capture-free-under-REPL gap
+(the note above) by threading an `is_repl` flag into
+`insert_apply_fn_clo_drop` reintroduced the EXACT SIGSEGV the guard exists to
+prevent (`repl_jit_cross_line` test 7, "stdlib List.length via precompile") —
+reverted. `task_spawn`-ing a genuinely capture-free closure from a REPL
+fragment still leaked one allocation per materialization.
 
 **Second attempt (2026-07-30), one real bug fixed, the leak still open.**
 Traced the crash to a genuine, independent gap: `lib/tir/llvm_repl.ml`'s
@@ -657,11 +658,87 @@ understood. Reverted the `is_repl` threading again (verified via
 **kept** the slot RC fix, since it is a real, independent correctness fix
 regardless of whether the capture-free leak is ever closed.
 
-`task_spawn`-ing a genuinely capture-free closure from a REPL fragment
-still leaks one allocation per materialization. Needs a proper stack trace
-or bisection through the stdlib-precompile path (not slots) before
-attempting `is_repl` a third time — guessing at the second mechanism from
-here would cost more than it's worth. Original report follows.
+**Third attempt (2026-07-30) — FIXED, and the crash the first two attempts
+kept hitting was never the mechanism either of them guessed at.**
+
+Diagnosed from an actual stack trace this time (`lldb -b` on
+`_build/default/test/run_codegen.exe -e repl_jit_cross_line`, with the drop
+forced on via a temporary env-var hack), which neither prior attempt took:
+
+```
+frame #0: 0x0000000000000000
+frame #1: repl_0.so`go$apply$218 + 432
+frame #2: repl_0.so`List.length$List_Int + 68
+```
+
+The crashing closure is `go`, the inner **self-recursive** helper of
+`List.length` — and it is capture-free, which is exactly why a blanket
+"drop capture-free apply fns under REPL" hit it. The over-release is
+straightforward once the frame is visible: a self-recursive capture-free
+apply fn ALREADY releases its own reference, through `lift_lambda`'s
+self-binding alias, via completely ordinary RC insertion. Confirmed in the
+emitted TIR (`MARCH_DUMP_TXT=perceus`):
+
+```
+fn go$apply($clo, lst, acc) =
+  let go = $clo in
+  case lst of
+    Nil()        -> dec_rc go; dec_rc lst; acc
+    Cons($f,$t)  -> ... call_ptr go(t, $t2)
+```
+
+`dec_rc go` on the dead path, transfer into `call_ptr go(..)` on the live
+one — the alias is an ordinary owned local and Perceus handles it correctly
+with no help. Adding an unconditional entry drop on top is a SECOND release
+of the same reference: rc hits 0 on the first call, the closure is freed,
+and the recursive dispatch reads a zeroed apply-fn slot. Hence frame #0 =
+0x0. Native never showed it because `static_closure_ok` routes native builds
+to the immortal global, where the over-release cannot reach 0.
+
+**The fix, and the third mechanism.** Two changes, each covering one of the
+two capture-free shapes; the second was found by measurement AFTER the first
+was green, and is genuinely independent:
+
+1. `lib/tir/perceus.ml` `insert_apply_fn_clo_drop ~repl` (threaded through
+   `insert_rc` ← `perceus ~repl` ← `lib/jit/repl_jit.ml`'s `lower_module`,
+   which passes `~repl:true` to match `Llvm_emit`'s `ctx.repl` exactly).
+   Under REPL only, an apply fn whose body mentions `$clo` **nowhere** gets
+   an entry `dec_rc $clo`. The `not (mem $clo (free_vars body))` test is the
+   whole correctness story: it is precisely what excludes the self-recursive
+   case above, which mentions `$clo` via its self-binding and must stay
+   untouched. Covers capture-free **lambdas**.
+
+2. `lib/tir/llvm_calls.ml` `clo_wrap_define ~drop_clo` (passed
+   `~drop_clo:ctx.repl` at all three emission sites — two in
+   `lib/tir/llvm_emit.ml`'s `emit_atom`, one in `lib/tir/llvm_repl.ml`'s
+   `emit_repl_fn_with_closure_slot`). Covers capture-free **top-level
+   function values**, which materialize an `@<fn>$clo_wrap` trampoline that
+   is synthesized at LLVM emission and has no TIR apply fn at all — so
+   Perceus can never reach it, and change (1) alone left it leaking at the
+   full pre-fix rate. This is sound alongside PR #123's slot-read `incrc`:
+   a slot-held closure now hands out a fresh reference per read, which the
+   wrapper's drop balances.
+
+**Measured** (new `test/test_codegen.ml` regression,
+`repl_jit_cross_line` "capture-free closure materialization does not leak",
+reading `march_live_allocs` via `dlsym` out of the JIT's own runtime `.so`
+so the fragments under test stay ordinary REPL input): over 2,000
+materializations in a REPL fragment, both shapes grew by exactly **2,000**
+before and **0** after. Each half is pinned independently — with only (1)
+applied, the lambda phase reports 0 and the top-level-fn phase still
+reports 2,000.
+
+**Native impact: none, and proven rather than argued.** Both arms are gated
+on `repl`/`ctx.repl`, and a program exercising both closure shapes plus
+`List.length` emits **byte-identical** `--emit-llvm --opt 2` IR before and
+after (928 lines, `diff` clean), with identical program output.
+
+Verified: `repl_jit_cross_line` fully green (10/10 including the new test)
+and re-run 20x for the flakiness this area has a history of (0 failures);
+full `dune build --root . @runtest` green apart from
+`adversarial-regressions` 39 (`MARCH_SANITIZE` 30s timeout), confirmed
+**pre-existing** by reverting the five source files to base via file-copy
+swap (never `git stash` in a march worktree) and reproducing it there.
 
   **Follow-up audit (2026-07-29, same day): the $clo drop is only sound because every C-runtime call site that invokes a closure's apply function now agrees on the calling convention — and four distinct families of call sites did not, each fixed in `runtime/march_runtime.c` / `lib/tir/llvm_emit.ml`:**
   - `__try_call`/`__try_call_val` (runtime/march_runtime.c) called their thunk once then explicitly `march_decrc`'d it — a second consumption of the reference the thunk's own apply function already released. Flaky, not deterministic (6/30 crashes on a single-capture thunk before the fix, 0/30 after) — freed memory frequently still looked valid enough not to crash immediately. `__try_call` is directly user-callable (`tir_names.ml` documents this) and one of `test/imports/erased_clo_native`'s dune-rule golden tests hit this exact shape, which is how it was traced after CI stayed red past the first (task_spawn) fix.

--- a/test/test_codegen.ml
+++ b/test/test_codegen.ml
@@ -1811,6 +1811,106 @@ let test_repl_jit_topfn_first_class_value () =
      with exn ->
        March_jit.Repl_jit.cleanup jit; raise exn)
 
+(* REPL/JIT counterpart of [test_lambda_static_closure_materialization_no_leak_
+   compiled].  Natively a capture-free closure is one immortal global
+   ([Llvm_ctx.intern_static_closure]), so nothing needs to release it; under the
+   REPL/JIT [Llvm_emit.static_closure_ok] is [not ctx.repl && ..], so the very
+   same lambda falls back to a fresh [march_alloc] per materialization — and
+   before the capture-free arm of [Perceus.insert_apply_fn_clo_drop] nothing
+   ever released THAT.  One leaked allocation per materialization.
+
+   Measured the way the native tests measure it, but with the gauge read from
+   OCaml (dlsym'ing [march_live_allocs] out of the JIT's own runtime .so)
+   rather than through a March extern, so the fragments under test stay
+   ordinary REPL input.  Warm the materialization site in one fragment, sample
+   the gauge, then run the same site 2,000 more times in a second fragment: a
+   leak makes the growth scale with the iteration count (~2,000), a correct
+   build leaves only the second fragment's own fixed compilation overhead. *)
+let test_repl_jit_capture_free_closure_no_leak () =
+  match setup_jit_runtime () with
+  | None -> ()
+  | Some runtime_so ->
+    let live_allocs =
+      let h = March_jit.Jit.dlopen runtime_so in
+      let sym = March_jit.Jit.dlsym h "march_live_allocs" in
+      fun () -> Int64.to_int (March_jit.Jit.call_void_to_int sym)
+    in
+    let jit = March_jit.Repl_jit.create ~runtime_so () in
+    (try
+       let type_map = Hashtbl.create 16 in
+       let tc_env = March_typecheck.Typecheck.base_env (March_errors.Errors.create ()) type_map in
+       let desugared_decl src = match parse_repl src with
+         | March_ast.Ast.ReplDecl d -> March_desugar.Desugar.desugar_decl d
+         | _ -> failwith "expected ReplDecl" in
+       (* `fn x -> x * 2` captures nothing, so each materialization is the
+          capture-free shape; `apply_it` forces it to be materialized as a
+          real first-class value rather than inlined into a direct call. *)
+       let fn_decls = [
+         desugared_decl "fn apply_it(f, n) do f(n) end";
+         desugared_decl
+           "fn materialize_loop(i, n, acc) do\n\
+           \  if i >= n do acc\n\
+           \  else materialize_loop(i + 1, n, acc + apply_it(fn x -> x * 2, i)) end\n\
+            end";
+         desugared_decl "fn double(x) do x * 2 end";
+         desugared_decl
+           "fn materialize_loop2(i, n, acc) do\n\
+           \  if i >= n do acc\n\
+           \  else materialize_loop2(i + 1, n, acc + apply_it(double, i)) end\n\
+            end";
+       ] in
+       let make_mod e =
+         let s = March_ast.Ast.dummy_span in
+         let clause = March_ast.Ast.{ fc_params = []; fc_guard = None; fc_body = e; fc_span = s } in
+         let main_def = March_ast.Ast.{
+           fn_name = { txt = "main"; span = s };
+           fn_vis = Public; fn_doc = None; fn_attrs = []; fn_ret_ty = None;
+           fn_clauses = [clause]; fn_bounds = [] } in
+         { March_ast.Ast.mod_name = { txt = "Repl"; span = s };
+           mod_decls = fn_decls @ [DFn (main_def, s)] }
+       in
+       let run src = match parse_repl src with
+         | March_ast.Ast.ReplExpr e ->
+           let e' = March_desugar.Desugar.desugar_expr e in
+           let (_, result) = March_jit.Repl_jit.run_expr jit ~tc_env (make_mod e') in
+           result
+         | _ -> failwith "expected ReplExpr"
+       in
+       (* Warm: compiles the fragment shape and settles any one-off allocation. *)
+       let warm = run "materialize_loop(0, 100, 0)" in
+       Alcotest.(check string) "warm loop result" "9900" warm;
+       let base = live_allocs () in
+       let bulk = run "materialize_loop(0, 2000, 0)" in
+       Alcotest.(check string) "bulk loop result" "3998000" bulk;
+       let grew = live_allocs () - base in
+       (* A leaking build grows by ~2,000 here (one closure per iteration).  The
+          bound is generous because a second REPL fragment legitimately allocates
+          a fixed amount of its own; it just must not scale with the loop. *)
+       if grew > 200 then
+         Alcotest.failf
+           "capture-free LAMBDA materialized 2,000 times in a REPL fragment \
+            leaked: march_live_allocs grew by %d (expected bounded, <= 200)" grew;
+       (* Second shape, and a genuinely independent mechanism: a top-level
+          function used as a value materializes an @<fn>$clo_wrap trampoline
+          closure, which is synthesized at LLVM emission and has no TIR apply fn
+          for Perceus to touch.  It leaked exactly the same 1-per-materialization
+          way until [clo_wrap_define ~drop_clo] was added, and it stayed leaking
+          after the Perceus-side fix alone — so it needs its own assertion. *)
+       let warm2 = run "materialize_loop2(0, 100, 0)" in
+       Alcotest.(check string) "warm top-level-fn loop result" "9900" warm2;
+       let base2 = live_allocs () in
+       let bulk2 = run "materialize_loop2(0, 2000, 0)" in
+       Alcotest.(check string) "bulk top-level-fn loop result" "3998000" bulk2;
+       let grew2 = live_allocs () - base2 in
+       if grew2 > 200 then
+         Alcotest.failf
+           "capture-free TOP-LEVEL FN value materialized 2,000 times in a REPL \
+            fragment leaked: march_live_allocs grew by %d (expected bounded, \
+            <= 200)" grew2;
+       March_jit.Repl_jit.cleanup jit
+     with exn ->
+       March_jit.Repl_jit.cleanup jit; raise exn)
+
 (** Test: List.length works correctly in JIT REPL with stdlib precompile.
 
     This is a regression test for the defun TVar bug: when the stdlib is
@@ -12175,6 +12275,7 @@ let codegen_suites =
         Alcotest.test_case "B11: stored closure returns untagged Int" `Quick test_repl_jit_stored_closure_returns_untagged_int;
         Alcotest.test_case "B11: self-referencing fn no duplicate clo_wrap" `Quick test_repl_jit_selfref_fn_no_duplicate_wrapper;
         Alcotest.test_case "top-level fn as first-class value" `Quick test_repl_jit_topfn_first_class_value;
+        Alcotest.test_case "capture-free closure materialization does not leak" `Quick test_repl_jit_capture_free_closure_no_leak;
         Alcotest.test_case "stdlib List.length via precompile" `Quick test_repl_jit_stdlib_list_length;
         Alcotest.test_case "B12: niche ADT cross-fragment (:load DMod then match)" `Quick test_repl_jit_niche_adt_cross_fragment;
       ];


### PR DESCRIPTION
## The bug

Natively a capture-free closure (a lambda or a top-level function used as a value, capturing nothing) is one immortal global — `Llvm_ctx.intern_static_closure` — so nothing needs to release it. `Llvm_emit.static_closure_ok` is `not ctx.repl && ..`, so under the REPL/JIT the same closure falls back to a fresh `march_alloc` per materialization, and **nothing ever released that**. One leaked allocation per use.

## Why two prior attempts failed

Both extended the `$clo`-release logic to capture-free apply fns under REPL, and both hit `EXC_BAD_ACCESS` at `0x0`, frame `#0 = 0x0`, in `repl_jit_cross_line`'s "stdlib List.length via precompile" — each diagnosed from the test name and symptom alone, and each guessed a different wrong mechanism.

An `lldb` backtrace named it in one shot:

```
frame #0: 0x0000000000000000
frame #1: repl_0.so`go$apply$218 + 432
frame #2: repl_0.so`List.length$List_Int + 68
```

`go` is `List.length`'s inner **self-recursive** helper. It is capture-free — hence caught by a blanket "drop capture-free apply fns" rule — but it *already* releases its own reference through `lift_lambda`'s self-binding alias, under completely ordinary RC insertion (`MARCH_DUMP_TXT=perceus`):

```
fn go$apply($clo, lst, acc) =
  let go = $clo in
  case lst of
    Nil()       -> dec_rc go; dec_rc lst; acc
    Cons($f,$t) -> ... call_ptr go(t, $t2)
```

`dec_rc go` on the dead path, transfer into `call_ptr go(..)` on the live one. The added drop was a **second release of the same reference**: rc reaches 0 on call 1, the closure is freed, and the recursive dispatch reads a zeroed apply-fn slot. Native never exposed it because the immortal global cannot reach 0.

## The fix — two arms, one per capture-free shape

The second was found by measurement *after* the first was already green, and is genuinely independent:

1. **`Perceus.insert_apply_fn_clo_drop ~repl`** (threaded via `insert_rc` ← `perceus ~repl` ← `Repl_jit.lower_module`, which passes `~repl:true` so the flag tracks `ctx.repl` exactly) drops `$clo` for an apply fn whose body mentions `$clo` **nowhere**. That test is the whole correctness story — it is precisely what excludes the self-recursive case above. Covers capture-free **lambdas**.

2. **`Llvm_calls.clo_wrap_define ~drop_clo`** (`~drop_clo:ctx.repl` at all three emission sites) covers capture-free **top-level function values**, whose `@<fn>$clo_wrap` trampoline is synthesized at LLVM emission and has no TIR apply fn for Perceus to reach — arm 1 alone left it leaking at the full pre-fix rate. Sound alongside #123's slot-read `incrc`: a slot-held closure hands out a fresh reference per read, which the wrapper's drop balances.

## Verification

- **New regression test** (`repl_jit_cross_line`, "capture-free closure materialization does not leak") reads `march_live_allocs` via `dlsym` out of the JIT's own runtime `.so`, so the fragments under test stay ordinary REPL input. Over 2,000 materializations: **grew by exactly 2,000 before, 0 after** — asserted separately per shape, so each arm is pinned independently (with only arm 1, the lambda phase reports 0 and the top-level-fn phase still reports 2,000).
- `repl_jit_cross_line` **10/10 green**, re-run **20x consecutively, 0 failures** (this area has a history of flaky RC bugs).
- Full `dune build --root . @runtest` green apart from `adversarial-regressions` 39 (`MARCH_SANITIZE` 30s timeout), confirmed **pre-existing** by reverting the source files to base via file-copy swap and reproducing it there.
- **Native output unchanged and proven so**: a program exercising both closure shapes plus `List.length` emits **byte-identical** `--emit-llvm --opt 2` IR before and after (928 lines, `diff` clean), with identical program output. Both arms are gated on `repl`/`ctx.repl`.
- `specs/todos.md`, `specs/progress.md`, `CHANGELOG.md` updated; `scripts/check-docs.sh` exits 0.