### PR TITLE
fix(parser): the `(`-led-statement rule now applies after a literal too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,20 @@ git log is authoritative for exact commits.
   nothing in-tree changed behaviour. Bracketed by
   `specs/lang/types/accept/t130_refine_let_annotation_checked_and_composes` and
   `specs/lang/types/reject/t131_refine_let_annotation_false`.
+- **The `(`-led-statement fix now also applies after a literal.** The initial
+  fix keyed the retag on a *value-ending* token — an identifier, a `)` or a
+  `]` — but the call rule takes an `expr_field`, which a bare literal also
+  reduces to, so `let _ = 1` followed by a line holding only `()` was still
+  glued into `1()`. Unlike the identifier case this never reached the
+  closure-ABI indirect call (a literal has no receiver to load a function
+  pointer from): codegen emitted **invalid LLVM** — `declare ptr @<lit>()` —
+  and clang rejected it with "expected function name", so the build failed
+  with a diagnostic pointing at generated IR rather than at the offending
+  source line. Interpreted, it raised `applied non-function value: 1`. The
+  statement decision now uses a wider "ends an expression" predicate that
+  includes `Int`/`Float`/`String`/`Bool`/atom literals; the narrower
+  value-ending test still drives the curried-call guard's paren
+  classification, so `f(1)(2)` diagnostics are unchanged.
 
 - **A statement starting with `(` is no longer glued onto the previous line as
   a call.** A block line holding only `()` — or any parenthesised/tuple

--- a/lib/parser/token_filter.ml
+++ b/lib/parser/token_filter.ml
@@ -122,6 +122,22 @@ let make (base_lexer : Lexing.lexbuf -> Parser.token) : Lexing.lexbuf -> Parser.
     | Parser.RPAREN | Parser.RBRACKET -> true
     | _ -> false
   in
+  (* Can this token END an expression?  A superset of [is_value_ending],
+     which stays as-is because it also decides whether a paren is a CALL's
+     arg list for the curried-call guard — a literal never opens one, so
+     `1(` must keep classifying as a group there.
+
+     The statement decision needs the wider notion: the grammar's call rule
+     takes an [expr_field], which a LITERAL also reduces to, so `let _ = 1`
+     ⏎ `()` was still glued into `1()`. Interpreted that raised "applied
+     non-function value: 1"; compiled it reached codegen as a call to a
+     literal and emitted invalid IR — `declare ptr @<lit>()` — which clang
+     rejected with "expected function name". *)
+  let ends_expression = function
+    | Parser.INT _ | Parser.FLOAT _ | Parser.STRING _
+    | Parser.BOOL _ | Parser.ATOM _ -> true
+    | t -> is_value_ending t
+  in
 
   let in_match () =
     not (Stack.is_empty stack) && Stack.top stack = Match
@@ -517,7 +533,15 @@ let make (base_lexer : Lexing.lexbuf -> Parser.token) : Lexing.lexbuf -> Parser.
           | Some t -> is_value_ending t
           | None -> false
         in
-        let starts_statement = value_ending_prev && !saw_nl_since_significant in
+        (* Statement decision uses the wider [ends_expression] (literals
+           included — see its comment); the paren-kind push below keeps the
+           narrower [is_value_ending] so the curried-call guard is unchanged. *)
+        let expr_ending_prev =
+          match !prev_significant with
+          | Some t -> ends_expression t
+          | None -> false
+        in
+        let starts_statement = expr_ending_prev && !saw_nl_since_significant in
         Stack.push (value_ending_prev && not starts_statement) paren_kinds;
         if starts_statement then Parser.LPAREN_STMT else tok
       | Parser.RPAREN ->

--- a/specs/lang/grammar/INDEX.md
+++ b/specs/lang/grammar/INDEX.md
@@ -1,4 +1,4 @@
-# Grammar corpus index (p01–p33 parse, 12 reject — r02/r07/r08 retired 2026-07-24; Task 1 seeded p01–p02/r01–r02, Task 2 added p03–p08/r03–r04, Task 3 added p09–p11/r05–r06, Task 4 added p12–p14/r07–r08, Task 5 added p15–p17/r09–r10, DSL-resolution pass added p18–p22/r11–r13, §7.3 curried-call resolution added p23–p24/r14, slice-8 companion added p25; item-110 ECond `>=`/`<=` regression added p26; item-700 dedicated `let?`-annotation error added r15; leading-`|` arm-separator and single-line cond-form parser fixes added p27–p28; as-patterns became reachable and retired r08 (2026-07-24), added p29; record patterns became reachable and retired r02/r07 (2026-07-24), added p30–p31; or-patterns added p32; the `(`-led-statement fix added p33)
+# Grammar corpus index (p01–p34 parse, 12 reject — r02/r07/r08 retired 2026-07-24; Task 1 seeded p01–p02/r01–r02, Task 2 added p03–p08/r03–r04, Task 3 added p09–p11/r05–r06, Task 4 added p12–p14/r07–r08, Task 5 added p15–p17/r09–r10, DSL-resolution pass added p18–p22/r11–r13, §7.3 curried-call resolution added p23–p24/r14, slice-8 companion added p25; item-110 ECond `>=`/`<=` regression added p26; item-700 dedicated `let?`-annotation error added r15; leading-`|` arm-separator and single-line cond-form parser fixes added p27–p28; as-patterns became reachable and retired r08 (2026-07-24), added p29; record patterns became reachable and retired r02/r07 (2026-07-24), added p30–p31; or-patterns added p32; the `(`-led-statement fix added p33; its literal-operand follow-up added p34)
 
 Navigable map of the resolved-grammar conformance corpus: each program in
 this directory (`specs/lang/grammar/parse/*.march`,
@@ -33,7 +33,7 @@ Run the whole corpus:
 MARCH_BIN=$PWD/_build/default/bin/main.exe bash specs/lang/grammar/check_grammar.sh
 ```
 
-Exit 0 iff every program behaves as declared (currently 45/45 — 33 parse, 12
+Exit 0 iff every program behaves as declared (currently 46/46 — 34 parse, 12
 reject).
 
 **Naming note:** this corpus uses `parse/` + `reject/` (not `accept/` +
@@ -89,6 +89,7 @@ shape is otherwise identical to `types/check_types.sh`.
 | [`parse/p31_record_pattern_in_let.march`](parse/p31_record_pattern_in_let.march) | §6.2 — record patterns also reachable through `let`'s `simple_pattern` call site | `let { x } = r; x` — the same `LBRACE`-led production, reached through the `let`-binding pattern position rather than a `match` arm. Was `reject/r07`; retired for the same reason as `p30`. |
 | [`parse/p32_or_pattern.march`](parse/p32_or_pattern.march) | §6.2 — `pattern_no_as`'s or-pattern layer (`pattern_alt PIPE separated_nonempty_list(PIPE, pattern_alt)`) | `match 1 do 1 \| 2 -> 10; _ -> 0 end` — builds `PatOr [PatLit 1; PatLit 2]`. `PIPE` also serves as `arm_sep`, but an arm separator only ever follows a complete branch (post-`->`), so LR(1) distinguishes the two uses with no new conflict (menhir's shift/reduce count stays at 9). The binding-rejection counterpart (`A(x) \| B(x)`) is a **type** error, not a parse error, so it lives in `specs/lang/types/reject/` (`t82`), not this corpus. |
 | [`parse/p33_paren_stmt_after_bare_ident.march`](parse/p33_paren_stmt_after_bare_ident.march) | §7.3 — the two-statement reading of a `(`-led line applies after ANY value-ending token, not just a call's `)` | `let _ = a`⏎`()` and `let _ = a`⏎`(1, 2)`. Companion to p24, which only pinned the `)`⏎`(` case: after a bare identifier the `(` was still classified as that identifier's argument list, so the binding parsed as `let _ = a()` — silently INVOKING the parameter (interpreted: "applied non-function value"; compiled: a closure-ABI indirect call through offset 16 of a String, EXC_BAD_ACCESS/exit 138). The token filter now retags such a `(` as `LPAREN_STMT`, which only the group/tuple/unit and pattern rules accept — never the call rule. Prints `ok`. |
+| [`parse/p34_paren_stmt_after_literal.march`](parse/p34_paren_stmt_after_literal.march) | §7.3 — the `(`-led-statement reading applies after a LITERAL too | p33 keyed the retag on a *value-ending* token (identifier, `)`, `]`), but the call rule takes an `expr_field`, which a bare literal also reduces to — so `let _ = 1` ⏎ `()` was still glued into `1()`. Unlike p33 this never reaches the closure-ABI path (a literal has no receiver to load a fn_ptr from): codegen emitted invalid LLVM, `declare ptr @<lit>()`, which clang rejected with "expected function name", failing the build with a diagnostic pointing at generated IR rather than the source. Covers Int, String and Bool operands. `--check` exit 0. |
 
 Task 2 (§4 Expressions, the precedence ladder) added p03–p08/r03–r04 above.
 Task 3 (§5 Blocks & statements) added p09–p11/r05–r06: block-sequencing,
@@ -124,7 +125,7 @@ p29 and retired r08 — the same pass, closing the record-pattern
 reachability gap, added p30/p31 and retired r02/r07 — the same pass, adding
 or-patterns, added p32 (the binding-rejection witness is a type error, not a
 parse error, so it lives in `specs/lang/types/reject/t82` instead) —
-45 programs total (33 `parse/`, 12 `reject/`). See
+46 programs total (34 `parse/`, 12 `reject/`). See
 `specs/plans/archive/2026-07-06-resolved-grammar-plan.md` for the task-by-task
 breakdown that built the first 27; the DSL-resolution pass and the
 `f(1)(2)` fix are tracked in their own commits rather than numbered plan

--- a/specs/lang/grammar/parse/p34_paren_stmt_after_literal.march
+++ b/specs/lang/grammar/parse/p34_paren_stmt_after_literal.march
@@ -1,0 +1,38 @@
+mod P34ParenStmtAfterLiteral do
+  -- §7.3 — companion to p33: the two-statement reading of a `(`-led line
+  -- applies after a LITERAL too, not only after an identifier or a `)`.
+  --
+  -- p33 fixed the token filter to retag a `(` that follows a *value-ending*
+  -- token across a newline, where "value-ending" meant an identifier, `)` or
+  -- `]`. But the call rule takes an `expr_field`, which a bare literal also
+  -- reduces to, so `let _ = 1` followed by a line holding only `()` was still
+  -- glued into `let _ = 1()`. That is a call to an integer: the interpreter
+  -- reported `applied non-function value: 1`, and compiled it reached codegen
+  -- as a call to a literal and emitted invalid LLVM — `declare ptr @<lit>()`
+  -- — which clang rejected with "expected function name", so the build failed
+  -- with a diagnostic pointing at generated IR rather than at the source.
+  --
+  -- Each function below must return unit having done nothing, and `main` must
+  -- print `ok`.
+  fn discard_int() do
+    let _ = 1
+    ()
+  end
+
+  fn discard_string() do
+    let _ = "s"
+    ()
+  end
+
+  fn discard_bool() do
+    let _ = true
+    ()
+  end
+
+  fn main() do
+    discard_int()
+    discard_string()
+    discard_bool()
+    println("ok")
+  end
+end

--- a/test/test_codegen.ml
+++ b/test/test_codegen.ml
@@ -9263,6 +9263,49 @@ let test_unit_tail_discard_runs_compiled () =
       "compiled binary prints ok and exits 0 (pre-fix: EXC_BAD_ACCESS, exit 138)"
       "ok\nEXIT:0" run_out
 
+(* Same shape after a LITERAL rather than an identifier. The first fix keyed
+   the retag on a "value-ending" token — an identifier, `)` or `]` — but the
+   call rule takes an `expr_field`, which a bare literal also reduces to, so
+   `let _ = 1` ⏎ `()` was still glued into `1()`.
+
+   This one does NOT reach the closure-ABI path: a literal has no receiver to
+   load a fn_ptr from, so codegen emitted a call to a name it never defined
+   and produced INVALID LLVM — `declare ptr @<lit>()` — which clang rejected
+   with "expected function name". The build failed pointing at generated IR
+   rather than at the source line, so assert on a clean compile-and-run. *)
+let unit_tail_literal_discard_src =
+  "mod UnitTailLit do\n\
+  \  fn f() do\n\
+  \    let _ = 1\n\
+  \    ()\n\
+  \  end\n\
+  \  fn main() do\n\
+  \    f()\n\
+  \    println(\"ok\")\n\
+  \  end\n\
+   end\n"
+
+let test_unit_tail_literal_discard_runs_compiled () =
+  let (project_root, main_exe, src, tmp) =
+    write_march_source ~name:"march_unittail_lit" unit_tail_literal_discard_src in
+  let interp_out = read_cmd_output (Printf.sprintf
+    "cd %s && %s %s 2>&1"
+    (Filename.quote project_root)
+    (Filename.quote main_exe) (Filename.quote src)) in
+  (* Pre-fix: "applied non-function value: 1". *)
+  Alcotest.(check string) "interpreter prints ok" "ok" interp_out;
+  let bin = Filename.concat tmp "unittaillitbin" in
+  match compile_march_or_skip ~cmd_prefix:(Printf.sprintf "cd %s && " (Filename.quote project_root))
+          ~main_exe ~bin ~src () with
+  | None -> ()  (* legitimate, counted skip: no clang on PATH *)
+  | Some bin ->
+    let run_out = read_cmd_output
+      (Printf.sprintf "%s 2>&1; echo EXIT:$?" (Filename.quote bin)) in
+    Alcotest.(check string)
+      "compiled binary prints ok and exits 0 (pre-fix: clang rejected \
+       `declare ptr @<lit>()`, so the binary never built)"
+      "ok\nEXIT:0" run_out
+
 (** Float arm with NO wildcard: a non-exhaustive float match must panic (the
     Task 1 / B3 `nonexhaustive_panic` fallback), not silently fall through to
     LLVM `unreachable` (undefined behaviour — observed, pre-fix, to print a
@@ -12874,6 +12917,8 @@ let codegen_suites =
             test_unit_tail_discard_no_indirect_call_ir;
           Alcotest.test_case "`()` tail after a discard runs compiled (exit 0)" `Quick
             test_unit_tail_discard_runs_compiled;
+          Alcotest.test_case "`()` tail after a LITERAL discard runs compiled (exit 0)" `Quick
+            test_unit_tail_literal_discard_runs_compiled;
         ] );
       ( "float_lit_match_codegen", [
           Alcotest.test_case "compiled float-literal match arm (B4)" `Quick


### PR DESCRIPTION
Follow-up to #129.

## The gap

#129 stopped a `(`-led line from being glued onto the previous line as a call, keying the retag on a **value-ending** token — an identifier, a `)`, or a `]`. But the call rule takes an `expr_field`, which a bare **literal** also reduces to. So this was still broken:

```march
fn f() do
  let _ = 1
  ()
end
```

It parsed as `let _ = 1()` — a call to an integer.

Unlike #129's identifier case, this never reaches the closure-ABI indirect call: a literal has no receiver to load a function pointer from. It fails differently, and more confusingly:

- **Compiled** — codegen emits *invalid LLVM*, `declare ptr @<lit>()`, which clang rejects with `error: expected function name`. The build fails with a diagnostic pointing at generated IR rather than at the offending source line.
- **Interpreted** — `applied non-function value: 1`.

Verified against pristine `main` with #129 in place.

## The fix

The statement decision now uses a wider `ends_expression` predicate that adds `Int`/`Float`/`String`/`Bool`/atom literals.

`is_value_ending` is deliberately left untouched: it *also* decides whether a paren opens a CALL's argument list for the curried-call guard, and a literal never opens one, so `1(` must keep classifying as a group there. Only `starts_statement` sees the wider notion — so `f(1)(2)` diagnostics are provably unchanged.

## Test plan

- [x] **RED→GREEN proven against #129 specifically** — reverting only this delta (leaving #129 in place) fails the new test with `applied non-function value: 1`, while #129's own two tests keep passing.
- [x] `test/test_codegen.ml` — literal variant of #129's runs-compiled test: asserts a clean compile and `ok` / exit 0.
- [x] `specs/lang/grammar/parse/p34_paren_stmt_after_literal.march` — conformance companion to p33, covering `Int`, `String` and `Bool` operands; whole grammar corpus green (34 parse + 12 reject).
- [x] eval 256/256 · compiler 619/619 · snapshots 33/33 · codegen 521/521
- [x] stdlib 826 run, 1 failure: the pre-existing `MARCH_SANITIZE` case. Per that test's own message I ran the prescribed check — a trivial unrelated `clang -fsanitize=address` binary hangs identically on this machine, so it's environmental, not a regression.
- [x] Menhir shift/reduce conflict count **unchanged at 9**; `scripts/check-docs.sh` passes.
- [x] Downstream: with this installed, [scroll](https://github.com/march-language/scroll) can drop its `()` → `None` workaround in `lib/processes.march` — `forge test` 228/228.