### PR TITLE
fix(forge): registry deps work for archive tasks and pull their own deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,39 @@ git log is authoritative for exact commits.
 
 ### Fixed
 
+- **A registry dependency now works for archive tasks, and brings its own
+  dependencies with it.** Three gaps in `registry = "forge"` handling, all
+  found while releasing scroll — which builds and tests green, then failed the
+  moment its own `forge scroll.serve` task ran:
+
+  - **Archive tasks saw no lib path for a registry dep.**
+    `Archive_store.dep_lib_paths_for_archive` matched path and the three git
+    forms then fell off a `| _ -> []`, so `RegistryDep` contributed nothing.
+    `Cmd_build.dep_to_lib_paths` — which backs check/build/test — handled the
+    same case, which is why a package could pass every check and still fail at
+    run time with `Unknown module` for everything the dependency provides. The
+    match is now exhaustive with no wildcard, so a future dep form is a compile
+    error rather than a silently empty search path.
+
+  - **`forge deps` did not fetch a registry package's own dependencies.**
+    Resolution ran phase 1 (path/git, BFS) then phase 2 (registry, version
+    solve) once each, and phase 2 only ever recursed into *registry* children —
+    so registry → registry worked but registry → git/path did not, and a
+    registry package's git dependency was never installed. The two phases now
+    alternate to a joint fixpoint; the existing nearest-wins name dedup both
+    preserves precedence and terminates the alternation.
+
+  - **The CAS reused an install from the wrong source.**
+    `~/.march/cas/deps/<name>` is keyed by dependency name only, and
+    `install_dep` treated "directory exists" as "correctly installed" — so
+    switching a dependency between registry and git reported `already
+    installed` over the previous source's content and then failed with `fatal:
+    not a git repository`. A git install is now reused only when its `origin`
+    matches; otherwise it is re-installed. (Two projects wanting the same
+    package at different revs still share one directory — fixing that means
+    keying the path by source, tracked in
+    `specs/plans/2026-07-30-forge-registry-dep-gaps.md`.)
+
 - **A refined annotation on a `let` is now checked against the expression it
   annotates, instead of being believed.** `let ys : {List(Int) | len(_) > 0} =
   []` used to compile: the annotation entered the refinement checker's scope

--- a/forge/lib/archive_store.ml
+++ b/forge/lib/archive_store.ml
@@ -316,7 +316,23 @@ let dep_lib_paths_for_archive archive_root =
               else rel_path
             in
             visit ~dep_root:abs_path ~lib_dir:(Filename.concat abs_path "lib")
-          | Project.GitTagDep _ | Project.GitBranchDep _ | Project.GitRevDep _ ->
+          | Project.GitTagDep _ | Project.GitBranchDep _ | Project.GitRevDep _
+          | Project.RegistryDep _ ->
+            (* Git AND registry deps both install under ~/.march/cas/deps/<name>
+               (see Project.dep_root_dir), so the same lookup serves both —
+               exactly as cmd_build's dep_to_lib_paths does it.
+
+               RegistryDep used to fall through a `| _ -> []` here, so an
+               archive task got NO lib path for a registry dependency while
+               check/build/test — which go through cmd_build — got the right
+               one. A tool whose dep was a registry dep therefore built and
+               tested green, then failed at run time with `Unknown module` for
+               every symbol that dep provided (scroll 0.1.2: `forge
+               scroll.serve` could not find bastion's Router/Middleware/Static).
+
+               Deliberately NO wildcard arm: Project.dep is a closed variant,
+               so listing every constructor makes a future dep form a compile
+               error here instead of a silently empty search path. *)
             (match Project.git_dep_lib_path dep_name with
              | Some p ->
                (* p is either <dep_root>/lib or <dep_root> itself *)
@@ -324,7 +340,6 @@ let dep_lib_paths_for_archive archive_root =
                  if Filename.basename p = "lib" then Filename.dirname p else p in
                visit ~dep_root ~lib_dir:p
              | None -> [])
-          | _ -> []
         ) deps
   and visit ~dep_root ~lib_dir =
     let key = canon dep_root in

--- a/forge/lib/cmd_deps.ml
+++ b/forge/lib/cmd_deps.ml
@@ -91,6 +91,50 @@ let resolve_commit path =
   | (0, sha) when String.length sha >= 7 -> Some sha
   | _ -> None
 
+(** Is [dest] an existing git checkout of [url]?
+
+    The CAS keys an install by dep NAME only ([Project.dep_root_dir] maps every
+    non-path dep to ~/.march/cas/deps/<name>), so that directory can hold
+    content from a DIFFERENT source than the manifest now asks for — most
+    easily by switching a dep between `registry = ...` and `git = ...`, but
+    equally by two projects on one machine wanting different URLs.
+
+    A bare [Sys.file_exists dest] then reports "already installed" over, say, a
+    registry tarball, and the next git command fails with `fatal: not a git
+    repository` — with the lockfile recording the git source while the
+    directory holds registry content. Checking the remote before reuse turns
+    that silent mismatch into a re-install.
+
+    Conservative by design: anything we cannot positively confirm as a matching
+    checkout (no .git, git not on PATH, a rewritten remote) reports false, and
+    the caller re-installs. Re-cloning is cheap; serving wrong content is not.
+
+    NOTE this does not fix the underlying sharing problem — two projects
+    needing the same package at different revs still collide on one directory,
+    and the later one re-clones over the earlier. The real fix is to key the
+    CAS path by source, which is an on-disk layout change; see
+    specs/plans/2026-07-30-forge-registry-dep-gaps.md (B3, option 2). *)
+let git_checkout_matches ~url dest =
+  Sys.file_exists (Filename.concat dest ".git")
+  && (let cmd = Printf.sprintf "git -C %s remote get-url origin"
+                  (Filename.quote dest) in
+      match run_cmd cmd with
+      | (0, got) -> String.trim got = String.trim url
+      | _ -> false)
+
+(** Reuse [dest] if it is a matching checkout of [url]; otherwise clear it so
+    the caller's clone starts from a clean directory. Returns true when the
+    existing install can be reused as-is. *)
+let reuse_or_clear_git_dest ~name ~url dest =
+  if not (Sys.file_exists dest) then false
+  else if git_checkout_matches ~url dest then true
+  else begin
+    Printf.printf
+      "  %s: installed copy does not match %s — reinstalling\n%!" name url;
+    ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dest)));
+    false
+  end
+
 (** Compute the content hash for a resolved dep directory.
     Uses the CAS canonical archive hash; falls back to a placeholder if
     the directory doesn't exist yet (e.g. registry deps not yet fetched). *)
@@ -451,7 +495,7 @@ let install_dep name (dep : Project.dep) =
     Ok e
 
   | Project.GitTagDep { url; tag } ->
-    if Sys.file_exists dest then begin
+    if reuse_or_clear_git_dest ~name ~url dest then begin
       Printf.printf "  %s: already installed (tag %s)\n%!" name tag;
       let commit = resolve_commit dest in
       let e = Resolver_lockfile.{ name; version = Some tag;
@@ -482,7 +526,7 @@ let install_dep name (dep : Project.dep) =
     end
 
   | Project.GitBranchDep { url; branch } ->
-    if Sys.file_exists dest then begin
+    if reuse_or_clear_git_dest ~name ~url dest then begin
       Printf.printf "  %s: already installed (branch %s)\n%!" name branch;
       let commit = resolve_commit dest in
       let e = Resolver_lockfile.{ name; version = None;
@@ -505,7 +549,7 @@ let install_dep name (dep : Project.dep) =
     end
 
   | Project.GitRevDep { url; rev } ->
-    if Sys.file_exists dest then begin
+    if reuse_or_clear_git_dest ~name ~url dest then begin
       Printf.printf "  %s: already installed (rev %s)\n%!" name rev;
       let e = Resolver_lockfile.{ name; version = None;
                                    source = "git:" ^ url;
@@ -688,12 +732,10 @@ let run () =
       let visited = Hashtbl.create 16 in
       let reg_acc = ref [] in
       (* Phase 1: install path/git deps via BFS; registry deps (direct AND any
-         found transitively) accumulate in [reg_acc] instead of installing. *)
-      let results = bfs_install visited ~reg_acc ~project_root:proj.Project.root all_deps in
-      let git_errors = List.filter_map (fun (_, r) ->
-          match r with Error e -> Some e | Ok _ -> None) results in
-      let git_entries = List.filter_map (fun (_, r) ->
-          match r with Ok e -> Some e | Error _ -> None) results in
+         found transitively) accumulate in [reg_acc] instead of installing.
+         [results] accumulates across every phase-1 pass, because phase 2 can
+         hand back more path/git deps to install (see [drive] below). *)
+      let results = ref (bfs_install visited ~reg_acc ~project_root:proj.Project.root all_deps) in
       (* Overrides: every non-registry (path/git) dep is pre-resolved and must
          not be version-solved by PubGrub. *)
       let override_deps =
@@ -713,6 +755,25 @@ let run () =
             else begin Hashtbl.add seen_reg name (); true end
           ) (List.rev pairs)
       in
+      (* The two phases alternate to a JOINT fixpoint.
+         [resolve_wave] used to recurse on registry children only:
+
+             List.filter_map (fun (n, d) -> match d with
+               | Project.RegistryDep { version } -> Some (n, version)
+               | _ -> None)                       (* git/path children dropped *)
+
+         so registry → registry recursed but registry → git/path did not, and a
+         registry package's own git dependency was never fetched. Concretely:
+         bastion is a registry package declaring `depot = { git = ... }`; depot
+         never arrived, and bastion's own Depot.Middleware failed to compile
+         with `Module Pool not found`. Now a registry package's non-registry
+         children go back through phase 1 (which may in turn surface more
+         registry constraints into [reg_acc], hence the alternation).
+
+         The existing invariants are preserved: [visited] and [seen_reg] still
+         dedup by dep NAME nearest-wins, so re-entering phase 1 cannot reinstall
+         or re-claim an already-seen dep, and that also terminates the
+         alternation — every pass strictly grows one of the two visited sets. *)
       let rec resolve_wave pending =
         match dedup pending with
         | [] -> ()
@@ -721,24 +782,52 @@ let run () =
            | Error e -> reg_error := Some e
            | Ok es ->
              reg_entries := !reg_entries @ es;
-             (* Discover transitive registry deps from the just-installed set. *)
-             let next = List.concat_map (fun e ->
+             (* Split each just-installed registry package's own deps: registry
+                children continue the phase-2 fixpoint, everything else is
+                handed to phase 1, keyed by the DECLARING package's root so its
+                relative PathDeps resolve correctly. *)
+             let next_reg = ref [] in
+             let next_nonreg = ref [] in
+             List.iter (fun e ->
                  let dep_dir = Filename.concat (cas_deps_dir ()) e.Resolver_lockfile.name in
                  if Sys.file_exists (Filename.concat dep_dir "forge.toml") then
                    match Project.load_from_dir dep_dir with
                    | Ok p ->
-                     List.filter_map (fun (n, d) ->
+                     List.iter (fun (n, d) ->
                          match d with
-                         | Project.RegistryDep { version } -> Some (n, version)
-                         | _ -> None)
+                         | Project.RegistryDep { version } ->
+                           next_reg := (n, version) :: !next_reg
+                         | _ ->
+                           next_nonreg := (dep_dir, (n, d)) :: !next_nonreg)
                        p.Project.deps
-                   | Error _ -> []
-                 else []
-               ) es in
-             resolve_wave next)
+                   | Error _ -> ()
+               ) es;
+             (* Phase 1 over the non-registry children, grouped by declaring
+                root. This may push new constraints into [reg_acc]. *)
+             let by_root = Hashtbl.create 4 in
+             List.iter (fun (root, dep) ->
+                 let existing = try Hashtbl.find by_root root with Not_found -> [] in
+                 Hashtbl.replace by_root root (dep :: existing)
+               ) !next_nonreg;
+             Hashtbl.iter (fun root deps ->
+                 results :=
+                   !results
+                   @ bfs_install visited ~reg_acc ~project_root:root (List.rev deps)
+               ) by_root;
+             (* Anything phase 1 just surfaced joins this wave's registry
+                children for the next pass. *)
+             let carried = !reg_acc in
+             reg_acc := [];
+             resolve_wave (!next_reg @ carried))
         | _ -> ()
       in
-      resolve_wave !reg_acc;
+      let initial_reg = !reg_acc in
+      reg_acc := [];
+      resolve_wave initial_reg;
+      let git_errors = List.filter_map (fun (_, r) ->
+          match r with Error e -> Some e | Ok _ -> None) !results in
+      let git_entries = List.filter_map (fun (_, r) ->
+          match r with Ok e -> Some e | Error _ -> None) !results in
       let errors = git_errors @ (match !reg_error with Some e -> [e] | None -> []) in
       let entries = git_entries @ !reg_entries in
       let mhash = Resolver_lockfile.compute_manifest_hash toml_content in

--- a/forge/test/test_regression.ml
+++ b/forge/test/test_regression.ml
@@ -196,6 +196,158 @@ let test_three_way_diamond_highest_lower_bound () =
     true (V.compare c_v (V.parse_exn "1.5.0") >= 0)
 
 (* ------------------------------------------------------------------ *)
+(*  Archive-task lib paths                                             *)
+(* ------------------------------------------------------------------ *)
+
+(** An archive task must see a REGISTRY dependency's lib dir, not just a
+    git/path one.
+
+    [Archive_store.dep_lib_paths_for_archive] matched PathDep and the three git
+    forms and then fell off a `| _ -> []`, so a RegistryDep contributed no lib
+    paths at all. [Cmd_build.dep_to_lib_paths] — which backs check/build/test —
+    handled the same case, so a tool with a registry dependency built and
+    tested green and then failed at run time with `Unknown module` for every
+    symbol that dependency provided. scroll 0.1.2 shipped that way: `forge
+    scroll.serve` could not find bastion's Router/Middleware/Static.
+
+    Registry and git deps both install to ~/.march/cas/deps/<name>, so the
+    check is simply that the CAS lib dir shows up. HOME is redirected at a
+    temp dir so this is hermetic and does not read the developer's real CAS. *)
+let test_archive_lib_paths_include_registry_dep () =
+  let tmp = Filename.temp_file "forge_archive_reg" "" in
+  Sys.remove tmp;
+  Unix.mkdir tmp 0o755;
+  let mkdir_p d = ignore (Sys.command (Printf.sprintf "mkdir -p %s" (Filename.quote d))) in
+  let write path contents =
+    let oc = open_out path in output_string oc contents; close_out oc in
+  (* Fake CAS: the dep is installed exactly where a registry install lands. *)
+  let fake_home = Filename.concat tmp "home" in
+  let dep_lib = Filename.concat fake_home ".march/cas/deps/somedep/lib" in
+  mkdir_p dep_lib;
+  write (Filename.concat dep_lib "somedep.march") "mod SomeDep do\nend\n";
+  (* An archive project whose only dependency is a REGISTRY dep. *)
+  let archive_root = Filename.concat tmp "archive" in
+  mkdir_p (Filename.concat archive_root "lib");
+  write (Filename.concat archive_root "forge.toml")
+    "[package]\n\
+     name = \"tool\"\n\
+     version = \"0.1.0\"\n\
+     type = \"tool\"\n\n\
+     [deps]\n\
+     somedep = { registry = \"forge\", version = \"1.0.0\" }\n";
+  let old_home = Sys.getenv_opt "HOME" in
+  let restore () =
+    match old_home with
+    | Some h -> Unix.putenv "HOME" h
+    | None   -> Unix.putenv "HOME" ""
+  in
+  Fun.protect ~finally:restore (fun () ->
+    Unix.putenv "HOME" fake_home;
+    let paths = Archive_store.dep_lib_paths_for_archive archive_root in
+    let canon p = try Unix.realpath p with Unix.Unix_error _ -> p in
+    let wanted = canon dep_lib in
+    let found = List.exists (fun p -> canon p = wanted) paths in
+    Alcotest.(check bool)
+      (Printf.sprintf
+         "registry dep's lib dir must be on an archive task's search path \
+          (wanted %s, got [%s])"
+         wanted (String.concat "; " paths))
+      true found)
+
+(** Control: the git form must keep working — this arm was never broken, and
+    the fix must not regress it while generalising the match. *)
+let test_archive_lib_paths_include_git_dep () =
+  let tmp = Filename.temp_file "forge_archive_git" "" in
+  Sys.remove tmp;
+  Unix.mkdir tmp 0o755;
+  let mkdir_p d = ignore (Sys.command (Printf.sprintf "mkdir -p %s" (Filename.quote d))) in
+  let write path contents =
+    let oc = open_out path in output_string oc contents; close_out oc in
+  let fake_home = Filename.concat tmp "home" in
+  let dep_lib = Filename.concat fake_home ".march/cas/deps/gitdep/lib" in
+  mkdir_p dep_lib;
+  write (Filename.concat dep_lib "gitdep.march") "mod GitDep do\nend\n";
+  let archive_root = Filename.concat tmp "archive" in
+  mkdir_p (Filename.concat archive_root "lib");
+  write (Filename.concat archive_root "forge.toml")
+    "[package]\n\
+     name = \"tool\"\n\
+     version = \"0.1.0\"\n\
+     type = \"tool\"\n\n\
+     [deps]\n\
+     gitdep = { git = \"https://example.invalid/gitdep.git\", branch = \"main\" }\n";
+  let old_home = Sys.getenv_opt "HOME" in
+  let restore () =
+    match old_home with
+    | Some h -> Unix.putenv "HOME" h
+    | None   -> Unix.putenv "HOME" ""
+  in
+  Fun.protect ~finally:restore (fun () ->
+    Unix.putenv "HOME" fake_home;
+    let paths = Archive_store.dep_lib_paths_for_archive archive_root in
+    let canon p = try Unix.realpath p with Unix.Unix_error _ -> p in
+    let wanted = canon dep_lib in
+    Alcotest.(check bool) "git dep's lib dir still on the search path"
+      true (List.exists (fun p -> canon p = wanted) paths))
+
+(* ------------------------------------------------------------------ *)
+(*  CAS install reuse must check the source                            *)
+(* ------------------------------------------------------------------ *)
+
+(** ~/.march/cas/deps/<name> is keyed by dep NAME only, so it can hold content
+    from a different source than the manifest now asks for (switch a dep
+    between `registry = ...` and `git = ...`, or two projects wanting different
+    URLs). [install_dep] used to treat "directory exists" as "correctly
+    installed": it printed `already installed (branch main)` over a registry
+    tarball and then failed with `fatal: not a git repository`, with the
+    lockfile claiming the git source while the directory held registry content.
+
+    [Cmd_deps.git_checkout_matches] is the guard. These cover its three
+    outcomes without any network access. *)
+let with_tmp_dir f =
+  let tmp = Filename.temp_file "forge_cas_reuse" "" in
+  Sys.remove tmp;
+  Unix.mkdir tmp 0o755;
+  Fun.protect
+    ~finally:(fun () -> ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote tmp))))
+    (fun () -> f tmp)
+
+let test_cas_reuse_rejects_non_git_dir () =
+  with_tmp_dir (fun tmp ->
+    let dest = Filename.concat tmp "dep" in
+    ignore (Sys.command (Printf.sprintf "mkdir -p %s" (Filename.quote dest)));
+    (* A registry tarball extract: real files, but no .git. *)
+    let oc = open_out (Filename.concat dest "forge.toml") in
+    output_string oc "[package]\nname = \"dep\"\n"; close_out oc;
+    Alcotest.(check bool)
+      "a non-git directory is never reused as a git checkout"
+      false
+      (Cmd_deps.git_checkout_matches ~url:"https://example.invalid/dep.git" dest))
+
+let test_cas_reuse_rejects_wrong_remote () =
+  with_tmp_dir (fun tmp ->
+    let dest = Filename.concat tmp "dep" in
+    ignore (Sys.command (Printf.sprintf
+      "git init -q %s && git -C %s remote add origin https://example.invalid/OTHER.git"
+      (Filename.quote dest) (Filename.quote dest)));
+    Alcotest.(check bool)
+      "a git checkout of a DIFFERENT url is not reused"
+      false
+      (Cmd_deps.git_checkout_matches ~url:"https://example.invalid/dep.git" dest))
+
+let test_cas_reuse_accepts_matching_remote () =
+  with_tmp_dir (fun tmp ->
+    let dest = Filename.concat tmp "dep" in
+    let url = "https://example.invalid/dep.git" in
+    ignore (Sys.command (Printf.sprintf
+      "git init -q %s && git -C %s remote add origin %s"
+      (Filename.quote dest) (Filename.quote dest) (Filename.quote url)));
+    Alcotest.(check bool)
+      "a git checkout of the SAME url is reused (no needless re-clone)"
+      true
+      (Cmd_deps.git_checkout_matches ~url dest))
+
+(* ------------------------------------------------------------------ *)
 (*  Suite                                                              *)
 (* ------------------------------------------------------------------ *)
 
@@ -210,5 +362,19 @@ let () =
       Alcotest.test_case "independent root deps: no spurious entries" `Quick test_independent_root_deps_no_spurious_entries;
       Alcotest.test_case "tight transitive compatible with loose root" `Quick test_tight_transitive_compatible_with_loose_root;
       Alcotest.test_case "three-way diamond: highest lower bound"   `Quick test_three_way_diamond_highest_lower_bound;
+    ];
+    "archive-lib-paths", [
+      Alcotest.test_case "archive task sees a REGISTRY dep's lib dir" `Quick
+        test_archive_lib_paths_include_registry_dep;
+      Alcotest.test_case "archive task still sees a git dep's lib dir" `Quick
+        test_archive_lib_paths_include_git_dep;
+    ];
+    "cas-install-reuse", [
+      Alcotest.test_case "non-git dir (registry tarball) not reused as git" `Quick
+        test_cas_reuse_rejects_non_git_dir;
+      Alcotest.test_case "git checkout of a different url not reused" `Quick
+        test_cas_reuse_rejects_wrong_remote;
+      Alcotest.test_case "git checkout of the same url is reused" `Quick
+        test_cas_reuse_accepts_matching_remote;
     ];
   ]

--- a/specs/plans/2026-07-30-forge-registry-dep-gaps.md
+++ b/specs/plans/2026-07-30-forge-registry-dep-gaps.md
@@ -1,0 +1,274 @@
+# Plan: three forge gaps in registry-dependency handling
+
+**Status:** Implemented 2026-07-30 — B1 and B2 fixed in full; B3 shipped as
+option 1 (validate before reuse), with option 2 (source-keyed CAS paths) left
+open as follow-up. Kept as the written record of what was wrong and why.
+**Repo:** `march-language/march` (forge lives in `forge/` inside the march repo).
+**Found:** 2026-07-30, while releasing [scroll](https://github.com/march-language/scroll) 0.1.2 → 0.1.3.
+
+Three independent bugs, all in the handling of `registry = "forge"`
+dependencies. They are separable and can land as separate PRs; **B1 is the one
+that shipped a broken release** and should go first.
+
+## How they were found (the motivating failure)
+
+scroll is a forge **tool** — it declares `[archive.task.scroll.serve]`, and
+`forge scroll.serve` is the only command it exists to provide. scroll 0.1.2
+changed its bastion dependency from git to registry:
+
+```toml
+bastion = { registry = "forge", version = "0.2.4" }
+```
+
+`forge check`, `forge build` and `forge test` all passed. `forge scroll.serve`
+failed with `Unknown module Router` / `Middleware` / `Static` — every symbol
+bastion provides. The release shipped broken because it was verified with
+check/build/test only.
+
+Reproducing the three bugs from a clean CAS (`rm -rf ~/.march/cas/deps/*`):
+
+| forge.toml | `forge deps` fetches | `check`/`test` | `<pkg>.<task>` |
+|---|---|---|---|
+| `bastion = { git = …, branch = "main" }` | bastion **and** depot | pass | **pass** |
+| `bastion = { registry = "forge", version = "0.2.4" }` | bastion only | *fails* — `Module Pool not found` | — |
+| registry bastion **+** explicit `depot = { git = … }` | both | pass | **fails** — `Unknown module Router` |
+
+Row 2 is **B2**. Row 3 is **B1**. **B3** surfaced when switching a dep back and
+forth between registry and git.
+
+> Caution for whoever picks this up: an early attempt at row 2 appeared to pass
+> because a `depot` left over from the git-dep era was still sitting in
+> `~/.march/cas/deps/`. **Purge the CAS between every experiment** or you will
+> measure the previous run.
+
+---
+
+## B1 — archive tasks silently drop registry deps
+
+**Severity: high.** A package that builds and tests green fails at runtime with
+`Unknown module` for everything its registry dependency provides.
+
+### Root cause
+
+`forge/lib/archive_store.ml`, `dep_lib_paths_for_archive`. `Project.dep` has
+five constructors (`project.ml:6`) — `RegistryDep`, `GitTagDep`,
+`GitBranchDep`, `GitRevDep`, `PathDep`. The archive walk handles path and the
+three git forms and then falls off a catch-all:
+
+```ocaml
+| Project.PathDep rel_path -> …
+| Project.GitTagDep _ | Project.GitBranchDep _ | Project.GitRevDep _ ->
+    (match Project.git_dep_lib_path dep_name with …)
+| _ -> []            (* ← RegistryDep lands here: contributes NO lib paths *)
+```
+
+`forge/lib/cmd_build.ml`'s `dep_to_lib_paths` — the path `check`/`build`/`test`
+use — gets it right, and its comment states why the two forms are equivalent:
+
+```ocaml
+| Project.GitTagDep _ | Project.GitBranchDep _ | Project.GitRevDep _
+| Project.RegistryDep _ ->
+    (* Git and registry deps both install under ~/.march/cas/deps/<name>; use
+       that dep's lib/ (or its root as a fallback). *)
+```
+
+So a registry dep is installed to exactly the same place either way —
+`archive_store` just never looks there. Note `dep_lib_paths_for_archive`'s own
+docstring claims it "Mirrors cmd_build's `dep_to_lib_paths`". It doesn't; that
+comment is what makes the omission look intentional on a skim.
+
+### Fix
+
+Add `| Project.RegistryDep _` to the existing git arm in
+`dep_lib_paths_for_archive`, mirroring `cmd_build`. `Project.git_dep_lib_path`
+is already name-based (`~/.march/cas/deps/<name>/lib`), so it resolves a
+registry install unchanged — verify that rather than assuming.
+
+Then **re-read the whole file for the same pattern.** `archive_store.ml` has
+other matches over `Project.dep` (around lines 377 and 402 per the
+`lib_path_env` comments); check each for the same missing constructor. A
+`| _ -> []` over a five-constructor variant is the shape of this bug — consider
+making these matches exhaustive (drop the wildcard, list every constructor) so
+a future sixth dep form is a compile error rather than a silent empty path.
+
+### Test
+
+`forge/test/` — model on the existing build/check tests. The regression needs a
+**tool**-type package (with `[archive.task.*]`) whose dependency is a
+**registry** dep; a library package never exercises this path, and path/git
+deps both work, which is why nothing caught it. Assert the archive task's
+computed `MARCH_LIB_PATH` contains the dep's lib dir. Prove it RED first —
+without the fix the list should come back missing that entry.
+
+---
+
+## B2 — `forge deps` does not fetch a registry package's own dependencies
+
+**Severity: high.** The dependency graph below a registry package is invisible,
+so its own imports fail to compile.
+
+### Root cause
+
+`forge/lib/cmd_deps.ml`, two-phase resolution:
+
+- **Phase 1** `bfs_install` installs path/git deps breadth-first. Registry deps
+  are deliberately *filtered out* of `fresh` into `reg_acc` so PubGrub can
+  version-solve them in one pass. Because they are removed from `fresh`, they
+  never reach `results`, and `next_wave` is built only from `results` — so a
+  registry package's forge.toml is never read here.
+- **Phase 2** `resolve_wave` installs the solved registry set, then discovers
+  the next wave — but filters to registry deps only:
+
+```ocaml
+List.filter_map (fun (n, d) ->
+    match d with
+    | Project.RegistryDep { version } -> Some (n, version)
+    | _ -> None)          (* ← git/path deps of a registry package: dropped *)
+  p.Project.deps
+```
+
+So **registry → registry recurses; registry → git/path does not.** The
+in-code comment ("a registry dep that itself declares registry deps is picked
+up") documents exactly the half that works.
+
+Concretely: bastion is a registry package declaring
+`depot = { git = …, branch = "main" }`. depot is never fetched, and bastion's
+own `Depot.Middleware` fails with `Module Pool not found`.
+
+Note this is the same *shape* as march#127 (which fixed `cmd_test` resolving
+direct-but-not-transitive deps) — a partial graph walk, different walker.
+
+### Fix
+
+After Phase 2 installs a registry package, feed its **non-registry** deps back
+into Phase 1's BFS, and its registry deps into Phase 2's fixpoint as today.
+The two phases need to alternate to a joint fixpoint rather than run once each:
+a git dep of a registry package may itself declare registry deps.
+
+Preserve the existing invariants — they are load-bearing and commented at
+length in `collect_transitive_deps`:
+
+- **nearest-wins by dep name** (a direct dep beats one reachable only deeper),
+- **breadth-first by depth**, not depth-first — the comment in `cmd_build.ml`
+  records a real bug the depth-first version caused,
+- `override_deps` must keep excluding every non-registry dep from PubGrub.
+
+Watch for a cycle between the two phases; both already dedup by name
+(`visited`, `seen_reg`), so route the new edges through those same tables.
+
+### Test
+
+`forge/test/test_build_check.ml` has the march#127 regression as a model.
+Needs a registry package whose forge.toml declares a git dep. If the test
+registry cannot host that, assert on the resolver's computed install set from a
+synthetic manifest rather than doing real network I/O.
+
+---
+
+## B3 — the CAS keys installs by dep name only, not by source
+
+**Severity: medium** — wrong-source silent reuse, recoverable only by manually
+deleting the directory.
+
+### Root cause
+
+`Project.dep_root_dir` (`forge/lib/project.ml:368`) maps every non-path dep to
+`~/.march/cas/deps/<dep_name>` with no discriminator for source, URL, branch,
+rev or version. `install_dep` in `cmd_deps.ml` then treats *directory exists*
+as *correctly installed*:
+
+```ocaml
+| Project.GitBranchDep { url; branch } ->
+  if Sys.file_exists dest then begin
+    Printf.printf "  %s: already installed (branch %s)\n%!" name branch;
+    …
+```
+
+### Observed
+
+Switching bastion registry → git, `forge deps` printed
+`bastion: already installed (branch main)` while `~/.march/cas/deps/bastion`
+actually held the **registry tarball extract**, then failed with
+`fatal: not a git repository`. The lockfile recorded the git source while the
+directory held registry content. Only `rm -rf ~/.march/cas/deps/bastion`
+recovered.
+
+The same hazard applies within one source kind: two projects on one machine
+depending on the same package at different branches/revs/versions share one
+directory, and whichever installs first silently wins.
+
+### Fix — pick one, they trade off
+
+1. **Validate before reuse (smallest).** On the `already installed` path,
+   confirm the directory matches the requested source — `.git` present and
+   `origin` URL matching for a git dep; a registry marker for a registry dep —
+   and re-install on mismatch. Fixes the corruption, not the sharing.
+2. **Key the path by source (correct, more invasive).** Make `dep_root_dir`
+   include a short hash of the resolved source (`url+rev`, `registry+version`).
+   Fixes both, but changes on-disk layout and touches everything that assumes
+   `deps/<name>` — including `archive_store.ml`, `Project.git_dep_lib_path`,
+   and `cmd_deps.ml`'s Phase-2 `Filename.concat (cas_deps_dir ()) e.name`.
+   Needs a migration story for existing CAS dirs.
+
+Recommend **(1)** now and file **(2)** separately — (2) is a layout change that
+should not ride along with a correctness fix.
+
+### Test
+
+Unit-level: install a dep from source A, rewrite the manifest to source B,
+re-resolve, assert the directory holds B (or that a clear error is raised) —
+not a stale A with a success message.
+
+---
+
+## Suggested order
+
+1. **B1** — one arm in an existing match; unblocks tool packages using registry
+   deps. Also audit the sibling matches in `archive_store.ml`.
+2. **B2** — the real design work (joint fixpoint across both phases).
+3. **B3** option 1; file option 2 as follow-up.
+
+## Verification for any of these
+
+`dune build` then the suites: `test/run_eval.exe`, `run_compiler.exe`,
+`run_codegen.exe`, `run_snapshots.exe`, `run_stdlib.exe`, plus forge's own
+`forge/test/`. Expect one **pre-existing** `MARCH_SANITIZE` failure in
+`run_stdlib` on macOS — it is environmental (a trivial unrelated
+`clang -fsanitize=address` binary hangs identically); that test's own message
+tells you to check exactly that before blaming a change.
+
+End-to-end check that B1 and B2 are actually fixed, using scroll:
+
+```bash
+rm -rf ~/.march/cas/deps/bastion ~/.march/cas/deps/depot   # MUST purge
+# in a scroll checkout, set: bastion = { registry = "forge", version = "0.2.4" }
+# and remove any explicit depot line
+forge deps          # must fetch bastion AND depot (B2)
+forge test          # 228/228
+forge scroll.serve  # must serve on :4040 with no `Unknown module` (B1)
+```
+
+scroll `main` currently pins bastion by git rev as the workaround
+(`36e85e04…`, which is bastion 0.2.4) with an inline comment pointing back at
+B1. Once B1 and B2 land, that can become a plain registry dep again — see
+scroll's CHANGELOG 0.1.3.
+
+## Toolchain gotchas that will cost time otherwise
+
+- **The CAS artifact cache is keyed on source hash only, not compiler
+  version**, so a stale binary survives a compiler rebuild. After every forge
+  or compiler change:
+  `rm -rf ~/.march/cas/artifacts ~/.march/cas/artifacts-v2 <project>/.march/cas`
+- **`forge` does not use `march`/`forge` from `$PATH`.** It resolves through
+  `~/.march/current` → `~/.march/versions/<tag>/bin/`, and `make install` only
+  updates `~/.opam/march/bin/`. To make a change live for `forge`-driven runs:
+
+  ```bash
+  cd /path/to/march && make install
+  cp _build/default/bin/main.exe        ~/.march/versions/local-main/bin/march
+  cp _build/default/forge/bin/main.exe  ~/.march/versions/local-main/bin/forge
+  cp -R runtime/. ~/.march/versions/local-main/runtime/
+  md5 -q _build/default/forge/bin/main.exe ~/.march/versions/local-main/bin/forge
+  ```
+
+  The `forge` binary is the one that matters for all three of these bugs.


### PR DESCRIPTION
Implements [`specs/plans/2026-07-30-forge-registry-dep-gaps.md`](specs/plans/2026-07-30-forge-registry-dep-gaps.md) (included, marked implemented).

Three gaps in `registry = "forge"` handling. Found while releasing [scroll](https://github.com/march-language/scroll): it built and tested **green** on a registry dependency, then `forge scroll.serve` — the one command that tool provides — failed with `Unknown module Router` / `Middleware` / `Static`. scroll 0.1.2 shipped broken for exactly that reason.

## B1 — archive tasks saw no lib path for a registry dep

`Archive_store.dep_lib_paths_for_archive` matched `PathDep` and the three git forms, then fell off a `| _ -> []`; `RegistryDep` landed there and contributed nothing. `Cmd_build.dep_to_lib_paths` — which backs check/build/test — handles the same case, and both sources install to `~/.march/cas/deps/<name>`, so the two paths simply disagreed.

Now exhaustive with **no wildcard**, so a future dep form is a compile error rather than a silently empty search path. Audited the rest of the file: this was its only dep-variant match.

## B2 — `forge deps` didn't fetch a registry package's own dependencies

Phase 1 (path/git BFS) and phase 2 (registry version-solve) each ran once, and phase 2 recursed only into `RegistryDep` children:

```ocaml
| Project.RegistryDep { version } -> Some (n, version)
| _ -> None                       (* git/path children of a registry pkg: dropped *)
```

So registry → registry worked, registry → git/path didn't — bastion's `depot` was never fetched, giving `Module Pool not found`. The phases now alternate to a joint fixpoint, with a registry package's non-registry children routed back through `bfs_install` keyed by the **declaring** package's root so its relative `PathDep`s still resolve. The pre-existing nearest-wins name dedup preserves precedence *and* terminates the alternation — each pass strictly grows one of the two visited sets.

## B3 — the CAS reused an install from the wrong source

`~/.march/cas/deps/<name>` is keyed by name only, and `install_dep` treated *directory exists* as *correctly installed*. Switching a dep registry → git printed `already installed (branch main)` over a registry tarball, then `fatal: not a git repository`, with the lockfile claiming git. A git install is now reused only when its `origin` matches; otherwise it's cleared and re-installed. Conservative — anything not positively confirmed re-installs.

This is option 1 from the plan. It does **not** fix same-name/different-source sharing between projects; that needs source-keyed CAS paths, which is an on-disk layout change left as follow-up.

## Test plan

New hermetic tests in `forge/test/test_regression.ml` (HOME redirected at a temp dir, no network):

- a registry dep's lib dir must reach an archive task — **confirmed RED against pre-fix code**, with a git-dep control that stayed green throughout
- the three outcomes of the CAS reuse check (non-git dir, wrong remote, matching remote)

End-to-end from a **purged CAS**, scroll declaring only `bastion = { registry = "forge", version = "0.2.4" }` and no explicit depot:

```
forge deps          -> downloads bastion 0.2.4 AND clones its depot   (B2)
forge check / test  -> clean, 228/228
forge scroll.serve  -> 0 errors, listening on :4040, GET / -> 200     (B1)
```

and switching that dep registry → git *without* purging now reports `installed copy does not match … — reinstalling` instead of corrupting the directory (B3).

Suites: all seven forge suites green (forge 130, resolver 43, solver 16, cas_package 14, patch 6, api_surface 25, regression 13) plus properties 3; eval 256/256, compiler 619/619, snapshots 33/33; `check-docs.sh` passes.

Once this lands, scroll can drop its git-rev pin and go back to a plain registry dep.