### PR TITLE
fix(ci): regenerate pagefind index in the stdlib-docs bot commit

### DIFF
--- a/.github/workflows/gen-stdlib-docs.yml
+++ b/.github/workflows/gen-stdlib-docs.yml
@@ -1,13 +1,23 @@
 name: Regenerate Stdlib Docs
 
 # The site at march-lang.org serves pre-generated HTML committed under docs/docs/stdlib/.
-# deploy-pages.yml only runs Jekyll over that committed HTML — it never runs the doc
-# generator — so the pages go stale whenever a stdlib module is added or changed (this
-# is how 11 modules added after 2026-04-13 went missing from the published docs).
+# It is served by GitHub's own legacy Jekyll build over this repo's docs/ (repo Pages
+# config: branch main, path /docs) — NOT by deploy-pages.yml, which publishes a
+# separately-built site to the external march-language.github.io repo. Neither path ever
+# runs the doc generator itself, so the committed pages go stale whenever a stdlib module
+# is added or changed (this is how 11 modules added after 2026-04-13 went missing from the
+# published docs).
 #
 # This workflow regenerates the stdlib API reference (docs/docs/stdlib/, served at
 # /docs/stdlib/) on every stdlib change and commits the result, so the committed HTML
 # can never drift from the stdlib source.
+#
+# It must also regenerate docs/pagefind/ in the same commit. ci.yml's doc-lint job runs
+# scripts/gen-docs-search-index.sh --check, whose digest is computed over every tracked
+# file under docs/ (git ls-files -- docs) — that includes docs/docs/stdlib/**, so any
+# bot-authored change to the stdlib pages invalidates the committed index digest. Without
+# regenerating it here, this workflow leaves main's doc-lint red until someone notices and
+# fixes it by hand (as happened after the docs/docs/stdlib/** commit on 2026-07-31).
 
 on:
   push:
@@ -44,18 +54,39 @@ jobs:
           eval $(opam env)
           scripts/gen-stdlib-docs.sh
 
+      # Needed for scripts/gen-docs-search-index.sh below: it runs `bundle install` +
+      # `jekyll build` over docs/ and then `npx pagefind` on the built site. Mirrors the
+      # toolchain versions deploy-pages.yml uses to build the same site.
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+          working-directory: docs
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # Regenerate the committed Pagefind index alongside the stdlib pages so the two
+      # never land in separate commits — see the digest-scope note above.
+      - name: Regenerate docs search index
+        run: scripts/gen-docs-search-index.sh
+
       - name: Commit regenerated docs
         run: |
           # The generator clones march_doc into ./march_doc; never commit that.
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          # No [skip ci]: the commit touches only docs/docs/stdlib/**, which is NOT in this
-          # workflow's trigger paths (so it won't self-retrigger) but IS in deploy-pages.yml's
-          # (docs/**), so the regenerated docs get published.
-          if git status --porcelain docs/docs/stdlib | grep -q .; then
-            git add docs/docs/stdlib
+          # No [skip ci]: the commit touches docs/docs/stdlib/** and docs/pagefind/**,
+          # neither of which is in this workflow's trigger paths (so it won't
+          # self-retrigger) but both of which ARE in deploy-pages.yml's (docs/**), so the
+          # regenerated docs get published.
+          if git status --porcelain docs/docs/stdlib docs/pagefind | grep -q .; then
+            git add docs/docs/stdlib docs/pagefind
             git commit -m "docs(stdlib): regenerate API docs from stdlib source"
             git push
           else
-            echo "docs/docs/stdlib already up to date — nothing to commit."
+            echo "docs/docs/stdlib and docs/pagefind already up to date — nothing to commit."
           fi


### PR DESCRIPTION
## Summary
- The `Regenerate Stdlib Docs` workflow committed `docs/docs/stdlib/**` without regenerating `docs/pagefind/`. `ci.yml`'s `doc-lint` job digests every tracked file under `docs/` (via `scripts/gen-docs-search-index.sh --check`), which includes the stdlib pages, so every bot-authored stdlib-docs commit left `main`'s doc-lint red until fixed by hand (as happened after 27906aff).
- Adds Ruby 3.3 + Node 20 setup (mirroring `deploy-pages.yml`) and runs `scripts/gen-docs-search-index.sh` in the same job, committing `docs/pagefind` alongside `docs/docs/stdlib`.
- Corrects the workflow's header comment, which misattributed march-lang.org's serving path to `deploy-pages.yml` (it's actually GitHub's own repo-level Pages build over `docs/`).

## Test plan
- [x] `bash scripts/check-docs.sh` exits 0
- [x] `bash scripts/gen-docs-search-index.sh --check` exits 0
- [x] Ran `scripts/gen-stdlib-docs.sh` then `scripts/gen-docs-search-index.sh` locally end-to-end (Jekyll build + Pagefind index, 190 pages indexed) to confirm the sequence the workflow now runs actually succeeds
- [ ] Not verified: an actual `workflow_dispatch` run of `gen-stdlib-docs.yml` on GitHub Actions (to confirm `ruby/setup-ruby` + `actions/setup-node` install cleanly on `ubuntu-24.04`)