### PR TITLE
test(oracle): allowlist string_parallel_scan as non-deterministic

### DIFF
--- a/test/test_oracle.ml
+++ b/test/test_oracle.ml
@@ -146,6 +146,16 @@ let nondeterministic_allowlist =
        (full-sweep MATCH) + test/native/{niche_ctor_ambiguity,
        dataframe_groupby_count}.march. *)
     "dataframe_bench";
+    (* Parallel string-scan scaling benchmark: prints "workers=N ms=T" wall-
+       clock lines for N in {1,2,4,8} before the final deterministic
+       "checksum=16000000" line. The timings are never byte-stable across
+       runs (let alone between interpreter and compiled binary), so this
+       program is structurally non-comparable, not a divergence — the
+       checksum is the only part worth pinning, and that already has
+       ground truth in the leading doc comment
+       (bench/string_parallel_scan.march: "Expected output:
+       checksum=16000000"). Same class as dataframe_bench above. *)
+    "string_parallel_scan";
     (* Interactive or needs real files *)
     "debugger"; "read_file";
     (* Supervision trees (start actors / servers; scheduler-order-dependent) *)


### PR DESCRIPTION
## Summary
- The interpreter-vs-compiled oracle sweep (`dune build --root . @test/oracle`) reported `bench/string_parallel_scan.march` as an un-triaged MISMATCH.
- Not a real divergence: the program prints wall-clock `workers=N ms=T` timing lines that can never be byte-stable across runs or backends. The trailing `checksum=16000000` line is the deterministic, meaningful part, and it already has documented ground truth in the bench file's own header comment.
- Adds `string_parallel_scan` to `nondeterministic_allowlist` in `test/test_oracle.ml`, following the existing `dataframe_bench` precedent.

## Test plan
- [x] Ran the full oracle sweep (`dune build --root . @test/oracle`, ~10 min): `string_parallel_scan` no longer appears as a mismatch and is correctly bucketed under `SKIPPED`. `TOTAL DIVERGENCES: 0`.
- [x] Confirmed via `git diff --stat` that this change is scoped to `test/test_oracle.ml` only.
- Note: found one unrelated pre-existing compiled-backend bug during verification (`test/native/nested_cons_ctor_heap.march` panics when compiled) — tracked separately, not part of this PR.