### PR TITLE
search: reverse-reference search (forge search --callers)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ git log is authoritative for exact commits.
 
 ### Added
 
+- `forge search --callers NAME`: reverse-reference search — find every
+  resolved call, constructor use, or qualified type reference to a
+  declaration, using the typechecker's own name resolution (not textual
+  matching).
+
 - **`derive Json for T` (record types) now also generates
   `from_json_events(events) : Result((T, List(JsonStream.Event)),
   Json.DecodeError)`, a second decoder that consumes `JsonStream`'s

--- a/docs/superpowers/plans/2026-08-01-forge-search-callers.md
+++ b/docs/superpowers/plans/2026-08-01-forge-search-callers.md
@@ -1,0 +1,843 @@
+# forge search --callers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `forge search --callers NAME`, a reverse-reference search that resolves who calls a function, uses a constructor, or references a type — reusing the existing `forge search` index and the typechecker's own name resolution (not a textual/grep heuristic).
+
+**Architecture:** The typechecker (`lib/typecheck/typecheck.ml`) already resolves every `EVar` call, `ECon` constructor use, and qualified `TyCon` type reference against `env` while typechecking. We add a small accumulator (`env.refs`) that records `(callee, caller, kind, file, line)` at the exact points where that resolution already succeeds, plus a `current_decl` tracker so each reference knows its enclosing function. `lib/search/search.ml`'s existing index (built by the same typecheck pass that already produces `type_map`) gains a `references` table keyed by callee. `forge/lib/cmd_search.ml` exposes it via `--callers`.
+
+**Tech Stack:** OCaml, dune, Alcotest (`test/test_search.ml`), Yojson for the on-disk index cache.
+
+## Global Constraints
+
+- Precision: resolution-based only. A reference is recorded ONLY when it resolves to a real declaration through the typechecker's own lookup — never a bare textual/name-only match.
+- Reference kinds tracked in this plan: function/value calls (Task 2), constructor uses (Task 3), and **qualified** type-annotation references only (Task 4) — see the accepted gaps below.
+- Index integration: extends the existing `Search.index` / `.march/search-index.json` cache and the existing `forge search` command. No new cache file, no new subcommand.
+- Traversal depth: direct references only. No `--depth N` / transitive closure.
+- Corpus: same as today's `forge search` (stdlib + project deps via `Project.load ()`).
+- **Accepted gaps (do not attempt to fix in this plan — call out clearly if discovered again):**
+  - Special-cased call forms that pattern-match a whole `EApp` before the generic `EVar` arm runs (`Chan.new`, `Chan.send`, `Chan.recv`, `Chan.close`, `Chan.choose`, `Chan.offer`, `MPST.new`, `MPST.send`, `MPST.recv`, `MPST.close`, `cap_narrow`, `mint_cap` — `lib/typecheck/typecheck.ml:4797-5290`) never reach the generic `EVar`/`ECon` hooks and will not appear as references. These are compiler builtins, not user-declared callees.
+  - Constructor resolution by expected type (`lib/typecheck/typecheck.ml:5961`, the `Ast.ECon (name, args, sp), exp_ty when ...` arm used to disambiguate same-named constructors from context) is a second, separate resolution path from the one this plan instruments (`typecheck.ml:5420`). Constructor calls resolved only through that path won't be recorded as references in this plan.
+  - Bare (unqualified) type-annotation references are not tracked — only explicitly-qualified `Mod.TypeName` annotations are. Unlike functions and constructors, the typechecker doesn't currently expose which module a bare type name resolved from a same-module vs. builtin binding, so recording it in v1 would risk misattributing the caller's own module for a cross-module bare reference.
+
+---
+
+## File Structure
+
+- **Modify `lib/typecheck/typecheck.ml`**: add `ref_record` type + `env.refs`/`env.current_decl` fields (Task 1); hook the generic `EVar` call-resolution arm and `check_fn` (Task 2); hook the `ECon` constructor-resolution arm (Task 3); hook `surface_ty`'s qualified `TyCon` case (Task 4); add `check_module_with_refs` next to `check_module` (Task 2).
+- **Modify `lib/search/search.ml`**: add `references` field to `index`, populate it from `TC.check_module_with_refs`, extend JSON (de)serialization, add `?callers` to `search_combined`, add reference-result formatters (Task 5).
+- **Modify `forge/lib/cmd_search.ml`**: add `--callers` flag and wire it through (Task 6).
+- **Modify `test/dune`**: add `march_typecheck march_parser march_lexer march_desugar march_ast` to the `test_search` stanza's `libraries` so tests can drive the typecheck pipeline directly (Task 2).
+- **Modify `test/test_search.ml`**: add reference-tracking tests for each kind, the ambiguous-ctor regression, the cache round-trip, and an end-to-end `--callers`-style query test (Tasks 2, 3, 4, 5, 7).
+
+---
+
+## Task 1: `ref_record` type + `env` scaffolding
+
+**Files:**
+- Modify: `lib/typecheck/typecheck.ml:487-488` (just before `type env = {`)
+- Modify: `lib/typecheck/typecheck.ml:707-709` (`make_env`)
+
+**Interfaces:**
+- Produces: `type ref_record = { callee : string; caller : string; ref_kind : [ \`Call | \`Ctor | \`TypeRef ]; ref_file : string; ref_line : int }`, and two new `env` fields: `refs : ref_record list ref` and `current_decl : string ref`.
+
+This task only adds inert scaffolding (an unused-until-later accumulator) — there is no new observable behavior to unit test, so the "test" is confirming the compiler still builds and the existing suite is unaffected.
+
+- [ ] **Step 1: Add the `ref_record` type immediately before `type env = {` (line 488)**
+
+```ocaml
+(** A resolved reference recorded during typechecking: [callee] used a
+    declaration that [caller] (both fully-qualified "Mod.name") owns, at
+    [ref_file]:[ref_line]. Populated only where resolution already succeeds —
+    never a textual guess. *)
+type ref_record = {
+  callee   : string;
+  caller   : string;
+  ref_kind : [ `Call | `Ctor | `TypeRef ];
+  ref_file : string;
+  ref_line : int;
+}
+```
+
+- [ ] **Step 2: Add the two fields to `type env = { ... }`, right after `type_map : (Ast.span, ty) Hashtbl.t;` (line 498)**
+
+```ocaml
+  refs : ref_record list ref;
+  (** Resolved call/ctor/type references accumulated during checking, for
+      `forge search --callers`. Shared (mutable) across all env copies
+      derived from the same root, same as [import_tracker]. *)
+  current_decl : string ref;
+  (** Fully-qualified name ("Mod.fn") of the top-level fn/impl-method whose
+      body is currently being checked. Set by [check_fn]; read wherever a
+      [ref_record] is recorded so it knows its caller. Empty string before
+      the first fn is entered. *)
+```
+
+- [ ] **Step 3: Initialize both fields in `make_env` (line 707-709), alongside `pending_constraints = ref []`**
+
+```ocaml
+let make_env errors type_map = {
+  vars = StrMap.empty; types = StrMap.empty; ctors = StrMap.empty; records = StrMap.empty;
+  level = 0; lin = [];
+  errors; pending_constraints = ref []; type_map;
+  refs = ref []; current_decl = ref "";
+  scheme_witnesses = Hashtbl.create 64;
+  inst_witnesses = Hashtbl.create 256;
+  interfaces = StrMap.empty; sigs = [];
+  mod_needs = []; module_caps = []; protocols = StrMap.empty; impls = StrMap.empty;
+  import_tracker = ref [];
+  import_idx = make_import_index ();
+  local_fns = StrMap.empty;
+  fn_arities = StrMap.empty;
+  plain_let_names = StringSet.empty;
+```
+
+(Keep every other existing field/line in `make_env` exactly as-is — only the one new line is inserted.)
+
+- [ ] **Step 4: Build and run the existing suite to confirm no regression**
+
+Run: `dune build lib/typecheck/typecheck.ml`
+Expected: builds clean (a record literal missing a field is a hard OCaml compile error, so a clean build already proves both fields are wired into every `env` construction site).
+
+Run: `scripts/run-tests.sh -q`
+Expected: same pass count as before this change (no behavior changed yet).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/typecheck/typecheck.ml
+git commit -m "typecheck: add ref_record accumulator scaffolding to env"
+```
+
+---
+
+## Task 2: Call-reference recording (`EVar`) + `check_module_with_refs`
+
+**Files:**
+- Modify: `lib/typecheck/typecheck.ml:4697-4704` (generic `EVar` arm in `infer_expr`)
+- Modify: `lib/typecheck/typecheck.ml:6690` (`check_fn`, to set `current_decl`)
+- Modify: `lib/typecheck/typecheck.ml:11122-11125` (add `check_module_with_refs` next to `check_module`)
+- Modify: `test/dune` (`test_search` stanza libraries)
+- Modify: `test/test_search.ml` (new test)
+
+**Interfaces:**
+- Consumes: `ref_record`, `env.refs`, `env.current_decl`, `env.local_fns : unit StrMap.t` (already exists — "function names defined by the module currently being checked"), `env.current_module : string` (already exists), `lookup_var`, `resolve_qualified_var` (all Task 1 / pre-existing).
+- Produces: `TC.check_module_with_refs : ?errors:Err.ctx -> Ast.module_ -> Err.ctx * (Ast.span, TC.ty) Hashtbl.t * TC.ref_record list`, used by Task 5.
+
+- [ ] **Step 1: Write the failing test in `test/test_search.ml`**
+
+First add the extra libraries `test_search` needs (edit `test/dune`, the `test_search` stanza at line 590-592):
+
+```
+ (name test_search)
+ (modules test_search)
+ (libraries march_search march_typecheck march_parser march_lexer march_desugar march_ast alcotest unix))
+```
+
+Then add this test to `test/test_search.ml` (near the top, after the Levenshtein tests, before `sample_index`):
+
+```ocaml
+(* ------------------------------------------------------------------ *)
+(* Reference tracking (forge search --callers)                        *)
+(* ------------------------------------------------------------------ *)
+
+module TC = March_typecheck.Typecheck
+
+(** Parse + desugar a source string into decls wrapped in a DMod, mirroring
+    [Search.parse_file]'s handling of a real .march file. *)
+let decls_of_source ~(file : string) (mod_name : string) (src : string) : Ast.decl list =
+  let module Ast = March_ast.Ast in
+  let lexbuf = Lexing.from_string src in
+  lexbuf.Lexing.lex_curr_p <- { lexbuf.Lexing.lex_curr_p with Lexing.pos_fname = file };
+  let m = March_parser.Parser.module_
+      (March_parser.Token_filter.make March_lexer.Lexer.token) lexbuf in
+  let m = March_desugar.Desugar.desugar_module m in
+  ignore mod_name;
+  [Ast.DMod (m.Ast.mod_name, Ast.Public, m.Ast.mod_decls, Ast.dummy_span)]
+
+let check_refs (files : (string * string * string) list) : TC.ref_record list =
+  (* [files] is (file, mod_name, src) list. *)
+  let module Ast = March_ast.Ast in
+  let all_decls = List.concat_map (fun (file, mod_name, src) ->
+      decls_of_source ~file mod_name src) files in
+  let synth : Ast.module_ =
+    { mod_name = { txt = "__test__"; span = Ast.dummy_span }; mod_decls = all_decls } in
+  let (_errors, _type_map, refs) = TC.check_module_with_refs synth in
+  refs
+
+let test_call_ref_same_module () =
+  let refs = check_refs [
+    ("a.march", "A", "mod A do\n  fn helper() do 1 end\n  fn main() do helper() end\nend\n");
+  ] in
+  let calls = List.filter (fun (r : TC.ref_record) -> r.ref_kind = `Call) refs in
+  Alcotest.(check bool) "helper call recorded" true
+    (List.exists (fun (r : TC.ref_record) ->
+         r.callee = "A.helper" && r.caller = "A.main") calls)
+
+let test_call_ref_cross_module () =
+  let refs = check_refs [
+    ("b.march", "B", "mod B do\n  fn util() do 1 end\nend\n");
+    ("a.march", "A", "mod A do\n  fn main() do B.util() end\nend\n");
+  ] in
+  let calls = List.filter (fun (r : TC.ref_record) -> r.ref_kind = `Call) refs in
+  Alcotest.(check bool) "cross-module B.util call recorded" true
+    (List.exists (fun (r : TC.ref_record) ->
+         r.callee = "B.util" && r.caller = "A.main") calls)
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dune build @test/test_search.exe 2>&1 | tail -40` (expect a compile error: `check_module_with_refs`/`ref_record`/`ref_kind` unbound, since Task 2's implementation doesn't exist yet).
+Expected: FAIL — build error referencing the missing `check_module_with_refs`/`ref_record`.
+
+- [ ] **Step 3: Hook `check_fn` to set `current_decl` (line 6690)**
+
+```ocaml
+let check_fn env (def : Ast.fn_def) fn_span : scheme =
+  env.current_decl := env.current_module ^ "." ^ def.fn_name.txt;
+  let env'    = enter_level env in
+```
+
+(One line inserted before the existing `let env' = enter_level env in`; nothing else in `check_fn` changes. `env.current_decl` is a shared `ref`, so this is visible to every nested `infer_expr` call for the rest of this function body, including impl-method bodies — `check_fn` is also the entry point `DImpl` uses at `typecheck.ml:9841`.)
+
+- [ ] **Step 4: Hook the generic `EVar` arm to record calls (lines 4697-4704)**
+
+```ocaml
+    (* ── Variables ────────────────────────────────────────────────── *)
+    | Ast.EVar name ->
+      record_use name.txt name.span env;
+      (match lookup_var name.txt env with
+       | Some sch ->
+         (if StrMap.mem name.txt env.local_fns then
+            env.refs := { callee = env.current_module ^ "." ^ name.txt;
+                          caller = !(env.current_decl);
+                          ref_kind = `Call;
+                          ref_file = name.span.Ast.file;
+                          ref_line = name.span.Ast.start_line } :: !(env.refs));
+         instantiate ~use_span:name.span env.level env sch
+       | None     ->
+         (* Try qualified module resolution: "Mod.func" *)
+         match resolve_qualified_var name.txt env with
+         | _, Some sch ->
+           env.refs := { callee = name.txt;
+                         caller = !(env.current_decl);
+                         ref_kind = `Call;
+                         ref_file = name.span.Ast.file;
+                         ref_line = name.span.Ast.start_line } :: !(env.refs);
+           instantiate ~use_span:name.span env.level env sch
+         | _ when is_confirmed_private_qualified name.txt env ->
+           (* A confirmed privacy violation (`Mod.priv_fn`) must be reported
+```
+
+(Everything from `| _ when is_confirmed_private_qualified ...` onward is unchanged existing code — only the two `if`/insertion blocks above are new. Note: `env.local_fns` guards the bare-name case so only genuine top-level function calls are recorded, not references to local `let`-bound values, which also live in `env.vars`.)
+
+- [ ] **Step 5: Add `check_module_with_refs` next to `check_module` (line 11122-11125)**
+
+```ocaml
+let check_module ?errors (m : Ast.module_) : Err.ctx * (Ast.span, ty) Hashtbl.t =
+  let (errs, type_map, _env) = check_module_core ?errors m in
+  (errs, type_map)
+
+(** Like [check_module], but also returns every resolved call/ctor/type
+    reference recorded during checking — used by [forge search --callers].
+    Order is call-order, most-recent-first is reversed back to source order. *)
+let check_module_with_refs ?errors (m : Ast.module_)
+    : Err.ctx * (Ast.span, ty) Hashtbl.t * ref_record list =
+  let (errs, type_map, final_env) = check_module_core ?errors m in
+  (errs, type_map, List.rev !(final_env.refs))
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `dune build @test/test_search.exe && ./_build/default/test/test_search.exe test 'reference'` (or `dune exec test/test_search.exe -- test`)
+Expected: PASS for `test_call_ref_same_module` and `test_call_ref_cross_module`. If you haven't registered the two tests in the Alcotest runner list at the bottom of `test/test_search.ml` yet, add them there now (follow the existing `"levenshtein", [...]` group pattern — add a `"references", [ Alcotest.test_case "same-module call" \`Quick test_call_ref_same_module; Alcotest.test_case "cross-module call" \`Quick test_call_ref_cross_module; ]` group) and re-run.
+
+- [ ] **Step 7: Run the full suite to confirm no regressions**
+
+Run: `scripts/run-tests.sh -q`
+Expected: all passing, count unchanged except the new test_search cases.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/typecheck/typecheck.ml test/dune test/test_search.ml
+git commit -m "typecheck: record resolved call references for forge search --callers"
+```
+
+---
+
+## Task 3: Constructor-reference recording (`ECon`)
+
+**Files:**
+- Modify: `lib/typecheck/typecheck.ml:5420-5429` (`ECon` arm in `infer_expr`)
+- Modify: `test/test_search.ml`
+
+**Interfaces:**
+- Consumes: `ctor_info.ci_module : string` (already exists, doc'd as "declaring module of this constructor's parent type").
+- Produces: additional `ref_record`s with `ref_kind = \`Ctor`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ocaml
+let test_ctor_ref_recorded () =
+  let refs = check_refs [
+    ("a.march", "A",
+     "mod A do\n  type Box = Empty | Full(Int)\n  fn main() do Full(1) end\nend\n");
+  ] in
+  let ctors = List.filter (fun (r : TC.ref_record) -> r.ref_kind = `Ctor) refs in
+  Alcotest.(check bool) "Full ctor use recorded" true
+    (List.exists (fun (r : TC.ref_record) ->
+         r.callee = "A.Full" && r.caller = "A.main") ctors)
+```
+
+Add it to `test/test_search.ml` next to the Task 2 tests and to the `"references"` Alcotest group.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dune build @test/test_search.exe && dune exec test/test_search.exe -- test`
+Expected: FAIL — `test_ctor_ref_recorded` reports no `A.Full`/`A.main` entry (nothing records ctor uses yet).
+
+- [ ] **Step 3: Hook the `ECon` arm (line 5420-5429)**
+
+```ocaml
+    (* ── Constructor application ──────────────────────────────────── *)
+    | Ast.ECon (name, args, sp) ->
+      (let ci_opt = match lookup_ctor_same_module name.txt env with
+         | Some _ as r -> r
+         | None ->
+         match lookup_ctor name.txt env with
+         | Some _ as r -> r
+         | None ->
+           (* Try qualified module resolution: "Mod.Ctor" *)
+           let _, resolved = resolve_qualified_ctor name.txt env in
+           resolved
+       in
+       (match ci_opt with
+        | Some ci ->
+          env.refs := { callee = ci.ci_module ^ "." ^
+                          (if String.contains name.txt '.'
+                           then (let i = String.rindex name.txt '.' in
+                                 String.sub name.txt (i + 1) (String.length name.txt - i - 1))
+                           else name.txt);
+                        caller = !(env.current_decl);
+                        ref_kind = `Ctor;
+                        ref_file = sp.Ast.file;
+                        ref_line = sp.Ast.start_line } :: !(env.refs)
+        | None -> ());
+       match ci_opt with
+       | None ->
+         let candidates = suggest_ctors name.txt env in
+```
+
+(The added block sits between the existing `let ci_opt = ... in` and the existing `match ci_opt with | None -> ...` — it re-matches `ci_opt` once purely to record the reference, then falls through to the original `match ci_opt with` unchanged. `name.txt` may already be `"Mod.Ctor"` for an explicitly-qualified constructor use, so the bare ctor name is extracted after the last `.` before re-qualifying with `ci.ci_module`, keeping the callee format consistent with Task 2's `"Mod.name"`.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dune build @test/test_search.exe && dune exec test/test_search.exe -- test`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `scripts/run-tests.sh -q`
+Expected: all passing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/typecheck/typecheck.ml test/test_search.ml
+git commit -m "typecheck: record resolved constructor references for forge search --callers"
+```
+
+---
+
+## Task 4: Qualified type-reference recording (`TyCon`)
+
+**Files:**
+- Modify: `lib/typecheck/typecheck.ml:3048-3052` (`surface_ty`'s `Ast.TyCon` case)
+- Modify: `test/test_search.ml`
+
+**Interfaces:**
+- Produces: additional `ref_record`s with `ref_kind = \`TypeRef`, for explicitly-qualified `Mod.TypeName` annotations only (see Global Constraints — bare type references are an accepted gap).
+
+- [ ] **Step 1: Read the exact current `Ast.TyCon` case before editing**
+
+Run: `sed -n '3040,3070p' lib/typecheck/typecheck.ml` and confirm the match arm shape and the span available (the surrounding `surface_ty` signature is `surface_ty env ~tvars (s : Ast.ty) : ty`, matching `Ast.TyCon (name, args)` — note `Ast.TyCon` carries a `name : Ast.name` with a `.span`, per `lib/ast/ast.ml`'s `TyCon of name * ty list`). If the arm shape has drifted from what's captured in this plan's Task-writing investigation, adapt the insertion point accordingly — the anchor is "wherever `Ast.TyCon (name, args)` is matched and resolves to a type", not the exact line number.
+
+- [ ] **Step 2: Write the failing test**
+
+```ocaml
+let test_typeref_qualified_recorded () =
+  let refs = check_refs [
+    ("b.march", "B", "mod B do\n  type Widget = Widget(Int)\nend\n");
+    ("a.march", "A", "mod A do\n  fn make(w: B.Widget) do w end\nend\n");
+  ] in
+  let tyrefs = List.filter (fun (r : TC.ref_record) -> r.ref_kind = `TypeRef) refs in
+  Alcotest.(check bool) "B.Widget annotation recorded" true
+    (List.exists (fun (r : TC.ref_record) ->
+         r.callee = "B.Widget" && r.caller = "A.make") tyrefs)
+```
+
+Add to `test/test_search.ml`'s `"references"` group.
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `dune build @test/test_search.exe && dune exec test/test_search.exe -- test`
+Expected: FAIL — no `TypeRef` entries exist yet.
+
+- [ ] **Step 4: Hook the qualified `Ast.TyCon` case in `surface_ty`**
+
+```ocaml
+  | Ast.TyCon (name, args) ->
+    (if String.contains name.Ast.txt '.' then
+       env.refs := { callee = name.Ast.txt;
+                     caller = !(env.current_decl);
+                     ref_kind = `TypeRef;
+                     ref_file = name.Ast.span.Ast.file;
+                     ref_line = name.Ast.span.Ast.start_line } :: !(env.refs));
+    (* ... existing resolution body unchanged below ... *)
+```
+
+Insert the `if`-block as the first line of the existing `Ast.TyCon (name, args) -> ...` arm body, leaving every subsequent line of that arm exactly as it already is. Only qualified names (containing `.`) are recorded, per the Global Constraints gap.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `dune build @test/test_search.exe && dune exec test/test_search.exe -- test`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `scripts/run-tests.sh -q`
+Expected: all passing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/typecheck/typecheck.ml test/test_search.ml
+git commit -m "typecheck: record qualified type-annotation references for forge search --callers"
+```
+
+---
+
+## Task 5: Extend `Search.index` with a `references` table
+
+**Files:**
+- Modify: `lib/search/search.ml` (`index` type, `build_stdlib_index`, `build_index_from_dirs`, `merge_indices`, JSON (de)serialization, `search_combined`, new formatters)
+- Modify: `test/test_search.ml`
+
+**Interfaces:**
+- Consumes: `TC.check_module_with_refs`, `TC.ref_record` (Task 2/3/4).
+- Produces: `index.references : (string, (string * string * int * string) list) Hashtbl.t` (callee qualified name -> `(caller, file, line, kind_string)` list); `Search.search_combined`'s new `?callers:string` param returning `(string * string * int * string) list`; `Search.format_references_plain`/`format_references_colored`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ocaml
+let test_index_references_roundtrip () =
+  let refs : Search.ref_entry list = [
+    { Search.callee = "A.helper"; caller = "A.main"; kind = "call"; file = "a.march"; line = 3 };
+  ] in
+  let idx = Search.{ (sample_index ()) with references = Search.references_of_list refs } in
+  let json = Search.index_to_json idx in
+  let idx2 = Search.index_from_json json in
+  let looked_up = Search.callers_of idx2 "A.helper" in
+  Alcotest.(check int) "one caller round-tripped" 1 (List.length looked_up)
+```
+
+Add to `test/test_search.ml`, registered in the Alcotest runner.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dune build @test/test_search.exe && dune exec test/test_search.exe -- test`
+Expected: FAIL — `Search.ref_entry`/`references_of_list`/`callers_of` unbound.
+
+- [ ] **Step 3: Add the `ref_entry` type and `index.references` field**
+
+In `lib/search/search.ml`, near the existing `type entry = { ... }` (line ~21-30):
+
+```ocaml
+type ref_entry = {
+  callee : string;   (* qualified name of the referenced declaration *)
+  caller : string;   (* qualified name of the enclosing declaration *)
+  kind   : string;   (* "call" | "ctor" | "type" *)
+  file   : string;
+  line   : int;
+}
+```
+
+In `type index = { ... }` (line ~33-36), add:
+
+```ocaml
+type index = {
+  entries      : entry list;
+  references   : (string, ref_entry list) Hashtbl.t;
+  version      : int;
+  generated_at : string;
+}
+```
+
+- [ ] **Step 4: Add helpers to build/query the references table**
+
+Immediately after the `type index` block:
+
+```ocaml
+let ref_kind_to_string = function
+  | `Call    -> "call"
+  | `Ctor    -> "ctor"
+  | `TypeRef -> "type"
+
+(** Group a flat list of ref_entry into the callee-keyed table [index.references] expects. *)
+let references_of_list (refs : ref_entry list) : (string, ref_entry list) Hashtbl.t =
+  let tbl : (string, ref_entry list) Hashtbl.t = Hashtbl.create 64 in
+  List.iter (fun (r : ref_entry) ->
+      let existing = Option.value ~default:[] (Hashtbl.find_opt tbl r.callee) in
+      Hashtbl.replace tbl r.callee (r :: existing)
+    ) refs;
+  tbl
+
+let callers_of (idx : index) (callee : string) : ref_entry list =
+  Option.value ~default:[] (Hashtbl.find_opt idx.references callee)
+```
+
+- [ ] **Step 5: Wire `TC.ref_record list` into index construction**
+
+Modify `typecheck_decls` (line 357-362) to also return refs, and thread them through `build_stdlib_index`/`build_index_from_dirs`:
+
+```ocaml
+let typecheck_decls (all_decls : Ast.decl list)
+    : (Ast.span, TC.ty) Hashtbl.t * ref_entry list =
+  let synth : Ast.module_ = {
+    mod_name  = { txt = "__stdlib__"; span = Ast.dummy_span };
+    mod_decls = all_decls;
+  } in
+  let (_errors, type_map, tc_refs) = TC.check_module_with_refs synth in
+  let refs = List.map (fun (r : TC.ref_record) ->
+      { callee = r.callee; caller = r.caller;
+        kind = ref_kind_to_string r.ref_kind;
+        file = r.ref_file; line = r.ref_line }
+    ) tc_refs in
+  (type_map, refs)
+
+(** Build a search index from all stdlib files, with typechecker-inferred types. *)
+let build_stdlib_index () : index =
+  let (decl_lists, source_files) = load_stdlib () in
+  let (type_map, refs) = typecheck_decls (List.concat decl_lists) in
+  let idx = build_index decl_lists ~source_files ~type_map () in
+  { idx with references = references_of_list refs }
+```
+
+`build_index_from_dirs` (line 370-381) doesn't currently call `typecheck_decls` at all (it calls `build_index decls ~source_files:paths ()` with no `type_map`, so params/return types come out unresolved for project-dependency-only builds — this is pre-existing behavior, not something this task changes). Update it to also typecheck and attach references, matching `build_stdlib_index`'s new shape:
+
+```ocaml
+let build_index_from_dirs (dirs : string list) : index =
+  let march_files_in dir = (* unchanged *)
+    try
+      Sys.readdir dir
+      |> Array.to_list
+      |> List.filter (fun f -> Filename.check_suffix f ".march")
+      |> List.sort String.compare
+      |> List.map (Filename.concat dir)
+    with Sys_error _ -> []
+  in
+  let paths = List.concat_map march_files_in dirs in
+  let decls = List.map parse_file paths in
+  let (type_map, refs) = typecheck_decls (List.concat decls) in
+  let idx = build_index decls ~source_files:paths ~type_map () in
+  { idx with references = references_of_list refs }
+```
+
+Update `merge_indices` (line ~383-385) to merge references too:
+
+```ocaml
+let merge_indices (a : index) (b : index) : index =
+  let merged = Hashtbl.copy a.references in
+  Hashtbl.iter (fun k v ->
+      let existing = Option.value ~default:[] (Hashtbl.find_opt merged k) in
+      Hashtbl.replace merged k (v @ existing)
+    ) b.references;
+  { a with entries = a.entries @ b.entries; references = merged }
+```
+
+- [ ] **Step 6: Extend JSON (de)serialization (lines 576-596)**
+
+```ocaml
+let ref_entry_to_json (r : ref_entry) : Yojson.Basic.t =
+  `Assoc [
+    "caller", `String r.caller;
+    "file",   `String r.file;
+    "line",   `Int r.line;
+    "kind",   `String r.kind;
+  ]
+
+let ref_entry_of_json (callee : string) (j : Yojson.Basic.t) : ref_entry =
+  let open Yojson.Basic.Util in
+  { callee;
+    caller = j |> member "caller" |> to_string;
+    file   = j |> member "file"   |> to_string;
+    line   = j |> member "line"   |> to_int;
+    kind   = j |> member "kind"   |> to_string;
+  }
+
+let index_to_json (idx : index) : string =
+  let refs_json : Yojson.Basic.t =
+    `Assoc (Hashtbl.fold (fun callee entries acc ->
+        (callee, `List (List.map ref_entry_to_json entries)) :: acc
+      ) idx.references [])
+  in
+  let j : Yojson.Basic.t = `Assoc [
+    "version",      `Int idx.version;
+    "generated_at", `String idx.generated_at;
+    "entries",      `List (List.map entry_to_json idx.entries);
+    "references",   refs_json;
+  ] in
+  Yojson.Basic.pretty_to_string j
+
+let index_from_json (s : string) : index =
+  let open Yojson.Basic.Util in
+  let j = Yojson.Basic.from_string s in
+  let references =
+    match j |> member "references" with
+    | `Null -> Hashtbl.create 0  (* old cache predating this field *)
+    | refs_json ->
+      let tbl = Hashtbl.create 64 in
+      (match refs_json with
+       | `Assoc kvs ->
+         List.iter (fun (callee, entries_json) ->
+             let entries = entries_json |> to_list |> List.map (ref_entry_of_json callee) in
+             Hashtbl.replace tbl callee entries
+           ) kvs
+       | _ -> ());
+      tbl
+  in
+  { version      = j |> member "version"      |> to_int;
+    generated_at = j |> member "generated_at" |> to_string;
+    entries      = j |> member "entries"      |> to_list |> List.map entry_of_json;
+    references;
+  }
+```
+
+Bump the cache version constant used when constructing a fresh index (find the `version = 1` — or similar — literal near `build_index`'s index construction and bump it by one) so a stale on-disk cache from before this change is distinguishable; `--rebuild` (already wired in `cmd_search.ml`) remains the manual way to force a fresh build either way.
+
+- [ ] **Step 7: Add `?callers` to `search_combined` and reference formatters**
+
+```ocaml
+(** Resolve [query] (bare or qualified) to every matching entry's qualified
+    name, then return their combined caller list. Bare names may match
+    entries in more than one module; all matches are merged rather than
+    treated as an error, consistent with [search_name]'s existing UX. *)
+let search_callers (idx : index) (query : string) : ref_entry list =
+  let qualified_of (e : entry) =
+    if e.module_name = "" then e.name else e.module_name ^ "." ^ e.name
+  in
+  let candidates =
+    if String.contains query '.' then [query]
+    else
+      idx.entries
+      |> List.filter (fun e -> e.name = query)
+      |> List.map qualified_of
+  in
+  List.concat_map (callers_of idx) candidates
+
+let format_ref_entry (r : ref_entry) : string =
+  Printf.sprintf "%s  %s:%d  (%s)" r.caller r.file r.line r.kind
+
+let format_references_plain (refs : ref_entry list) : unit =
+  if refs = [] then print_endline "no references found"
+  else List.iter (fun r -> print_endline (format_ref_entry r)) refs
+
+let format_references_colored (refs : ref_entry list) : unit =
+  if refs = [] then Printf.printf "\027[2mno references found\027[0m\n"
+  else begin
+    let bold = "\027[1m" and dim = "\027[2m" and reset = "\027[0m" in
+    List.iter (fun r ->
+        Printf.printf "%s%s%s  %s%s:%d%s  %s(%s)%s\n"
+          bold r.caller reset dim r.file r.line reset dim r.kind reset
+      ) refs
+  end
+```
+
+(`search_combined` itself is left untouched — `--callers` is a distinct query mode from name/type/doc search, so `cmd_search.ml` will call `search_callers` directly rather than folding it into `search_combined`'s scoring pipeline, which returns a different result shape.)
+
+- [ ] **Step 8: Run test to verify it passes**
+
+Run: `dune build @test/test_search.exe && dune exec test/test_search.exe -- test`
+Expected: PASS for `test_index_references_roundtrip`.
+
+- [ ] **Step 9: Run the full suite**
+
+Run: `scripts/run-tests.sh -q`
+Expected: all passing.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add lib/search/search.ml test/test_search.ml
+git commit -m "search: add references table to the search index (call/ctor/type)"
+```
+
+---
+
+## Task 6: `forge search --callers` CLI flag
+
+**Files:**
+- Modify: `forge/lib/cmd_search.ml`
+- Modify: whichever file parses `forge search`'s CLI args and dispatches to `Cmd_search.run` (find it with `forge search --type` as the anchor: `grep -rn -- '--type' forge/bin forge/lib` before editing, since this plan's investigation didn't trace the arg-parser file directly — follow the exact pattern already used for `--type`/`--doc`).
+
+**Interfaces:**
+- Consumes: `Search.search_callers`, `Search.format_references_plain`, `Search.format_references_colored` (Task 5).
+
+- [ ] **Step 1: Locate the CLI arg definition for `--type`/`--doc`**
+
+Run: `grep -rn -- '"--type"\|"--doc"' forge/ | grep -v _build`
+Read the matched file's arg-parsing block in full before editing, so the new `--callers` flag follows the exact same option-definition pattern (flag name, help text, how it's threaded into `Cmd_search.run`'s labeled arguments).
+
+- [ ] **Step 2: Add `~callers` to `Cmd_search.run`'s signature (`forge/lib/cmd_search.ml:127`)**
+
+```ocaml
+let run ~query ~type_sig ~doc_query ~callers ~limit ~as_json ~plain ~rebuild () =
+```
+
+- [ ] **Step 3: Branch on `callers` before the existing search dispatch**
+
+Replace the body from `match load_or_build_index ...` (line 138) onward:
+
+```ocaml
+  match load_or_build_index ~verbose:false ~root all_deps with
+  | Error msg -> Printf.eprintf "error: %s\n%!" msg; exit 1
+  | Ok idx ->
+    if String.length callers > 0 then begin
+      let refs = Search.search_callers idx callers in
+      if as_json then begin
+        let j : Yojson.Basic.t = `List (List.map (fun (r : Search.ref_entry) ->
+            `Assoc [ "caller", `String r.Search.caller; "file", `String r.Search.file;
+                     "line", `Int r.Search.line; "kind", `String r.Search.kind ]
+          ) refs) in
+        print_string (Yojson.Basic.pretty_to_string j); print_newline ()
+      end else if plain || not (Unix.isatty Unix.stdout) then
+        Search.format_references_plain refs
+      else
+        Search.format_references_colored refs
+    end else begin
+      let name_q     = if String.length query    > 0 then Some query    else None in
+      let type_q     = if String.length type_sig > 0 then Some type_sig else None in
+      let doc_q      = if String.length doc_query > 0 then Some doc_query else None in
+      let results =
+        if name_q = None && type_q = None && doc_q = None then
+          (Printf.printf "index contains %d entries (stdlib + deps)\n%!"
+             (List.length idx.Search.entries);
+           [])
+        else
+          Search.search_combined idx ?name:name_q ?type_sig:type_q ?doc_query:doc_q ()
+      in
+      print_results ~as_json ~plain ~limit results
+    end
+```
+
+- [ ] **Step 4: Update the caller of `Cmd_search.run` to pass `~callers`**
+
+In the file found in Step 1, add a `--callers` string-arg definition (default `""`, same shape as `--type`) and pass it through as `~callers` in the call to `Cmd_search.run`.
+
+- [ ] **Step 5: Build and smoke-test manually**
+
+Run: `dune build forge/bin/main.exe`
+Expected: builds clean.
+
+Run (from a directory with a `forge.toml`, or any march project):
+```bash
+cd /tmp && mkdir -p callers_smoke && cd callers_smoke && \
+  echo 'mod A do
+  fn helper() do 1 end
+  fn main() do helper() end
+end' > a.march && \
+  /Users/80197052/code/march/_build/default/forge/bin/main.exe search --callers helper --rebuild
+```
+Expected: prints one reference line for `A.main` at `a.march:3` (adjust the exact `forge` invocation to match whatever `forge/bin/main.exe`'s actual entry point/command name is, discovered in Step 1 — this is a manual smoke check, not the automated test, which is Task 7).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add forge/lib/cmd_search.ml
+git commit -m "forge: add --callers flag to forge search"
+```
+
+(Also `git add` whichever CLI arg-parser file was modified in Step 4 — its exact path is discovered in Step 1.)
+
+---
+
+## Task 7: End-to-end tests + ambiguous-ctor regression + docs/changelog
+
+**Files:**
+- Modify: `test/test_search.ml`
+- Modify: `specs/todos/` / `specs/progress/` (per CLAUDE.md: move the filed todo to progress)
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-6.
+
+- [ ] **Step 1: Write the ambiguous-ctor regression test**
+
+This directly guards the class of bug on record in project memory (`project_ambiguous_ctor_current_module.md` — stdlib ADTs sharing a bare ctor name at different tags miscompiled because `lookup_ctor` didn't prefer the current module; the fix made `lookup_ctor` module-aware). This test proves reference-tracking inherits that same current-module preference rather than reintroducing the bug at the reference layer.
+
+```ocaml
+let test_ambiguous_ctor_ref_prefers_current_module () =
+  let refs = check_refs [
+    ("x.march", "X", "mod X do\n  type Status = Active | Done\nend\n");
+    ("y.march", "Y",
+     "mod Y do\n  type Status = Active | Done\n  fn main() do Active end\nend\n");
+  ] in
+  let ctors = List.filter (fun (r : TC.ref_record) -> r.ref_kind = `Ctor) refs in
+  Alcotest.(check bool) "Y.main's Active resolves to Y.Active, not X.Active" true
+    (List.exists (fun (r : TC.ref_record) ->
+         r.callee = "Y.Active" && r.caller = "Y.main") ctors);
+  Alcotest.(check bool) "no false X.Active reference from Y.main" false
+    (List.exists (fun (r : TC.ref_record) ->
+         r.callee = "X.Active" && r.caller = "Y.main") ctors)
+```
+
+- [ ] **Step 2: Write the "no references" (empty result) test**
+
+```ocaml
+let test_no_references_is_empty_not_error () =
+  let refs = check_refs [
+    ("a.march", "A", "mod A do\n  fn unused() do 1 end\n  fn main() do 2 end\nend\n");
+  ] in
+  let tbl = Search.references_of_list
+      (List.map (fun (r : TC.ref_record) ->
+           { Search.callee = r.callee; caller = r.caller;
+             kind = Search.ref_kind_to_string r.ref_kind;
+             file = r.ref_file; line = r.ref_line })
+          refs) in
+  Alcotest.(check int) "unused fn has zero recorded callers" 0
+    (List.length (Search.callers_of { (sample_index ()) with Search.references = tbl } "A.unused"))
+```
+
+- [ ] **Step 3: Register all new tests in the Alcotest runner and run them**
+
+Add every `test_*` function written in Tasks 2-4 and 7 to a `"references"` test group at the bottom of `test/test_search.ml`, following the file's existing `Alcotest.run "search" [ "levenshtein", [...]; ...; "references", [...] ]` structure.
+
+Run: `dune build @test/test_search.exe && dune exec test/test_search.exe -- test`
+Expected: PASS for all reference tests, including the two new ones in this task.
+
+- [ ] **Step 4: Run the full project suite**
+
+Run: `scripts/run-tests.sh` (full, not `-q` — this is the pre-merge full run per CLAUDE.md)
+Expected: all passing, no regressions elsewhere.
+
+- [ ] **Step 5: Update specs/todos and specs/progress**
+
+Check whether a todo file already covers this (search `specs/todos/` for "reverse" or "callers" or "search"); if one exists, `git mv` it to `specs/progress/` with today's date. If none exists (this feature was designed fresh in this session, not from a pre-filed todo), create `specs/progress/2026-08-01-forge-search-callers-reverse-reference-search.md` directly, briefly describing what shipped (per the `specs/progress/README.md` convention — read that file's format before writing, since this plan doesn't reproduce its exact template).
+
+- [ ] **Step 6: Update CHANGELOG.md**
+
+Add under `## [Unreleased]` → `### Added`:
+
+```
+- `forge search --callers NAME`: reverse-reference search — find every resolved call, constructor use, or qualified type reference to a declaration, using the typechecker's own name resolution (not textual matching).
+```
+
+- [ ] **Step 7: Final commit**
+
+```bash
+git add test/test_search.ml specs/progress/ CHANGELOG.md
+git commit -m "search: add --callers regression tests, changelog, and progress entry"
+```
+
+(If a `specs/todos/` file was moved via `git mv` in Step 5, that rename is already staged by the `git mv` itself — include it in this same commit rather than a separate one.)

--- a/docs/superpowers/specs/2026-08-01-forge-search-reverse-references-design.md
+++ b/docs/superpowers/specs/2026-08-01-forge-search-reverse-references-design.md
@@ -1,0 +1,148 @@
+# `forge search --callers`: reverse-reference search
+
+Date: 2026-08-01
+Status: approved
+
+## Problem
+
+`forge search` (`lib/search/search.ml`, `forge/lib/cmd_search.ml`) already indexes March
+declarations (name, module, kind, signature, doc, file, line) via a real typecheck pass
+(`Search.typecheck_decls` → `TC.check_module`), and supports name search, type-signature
+search, and doc-keyword search. It has no notion of *references*: there is no way to ask
+"what calls `Foo.bar`?" or "what uses this constructor/type?" without falling back to grep,
+which produces false positives whenever a name is reused across modules and misses
+qualified-vs-bare-name variance.
+
+This matters most for ownership/RC-style audits (e.g. auditing every call site of a runtime
+closure-drop function across the compiler) and for general "is this still used anywhere"
+questions before deleting a declaration.
+
+## Scope (v1)
+
+- **Precision**: exact, resolution-based — not a textual/name-heuristic scan. A reference is
+  only recorded when it resolves to a specific declaration, using the same resolution logic
+  (`lookup_ctor`, current-module preference, etc.) the typechecker already applies. This
+  means reverse-reference search inherits the existing ambiguous-ctor disambiguation
+  behavior for free, rather than reimplementing it.
+- **Reference kinds tracked**: function/value calls (`EVar` in call position), constructor
+  uses (`ECon`), and type-annotation references. Not just calls — matches the ownership-audit
+  use case, where a wildcard-decl walk or a type reference matters as much as a call.
+- **Index integration**: extends the existing `Search.index` / `.march/search-index.json`
+  cache, built in the same typecheck pass that already produces `type_map`. One cache, one
+  `--rebuild` flag, one `forge search` command.
+- **Traversal depth**: direct references only. No `--depth N` / transitive closure in v1 —
+  that can be layered on top later by repeatedly querying direct callers, or added as a
+  follow-up once direct lookup is proven useful.
+- **Corpus**: same as today's `forge search` — stdlib + project dependencies resolved via
+  `Project.load()` and `dep_source_dirs`. No new directory-walking logic.
+
+## Non-goals (v1)
+
+- Transitive/"reachability" queries (`--depth N`).
+- Indexing references inside non-March artifacts (TIR dumps, snapshot goldens).
+- A standalone command separate from `forge search`.
+
+## Design
+
+### Typecheck: emit resolved references
+
+`Search.typecheck_decls` currently calls `TC.check_module` and keeps only the returned
+`type_map : (Ast.span, TC.ty) Hashtbl.t`. `TC.check_module` will additionally return (or
+accept an output accumulator for) a list of resolved references:
+
+```ocaml
+type ref_record = {
+  callee   : string;  (* qualified name of the referenced declaration *)
+  caller   : string;  (* qualified name of the enclosing declaration *)
+  ref_kind : [ `Call | `Ctor | `TypeRef ];
+  file     : string;
+  line     : int;
+}
+```
+
+These are populated at the same resolution points that already exist in
+`lib/typecheck/typecheck.ml`:
+
+- The `EVar` call-position handler near `record_use` (`typecheck.ml:4698`), which already
+  resolves a bare/qualified name against `env` — extended to also emit a `ref_record` when
+  resolution succeeds.
+- The `ECon` constructor resolution paths (`lookup_ctor`, `lookup_ctor_same_module`,
+  `lookup_ctor_in_type`, `lookup_ctor_in_type_unique` — `typecheck.ml:912-1004`), which
+  already implement the current-module-preference logic from the ambiguous-ctor fix; each
+  successful resolution emits a `ref_record` with `ref_kind = `Ctor`.
+- Type-annotation resolution (wherever `Ast.TyCon` names are resolved against the type
+  environment) emits `ref_record` with `ref_kind = `TypeRef`.
+
+No new AST walk is introduced — this piggybacks on resolution work the typechecker already
+performs, so it stays consistent with what actually compiles (unlike a separate best-effort
+resolver that could drift from real semantics).
+
+The "enclosing declaration" (`caller`) is tracked via a small stack/current-decl reference
+threaded through `check_module`'s existing per-declaration dispatch — pushed on entering a
+top-level `fn`/`impl` method body, popped on exit.
+
+### Search index
+
+`Search.index` gains a references table:
+
+```ocaml
+type index = {
+  entries      : entry list;
+  references   : (string, (string * string * int * string) list) Hashtbl.t;
+    (* callee qualified name -> [(caller qualified name, file, line, kind); ...] *)
+  version      : int;
+  generated_at : string;
+}
+```
+
+Built in `Search.build_index`/`build_stdlib_index`/`build_index_from_dirs` alongside
+`entries`, from the `ref_record list` now returned by `typecheck_decls`. Serialized in the
+same JSON cache (`index_to_json`/`index_from_json`), bumping `version` since existing cache
+files won't have a `references` field (missing field → empty table on load, triggering a
+rebuild path consistent with how `--rebuild` already works).
+
+### Query layer
+
+`Search.search_combined` gains an optional `?callers:string` parameter. When present:
+
+1. Resolve the given name to a qualified declaration name using the same lookup the
+   existing name-search path uses (so `--callers bar` and `--callers Foo.bar` both work when
+   unambiguous, matching existing UX for `--type`/name queries).
+2. Look up `references` for that qualified name; return the `(caller, file, line, kind)`
+   list as the result set.
+
+### CLI
+
+`forge/lib/cmd_search.ml`: new `--callers NAME` flag, parsed and threaded through exactly
+like `--type`/`--doc` today. Reuses `load_or_build_index`, `--rebuild`, `--json`, `--plain`,
+`--limit`. Output formatting (`format_results_plain`/`format_results_colored`) gets a
+reference-result variant (`caller — file:line (kind)`).
+
+### Error handling
+
+An unresolvable or unreferenced name is not an error — same "no results" UX as today's name
+search when nothing matches. This is consistent with the existing command's behavior and
+avoids introducing a new error path.
+
+## Testing
+
+Extend `test/test_search.ml`:
+
+- One fixture per reference kind (call, constructor use, type reference) — assert the
+  expected `(caller, file, line, kind)` entries appear for a known callee.
+- A regression test pinning ambiguous-ctor resolution for references: two modules
+  defining the same bare constructor name, verify `--callers` on the current-module ctor
+  only returns references that actually resolve to it (not the other module's ctor) —
+  directly guards against the class of bug recorded in
+  `project_ambiguous_ctor_current_module.md`.
+- A "no references" case for a declaration that exists but is never called/used, confirming
+  it returns an empty result rather than an error.
+- A cache round-trip test: build index with references, serialize to JSON, reload, confirm
+  `references` survives `index_to_json`/`index_from_json`.
+
+## Follow-ups (explicitly out of scope here)
+
+- `--depth N` transitive closure.
+- Extending resolution to interface-impl references (a type implementing an interface,
+  independent of any explicit call), which the RC-audit use case may eventually want but
+  wasn't part of this design's approved scope.

--- a/forge/bin/main.ml
+++ b/forge/bin/main.ml
@@ -501,6 +501,10 @@ let search_cmd =
     Arg.(value & opt string "" &
          info ["doc"; "d"] ~docv:"KEYWORDS" ~doc:"Keywords to search in doc strings")
   in
+  let callers =
+    Arg.(value & opt string "" &
+         info ["callers"] ~docv:"NAME" ~doc:"Find call sites that reference NAME (reverse-reference search)")
+  in
   let limit =
     Arg.(value & opt int 20 &
          info ["limit"; "n"] ~docv:"N" ~doc:"Maximum number of results (default 20)")
@@ -514,13 +518,13 @@ let search_cmd =
   let rebuild =
     Arg.(value & flag & info ["rebuild"] ~doc:"Rebuild the search index before searching")
   in
-  let run q t d n j p r =
-    Cmd_search.run ~query:q ~type_sig:t ~doc_query:d ~limit:n ~as_json:j ~plain:p ~rebuild:r ()
+  let run q t d c n j p r =
+    Cmd_search.run ~query:q ~type_sig:t ~doc_query:d ~callers:c ~limit:n ~as_json:j ~plain:p ~rebuild:r ()
   in
   Cmd.v
     (Cmd.info "search"
        ~doc:"Search stdlib and dependencies for functions, types, and constructors")
-    Term.(const run $ query $ type_sig $ doc_query $ limit $ as_json $ plain $ rebuild)
+    Term.(const run $ query $ type_sig $ doc_query $ callers $ limit $ as_json $ plain $ rebuild)
 
 (* --------------------------------------------------------------- forge publish *)
 

--- a/forge/lib/cmd_search.ml
+++ b/forge/lib/cmd_search.ml
@@ -58,12 +58,18 @@ let build_combined_index ~root all_deps =
   if dirs = [] then stdlib_idx
   else Search.merge_indices stdlib_idx (Search.build_index_from_dirs dirs)
 
-(** Load cached index if it exists, otherwise build from stdlib + deps. *)
+(** Load cached index if it exists AND matches the current on-disk cache
+    shape, otherwise (re)build from stdlib + deps. A version mismatch — e.g.
+    a cache written before [Search.current_index_version] was bumped for the
+    [references] table this feature added — is treated exactly like a cache
+    miss: without this check, a pre-existing cache would be loaded as-is
+    forever (missing [references] entirely, since [Search.index_from_json]
+    defaults an absent field to an empty table) and `--callers` would
+    silently report "no references found" for everyone with an existing
+    cache, never rebuilding on its own. *)
 let load_or_build_index ~verbose ~root all_deps =
   let cache = index_cache_path root in
-  if Sys.file_exists cache then begin
-    (if verbose then
-       Printf.eprintf "forge search: loading index from %s\n%!" cache);
+  let load_cached () =
     let ic = open_in cache in
     let n  = in_channel_length ic in
     let buf = Bytes.create n in
@@ -72,7 +78,25 @@ let load_or_build_index ~verbose ~root all_deps =
     (try Ok (Search.index_from_json (Bytes.to_string buf))
      with Failure msg ->
        Error (Printf.sprintf "failed to parse search index: %s" msg))
-  end else begin
+  in
+  let cached_and_fresh =
+    if not (Sys.file_exists cache) then None
+    else match load_cached () with
+      | Ok idx when idx.Search.version = Search.current_index_version -> Some (Ok idx)
+      | Ok _ ->
+        (if verbose then
+           Printf.eprintf
+             "forge search: cached index at %s is stale (version mismatch), rebuilding...\n%!"
+             cache);
+        None
+      | Error _ as e -> Some e (* corrupt cache: surface the parse error, don't silently rebuild over it *)
+  in
+  match cached_and_fresh with
+  | Some result ->
+    (if verbose then
+       Printf.eprintf "forge search: loading index from %s\n%!" cache);
+    result
+  | None -> begin
     (if verbose then
        Printf.eprintf "forge search: building index from stdlib and deps...\n%!");
     let idx = build_combined_index ~root all_deps in
@@ -133,7 +157,7 @@ let run ~query ~type_sig ~doc_query ~callers ~limit ~as_json ~plain ~rebuild () 
   | Error msg -> Printf.eprintf "error: %s\n%!" msg; exit 1
   | Ok idx ->
     if String.length callers > 0 then begin
-      let refs = Search.search_callers idx callers in
+      let refs = take limit (Search.search_callers idx callers) in
       if as_json then begin
         let j : Yojson.Basic.t = `List (List.map Search.ref_entry_to_json refs) in
         print_string (Yojson.Basic.pretty_to_string j); print_newline ()

--- a/forge/lib/cmd_search.ml
+++ b/forge/lib/cmd_search.ml
@@ -1,4 +1,4 @@
-(** forge search [QUERY] [--type TYPE] [--doc KEYWORDS] [--limit N] [--json]
+(** forge search [QUERY] [--type TYPE] [--doc KEYWORDS] [--callers NAME] [--limit N] [--json]
 
     Hoogle-style search across March stdlib and project dependencies.
     Searches function names, type signatures, and doc strings. *)
@@ -118,7 +118,7 @@ let print_results ~as_json ~plain ~limit results =
 (* Command                                                             *)
 (* ------------------------------------------------------------------ *)
 
-let run ~query ~type_sig ~doc_query ~limit ~as_json ~plain ~rebuild () =
+let run ~query ~type_sig ~doc_query ~callers ~limit ~as_json ~plain ~rebuild () =
   let (root, all_deps) = match Project.load () with
     | Ok p  ->
       let deps = p.Project.deps @ p.Project.dev_deps @ p.Project.dev_only_deps in
@@ -132,16 +132,27 @@ let run ~query ~type_sig ~doc_query ~limit ~as_json ~plain ~rebuild () =
   match load_or_build_index ~verbose:false ~root all_deps with
   | Error msg -> Printf.eprintf "error: %s\n%!" msg; exit 1
   | Ok idx ->
-    let name_q     = if String.length query    > 0 then Some query    else None in
-    let type_q     = if String.length type_sig > 0 then Some type_sig else None in
-    let doc_q      = if String.length doc_query > 0 then Some doc_query else None in
-    let results =
-      if name_q = None && type_q = None && doc_q = None then
-        (* No query — print a summary *)
-        (Printf.printf "index contains %d entries (stdlib + deps)\n%!"
-           (List.length idx.Search.entries);
-         [])
+    if String.length callers > 0 then begin
+      let refs = Search.search_callers idx callers in
+      if as_json then begin
+        let j : Yojson.Basic.t = `List (List.map Search.ref_entry_to_json refs) in
+        print_string (Yojson.Basic.pretty_to_string j); print_newline ()
+      end else if plain || not (Unix.isatty Unix.stdout) then
+        Search.format_references_plain refs
       else
-        Search.search_combined idx ?name:name_q ?type_sig:type_q ?doc_query:doc_q ()
-    in
-    print_results ~as_json ~plain ~limit results
+        Search.format_references_colored refs
+    end else begin
+      let name_q     = if String.length query    > 0 then Some query    else None in
+      let type_q     = if String.length type_sig > 0 then Some type_sig else None in
+      let doc_q      = if String.length doc_query > 0 then Some doc_query else None in
+      let results =
+        if name_q = None && type_q = None && doc_q = None then
+          (* No query — print a summary *)
+          (Printf.printf "index contains %d entries (stdlib + deps)\n%!"
+             (List.length idx.Search.entries);
+           [])
+        else
+          Search.search_combined idx ?name:name_q ?type_sig:type_q ?doc_query:doc_q ()
+      in
+      print_results ~as_json ~plain ~limit results
+    end

--- a/forge/test/dune
+++ b/forge/test/dune
@@ -3,7 +3,7 @@
         test_api_surface test_properties test_regression)
  (modules test_forge test_resolver test_solver test_cas_package test_patch
           test_api_surface test_properties test_regression)
- (libraries march_forge alcotest unix qcheck-core qcheck-alcotest march_cas))
+ (libraries march_forge march_search alcotest unix qcheck-core qcheck-alcotest march_cas))
 
 ; QUARANTINED from `runtest` (2026-07-24): test_build_check.ml's "forge check"/
 ; "forge build" cases shell out to a real `march check` subprocess

--- a/forge/test/test_forge.ml
+++ b/forge/test/test_forge.ml
@@ -1392,6 +1392,126 @@ let test_branch_legacy_manifest_forces_activate3 () =
   Alcotest.(check bool) "ACTIVATE3 forced by legacy manifest (no caps= anywhere)" false
     (activate4_selected ~manifest:legacy_manifest ~no_cap_gate:false)
 
+(* ------------------------------------------------------- search index cache *)
+
+(** Final-review Critical 1: a cache written before [Search.current_index_version]
+    was bumped (e.g. a v1 cache predating the `references` table) must be
+    treated as a cache miss and rebuilt, not loaded as-is forever. Writes a
+    hand-crafted stale-version cache file, then asserts [load_or_build_index]
+    silently rebuilds it to the current version rather than returning it
+    unchanged. *)
+let test_load_or_build_index_rebuilds_on_stale_version () =
+  let tmpdir = Filename.temp_dir "test_search_cache_" "" in
+  Fun.protect
+    ~finally:(fun () ->
+        ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote tmpdir))))
+    (fun () ->
+       let cache_path = Cmd_search.index_cache_path tmpdir in
+       Project.mkdir_p (Filename.dirname cache_path);
+       let oc = open_out cache_path in
+       (* Shape of a pre-[references] cache: version 1, no "references" key. *)
+       output_string oc
+         {|{"version":1,"generated_at":"2020-01-01T00:00:00Z","entries":[]}|};
+       close_out oc;
+       match Cmd_search.load_or_build_index ~verbose:false ~root:tmpdir [] with
+       | Error msg -> Alcotest.fail msg
+       | Ok idx ->
+         Alcotest.(check bool) "stale v1 cache is rebuilt to the current version" true
+           (idx.March_search.Search.version = March_search.Search.current_index_version);
+         Alcotest.(check bool) "rebuilt index has real entries, not the stale empty stub" true
+           (List.length idx.March_search.Search.entries > 0))
+
+(** Companion to the above: a cache that's already current must be loaded
+    as-is (no unnecessary rebuild) — pins that the version check only
+    triggers on an actual mismatch. *)
+let test_load_or_build_index_reuses_fresh_cache () =
+  let tmpdir = Filename.temp_dir "test_search_cache_fresh_" "" in
+  Fun.protect
+    ~finally:(fun () ->
+        ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote tmpdir))))
+    (fun () ->
+       let cache_path = Cmd_search.index_cache_path tmpdir in
+       Project.mkdir_p (Filename.dirname cache_path);
+       let refs = March_search.Search.references_of_list
+           [ { March_search.Search.callee = "A.helper"; caller = "A.main";
+               kind = "call"; file = "a.march"; line = 1 } ] in
+       let idx = March_search.Search.{
+           version = current_index_version;
+           generated_at = "2026-01-01T00:00:00Z";
+           references = refs;
+           entries = [];
+         } in
+       let oc = open_out cache_path in
+       output_string oc (March_search.Search.index_to_json idx);
+       close_out oc;
+       match Cmd_search.load_or_build_index ~verbose:false ~root:tmpdir [] with
+       | Error msg -> Alcotest.fail msg
+       | Ok idx2 ->
+         Alcotest.(check int) "fresh cache loaded as-is (not rebuilt over)" 0
+           (List.length idx2.March_search.Search.entries);
+         Alcotest.(check int) "fresh cache's references survive the load" 1
+           (List.length (March_search.Search.callers_of idx2 "A.helper")))
+
+(** Final-review Important 6: `--limit` was applied to the name/type/doc
+    search path (via [print_results]'s [take]) but never to the `--callers`
+    branch, so `--limit` silently had no effect on reverse-reference
+    queries. Runs [Cmd_search.run] end-to-end with a pre-seeded fresh-version
+    cache (avoiding a real stdlib rebuild) containing 3 references to one
+    callee, with `--limit 1`, and captures stdout (the command prints
+    directly rather than returning a value) to confirm only 1 comes back. *)
+let test_callers_respects_limit () =
+  let tmpdir = Filename.temp_dir "test_search_limit_" "" in
+  let old_cwd = Sys.getcwd () in
+  Fun.protect
+    ~finally:(fun () ->
+        Unix.chdir old_cwd;
+        ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote tmpdir))))
+    (fun () ->
+       Unix.chdir tmpdir;
+       let cache_path = Cmd_search.index_cache_path "." in
+       Project.mkdir_p (Filename.dirname cache_path);
+       let refs = March_search.Search.references_of_list [
+           { March_search.Search.callee = "A.helper"; caller = "A.one";
+             kind = "call"; file = "a.march"; line = 1 };
+           { March_search.Search.callee = "A.helper"; caller = "A.two";
+             kind = "call"; file = "a.march"; line = 2 };
+           { March_search.Search.callee = "A.helper"; caller = "A.three";
+             kind = "call"; file = "a.march"; line = 3 };
+         ] in
+       let idx = March_search.Search.{
+           version = current_index_version;
+           generated_at = "2026-01-01T00:00:00Z";
+           references = refs;
+           entries = [];
+         } in
+       let oc = open_out cache_path in
+       output_string oc (March_search.Search.index_to_json idx);
+       close_out oc;
+       (* Capture stdout: [Cmd_search.run] prints directly rather than
+          returning a value. *)
+       let out_path = Filename.temp_file "test_search_limit_stdout_" ".json" in
+       Fun.protect
+         ~finally:(fun () -> (try Sys.remove out_path with Sys_error _ -> ()))
+         (fun () ->
+            let saved_stdout = Unix.dup Unix.stdout in
+            let out_fd = Unix.openfile out_path [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC] 0o600 in
+            Unix.dup2 out_fd Unix.stdout;
+            Unix.close out_fd;
+            Fun.protect
+              ~finally:(fun () ->
+                  Unix.dup2 saved_stdout Unix.stdout;
+                  Unix.close saved_stdout)
+              (fun () ->
+                 Cmd_search.run ~query:"" ~type_sig:"" ~doc_query:"" ~callers:"A.helper"
+                   ~limit:1 ~as_json:true ~plain:true ~rebuild:false ());
+            let captured = read_file out_path in
+            let j = Yojson.Basic.from_string captured in
+            match j with
+            | `List items ->
+              Alcotest.(check int) "--limit 1 truncates 3 references down to 1"
+                1 (List.length items)
+            | _ -> Alcotest.fail "expected a JSON list from --callers --json"))
+
 (* -------------------------------------------------------------------- suite *)
 
 let () =
@@ -1553,5 +1673,13 @@ let () =
       Alcotest.test_case "branch: caps present, no flag -> ACTIVATE4" `Quick test_branch_caps_present_no_flag_selects_activate4;
       Alcotest.test_case "branch: --no-cap-gate forces ACTIVATE3" `Quick test_branch_no_cap_gate_flag_forces_activate3;
       Alcotest.test_case "branch: legacy manifest forces ACTIVATE3" `Quick test_branch_legacy_manifest_forces_activate3;
+    ];
+    "search_index_cache", [
+      Alcotest.test_case "stale version cache is rebuilt" `Quick
+        test_load_or_build_index_rebuilds_on_stale_version;
+      Alcotest.test_case "fresh version cache is reused" `Quick
+        test_load_or_build_index_reuses_fresh_cache;
+      Alcotest.test_case "--callers respects --limit" `Quick
+        test_callers_respects_limit;
     ];
   ]

--- a/lib/jit/repl_jit.ml
+++ b/lib/jit/repl_jit.ml
@@ -523,7 +523,13 @@ let register_module_decl ctx ~tc_env (d : March_ast.Ast.decl) =
       mod_decls = [d]
     } in
     let errors = March_errors.Errors.create () in
-    let env = { tc_env with March_typecheck.Typecheck.errors } in
+    let env = { tc_env with March_typecheck.Typecheck.errors;
+      (* Reset per-call — this env is reused across the whole REPL/JIT
+         session, so without this [refs] would accumulate unboundedly
+         across every fragment typed at the REPL (nothing reads it here);
+         see [Typecheck_cache.derive]'s identical reset for the LSP's
+         analogous reused env. *)
+      refs = ref []; current_decl = ref "" } in
     (try
       let (_, type_map) = March_typecheck.Typecheck.check_module_with_env env m in
       let tir = lower_module ~type_map ~stdlib_context:ctx.stdlib_decls m in
@@ -548,7 +554,13 @@ let run_expr ctx ~tc_env m =
   (* Typecheck and lower BEFORE advancing the counter so a failure leaves no gap. *)
   let repl_vars = List.map (fun (bare, _, _) -> bare) ctx.var_slots in
   let errors = March_errors.Errors.create () in
-  let env = { tc_env with March_typecheck.Typecheck.errors } in
+  let env = { tc_env with March_typecheck.Typecheck.errors;
+      (* Reset per-call — this env is reused across the whole REPL/JIT
+         session, so without this [refs] would accumulate unboundedly
+         across every fragment typed at the REPL (nothing reads it here);
+         see [Typecheck_cache.derive]'s identical reset for the LSP's
+         analogous reused env. *)
+      refs = ref []; current_decl = ref "" } in
   let (_, type_map) = time_phase "typecheck"
     (fun () -> March_typecheck.Typecheck.check_module_with_env env m) in
   let tir = time_phase "lower+mono+opt"
@@ -663,7 +675,13 @@ let run_decl ctx ~tc_env ~is_fn_decl ~bind_name m =
   (* Typecheck and lower BEFORE advancing the counter — failures leave no gap. *)
   let repl_vars = List.map (fun (bare, _, _) -> bare) ctx.var_slots in
   let errors = March_errors.Errors.create () in
-  let env = { tc_env with March_typecheck.Typecheck.errors } in
+  let env = { tc_env with March_typecheck.Typecheck.errors;
+      (* Reset per-call — this env is reused across the whole REPL/JIT
+         session, so without this [refs] would accumulate unboundedly
+         across every fragment typed at the REPL (nothing reads it here);
+         see [Typecheck_cache.derive]'s identical reset for the LSP's
+         analogous reused env. *)
+      refs = ref []; current_decl = ref "" } in
   let (_, type_map) = March_typecheck.Typecheck.check_module_with_env env m in
   let tir = lower_module ~type_map ~stdlib_context:ctx.stdlib_decls ~repl_vars m in
   register_type_defs ctx tir.March_tir.Tir.tm_types;

--- a/lib/search/search.ml
+++ b/lib/search/search.ml
@@ -44,6 +44,15 @@ type index = {
   generated_at : string;
 }
 
+(** The [index.version] a freshly-[build_index]'d index carries. Bumped
+    whenever the on-disk cache's shape changes in a way an old cache can't
+    satisfy (e.g. the [references] table added in this feature) — a cache
+    reader (see [forge/lib/cmd_search.ml]'s [load_or_build_index]) MUST
+    compare a loaded index's [version] against this constant and treat a
+    mismatch as a cache miss (rebuild), or a stale pre-existing cache from
+    before the bump silently keeps serving without the new data forever. *)
+let current_index_version = 2
+
 let ref_kind_to_string = function
   | `Call    -> "call"
   | `Ctor    -> "ctor"
@@ -313,7 +322,7 @@ let build_index (decl_lists : Ast.decl list list) ~(source_files : string list)
       (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
       tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
   in
-  { entries; references = Hashtbl.create 0; version = 2; generated_at = now }
+  { entries; references = Hashtbl.create 0; version = current_index_version; generated_at = now }
 
 (* ------------------------------------------------------------------ *)
 (* Stdlib loading (mirrors lsp/lib/analysis.ml)                       *)
@@ -379,17 +388,41 @@ let load_stdlib () : Ast.decl list list * string list =
     let decls = List.map parse_file paths in
     (decls, paths)
 
+(** Synthetic outer module name [typecheck_decls] wraps every decl list in
+    (below) so [TC.check_module_with_refs] has a single module to check.
+    Every actual stdlib/project file is itself wrapped in its own [DMod] by
+    [parse_file], so this name is invisible almost everywhere — EXCEPT
+    [prelude.march], whose decls [parse_file] deliberately unwraps to
+    top-level (prelude names are meant to be bare, unqualified), which
+    leaves them checked with [env.current_module] equal to THIS synthetic
+    name rather than a real module. Without stripping it back out here, a
+    prelude-defined fn/ctor/type reference would surface as a callee/caller
+    like "__stdlib__.map" instead of the correct bare "map". *)
+let synthetic_module_name = "__stdlib__"
+
+(** Strip a leading [synthetic_module_name ^ "."] qualifier some
+    [TC.ref_record]'s [callee]/[caller] may carry (see [synthetic_module_name]),
+    so it never leaks into a user-visible reference string. *)
+let unqualify_synthetic_module (s : string) : string =
+  let prefix = synthetic_module_name ^ "." in
+  let plen = String.length prefix in
+  if s = synthetic_module_name then ""
+  else if String.length s > plen && String.sub s 0 plen = prefix then
+    String.sub s plen (String.length s - plen)
+  else s
+
 (** Typecheck a flat list of stdlib decls and return the span→type map plus
     the reference table (calls/ctor uses/type refs) recorded along the way. *)
 let typecheck_decls (all_decls : Ast.decl list)
     : (Ast.span, TC.ty) Hashtbl.t * ref_entry list =
   let synth : Ast.module_ = {
-    mod_name  = { txt = "__stdlib__"; span = Ast.dummy_span };
+    mod_name  = { txt = synthetic_module_name; span = Ast.dummy_span };
     mod_decls = all_decls;
   } in
   let (_errors, type_map, tc_refs) = TC.check_module_with_refs synth in
   let refs = List.map (fun (r : TC.ref_record) ->
-      { callee = r.callee; caller = r.caller;
+      { callee = unqualify_synthetic_module r.callee;
+        caller = unqualify_synthetic_module r.caller;
         kind = ref_kind_to_string r.ref_kind;
         file = r.ref_file; line = r.ref_line }
     ) tc_refs in
@@ -584,6 +617,12 @@ let search_callers (idx : index) (query : string) : ref_entry list =
       idx.entries
       |> List.filter (fun e -> e.name = query)
       |> List.map qualified_of
+      (* A type and a same-named constructor (the common `type Foo = Foo(...)`
+         newtype pattern — ~80 occurrences in the real stdlib) are separate
+         [entries] that qualify to the same name. Without deduping, [callers_of]
+         gets called twice for that one qualified name and every reference to
+         it is double-counted in the output. *)
+      |> List.sort_uniq String.compare
   in
   List.concat_map (callers_of idx) candidates
 

--- a/lib/search/search.ml
+++ b/lib/search/search.ml
@@ -29,11 +29,37 @@ type entry = {
   return_type : string option;
 }
 
+type ref_entry = {
+  callee : string;   (* qualified name of the referenced declaration *)
+  caller : string;   (* qualified name of the enclosing declaration *)
+  kind   : string;   (* "call" | "ctor" | "type" *)
+  file   : string;
+  line   : int;
+}
+
 type index = {
   entries      : entry list;
+  references   : (string, ref_entry list) Hashtbl.t;
   version      : int;
   generated_at : string;
 }
+
+let ref_kind_to_string = function
+  | `Call    -> "call"
+  | `Ctor    -> "ctor"
+  | `TypeRef -> "type"
+
+(** Group a flat list of ref_entry into the callee-keyed table [index.references] expects. *)
+let references_of_list (refs : ref_entry list) : (string, ref_entry list) Hashtbl.t =
+  let tbl : (string, ref_entry list) Hashtbl.t = Hashtbl.create 64 in
+  List.iter (fun (r : ref_entry) ->
+      let existing = Option.value ~default:[] (Hashtbl.find_opt tbl r.callee) in
+      Hashtbl.replace tbl r.callee (r :: existing)
+    ) refs;
+  tbl
+
+let callers_of (idx : index) (callee : string) : ref_entry list =
+  Option.value ~default:[] (Hashtbl.find_opt idx.references callee)
 
 (* ------------------------------------------------------------------ *)
 (* Levenshtein distance                                                *)
@@ -287,7 +313,7 @@ let build_index (decl_lists : Ast.decl list list) ~(source_files : string list)
       (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
       tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
   in
-  { entries; version = 1; generated_at = now }
+  { entries; references = Hashtbl.create 0; version = 2; generated_at = now }
 
 (* ------------------------------------------------------------------ *)
 (* Stdlib loading (mirrors lsp/lib/analysis.ml)                       *)
@@ -353,20 +379,28 @@ let load_stdlib () : Ast.decl list list * string list =
     let decls = List.map parse_file paths in
     (decls, paths)
 
-(** Typecheck a flat list of stdlib decls and return the span→type map. *)
-let typecheck_decls (all_decls : Ast.decl list) : (Ast.span, TC.ty) Hashtbl.t =
+(** Typecheck a flat list of stdlib decls and return the span→type map plus
+    the reference table (calls/ctor uses/type refs) recorded along the way. *)
+let typecheck_decls (all_decls : Ast.decl list)
+    : (Ast.span, TC.ty) Hashtbl.t * ref_entry list =
   let synth : Ast.module_ = {
     mod_name  = { txt = "__stdlib__"; span = Ast.dummy_span };
     mod_decls = all_decls;
   } in
-  let (_errors, type_map) = TC.check_module synth in
-  type_map
+  let (_errors, type_map, tc_refs) = TC.check_module_with_refs synth in
+  let refs = List.map (fun (r : TC.ref_record) ->
+      { callee = r.callee; caller = r.caller;
+        kind = ref_kind_to_string r.ref_kind;
+        file = r.ref_file; line = r.ref_line }
+    ) tc_refs in
+  (type_map, refs)
 
 (** Build a search index from all stdlib files, with typechecker-inferred types. *)
 let build_stdlib_index () : index =
   let (decl_lists, source_files) = load_stdlib () in
-  let type_map = typecheck_decls (List.concat decl_lists) in
-  build_index decl_lists ~source_files ~type_map ()
+  let (type_map, refs) = typecheck_decls (List.concat decl_lists) in
+  let idx = build_index decl_lists ~source_files ~type_map () in
+  { idx with references = references_of_list refs }
 
 (** Build an index from all .march files found in [dirs] (non-recursive). *)
 let build_index_from_dirs (dirs : string list) : index =
@@ -381,11 +415,18 @@ let build_index_from_dirs (dirs : string list) : index =
   in
   let paths = List.concat_map march_files_in dirs in
   let decls = List.map parse_file paths in
-  build_index decls ~source_files:paths ()
+  let (type_map, refs) = typecheck_decls (List.concat decls) in
+  let idx = build_index decls ~source_files:paths ~type_map () in
+  { idx with references = references_of_list refs }
 
 (** Merge two indices into one. *)
 let merge_indices (a : index) (b : index) : index =
-  { a with entries = a.entries @ b.entries }
+  let merged = Hashtbl.copy a.references in
+  Hashtbl.iter (fun k v ->
+      let existing = Option.value ~default:[] (Hashtbl.find_opt merged k) in
+      Hashtbl.replace merged k (v @ existing)
+    ) b.references;
+  { a with entries = a.entries @ b.entries; references = merged }
 
 (* ------------------------------------------------------------------ *)
 (* Search helpers                                                      *)
@@ -529,6 +570,40 @@ let search_combined (idx : index)
     ) idx.entries
     |> List.sort (fun (_, s1) (_, s2) -> compare s2 s1)
 
+(** Resolve [query] (bare or qualified) to every matching entry's qualified
+    name, then return their combined caller list. Bare names may match
+    entries in more than one module; all matches are merged rather than
+    treated as an error, consistent with [search_name]'s existing UX. *)
+let search_callers (idx : index) (query : string) : ref_entry list =
+  let qualified_of (e : entry) =
+    if e.module_name = "" then e.name else e.module_name ^ "." ^ e.name
+  in
+  let candidates =
+    if String.contains query '.' then [query]
+    else
+      idx.entries
+      |> List.filter (fun e -> e.name = query)
+      |> List.map qualified_of
+  in
+  List.concat_map (callers_of idx) candidates
+
+let format_ref_entry (r : ref_entry) : string =
+  Printf.sprintf "%s  %s:%d  (%s)" r.caller r.file r.line r.kind
+
+let format_references_plain (refs : ref_entry list) : unit =
+  if refs = [] then print_endline "no references found"
+  else List.iter (fun r -> print_endline (format_ref_entry r)) refs
+
+let format_references_colored (refs : ref_entry list) : unit =
+  if refs = [] then Printf.printf "\027[2mno references found\027[0m\n"
+  else begin
+    let bold = "\027[1m" and dim = "\027[2m" and reset = "\027[0m" in
+    List.iter (fun r ->
+        Printf.printf "%s%s%s  %s%s:%d%s  %s(%s)%s\n"
+          bold r.caller reset dim r.file r.line reset dim r.kind reset
+      ) refs
+  end
+
 (* ------------------------------------------------------------------ *)
 (* JSON serialization                                                  *)
 (* ------------------------------------------------------------------ *)
@@ -573,20 +648,58 @@ let entry_of_json (j : Yojson.Basic.t) : entry =
     return_type = j |> member "return_type" |> to_string_option;
   }
 
+let ref_entry_to_json (r : ref_entry) : Yojson.Basic.t =
+  `Assoc [
+    "caller", `String r.caller;
+    "file",   `String r.file;
+    "line",   `Int r.line;
+    "kind",   `String r.kind;
+  ]
+
+let ref_entry_of_json (callee : string) (j : Yojson.Basic.t) : ref_entry =
+  let open Yojson.Basic.Util in
+  { callee;
+    caller = j |> member "caller" |> to_string;
+    file   = j |> member "file"   |> to_string;
+    line   = j |> member "line"   |> to_int;
+    kind   = j |> member "kind"   |> to_string;
+  }
+
 let index_to_json (idx : index) : string =
+  let refs_json : Yojson.Basic.t =
+    `Assoc (Hashtbl.fold (fun callee entries acc ->
+        (callee, `List (List.map ref_entry_to_json entries)) :: acc
+      ) idx.references [])
+  in
   let j : Yojson.Basic.t = `Assoc [
     "version",      `Int idx.version;
     "generated_at", `String idx.generated_at;
     "entries",      `List (List.map entry_to_json idx.entries);
+    "references",   refs_json;
   ] in
   Yojson.Basic.pretty_to_string j
 
 let index_from_json (s : string) : index =
   let open Yojson.Basic.Util in
   let j = Yojson.Basic.from_string s in
+  let references =
+    match j |> member "references" with
+    | `Null -> Hashtbl.create 0  (* old cache predating this field *)
+    | refs_json ->
+      let tbl = Hashtbl.create 64 in
+      (match refs_json with
+       | `Assoc kvs ->
+         List.iter (fun (callee, entries_json) ->
+             let entries = entries_json |> to_list |> List.map (ref_entry_of_json callee) in
+             Hashtbl.replace tbl callee entries
+           ) kvs
+       | _ -> ());
+      tbl
+  in
   { version      = j |> member "version"      |> to_int;
     generated_at = j |> member "generated_at" |> to_string;
     entries      = j |> member "entries"      |> to_list |> List.map entry_of_json;
+    references;
   }
 
 (* ------------------------------------------------------------------ *)
@@ -622,7 +735,7 @@ let format_results_colored (results : (entry * float) list) : unit =
       | Some s -> (try int_of_string s with _ -> 80)
       | None   -> 80
     in
-    List.iter (fun (e, _) ->
+    List.iter (fun ((e : entry), _) ->
       let loc = Printf.sprintf "%s:%d" (Filename.basename e.file) e.line in
       let name_visible =
         (if e.module_name = "" then "" else e.module_name ^ ".") ^ e.name

--- a/lib/typecheck/typecheck.ml
+++ b/lib/typecheck/typecheck.ml
@@ -485,6 +485,18 @@ type proto_info = {
 
 module StrMap = Map.Make(String)
 
+(** A resolved reference recorded during typechecking: [callee] used a
+    declaration that [caller] (both fully-qualified "Mod.name") owns, at
+    [ref_file]:[ref_line]. Populated only where resolution already succeeds —
+    never a textual guess. *)
+type ref_record = {
+  callee   : string;
+  caller   : string;
+  ref_kind : [ `Call | `Ctor | `TypeRef ];
+  ref_file : string;
+  ref_line : int;
+}
+
 type env = {
   vars    : scheme StrMap.t;               (** Term variable → scheme *)
   types   : int StrMap.t;                  (** Type constructor name → arity *)
@@ -496,6 +508,15 @@ type env = {
   errors  : Err.ctx;
   pending_constraints : constraint_ list ref; (** Accumulated use-site constraints *)
   type_map : (Ast.span, ty) Hashtbl.t;
+  refs : ref_record list ref;
+  (** Resolved call/ctor/type references accumulated during checking, for
+      `forge search --callers`. Shared (mutable) across all env copies
+      derived from the same root, same as [import_tracker]. *)
+  current_decl : string ref;
+  (** Fully-qualified name ("Mod.fn") of the top-level fn/impl-method whose
+      body is currently being checked. Set by [check_fn]; read wherever a
+      [ref_record] is recorded so it knows its caller. Empty string before
+      the first fn is entered. *)
   scheme_witnesses : (int list, constraint_ list * ty) Hashtbl.t;
   (** A1 (--emit-core-ast v2): every HM scheme instantiated during checking,
       deduped by its quantified-id list -> (constraints, body). Populated at
@@ -709,6 +730,7 @@ let make_env errors type_map = {
   vars = StrMap.empty; types = StrMap.empty; ctors = StrMap.empty; records = StrMap.empty;
   level = 0; lin = [];
   errors; pending_constraints = ref []; type_map;
+  refs = ref []; current_decl = ref "";
   scheme_witnesses = Hashtbl.create 64;
   inst_witnesses = Hashtbl.create 256;
   interfaces = StrMap.empty; sigs = [];

--- a/lib/typecheck/typecheck.ml
+++ b/lib/typecheck/typecheck.ml
@@ -4719,11 +4719,37 @@ let rec infer_expr env (e : Ast.expr) : ty =
     | Ast.EVar name ->
       record_use name.txt name.span env;
       (match lookup_var name.txt env with
-       | Some sch -> instantiate ~use_span:name.span env.level env sch
+       | Some sch ->
+         (if StrMap.mem name.txt env.local_fns then
+            env.refs := { callee = env.current_module ^ "." ^ name.txt;
+                          caller = !(env.current_decl);
+                          ref_kind = `Call;
+                          ref_file = name.span.Ast.file;
+                          ref_line = name.span.Ast.start_line } :: !(env.refs)
+          else if String.contains name.txt '.' then
+            (* Already-qualified "Mod.name" resolved directly out of env.vars —
+               this is how same-compilation cross-module DMod exports work (see
+               the [Ast.DMod] branch of [check_decl], which binds "Mod.member"
+               straight into the outer env.vars rather than routing through
+               [resolve_qualified_var]/[Module_registry]). A dotted name can
+               never be a local `let`-bound variable, so this is always a
+               genuine cross-module reference. *)
+            env.refs := { callee = name.txt;
+                          caller = !(env.current_decl);
+                          ref_kind = `Call;
+                          ref_file = name.span.Ast.file;
+                          ref_line = name.span.Ast.start_line } :: !(env.refs));
+         instantiate ~use_span:name.span env.level env sch
        | None     ->
          (* Try qualified module resolution: "Mod.func" *)
          match resolve_qualified_var name.txt env with
-         | _, Some sch -> instantiate ~use_span:name.span env.level env sch
+         | _, Some sch ->
+           env.refs := { callee = name.txt;
+                         caller = !(env.current_decl);
+                         ref_kind = `Call;
+                         ref_file = name.span.Ast.file;
+                         ref_line = name.span.Ast.start_line } :: !(env.refs);
+           instantiate ~use_span:name.span env.level env sch
          | _ when is_confirmed_private_qualified name.txt env ->
            (* A confirmed privacy violation (`Mod.priv_fn`) must be reported
               as such — falling through to the dot-suffix fallback below would
@@ -6710,6 +6736,7 @@ let warn_unused_params env (params : Ast.fn_param list) (body : Ast.expr) _fn_sp
     5. Leave level and generalize the function type.
     6. Return the scheme so the caller can update the env. *)
 let check_fn env (def : Ast.fn_def) fn_span : scheme =
+  env.current_decl := env.current_module ^ "." ^ def.fn_name.txt;
   let env'    = enter_level env in
   (* Self-reference for recursion — a fresh var that will get unified
      with the actual type as the body is checked.
@@ -11145,6 +11172,14 @@ let check_module_core ?(errors = Err.create ()) ?seed_env (m : Ast.module_)
 let check_module ?errors (m : Ast.module_) : Err.ctx * (Ast.span, ty) Hashtbl.t =
   let (errs, type_map, _env) = check_module_core ?errors m in
   (errs, type_map)
+
+(** Like [check_module], but also returns every resolved call/ctor/type
+    reference recorded during checking — used by [forge search --callers].
+    Order is call-order, most-recent-first is reversed back to source order. *)
+let check_module_with_refs ?errors (m : Ast.module_)
+    : Err.ctx * (Ast.span, ty) Hashtbl.t * ref_record list =
+  let (errs, type_map, final_env) = check_module_core ?errors m in
+  (errs, type_map, List.rev !(final_env.refs))
 
 (** Like [check_module] but starts from a pre-built environment.
     Used by the REPL JIT to typecheck user expressions incrementally

--- a/lib/typecheck/typecheck.ml
+++ b/lib/typecheck/typecheck.ml
@@ -781,6 +781,25 @@ let make_env errors type_map = {
 let enter_level env = { env with level = env.level + 1 }
 let leave_level env = { env with level = env.level - 1 }
 
+(** Run [f] with [env.current_decl] temporarily blanked to "" — for
+    [surface_ty] calls that check a type with NO enclosing function (an
+    interface method signature, an impl header/when-constraint type): without
+    this, [env.current_decl] is left over from whatever [DFn] happened to be
+    checked immediately before in module order (it is set only by [check_fn]
+    and never reset — see [current_decl]'s doc comment), so a qualified
+    `TyCon` reference recorded there would be silently misattributed to an
+    unrelated function.  The [`TyCon] hook in [surface_ty] skips recording
+    entirely when [caller = ""], so blanking here means "don't record a
+    reference for this callerless type position" rather than emitting a
+    deliberately-empty [caller].  [current_decl] is a mutable ref shared
+    across all [env] copies (like [import_tracker]), so this must restore the
+    prior value afterward — including when [f] raises — rather than leaving
+    it blanked for whatever is checked next. *)
+let with_no_caller (env : env) (f : unit -> 'a) : 'a =
+  let saved = !(env.current_decl) in
+  env.current_decl := "";
+  Fun.protect ~finally:(fun () -> env.current_decl := saved) f
+
 (** Is [r] an [offer] continuation still awaiting per-arm refinement?
     Physical identity on purpose: [env.offer_unrefined] tracks the exact ref
     [Chan.offer] minted, and the ref cell IS the channel's identity for the
@@ -3094,7 +3113,13 @@ let name_is_variant env name =
 let rec surface_ty env ~(tvars : (string * ty) list ref) (s : Ast.ty) : ty =
   match s with
   | Ast.TyCon (name, args) ->
-    (if String.contains name.Ast.txt '.' then
+    (* Skip when [caller = ""]: either no fn has been entered yet, or (since
+       Fix round 1) a callerless surface_ty call site — interface method
+       signature, impl header/when-constraint — deliberately blanked
+       [current_decl] via [with_no_caller] to suppress recording rather than
+       misattribute to an unrelated function. Either way, an empty caller was
+       never a meaningful attribution for `forge search --callers`. *)
+    (if String.contains name.Ast.txt '.' && !(env.current_decl) <> "" then
        env.refs := { callee = name.Ast.txt;
                      caller = !(env.current_decl);
                      ref_kind = `TypeRef;
@@ -3306,7 +3331,9 @@ let () = inject_iface_exports_ref := (fun mod_name exports env ->
           (* Use level 1 for the interface type parameter so generalize 0 quantifies it. *)
           let a = fresh_var 1 in
           let tvars = ref [(idef.iface_param.txt, a)] in
-          let ty = surface_ty env ~tvars m.md_ty in
+          (* No enclosing function checks a cross-module interface's own
+             method signature — see [with_no_caller]. *)
+          let ty = with_no_caller env (fun () -> surface_ty env ~tvars m.md_ty) in
           let a_id = match a with
             | TVar r -> (match !r with Unbound (id, _) -> id | _ -> 0)
             | _ -> 0
@@ -7358,7 +7385,12 @@ let prebind_interface_decl ~prefix (idef : Ast.interface_def) (e : env) : env =
       let tmp_env = { e with errors = tmp_errors } in
       let a = fresh_var 1 in
       let tvars = ref [(idef.iface_param.txt, a)] in
-      let ty = surface_ty tmp_env ~tvars m.md_ty in
+      (* Prebinding an interface method's own signature has no enclosing
+         function either — see [with_no_caller]. [tmp_env] shares [refs] and
+         [current_decl] with [e] (record-copy, not clone of the ref cells),
+         so blanking through [tmp_env] is equally visible to the [TyCon]
+         hook. *)
+      let ty = with_no_caller tmp_env (fun () -> surface_ty tmp_env ~tvars m.md_ty) in
       let a_id = match a with
         | TVar r -> (match !r with Unbound (id, _) -> id | _ -> 0)
         | _ -> 0
@@ -9836,7 +9868,9 @@ let rec check_decl env (d : Ast.decl) : env =
         (* Use level+1 so the interface type parameter gets quantified by generalize. *)
         let a = fresh_var (env.level + 1) in
         let tvars = ref [(idef.iface_param.txt, a)] in
-        let ty = surface_ty env ~tvars m.md_ty in
+        (* An interface method signature has no enclosing function — see
+           [with_no_caller]. *)
+        let ty = with_no_caller env (fun () -> surface_ty env ~tvars m.md_ty) in
         let a_id = match a with
           | TVar r -> (match !r with Unbound (id, _) -> id | _ -> 0)
           | _ -> 0
@@ -9860,7 +9894,9 @@ let rec check_decl env (d : Ast.decl) : env =
     (* Instantiate the impl type, sharing tvars so the 'when' constraints
        can reference the same type variables as the impl type itself. *)
     let tvars = ref [] in
-    let inst_ty = surface_ty env ~tvars idef.impl_ty in
+    (* The impl header's own type (`impl Iface(T)`) has no enclosing
+       function — see [with_no_caller]. *)
+    let inst_ty = with_no_caller env (fun () -> surface_ty env ~tvars idef.impl_ty) in
     (* Register this implementation so CInterface constraints can be discharged. *)
     let env_with_impl = { env with impls =
       (let key = idef.impl_iface.txt in
@@ -9870,7 +9906,9 @@ let rec check_decl env (d : Ast.decl) : env =
        StrMap.add key ((inst_ty, idef.impl_iface.span, None) :: lst) env.impls) } in
     (* Check 'when' constraints: each C(T) must already be implemented. *)
     List.iter (fun ((cname : Ast.name), ctys) ->
-        match List.map (surface_ty env ~tvars) ctys with
+        (* A `when C(T)` constraint type is also part of the impl header,
+           with no enclosing function — see [with_no_caller]. *)
+        match with_no_caller env (fun () -> List.map (surface_ty env ~tvars) ctys) with
         | [cty] ->
           let cty = repr cty in
           (match cty with

--- a/lib/typecheck/typecheck.ml
+++ b/lib/typecheck/typecheck.ml
@@ -497,6 +497,19 @@ type ref_record = {
   ref_line : int;
 }
 
+(** Qualify [name] with [modname] the one way every [ref_record] site should:
+    ["Mod.name"], or bare [name] when [modname] is empty. An empty module
+    name shows up for prelude constructors ([Cons]/[Nil]/[Some]/[None]/[Ok]/
+    [Err], whose [ci_module] is "") and for the bare-module case generally —
+    without this, ad-hoc `modname ^ "." ^ name` concatenation at each
+    recording site produces a callee/caller literally starting with "." for
+    those references, which [Search.search_callers]'s query-side lookup can
+    never match (its own [qualified_of] already treats an empty module name
+    this way). Shared by the [EVar]/[ECon]/[TyCon] reference-recording hooks
+    so the convention can't drift between them. *)
+let qualify_ref_name (modname : string) (name : string) : string =
+  if modname = "" then name else modname ^ "." ^ name
+
 type env = {
   vars    : scheme StrMap.t;               (** Term variable → scheme *)
   types   : int StrMap.t;                  (** Type constructor name → arity *)
@@ -1455,10 +1468,21 @@ let suggest_ctors (name : string) (env : env) : (string * string) list =
    based on a label the peer never actually returned: the exact `Chan.offer`
    soundness hole this file's [offer_unrefined] field exists to close, just
    reached through a shadowed name instead of a bare missing `match`. *)
+(* [local_fns] shadowing discipline (mirrors the [fn_arities]/[plain_let_names]
+   removals above): [local_fns] marks a name as "genuinely the current
+   module's own top-level fn" and the [EVar] Call-ref-recording hook
+   (`forge search --callers`) trusts that membership check alone to decide
+   whether a bare-name use is a real call to that top-level fn. Without
+   retiring the entry here, a parameter or local `let` that shadows a
+   top-level fn name (e.g. `fn wrapper(helper) do helper() end` when `helper`
+   is also a top-level fn) would have its LOCAL variable's use misrecorded as
+   a call to the shadowed top-level fn — a textual name match masquerading as
+   a resolution-based one. *)
 let bind_var name sch env =
   { env with vars = StrMap.add name sch env.vars;
              fn_arities = StrMap.remove name env.fn_arities;
              plain_let_names = StringSet.remove name env.plain_let_names;
+             local_fns = StrMap.remove name env.local_fns;
              offer_labels = List.filter (fun (n, _) -> n <> name) env.offer_labels }
 
 let bind_vars bindings env =
@@ -4777,13 +4801,14 @@ let rec infer_expr env (e : Ast.expr) : ty =
       record_use name.txt name.span env;
       (match lookup_var name.txt env with
        | Some sch ->
-         (if StrMap.mem name.txt env.local_fns then
-            env.refs := { callee = env.current_module ^ "." ^ name.txt;
+         (if StrMap.mem name.txt env.local_fns && !(env.current_decl) <> "" then
+            env.refs := { callee = qualify_ref_name env.current_module name.txt;
                           caller = !(env.current_decl);
                           ref_kind = `Call;
                           ref_file = name.span.Ast.file;
                           ref_line = name.span.Ast.start_line } :: !(env.refs)
-          else if String.contains name.txt '.' && StrMap.mem name.txt env.qual_fn_names then
+          else if String.contains name.txt '.' && StrMap.mem name.txt env.qual_fn_names
+                  && !(env.current_decl) <> "" then
             (* Already-qualified "Mod.name" resolved directly out of env.vars —
                this is how same-compilation cross-module DMod exports work (see
                the [Ast.DMod] branch of [check_decl], which binds "Mod.member"
@@ -4810,7 +4835,7 @@ let rec infer_expr env (e : Ast.expr) : ty =
               there for the ExFn case, so this correctly excludes a qualified
               reference to a registry-loaded module's public [DLet]
               value/constant (ExValue). See [qual_fn_names]'s doc comment. *)
-           (if StrMap.mem name.txt env'.qual_fn_names then
+           (if StrMap.mem name.txt env'.qual_fn_names && !(env.current_decl) <> "" then
               env.refs := { callee = name.txt;
                             caller = !(env.current_decl);
                             ref_kind = `Call;
@@ -5544,8 +5569,8 @@ let rec infer_expr env (e : Ast.expr) : ty =
            resolved
        in
        (match ci_opt with
-        | Some ci ->
-          env.refs := { callee = ci.ci_module ^ "." ^
+        | Some ci when !(env.current_decl) <> "" ->
+          env.refs := { callee = qualify_ref_name ci.ci_module
                           (if String.contains name.txt '.'
                            then (let i = String.rindex name.txt '.' in
                                  String.sub name.txt (i + 1) (String.length name.txt - i - 1))
@@ -5554,7 +5579,7 @@ let rec infer_expr env (e : Ast.expr) : ty =
                         ref_kind = `Ctor;
                         ref_file = sp.Ast.file;
                         ref_line = sp.Ast.start_line } :: !(env.refs)
-        | None -> ());
+        | Some _ | None -> ());
        match ci_opt with
        | None ->
          let candidates = suggest_ctors name.txt env in
@@ -6815,8 +6840,23 @@ let warn_unused_params env (params : Ast.fn_param list) (body : Ast.expr) _fn_sp
     5. Leave level and generalize the function type.
     6. Return the scheme so the caller can update the env. *)
 let check_fn env (def : Ast.fn_def) fn_span : scheme =
-  env.current_decl := env.current_module ^ "." ^ def.fn_name.txt;
+  (* [current_decl] is a single shared ref, not a stack — save/restore around
+     the whole body so it never leaks into whatever gets checked next once
+     this fn's body is done (nested fns, a later top-level decl, etc.). This
+     mirrors [with_no_caller]'s save/restore pattern but restores the PREVIOUS
+     caller rather than blanking to "", since [check_fn] can itself be nested
+     (a closure body containing a locally-defined named fn). *)
+  let saved_caller = !(env.current_decl) in
+  env.current_decl := qualify_ref_name env.current_module def.fn_name.txt;
+  Fun.protect ~finally:(fun () -> env.current_decl := saved_caller) (fun () ->
   let env'    = enter_level env in
+  (* Captured BEFORE the self-bind below (which unconditionally clears any
+     [local_fns] entry for this name, per [bind_var]'s shadowing discipline)
+     so we know whether to restore it afterward — this fn is only a genuine
+     top-level Call-recording target if it already was one; an impl method
+     (checked via [check_fn] too, but never registered in [local_fns] to
+     begin with) must not spuriously become one. *)
+  let was_local_fn = StrMap.mem def.fn_name.txt env'.local_fns in
   (* Self-reference for recursion — a fresh var that will get unified
      with the actual type as the body is checked.
      For default-arg wrappers (multiple DFn with the same name), the full-arity
@@ -6847,15 +6887,23 @@ let check_fn env (def : Ast.fn_def) fn_span : scheme =
       let sv = fresh_var env'.level in
       (sv, bind_var def.fn_name.txt (Mono sv) env', None)
   in
-  (* The self-bind above cleared any fn_arities entry for this name (shadow
-     semantics — correct when a NESTED fn shadows a top-level fn of different
-     arity).  Re-register the CURRENT def's own arity so recursive calls in the
-     body are still arity-checked, against the right arity either way. *)
+  (* The self-bind above cleared any fn_arities/local_fns entry for this name
+     (shadow semantics — correct when a NESTED fn shadows a top-level fn of
+     different arity).  Re-register the CURRENT def's own arity so recursive
+     calls in the body are still arity-checked, against the right arity
+     either way — and re-register [local_fns] so a recursive call to this
+     same top-level fn is still recorded as a genuine Call reference (see
+     [bind_var]'s [local_fns] shadowing-discipline comment; [check_fn] is
+     only ever called for actual top-level/impl-method fns, never a nested
+     local `fn`, so it is always correct to restore this membership here). *)
   let env_rec =
     let arity = match def.fn_clauses with
       | c :: _ -> List.length c.Ast.fc_params | [] -> 0 in
     { env_rec with fn_arities =
-        StrMap.add def.fn_name.txt (arity, def.fn_name.span) env_rec.fn_arities } in
+        StrMap.add def.fn_name.txt (arity, def.fn_name.span) env_rec.fn_arities;
+      local_fns =
+        if was_local_fn then StrMap.add def.fn_name.txt () env_rec.local_fns
+        else env_rec.local_fns } in
 
   let sch = match def.fn_clauses with
     | [] ->
@@ -7144,7 +7192,7 @@ let check_fn env (def : Ast.fn_def) fn_span : scheme =
    | _ -> ());
 
   ignore (leave_level env');
-  sch
+  sch)
 
 (** [impl_matches_ty impl_ty target_ty] returns true if [target_ty] could be
     satisfied by an implementation typed as [impl_ty].  Free unification
@@ -9289,14 +9337,26 @@ let rec check_decl env (d : Ast.decl) : env =
   | Ast.DFn (def, sp) ->
     let sch = check_fn env def sp in
     discharge_constraints env sp;
+    let was_local_fn = StrMap.mem def.fn_name.txt env.local_fns in
     let env = bind_var def.fn_name.txt sch env in
-    (* bind_var cleared this fn's own fn_arities entry (shadow semantics);
-       restore it so later same-module calls keep the direct-call arity check. *)
+    (* bind_var cleared this fn's own fn_arities/local_fns entries (shadow
+       semantics); restore them so later same-module calls keep the
+       direct-call arity check AND keep being recorded as genuine Call
+       references (see [bind_var]'s [local_fns] shadowing-discipline
+       comment — this is [check_fn]'s post-hoc mirror site: the module's
+       pass-1 prebind put this fn's name in [local_fns] before [check_fn]
+       ran; without restoring it here, EVERY same-module call to a fn
+       checked later than its own definition would silently stop being
+       recorded, since [bind_var]'s unconditional removal has nothing left
+       to re-add it). *)
     let env =
       let arity = match def.fn_clauses with
         | c :: _ -> List.length c.Ast.fc_params | [] -> 0 in
       { env with fn_arities =
-          StrMap.add def.fn_name.txt (arity, def.fn_name.span) env.fn_arities } in
+          StrMap.add def.fn_name.txt (arity, def.fn_name.span) env.fn_arities;
+        local_fns =
+          if was_local_fn then StrMap.add def.fn_name.txt () env.local_fns
+          else env.local_fns } in
     (* Reconcile the QUALIFIED prebind (`Mod.fn`) with the fn's REAL body-checked
        scheme.  desugar's [qualify_module_refs] (lib/desugar/desugar.ml) rewrites
        every intra-nested-module reference to the qualified form (e.g. `App.id`),
@@ -9351,7 +9411,12 @@ let rec check_decl env (d : Ast.decl) : env =
 
   | Ast.DLet (_vis, b, sp) ->
     let env' = enter_level env in
-    let rhs_ty = infer_expr env' b.bind_expr in
+    (* A top-level `let` binding's RHS has no enclosing function — see
+       [with_no_caller]. Without this, any Call/Ctor reference in the RHS
+       gets misattributed to whatever [DFn] [check_decl] happened to check
+       last in module order (or a stale caller from an earlier file in a
+       multi-file compilation). *)
+    let rhs_ty = with_no_caller env' (fun () -> infer_expr env' b.bind_expr) in
     Hashtbl.replace env.type_map sp (repr rhs_ty);
     let bindings, pat_ty = infer_pattern ~expected:rhs_ty env' b.bind_pat in
     unify env' ~span:sp ~reason:(Some (RLetBind sp)) rhs_ty pat_ty;
@@ -9474,9 +9539,12 @@ let rec check_decl env (d : Ast.decl) : env =
                    ci_arg_tys = arg_tys; ci_module = env.current_module; ci_vis = Ast.Public } in
         { acc_env with ctors = add_ctor h.ah_msg.txt ci acc_env.ctors }
       ) env_with_actor_ctor actor.actor_handlers in
-    (* Check init expression — must return the state record type *)
-    check_expr env_with_ctors actor.actor_init state_ty
-      ~reason:(Some (RBuiltin "actor init must return the initial state record"));
+    (* Check init expression — must return the state record type.  Neither
+       the init expr nor any handler body below is checked via [check_fn], so
+       there is no enclosing function — see [with_no_caller]. *)
+    with_no_caller env_with_ctors (fun () ->
+      check_expr env_with_ctors actor.actor_init state_ty
+        ~reason:(Some (RBuiltin "actor init must return the initial state record")));
     (* Check handlers with state and message params in scope *)
     List.iter (fun (h : Ast.actor_handler) ->
         let handler_env = bind_var "state" (Mono state_ty) env_with_ctors in
@@ -9495,8 +9563,9 @@ let rec check_decl env (d : Ast.decl) : env =
                 e
             ) handler_env h.ah_params
         in
-        (* Handler body must return the state record type — emit rich diagnostic *)
-        let inferred = infer_expr handler_env h.ah_body in
+        (* Handler body must return the state record type — emit rich
+           diagnostic. No enclosing function — see [with_no_caller]. *)
+        let inferred = with_no_caller handler_env (fun () -> infer_expr handler_env h.ah_body) in
         let shadow_env = { handler_env with errors = Err.create () } in
         (* Note: pending_constraints and type_map are shared (shallow copy) —
            intentional; only error reporting is isolated. *)
@@ -9999,11 +10068,14 @@ let rec check_decl env (d : Ast.decl) : env =
                 use check_expr directly against the expected type. *)
              (match def.fn_clauses with
               | [{ fc_params = []; fc_body; _ }] when iface_method.md_default <> None ->
-                (* Default method injected by desugar — just check the body expr *)
-                check_expr env fc_body expected_ty
-                  ~reason:(Some (RBuiltin
-                    (Printf.sprintf "default `%s` in interface `%s`"
-                       mname.txt idef.impl_iface.txt)))
+                (* Default method injected by desugar — just check the body
+                   expr. This bypasses [check_fn], so there is no enclosing
+                   function — see [with_no_caller]. *)
+                with_no_caller env (fun () ->
+                  check_expr env fc_body expected_ty
+                    ~reason:(Some (RBuiltin
+                      (Printf.sprintf "default `%s` in interface `%s`"
+                         mname.txt idef.impl_iface.txt))))
               | _ ->
                 let actual_sch = check_fn env def _sp in
                 let actual_ty = instantiate env.level env actual_sch in
@@ -10034,11 +10106,14 @@ let rec check_decl env (d : Ast.decl) : env =
     end
 
   | Ast.DExtern (edef, _sp) ->
-    (* Register each foreign function as a monomorphic binding. *)
+    (* Register each foreign function as a monomorphic binding. An extern
+       fn's own signature has no enclosing function — see [with_no_caller]. *)
     List.fold_left (fun env (ef : Ast.extern_fn) ->
         let tvars = ref [] in
-        let param_tys = List.map (fun (_, t) -> surface_ty env ~tvars t) ef.ef_params in
-        let ret_ty = surface_ty env ~tvars ef.ef_ret_ty in
+        let param_tys, ret_ty = with_no_caller env (fun () ->
+            let param_tys = List.map (fun (_, t) -> surface_ty env ~tvars t) ef.ef_params in
+            let ret_ty = surface_ty env ~tvars ef.ef_ret_ty in
+            (param_tys, ret_ty)) in
         let ty = List.fold_right (fun pt acc -> TArrow (pt, acc)) param_tys ret_ty in
         bind_var ef.ef_name.txt (Mono ty) env
       ) env edef.ext_fns
@@ -10284,9 +10359,11 @@ let rec check_decl env (d : Ast.decl) : env =
     env
 
   | Ast.DTest (tdef, sp) ->
-    (* Typecheck the test body; it must be Unit. *)
-    check_expr env tdef.test_body t_unit
-      ~reason:(Some (RBuiltin (Printf.sprintf "test body of \"%s\" must produce Unit" tdef.test_name)));
+    (* Typecheck the test body; it must be Unit. No enclosing function — see
+       [with_no_caller]. *)
+    with_no_caller env (fun () ->
+      check_expr env tdef.test_body t_unit
+        ~reason:(Some (RBuiltin (Printf.sprintf "test body of \"%s\" must produce Unit" tdef.test_name))));
     Hashtbl.replace env.type_map sp t_unit;
     env
 
@@ -10296,12 +10373,16 @@ let rec check_decl env (d : Ast.decl) : env =
     env'
 
   | Ast.DSetup (body, sp) ->
-    check_expr env body t_unit ~reason:(Some (RBuiltin "setup body must produce Unit"));
+    (* No enclosing function — see [with_no_caller]. *)
+    with_no_caller env (fun () ->
+      check_expr env body t_unit ~reason:(Some (RBuiltin "setup body must produce Unit")));
     Hashtbl.replace env.type_map sp t_unit;
     env
 
   | Ast.DSetupAll (body, sp) ->
-    check_expr env body t_unit ~reason:(Some (RBuiltin "setup_all body must produce Unit"));
+    (* No enclosing function — see [with_no_caller]. *)
+    with_no_caller env (fun () ->
+      check_expr env body t_unit ~reason:(Some (RBuiltin "setup_all body must produce Unit")));
     Hashtbl.replace env.type_map sp t_unit;
     env
 

--- a/lib/typecheck/typecheck.ml
+++ b/lib/typecheck/typecheck.ml
@@ -567,6 +567,17 @@ type env = {
       number of arguments panics at runtime (and the compiler miscompiles
       under-application into a body call with a garbage argument).  Used to
       reject wrong-arity calls of these functions at the call site. *)
+  qual_fn_names : unit StrMap.t;
+  (** Qualified ("Mod.name") keys in [vars] that denote a genuine top-level
+      function — i.e. a [DFn] (or a registry [ExFn] export), never a [DLet]
+      value/constant. Populated at two sites: the [Ast.DMod] export step
+      (mirrors [new_names], restricted to keys already known to be functions
+      via [local_fns]/[qual_fn_names] of the inner env — so it composes
+      correctly across nested modules) and [load_module_into_env]'s [ExFn]
+      arm (registry-loaded modules). Consulted by the [Ast.EVar] reference-
+      recording hook so a qualified value reference (`Mod.SOME_CONST`) is
+      never recorded as a `` `Call `` reference — see [local_fns] for the
+      bare-name analogue of this same distinction. *)
   plain_let_names : StringSet.t;
   (** Names most recently bound by a simple, unrestricted `let name = expr`
       (single-variable pattern — see the [Ast.ELet] case of [infer_block]).
@@ -739,6 +750,7 @@ let make_env errors type_map = {
   import_idx = make_import_index ();
   local_fns = StrMap.empty;
   fn_arities = StrMap.empty;
+  qual_fn_names = StrMap.empty;
   plain_let_names = StringSet.empty;
   proof_caps = [];
   always_linear_types = [];
@@ -1155,11 +1167,19 @@ let load_module_into_env (mod_name : string) (exports : March_modules.Module_reg
          [ExCtor] path already produces for private constructors.
          [ExType]/[ExRecord] stay UNGATED on purpose: March uses the opaque-type
          pattern, where a private [ptype]'s bare NAME stays referenceable across
-         modules (e.g. `ConsistentHash.HashRing(String)` on a public param) while
-         only its CONSTRUCTOR is hidden — enforced by the [ExCtor] gate below. *)
+         modules (e.g. `ConsistentHash.HashRing(String)` on a param) while
+         only its CONSTRUCTOR is hidden — enforced by the [ExCtor] gate below.
+         [ExFn] additionally seeds [qual_fn_names] so the [EVar] reference-
+         recording hook can tell a genuine function export (`ExFn`) apart
+         from a plain value/constant export (`ExValue`) — see
+         [qual_fn_names]'s doc comment. *)
       if not entry.ex_public then env
       else if StrMap.mem qname env.vars then env
-      else { env with vars = StrMap.add qname (Mono (fresh_var 0)) env.vars }
+      else
+        let env = { env with vars = StrMap.add qname (Mono (fresh_var 0)) env.vars } in
+        (match entry.ex_kind with
+         | ExFn -> { env with qual_fn_names = StrMap.add qname () env.qual_fn_names }
+         | _ -> env)
     | ExType arity ->
       (* Register the qualified name AND the BARE type name.  March uses a single
          global type namespace (see [surface_ty]'s [canon_name]): a type's bare
@@ -4726,14 +4746,18 @@ let rec infer_expr env (e : Ast.expr) : ty =
                           ref_kind = `Call;
                           ref_file = name.span.Ast.file;
                           ref_line = name.span.Ast.start_line } :: !(env.refs)
-          else if String.contains name.txt '.' then
+          else if String.contains name.txt '.' && StrMap.mem name.txt env.qual_fn_names then
             (* Already-qualified "Mod.name" resolved directly out of env.vars —
                this is how same-compilation cross-module DMod exports work (see
                the [Ast.DMod] branch of [check_decl], which binds "Mod.member"
                straight into the outer env.vars rather than routing through
-               [resolve_qualified_var]/[Module_registry]). A dotted name can
-               never be a local `let`-bound variable, so this is always a
-               genuine cross-module reference. *)
+               [resolve_qualified_var]/[Module_registry]). The [qual_fn_names]
+               membership check excludes a qualified reference to a public
+               top-level [DLet] constant/value — [DMod]'s export step binds
+               those into [env.vars] the exact same way it binds a [DFn], so a
+               bare dotted-name check alone cannot tell them apart; only
+               [qual_fn_names] (populated exclusively from [DFn]s, see its doc
+               comment) can. *)
             env.refs := { callee = name.txt;
                           caller = !(env.current_decl);
                           ref_kind = `Call;
@@ -4743,12 +4767,18 @@ let rec infer_expr env (e : Ast.expr) : ty =
        | None     ->
          (* Try qualified module resolution: "Mod.func" *)
          match resolve_qualified_var name.txt env with
-         | _, Some sch ->
-           env.refs := { callee = name.txt;
-                         caller = !(env.current_decl);
-                         ref_kind = `Call;
-                         ref_file = name.span.Ast.file;
-                         ref_line = name.span.Ast.start_line } :: !(env.refs);
+         | env', Some sch ->
+           (* [env'] is the env AFTER [load_module_into_env] merged the
+              resolved module's exports — [qual_fn_names] is only populated
+              there for the ExFn case, so this correctly excludes a qualified
+              reference to a registry-loaded module's public [DLet]
+              value/constant (ExValue). See [qual_fn_names]'s doc comment. *)
+           (if StrMap.mem name.txt env'.qual_fn_names then
+              env.refs := { callee = name.txt;
+                            caller = !(env.current_decl);
+                            ref_kind = `Call;
+                            ref_file = name.span.Ast.file;
+                            ref_line = name.span.Ast.start_line } :: !(env.refs));
            instantiate ~use_span:name.span env.level env sch
          | _ when is_confirmed_private_qualified name.txt env ->
            (* A confirmed privacy violation (`Mod.priv_fn`) must be reported
@@ -9541,6 +9571,19 @@ let rec check_decl env (d : Ast.decl) : env =
         then (name.txt ^ "." ^ k, sch) :: acc
         else acc
       ) inner_env.vars [] in
+    (* Of the newly-exported qualified names, which denote a genuine function
+       (as opposed to a plain [DLet] value/constant)?  A key [k] is
+       function-backed either because it's one of THIS module's own [DFn]s
+       (tracked bare in [inner_env.local_fns]) or because it is itself an
+       already-qualified key re-exported from a nested public [DMod] (tracked
+       in [inner_env.qual_fn_names], populated by that nested module's own
+       pass through this same branch) — see [qual_fn_names]'s doc comment. *)
+    let new_fn_quals = StrMap.fold (fun k _sch acc ->
+        if is_pub_key k &&
+           (StrMap.mem k inner_env.local_fns || StrMap.mem k inner_env.qual_fn_names)
+        then StrMap.add (name.txt ^ "." ^ k) () acc
+        else acc
+      ) inner_env.vars StrMap.empty in
     (* Also export type names and constructors from public DMod into outer scope.
        Types defined in a module (e.g. IOList, Option) are referred to by their
        bare name throughout user code, not prefixed.
@@ -9606,6 +9649,7 @@ let rec check_decl env (d : Ast.decl) : env =
                       else ci :: acc) new_cis old_cis in
                     Some merged) all_new env'.ctors);
       records = StrMap.union (fun _k v _ -> Some v) new_records env'.records;
+      qual_fn_names = StrMap.union (fun _k a _ -> Some a) new_fn_quals env'.qual_fn_names;
       module_caps = (name.txt, inner_needs) :: env'.module_caps;
       proof_caps = inner_env.proof_caps;
       always_linear_types = inner_env.always_linear_types;

--- a/lib/typecheck/typecheck.ml
+++ b/lib/typecheck/typecheck.ml
@@ -569,15 +569,19 @@ type env = {
       reject wrong-arity calls of these functions at the call site. *)
   qual_fn_names : unit StrMap.t;
   (** Qualified ("Mod.name") keys in [vars] that denote a genuine top-level
-      function — i.e. a [DFn] (or a registry [ExFn] export), never a [DLet]
-      value/constant. Populated at two sites: the [Ast.DMod] export step
-      (mirrors [new_names], restricted to keys already known to be functions
-      via [local_fns]/[qual_fn_names] of the inner env — so it composes
-      correctly across nested modules) and [load_module_into_env]'s [ExFn]
-      arm (registry-loaded modules). Consulted by the [Ast.EVar] reference-
-      recording hook so a qualified value reference (`Mod.SOME_CONST`) is
-      never recorded as a `` `Call `` reference — see [local_fns] for the
-      bare-name analogue of this same distinction. *)
+      function — i.e. a [DFn], an interface method, or a registry [ExFn]
+      export — never a [DLet] value/constant. Populated at three sites: the
+      [Ast.DMod] export step (mirrors [new_names], restricted to keys
+      already known to be functions via [local_fns]/[qual_fn_names] of the
+      inner env — so it composes correctly across nested modules),
+      [load_module_into_env]'s [ExFn] arm (registry-loaded modules), and
+      [prebind_interface_decl] (interface methods, bound as both
+      "Iface.method" and "Mod.Iface.method" — a call-syntax reference to
+      these bypasses both other sources entirely). Consulted by the
+      [Ast.EVar] reference-recording hook so a qualified value reference
+      (`Mod.SOME_CONST`) is never recorded as a `` `Call `` reference, while
+      a qualified function/interface-method call still is — see [local_fns]
+      for the bare-name analogue of this same distinction. *)
   plain_let_names : StringSet.t;
   (** Names most recently bound by a simple, unrestricted `let name = expr`
       (single-variable pattern — see the [Ast.ELet] case of [infer_block]).
@@ -7346,9 +7350,23 @@ let prebind_interface_decl ~prefix (idef : Ast.interface_def) (e : env) : env =
         | Poly (ids, cs, t) -> Poly (ids, CInterface (idef.iface_name.txt, a) :: cs, t)
         | Mono t -> Poly ([a_id], [CInterface (idef.iface_name.txt, a)], t)
       in
-      let e1 = { e with vars = StrMap.add full_qualified sch e.vars } in
+      (* Both dotted keys bound here ([full_qualified] = "Mod.Iface.method",
+         [iface_qualified] = "Iface.method") are genuine function bindings —
+         an interface method, never a [DLet] value — so both are also
+         registered in [qual_fn_names]. This is a THIRD source of qualified
+         function names (alongside [Ast.DMod] exports and registry [ExFn]
+         entries): call syntax like `Show.show(x)` normalizes to
+         [Ast.EVar "Show.show"] (the [Ast.EApp (Ast.EField (Ast.ECon ...))]
+         rule) and resolves straight out of [env.vars] here, bypassing both
+         of the other two sources entirely — so without this, the [EVar]
+         reference-recording hook's [qual_fn_names] gate would wrongly treat
+         every qualified interface-method call as non-function-backed and
+         silently drop it. See [qual_fn_names]'s doc comment. *)
+      let e1 = { e with vars = StrMap.add full_qualified sch e.vars;
+                        qual_fn_names = StrMap.add full_qualified () e.qual_fn_names } in
       let e1 = if StrMap.mem iface_qualified e1.vars then e1
-               else { e1 with vars = StrMap.add iface_qualified sch e1.vars } in
+               else { e1 with vars = StrMap.add iface_qualified sch e1.vars;
+                              qual_fn_names = StrMap.add iface_qualified () e1.qual_fn_names } in
       if StrMap.mem m.md_name.txt e1.vars then e1
       else { e1 with vars = StrMap.add m.md_name.txt sch e1.vars }
     end

--- a/lib/typecheck/typecheck.ml
+++ b/lib/typecheck/typecheck.ml
@@ -5510,6 +5510,18 @@ let rec infer_expr env (e : Ast.expr) : ty =
            let _, resolved = resolve_qualified_ctor name.txt env in
            resolved
        in
+       (match ci_opt with
+        | Some ci ->
+          env.refs := { callee = ci.ci_module ^ "." ^
+                          (if String.contains name.txt '.'
+                           then (let i = String.rindex name.txt '.' in
+                                 String.sub name.txt (i + 1) (String.length name.txt - i - 1))
+                           else name.txt);
+                        caller = !(env.current_decl);
+                        ref_kind = `Ctor;
+                        ref_file = sp.Ast.file;
+                        ref_line = sp.Ast.start_line } :: !(env.refs)
+        | None -> ());
        match ci_opt with
        | None ->
          let candidates = suggest_ctors name.txt env in

--- a/lib/typecheck/typecheck.ml
+++ b/lib/typecheck/typecheck.ml
@@ -3094,6 +3094,12 @@ let name_is_variant env name =
 let rec surface_ty env ~(tvars : (string * ty) list ref) (s : Ast.ty) : ty =
   match s with
   | Ast.TyCon (name, args) ->
+    (if String.contains name.Ast.txt '.' then
+       env.refs := { callee = name.Ast.txt;
+                     caller = !(env.current_decl);
+                     ref_kind = `TypeRef;
+                     ref_file = name.Ast.span.Ast.file;
+                     ref_line = name.Ast.span.Ast.start_line } :: !(env.refs));
     (* Special case: Chan(Role, Proto) — session-typed channel endpoint.
        Users write Chan(RoleName, ProtoName) in type annotations.
        The parser produces TyCon("Chan", [TyCon("Role",[]), TyCon("Proto",[])]).

--- a/lsp/lib/typecheck_cache.ml
+++ b/lsp/lib/typecheck_cache.ml
@@ -40,13 +40,20 @@ let base_env () : Tc.env =
    give fresh mutable state so layering user decls cannot mutate the shared
    base. [type_map] is COPIED so stdlib span->type entries survive for
    cross-stdlib hover. Mutable fields per typecheck.ml:359-391:
-   errors, type_map, pending_constraints, import_tracker. *)
+   errors, type_map, pending_constraints, import_tracker, refs, current_decl.
+   Every mutable [Tc.env] field MUST be listed here — this is a process-
+   lifetime LSP server, so any field left off this list quietly accumulates
+   forever across every keystroke's re-analysis instead of being scoped to
+   one analysis (e.g. [refs] before this fix: nothing in the LSP ever reads
+   it, so it just grew, unbounded, for the life of the server). *)
 let derive (base : Tc.env) : Tc.env =
   { base with
     Tc.errors           = Err.create ();
     type_map            = Hashtbl.copy base.Tc.type_map;
     pending_constraints = ref [];
-    import_tracker      = ref [] }
+    import_tracker      = ref [];
+    refs                = ref [];
+    current_decl        = ref "" }
 
 (* ── stdlib + deps env ───────────────────────────────────────────────────── *)
 

--- a/specs/progress/2026-08-01-forge-search-callers-final-review-fixes.md
+++ b/specs/progress/2026-08-01-forge-search-callers-final-review-fixes.md
@@ -1,0 +1,83 @@
+# `forge search --callers`: final review fix wave
+
+Landed 2026-08-01, on top of `5397f979` (the 7-task feature landing).
+
+**What this fixed.** The final whole-branch review of `forge search
+--callers` (see `specs/progress/2026-08-01-forge-search-callers-reverse-reference-search.md`
+for the feature itself) found 7 issues after all 7 individual tasks had
+already passed per-task review. All 7 were fixed in this single wave since
+the fixes interact:
+
+1. **Critical — cache version bump was inert.** `Search.build_index` bumped
+   `version` to 2 when the `references` table was added, but nothing ever
+   compared a loaded cache's version against it — an existing user's stale
+   v1 cache silently returned "no references found" forever.
+   `forge/lib/cmd_search.ml`'s `load_or_build_index` now checks
+   `idx.version = Search.current_index_version` (new named constant,
+   `lib/search/search.ml`) and rebuilds on mismatch.
+2. **Critical — `current_decl` leaked across unrelated functions for
+   Call/Ctor.** `env.current_decl` was set by `check_fn` but never restored,
+   so a reference recorded at a "callerless" position (top-level `let`,
+   `test`/`setup` blocks, actor bodies, default interface-method bodies,
+   extern signatures) got attributed to whatever function was checked last
+   in module order — wrong, and shown to cross file boundaries in
+   multi-file compilation. `check_fn` now saves/restores `current_decl` via
+   `Fun.protect`; every other callerless `check_decl` arm (systematically
+   found via grep for `infer_expr`/`check_expr`/`surface_ty` call sites
+   outside `check_fn`) is wrapped in the existing `with_no_caller` helper;
+   the `EVar`/`ECon` hooks now skip recording when `caller = ""`, matching
+   `TyCon`'s existing behavior.
+3. **Important — prelude/synthetic-module qualification inconsistency.**
+   The `EVar`/`ECon`/`check_fn` hooks built `modname ^ "." ^ name` ad hoc,
+   producing a leading `.` for prelude ctors (`ci_module = ""`) and leaking
+   `Search.typecheck_decls`'s `"__stdlib__"` synthetic wrapper module name
+   into references from `prelude.march`'s deliberately-unwrapped top-level
+   decls. Unified behind one `qualify_ref_name` helper in `typecheck.ml`;
+   `search.ml` strips the `__stdlib__.` prefix before building `ref_entry`s.
+4. **Important — `local_fns` shadowing gap.** A function parameter or local
+   `let` shadowing a top-level fn name (e.g. `fn wrapper(helper) do
+   helper() end` where `helper` is also a top-level fn) had its local
+   variable's use misrecorded as a Call to the shadowed top-level fn — a
+   textual match, not a resolution-based one. `bind_var` now clears
+   `local_fns` on rebind (mirroring the existing `fn_arities`/
+   `plain_let_names` clears), with matching conditional restores at the two
+   sites that re-bind a genuine top-level fn's own name after checking it.
+5. **Important — LSP/JIT reused envs never reset `refs`/`current_decl`.**
+   `lsp/lib/typecheck_cache.ml`'s `derive` and `lib/jit/repl_jit.ml`'s three
+   per-call env constructions reset `errors`/`type_map`/etc. but not the two
+   new mutable fields — an unbounded per-keystroke/per-REPL-fragment memory
+   leak in a process-lifetime server. Both now reset `refs`/`current_decl`.
+6. **Important — `--limit` silently ignored for `--callers`.**
+   `forge/lib/cmd_search.ml`'s `--callers` branch never called `take limit`
+   on its results. Fixed.
+7. **Important — undeduped type+ctor candidates double-counted
+   references.** `search_callers`'s bare-name candidate resolution didn't
+   dedupe qualified names before calling `callers_of` on each, so the common
+   `type Foo = Foo(...)` newtype pattern (~80 occurrences in the real
+   stdlib) double-reported every reference. Fixed with `List.sort_uniq`.
+
+**Regression caught mid-fix.** Fixing #2's `check_fn` save/restore, combined
+with #4's `bind_var` change, initially broke two PRE-EXISTING passing tests
+(`test_call_ref_same_module`, `test_call_ref_cross_module`): `check_decl`'s
+`DFn` arm rebinds a function's own name via `bind_var` right after
+`check_fn` returns, which (once `bind_var` started clearing `local_fns`)
+wiped the function's own `local_fns` membership — so every same-module call
+to a function checked *earlier* in the module silently stopped being
+recorded. Caught by re-running the full `test_search.exe` suite immediately
+after the change (not assumed clean); fixed by restoring `local_fns`
+alongside the existing `fn_arities` restore at that site.
+
+**Test coverage added.** 9 new cases in `test/test_search.ml`'s
+`"references"`/`"integration"` groups (findings 2–4, 7) and 3 new cases in
+`forge/test/test_forge.ml`'s new `"search_index_cache"` group (findings 1,
+6). Finding 5 (env resets) verified by code inspection only — impractical to
+assert an unbounded-leak absence in a unit test within scope.
+
+**Full-suite result.** `test_search.exe` 46/46, `test_forge.exe` 133/133,
+the other 6 forge test binaries all green, `run_compiler.exe` 628/628,
+`run_eval.exe` 256/256, `run_codegen.exe` 541/541, `run_stdlib.exe` 828/829
+(1 pre-existing `MARCH_SANITIZE` ASAN-timeout flake, `adversarial-regressions`
+#39, already judged unrelated by the final reviewer).
+
+See `.superpowers/sdd/2026-08-01-forge-search-callers/final-fix-report.md`
+for the full per-finding detail (file:line, exact test names, results).

--- a/specs/progress/2026-08-01-forge-search-callers-reverse-reference-search.md
+++ b/specs/progress/2026-08-01-forge-search-callers-reverse-reference-search.md
@@ -1,0 +1,57 @@
+# `forge search --callers NAME` — reverse-reference search
+
+Landed 2026-08-01.
+
+**What shipped.** `forge search --callers NAME` finds every resolved call,
+constructor use, or qualified type reference to a declaration, using the
+typechecker's own name resolution rather than textual/grep matching. Given a
+bare or `Mod.name`-qualified target, it reports every `caller` that resolved
+against it during typechecking, with file/line.
+
+**How it works.** The typechecker (`lib/typecheck/typecheck.ml`) now records
+a `ref_record` (`callee`, `caller`, `` `Call``/`` `Ctor``/`` `TypeRef``, file,
+line) at each of three resolution hooks: function calls (`Ast.EVar`/`EApp`
+qualified-name resolution — same-module, cross-module, and interface-method
+dispatch all funnel through `qual_fn_names`), constructor application
+(`Ast.ECon`, both bare and explicitly-qualified `Mod.Ctor`), and qualified
+type annotations (`Ast.TyCon` in `surface_ty`). `check_module_with_refs`
+exposes the accumulated list alongside the existing diagnostics/type-map
+return values. `March_search.Search.index` gained a `references` field (a
+`callee -> ref_entry list` table, built by `references_of_list`) that
+persists to and rehydrates from the on-disk JSON cache (`index_to_json`/
+`index_from_json` tolerate old caches with no `references` key — empty
+table, not an error). `Search.callers_of`/`search_callers` look up a target
+by bare or qualified name, merging matches across modules when the query is
+bare (`search_callers idx "helper"` returns callers of every module's
+`helper`). `forge search --callers NAME` (`forge/cmd_search.ml`) is the CLI
+entry point.
+
+**Known gap, tracked separately.** A qualified type reference that appears
+*only* inside an `interface` method signature or an `impl`/`when`-constraint
+header is not recorded at all — there is no enclosing function to name as
+`caller` for those positions. See
+`specs/todos/2026-08-01-forge-search-callers-interface-impl-typeref-gap.md`
+for the detail; deliberately scoped out of this v1 rather than fixed.
+
+**Regression coverage added in the final task.** Two more cases in
+`test/test_search.ml`'s `references` group:
+
+- `test_ambiguous_ctor_ref_prefers_current_module` — guards the class of bug
+  on record in project memory (`lookup_ctor`'s current-module preference: two
+  modules sharing a bare constructor name at different tags previously
+  miscompiled because module preference wasn't applied). Proves
+  reference-tracking inherits the same current-module preference: two
+  modules each declaring `type Status = Active | Done`, only the second
+  (`Y`) using bare `Active`, must resolve and record `Y.Active`, never
+  `X.Active`. Verified RED (temporarily neutering `lookup_ctor`'s
+  current-module filter *and* `add_ctor`'s recency front-loading, since
+  either alone still recovers the right answer through the other
+  mechanism) before confirming GREEN against the shipped code.
+- `test_no_references_is_empty_not_error` — an unreferenced declaration
+  (`A.unused`) returns zero callers, not an error, matching the "no results"
+  UX used elsewhere in `forge search`. Verified RED by temporarily stubbing
+  `Search.callers_of` to always return a nonempty list.
+
+At landing: `test_search` 38 tests (was 36, +2). Full project suite
+(`scripts/run-tests.sh`, non-`-q`) green; see the task-7 report for the exact
+run output.

--- a/specs/todos/2026-08-01-forge-search-callers-interface-impl-typeref-gap.md
+++ b/specs/todos/2026-08-01-forge-search-callers-interface-impl-typeref-gap.md
@@ -1,0 +1,41 @@
+`[P3]` **`forge search --callers` never records qualified type references that appear
+only in an interface method signature or an impl/when-constraint header.**
+
+Part of the `forge search --callers` reverse-reference-search plan
+(`.claude/worktrees/eager-volhard-387ed0/.superpowers/sdd/2026-08-01-forge-search-callers/`).
+Task 4 added `` `TypeRef `` recording for explicitly-qualified `Mod.TypeName`
+type annotations, hooked into `Ast.TyCon`'s arm of `surface_ty`
+(`lib/typecheck/typecheck.ml`). During implementation review, a real
+misattribution bug surfaced: `env.current_decl` (the "caller" a reference gets
+attributed to) is set only by `check_fn` and never reset, so any `surface_ty`
+call site with no enclosing function — an interface method signature
+(`Ast.DInterface`, `lib/typecheck/typecheck.ml`'s `check_decl` arm and the
+`prebind_interface_decl`/`inject_iface_exports_ref` cross-module twins), or an
+impl header/`when`-constraint type (`Ast.DImpl`) — was reading whatever
+function happened to be checked immediately before it in module order,
+producing a confidently wrong caller for `forge search --callers`.
+
+**Fix round 1 (2026-08-01, same commit as this file):** rather than emit a
+wrong caller, these call sites now wrap their `surface_ty` call in
+`with_no_caller` (`lib/typecheck/typecheck.ml`, defined just after
+`enter_level`/`leave_level`), which blanks `env.current_decl` to `""` for the
+duration of the call; the `` `TyCon `` hook itself skips recording entirely
+when `caller = ""`. Net effect: a qualified type used *only* inside an
+interface method signature or an impl/when-constraint header is no longer
+recorded as a `` `TypeRef `` reference at all — not attributed, not present.
+Pinned by `test_typeref_interface_sig_no_stale_caller` in
+`test/test_search.ml`.
+
+**Still open:** these positions simply aren't tracked. A user running
+`forge search --callers B.Widget` will not see a hit for a `B.Widget` used
+only in `interface Foo(a) do fn conv: a -> B.Widget end` or
+`impl Show(B.Widget) do ... end`, even though that's a legitimate reference a
+completionist reverse-lookup should probably surface. Closing this gap
+properly needs a real "what declaration is this?" concept for interface/impl
+headers (there is no enclosing function to name as `caller` — the natural
+`caller` would be something like `"A.Foo"` for the interface itself, or
+`"impl Show for B.Widget"`, neither of which fits the current `ref_record`'s
+`caller : string` field, which was designed to hold a fully-qualified
+`Mod.fn` name). Scoped out of the `forge search --callers` v1 plan (Tasks
+1-7) as a follow-up; revisit if/when interface/impl-header references turn
+out to matter in practice.

--- a/test/dune
+++ b/test/dune
@@ -589,7 +589,7 @@
 (test
  (name test_search)
  (modules test_search)
- (libraries march_search alcotest unix))
+ (libraries march_search march_typecheck march_parser march_lexer march_desugar march_ast alcotest unix))
 
 ; ── Core-AST -> JSON serializer smoke tests (emit-core-ast-a0 Task 1) ─────
 (test

--- a/test/test_search.ml
+++ b/test/test_search.ml
@@ -33,6 +33,52 @@ let test_levenshtein_kitten_sitting () =
     (Search.levenshtein "kitten" "sitting")
 
 (* ------------------------------------------------------------------ *)
+(* Reference tracking (forge search --callers)                        *)
+(* ------------------------------------------------------------------ *)
+
+module TC = March_typecheck.Typecheck
+module Ast = March_ast.Ast
+
+(** Parse + desugar a source string into decls wrapped in a DMod, mirroring
+    [Search.parse_file]'s handling of a real .march file. *)
+let decls_of_source ~(file : string) (mod_name : string) (src : string) : Ast.decl list =
+  let lexbuf = Lexing.from_string src in
+  lexbuf.Lexing.lex_curr_p <- { lexbuf.Lexing.lex_curr_p with Lexing.pos_fname = file };
+  let m = March_parser.Parser.module_
+      (March_parser.Token_filter.make March_lexer.Lexer.token) lexbuf in
+  let m = March_desugar.Desugar.desugar_module m in
+  ignore mod_name;
+  [Ast.DMod (m.Ast.mod_name, Ast.Public, m.Ast.mod_decls, Ast.dummy_span)]
+
+let check_refs (files : (string * string * string) list) : TC.ref_record list =
+  (* [files] is (file, mod_name, src) list. *)
+  let all_decls = List.concat_map (fun (file, mod_name, src) ->
+      decls_of_source ~file mod_name src) files in
+  let synth : Ast.module_ =
+    { mod_name = { txt = "__test__"; span = Ast.dummy_span }; mod_decls = all_decls } in
+  let (_errors, _type_map, refs) = TC.check_module_with_refs synth in
+  refs
+
+let test_call_ref_same_module () =
+  let refs = check_refs [
+    ("a.march", "A", "mod A do\n  fn helper() do 1 end\n  fn main() do helper() end\nend\n");
+  ] in
+  let calls = List.filter (fun (r : TC.ref_record) -> r.ref_kind = `Call) refs in
+  Alcotest.(check bool) "helper call recorded" true
+    (List.exists (fun (r : TC.ref_record) ->
+         r.callee = "A.helper" && r.caller = "A.main") calls)
+
+let test_call_ref_cross_module () =
+  let refs = check_refs [
+    ("b.march", "B", "mod B do\n  fn util() do 1 end\nend\n");
+    ("a.march", "A", "mod A do\n  fn main() do B.util() end\nend\n");
+  ] in
+  let calls = List.filter (fun (r : TC.ref_record) -> r.ref_kind = `Call) refs in
+  Alcotest.(check bool) "cross-module B.util call recorded" true
+    (List.exists (fun (r : TC.ref_record) ->
+         r.callee = "B.util" && r.caller = "A.main") calls)
+
+(* ------------------------------------------------------------------ *)
 (* Build a small in-memory index for search tests                     *)
 (* ------------------------------------------------------------------ *)
 
@@ -321,6 +367,11 @@ let integration_tests = [
   "stdlib_list_module",   `Slow, test_stdlib_search_list_module;
 ]
 
+let references_tests = [
+  "same-module call",   `Quick, test_call_ref_same_module;
+  "cross-module call",  `Quick, test_call_ref_cross_module;
+]
+
 let () =
   Alcotest.run "march_search" [
     "levenshtein",   levenshtein_tests;
@@ -330,4 +381,5 @@ let () =
     "combined",      combined_search_tests;
     "json",          json_tests;
     "integration",   integration_tests;
+    "references",    references_tests;
   ]

--- a/test/test_search.ml
+++ b/test/test_search.ml
@@ -197,6 +197,130 @@ let test_typeref_interface_sig_no_stale_caller () =
   Alcotest.(check int) "B.Widget in interface signature not recorded at all"
     0 (List.length tyrefs)
 
+(** Final-review Critical 2: a Call reference in a top-level `let` body (a
+    [DLet], never checked via [check_fn]) must never be attributed to
+    whatever [DFn] happened to be checked last in module order. Before the
+    fix, [env.current_decl] was set-and-never-restored by [check_fn], so it
+    leaked across the rest of the module; this reference would have been
+    wrongly recorded with caller = "A.unrelated" (the last fn checked before
+    the `let`). *)
+let test_call_ref_toplevel_let_no_stale_caller () =
+  let refs = check_refs [
+    ("a.march", "A",
+     "mod A do\n\
+     \  fn unrelated() do 1 end\n\
+     \  fn helper() do 2 end\n\
+     \  let x = helper()\n\
+      end\n");
+  ] in
+  let calls = List.filter (fun (r : TC.ref_record) ->
+      r.ref_kind = `Call && r.callee = "A.helper") refs in
+  Alcotest.(check bool) "A.helper call from the top-level `let` never attributed to A.unrelated"
+    false (List.exists (fun (r : TC.ref_record) -> r.caller = "A.unrelated") calls)
+
+(** Same scenario, but cross-file/cross-module: a `let` in a SEPARATE module
+    checked after another module's `fn` must not inherit that other
+    module's function as its caller. This is the reviewer's reproduction of
+    the leak crossing file boundaries in multi-file compilation. *)
+let test_call_ref_toplevel_let_no_stale_caller_cross_module () =
+  let refs = check_refs [
+    ("a.march", "A", "mod A do\n  fn unrelated() do 1 end\nend\n");
+    ("b.march", "B",
+     "mod B do\n  fn helper() do 2 end\n  let x = helper()\nend\n");
+  ] in
+  let calls = List.filter (fun (r : TC.ref_record) ->
+      r.ref_kind = `Call && r.callee = "B.helper") refs in
+  Alcotest.(check bool)
+    "B.helper call from B's top-level `let` never attributed to A.unrelated"
+    false (List.exists (fun (r : TC.ref_record) -> r.caller = "A.unrelated") calls)
+
+(** A recursive call from inside a top-level `fn` checked AFTER an unrelated
+    `let` must still resolve to its own fn as caller (not "" and not the
+    unrelated `let`'s non-existent caller) — proving the [check_fn]
+    save/restore doesn't overcorrect into losing legitimate attribution. *)
+let test_call_ref_fn_after_let_still_attributed () =
+  let refs = check_refs [
+    ("a.march", "A",
+     "mod A do\n\
+     \  let y = 1\n\
+     \  fn helper() do 1 end\n\
+     \  fn main() do helper() end\n\
+      end\n");
+  ] in
+  let calls = List.filter (fun (r : TC.ref_record) -> r.ref_kind = `Call) refs in
+  Alcotest.(check bool) "A.main -> A.helper still recorded after an unrelated `let`" true
+    (List.exists (fun (r : TC.ref_record) ->
+         r.callee = "A.helper" && r.caller = "A.main") calls)
+
+(** Final-review Important 4: a function PARAMETER that shadows a top-level
+    fn name must resolve as the local parameter, not the shadowed top-level
+    fn — a bare-name Call reference here would otherwise be a textual match,
+    not a resolution-based one (this feature's core precision constraint). *)
+let test_call_ref_param_shadow_not_recorded_as_toplevel_call () =
+  let refs = check_refs [
+    ("a.march", "A",
+     "mod A do\n\
+     \  fn helper() do 1 end\n\
+     \  fn wrapper(helper) do helper() end\n\
+      end\n");
+  ] in
+  let calls = List.filter (fun (r : TC.ref_record) ->
+      r.ref_kind = `Call && r.callee = "A.helper") refs in
+  Alcotest.(check int)
+    "wrapper's shadowed local `helper` param is never recorded as a call to A.helper"
+    0 (List.length calls)
+
+(** Companion positive case: with NO shadowing, the exact same call shape
+    must still be recorded — pinning that the [bind_var]/[local_fns] fix
+    only suppresses the shadowed case, not genuine top-level recursive/
+    self-referential calls. *)
+let test_call_ref_no_shadow_still_recorded () =
+  let refs = check_refs [
+    ("a.march", "A",
+     "mod A do\n\
+     \  fn helper() do 1 end\n\
+     \  fn wrapper() do helper() end\n\
+      end\n");
+  ] in
+  let calls = List.filter (fun (r : TC.ref_record) ->
+      r.ref_kind = `Call && r.callee = "A.helper") refs in
+  Alcotest.(check bool) "wrapper -> A.helper recorded when there is no shadowing" true
+    (List.exists (fun (r : TC.ref_record) -> r.caller = "A.wrapper") calls)
+
+(** Final-review Important 3: no recorded callee/caller should ever start
+    with a literal "." (the tell for an empty-module ad-hoc
+    `modname ^ "." ^ name` concatenation, e.g. a prelude ctor whose
+    [ci_module] is "") nor contain the "__stdlib__" synthetic wrapper module
+    name (see [Search.synthetic_module_name]) that [typecheck_decls]'s
+    outer synthetic module can leak into a reference recorded from
+    [prelude.march]'s deliberately-unwrapped top-level decls. Cheap,
+    high-value regression guard the reviewer suggested directly. *)
+let test_no_leading_dot_or_synthetic_module_in_refs () =
+  let refs = check_refs [
+    ("a.march", "A",
+     "mod A do\n\
+     \  fn main() do Some(1) end\n\
+      end\n");
+  ] in
+  List.iter (fun (r : TC.ref_record) ->
+      Alcotest.(check bool)
+        (Printf.sprintf "callee %S does not start with '.'" r.callee)
+        false (String.length r.callee > 0 && r.callee.[0] = '.');
+      Alcotest.(check bool)
+        (Printf.sprintf "caller %S does not start with '.'" r.caller)
+        false (String.length r.caller > 0 && r.caller.[0] = '.');
+      let contains_stdlib s =
+        let needle = "__stdlib__" in
+        let nlen = String.length needle in
+        let slen = String.length s in
+        let rec go i = i + nlen <= slen &&
+                       (String.sub s i nlen = needle || go (i + 1)) in
+        slen >= nlen && go 0
+      in
+      Alcotest.(check bool) "callee has no __stdlib__ leak" false (contains_stdlib r.callee);
+      Alcotest.(check bool) "caller has no __stdlib__ leak" false (contains_stdlib r.caller)
+    ) refs
+
 (* ------------------------------------------------------------------ *)
 (* Build a small in-memory index for search tests                     *)
 (* ------------------------------------------------------------------ *)
@@ -428,6 +552,34 @@ let test_stdlib_search_map () =
   Alcotest.(check bool) "found map in stdlib" true
     (List.length results > 0)
 
+(** Final-review Important 3, exercised against the REAL stdlib build (the
+    [check_refs] unit-test helper always wraps decls in a [DMod], so it can
+    never reproduce the [prelude.march]-unwrapping leak path — only
+    [Search.build_stdlib_index]'s real [typecheck_decls] call, which uses the
+    actual "__stdlib__" synthetic wrapper module, can). No recorded
+    callee/caller may start with "." or contain "__stdlib__". *)
+let test_stdlib_refs_no_synthetic_module_leak () =
+  let idx = Search.build_stdlib_index () in
+  let contains_stdlib s =
+    let needle = "__stdlib__" in
+    let nlen = String.length needle in
+    let slen = String.length s in
+    let rec go i = i + nlen <= slen &&
+                   (String.sub s i nlen = needle || go (i + 1)) in
+    slen >= nlen && go 0
+  in
+  let bad = ref [] in
+  Hashtbl.iter (fun callee entries ->
+      if (String.length callee > 0 && callee.[0] = '.') || contains_stdlib callee then
+        bad := ("callee:" ^ callee) :: !bad;
+      List.iter (fun (e : Search.ref_entry) ->
+          if (String.length e.caller > 0 && e.caller.[0] = '.') || contains_stdlib e.caller then
+            bad := ("caller:" ^ e.caller) :: !bad
+        ) entries
+    ) idx.Search.references;
+  Alcotest.(check (list string)) "no leading-dot or __stdlib__ leaks in stdlib references"
+    [] (List.sort_uniq String.compare !bad)
+
 let test_stdlib_search_list_module () =
   let idx = Search.build_stdlib_index () in
   let results = Search.search_name idx "map" in
@@ -479,6 +631,27 @@ let test_search_callers_bare_name_merges_modules () =
   Alcotest.(check int) "bare name merges both modules' callers" 2 (List.length callers);
   Alcotest.(check bool) "A.main present" true (List.mem "A.main" callers_names);
   Alcotest.(check bool) "B.main present" true (List.mem "B.main" callers_names)
+
+(** Final-review Important 7: a type and a same-named constructor (the
+    common `type Foo = Foo(...)` newtype pattern — ~80 occurrences in the
+    real stdlib per the reviewer) are TWO separate [entries] that qualify to
+    the same name. Before deduping the candidate list, [search_callers]
+    called [callers_of] once per entry, so every reference to that one
+    qualified name was double-counted in the output. *)
+let test_search_callers_dedupes_type_and_ctor_same_name () =
+  let idx = Search.{
+    (sample_index ()) with
+    references = Search.references_of_list [
+      { Search.callee = "A.Widget"; caller = "A.main"; kind = "call"; file = "a.march"; line = 1 };
+    ];
+    entries = [
+      make_entry "Widget" ~module_name:"A" ~kind:Search.Type_;
+      make_entry "Widget" ~module_name:"A" ~kind:Search.Constructor;
+    ];
+  } in
+  let callers = Search.search_callers idx "Widget" in
+  Alcotest.(check int) "one reference to A.Widget is reported once, not twice"
+    1 (List.length callers)
 
 (** Regression guard for the class of bug on record in project memory
     (`project_ambiguous_ctor_current_module.md`): two modules that share a
@@ -565,6 +738,8 @@ let integration_tests = [
   "stdlib_nonempty",      `Slow, test_stdlib_index_nonempty;
   "stdlib_search_map",    `Slow, test_stdlib_search_map;
   "stdlib_list_module",   `Slow, test_stdlib_search_list_module;
+  "stdlib refs: no synthetic-module leak",
+                           `Slow, test_stdlib_refs_no_synthetic_module_leak;
 ]
 
 let references_tests = [
@@ -585,10 +760,24 @@ let references_tests = [
                                     `Quick, test_index_from_json_missing_references;
   "search_callers merges bare-name matches across modules",
                                     `Quick, test_search_callers_bare_name_merges_modules;
+  "search_callers dedupes type+ctor same-name candidates",
+                                    `Quick, test_search_callers_dedupes_type_and_ctor_same_name;
   "ambiguous ctor ref prefers current module",
                                     `Quick, test_ambiguous_ctor_ref_prefers_current_module;
   "no references is empty not error",
                                     `Quick, test_no_references_is_empty_not_error;
+  "toplevel let: no stale caller from a prior unrelated fn",
+                                    `Quick, test_call_ref_toplevel_let_no_stale_caller;
+  "toplevel let: no stale caller across module/file boundary",
+                                    `Quick, test_call_ref_toplevel_let_no_stale_caller_cross_module;
+  "fn checked after an unrelated let still gets its own caller",
+                                    `Quick, test_call_ref_fn_after_let_still_attributed;
+  "param shadowing a top-level fn name is not recorded as a call",
+                                    `Quick, test_call_ref_param_shadow_not_recorded_as_toplevel_call;
+  "no shadowing: call still recorded",
+                                    `Quick, test_call_ref_no_shadow_still_recorded;
+  "no leading-dot or __stdlib__ leak in recorded refs",
+                                    `Quick, test_no_leading_dot_or_synthetic_module_in_refs;
 ]
 
 let () =

--- a/test/test_search.ml
+++ b/test/test_search.ml
@@ -127,6 +127,16 @@ let test_qualified_iface_method_call_ref () =
     (List.exists (fun (r : TC.ref_record) ->
          r.callee = "Show2.show" && r.caller = "A.main") calls)
 
+let test_ctor_ref_recorded () =
+  let refs = check_refs [
+    ("a.march", "A",
+     "mod A do\n  type Box = Empty | Full(Int)\n  fn main() do Full(1) end\nend\n");
+  ] in
+  let ctors = List.filter (fun (r : TC.ref_record) -> r.ref_kind = `Ctor) refs in
+  Alcotest.(check bool) "Full ctor use recorded" true
+    (List.exists (fun (r : TC.ref_record) ->
+         r.callee = "A.Full" && r.caller = "A.main") ctors)
+
 (* ------------------------------------------------------------------ *)
 (* Build a small in-memory index for search tests                     *)
 (* ------------------------------------------------------------------ *)
@@ -422,6 +432,7 @@ let references_tests = [
   "qualified let-const excluded",  `Quick, test_qualified_let_const_not_call_ref;
   "qualified interface-method call recorded",
                                     `Quick, test_qualified_iface_method_call_ref;
+  "ctor use recorded",             `Quick, test_ctor_ref_recorded;
 ]
 
 let () =

--- a/test/test_search.ml
+++ b/test/test_search.ml
@@ -137,6 +137,22 @@ let test_ctor_ref_recorded () =
     (List.exists (fun (r : TC.ref_record) ->
          r.callee = "A.Full" && r.caller = "A.main") ctors)
 
+(** A cross-module QUALIFIED constructor use (`B.Full(1)`) must be recorded
+    with callee = "B.Full" — exercising the [String.contains name.txt '.']
+    stripping branch in the [ECon] hook, which extracts the bare ctor name
+    ("Full") from the already-dotted [name.txt] ("B.Full") before
+    re-qualifying with [ci.ci_module] ("B"). Without the strip, this would
+    double-qualify to "B.B.Full". *)
+let test_ctor_ref_qualified_cross_module () =
+  let refs = check_refs [
+    ("b.march", "B", "mod B do\n  type Box = Full(Int)\nend\n");
+    ("a.march", "A", "mod A do\n  fn main() do B.Full(1) end\nend\n");
+  ] in
+  let ctors = List.filter (fun (r : TC.ref_record) -> r.ref_kind = `Ctor) refs in
+  Alcotest.(check bool) "B.Full qualified ctor use recorded without double-qualification" true
+    (List.exists (fun (r : TC.ref_record) ->
+         r.callee = "B.Full" && r.caller = "A.main") ctors)
+
 (* ------------------------------------------------------------------ *)
 (* Build a small in-memory index for search tests                     *)
 (* ------------------------------------------------------------------ *)
@@ -433,6 +449,8 @@ let references_tests = [
   "qualified interface-method call recorded",
                                     `Quick, test_qualified_iface_method_call_ref;
   "ctor use recorded",             `Quick, test_ctor_ref_recorded;
+  "qualified cross-module ctor use recorded",
+                                    `Quick, test_ctor_ref_qualified_cross_module;
 ]
 
 let () =

--- a/test/test_search.ml
+++ b/test/test_search.ml
@@ -78,6 +78,28 @@ let test_call_ref_cross_module () =
     (List.exists (fun (r : TC.ref_record) ->
          r.callee = "B.util" && r.caller = "A.main") calls)
 
+(** A public top-level `let` (a [DLet], not a [DFn]) must never be recorded as
+    a [`Call] reference, even when it is referenced through call syntax
+    (`B.some_const()`) from another module. [DMod]'s export step binds a
+    public [DLet] into the outer [env.vars] under "Mod.name" the exact same
+    way it binds a public [DFn] (see [new_names] in the [Ast.DMod] arm of
+    [check_decl]), so a bare "does this dotted name resolve" check cannot
+    distinguish them — only [qual_fn_names] (populated exclusively from
+    [DFn]s/registry [ExFn]s) can. Call syntax is used here (rather than a
+    bare `B.some_const` value reference) because a qualified name only ever
+    becomes an [Ast.EVar] — the code path this task's hook lives on — via the
+    `Mod.member(args)` call-normalization in [infer_expr]; a bare qualified
+    VALUE reference parses as [Ast.EField] instead, a wholly separate
+    (unhooked, out-of-scope) code path. *)
+let test_qualified_let_const_not_call_ref () =
+  let refs = check_refs [
+    ("b.march", "B", "mod B do\n  let some_const = 42\nend\n");
+    ("a.march", "A", "mod A do\n  fn main() do B.some_const() end\nend\n");
+  ] in
+  let calls = List.filter (fun (r : TC.ref_record) -> r.ref_kind = `Call) refs in
+  Alcotest.(check bool) "B.some_const (a DLet, not a DFn) never recorded as Call" false
+    (List.exists (fun (r : TC.ref_record) -> r.callee = "B.some_const") calls)
+
 (* ------------------------------------------------------------------ *)
 (* Build a small in-memory index for search tests                     *)
 (* ------------------------------------------------------------------ *)
@@ -368,8 +390,9 @@ let integration_tests = [
 ]
 
 let references_tests = [
-  "same-module call",   `Quick, test_call_ref_same_module;
-  "cross-module call",  `Quick, test_call_ref_cross_module;
+  "same-module call",         `Quick, test_call_ref_same_module;
+  "cross-module call",        `Quick, test_call_ref_cross_module;
+  "qualified let-const excluded", `Quick, test_qualified_let_const_not_call_ref;
 ]
 
 let () =

--- a/test/test_search.ml
+++ b/test/test_search.ml
@@ -210,6 +210,7 @@ let sample_index () : Search.index =
   Search.{
     version      = 1;
     generated_at = "2026-01-01T00:00:00Z";
+    references   = Hashtbl.create 0;
     entries      = [
       make_entry "map"
         ~signature:"List.map(xs: List(a), f: fn(a) -> b) -> List(b)"
@@ -436,6 +437,49 @@ let test_stdlib_search_list_module () =
   Alcotest.(check bool) "List.map found in stdlib" true
     (List.length list_results > 0)
 
+let test_index_references_roundtrip () =
+  let refs : Search.ref_entry list = [
+    { Search.callee = "A.helper"; caller = "A.main"; kind = "call"; file = "a.march"; line = 3 };
+  ] in
+  let idx = Search.{ (sample_index ()) with references = Search.references_of_list refs } in
+  let json = Search.index_to_json idx in
+  let idx2 = Search.index_from_json json in
+  let looked_up = Search.callers_of idx2 "A.helper" in
+  Alcotest.(check int) "one caller round-tripped" 1 (List.length looked_up)
+
+let test_index_from_json_missing_references () =
+  (* Old cache files predate the "references" key entirely. *)
+  let idx = sample_index () in
+  let json_without_refs = Search.index_to_json idx in
+  (* index_to_json always includes "references" now; simulate an old cache by
+     stripping the key so index_from_json's tolerance is actually exercised. *)
+  let j = Yojson.Basic.from_string json_without_refs in
+  let stripped = match j with
+    | `Assoc kvs -> `Assoc (List.filter (fun (k, _) -> k <> "references") kvs)
+    | other -> other
+  in
+  let idx2 = Search.index_from_json (Yojson.Basic.to_string stripped) in
+  Alcotest.(check int) "missing references key yields empty table"
+    0 (List.length (Search.callers_of idx2 "anything"))
+
+let test_search_callers_bare_name_merges_modules () =
+  let idx = Search.{
+    (sample_index ()) with
+    references = Search.references_of_list [
+      { Search.callee = "A.helper"; caller = "A.main"; kind = "call"; file = "a.march"; line = 1 };
+      { Search.callee = "B.helper"; caller = "B.main"; kind = "call"; file = "b.march"; line = 2 };
+    ];
+    entries = [
+      make_entry "helper" ~module_name:"A";
+      make_entry "helper" ~module_name:"B";
+    ];
+  } in
+  let callers = Search.search_callers idx "helper" in
+  let callers_names = List.map (fun (r : Search.ref_entry) -> r.caller) callers in
+  Alcotest.(check int) "bare name merges both modules' callers" 2 (List.length callers);
+  Alcotest.(check bool) "A.main present" true (List.mem "A.main" callers_names);
+  Alcotest.(check bool) "B.main present" true (List.mem "B.main" callers_names)
+
 (* ------------------------------------------------------------------ *)
 (* Test suite registration                                             *)
 (* ------------------------------------------------------------------ *)
@@ -499,6 +543,11 @@ let references_tests = [
                                     `Quick, test_typeref_qualified_recorded;
   "interface-signature type-ref has no stale caller",
                                     `Quick, test_typeref_interface_sig_no_stale_caller;
+  "index references roundtrip",    `Quick, test_index_references_roundtrip;
+  "index_from_json tolerates missing references key",
+                                    `Quick, test_index_from_json_missing_references;
+  "search_callers merges bare-name matches across modules",
+                                    `Quick, test_search_callers_bare_name_merges_modules;
 ]
 
 let () =

--- a/test/test_search.ml
+++ b/test/test_search.ml
@@ -167,6 +167,36 @@ let test_typeref_qualified_recorded () =
     (List.exists (fun (r : TC.ref_record) ->
          r.callee = "B.Widget" && r.caller = "A.make") tyrefs)
 
+(** Fix round 1 regression: a qualified type used ONLY in an interface
+    method signature — which has no enclosing function — must never be
+    recorded with a [caller] borrowed from some unrelated function that
+    happened to be checked earlier in the same module (see
+    [with_no_caller]/the [`TyCon] hook's `caller <> ""` gate). Before the
+    fix, `B.Widget` here was recorded twice: once with `caller = ""` (the
+    lazy cross-module injection path) and once with `caller = "A.helper"`
+    (the direct [DInterface] path, misattributed because [helper]'s body was
+    the last thing checked before the interface). After the fix, no
+    [`TypeRef] for `B.Widget` is recorded at all — a missing reference is
+    honest; a wrong caller is not. *)
+let test_typeref_interface_sig_no_stale_caller () =
+  let refs = check_refs [
+    ("b.march", "B", "mod B do\n  type Widget = Widget(Int)\nend\n");
+    ("a.march", "A",
+     "mod A do\n\
+     \  fn helper() do 1 end\n\
+     \  interface Foo(a) do\n\
+     \    fn conv: a -> B.Widget\n\
+     \  end\n\
+      end\n");
+  ] in
+  let tyrefs = List.filter (fun (r : TC.ref_record) ->
+      r.ref_kind = `TypeRef && r.callee = "B.Widget") refs in
+  Alcotest.(check bool)
+    "B.Widget in interface signature never attributed to A.helper" false
+    (List.exists (fun (r : TC.ref_record) -> r.caller = "A.helper") tyrefs);
+  Alcotest.(check int) "B.Widget in interface signature not recorded at all"
+    0 (List.length tyrefs)
+
 (* ------------------------------------------------------------------ *)
 (* Build a small in-memory index for search tests                     *)
 (* ------------------------------------------------------------------ *)
@@ -467,6 +497,8 @@ let references_tests = [
                                     `Quick, test_ctor_ref_qualified_cross_module;
   "qualified type-annotation recorded",
                                     `Quick, test_typeref_qualified_recorded;
+  "interface-signature type-ref has no stale caller",
+                                    `Quick, test_typeref_interface_sig_no_stale_caller;
 ]
 
 let () =

--- a/test/test_search.ml
+++ b/test/test_search.ml
@@ -480,6 +480,43 @@ let test_search_callers_bare_name_merges_modules () =
   Alcotest.(check bool) "A.main present" true (List.mem "A.main" callers_names);
   Alcotest.(check bool) "B.main present" true (List.mem "B.main" callers_names)
 
+(** Regression guard for the class of bug on record in project memory
+    (`project_ambiguous_ctor_current_module.md`): two modules that share a
+    bare constructor name at different tags miscompiled because
+    [lookup_ctor] didn't prefer the current module. This proves
+    reference-tracking inherits that same current-module preference rather
+    than reintroducing the bug at the reference layer — [Y.main]'s bare
+    [Active] must resolve (and be recorded) as [Y.Active], never as the
+    same-named [X.Active] from the other module. *)
+let test_ambiguous_ctor_ref_prefers_current_module () =
+  let refs = check_refs [
+    ("x.march", "X", "mod X do\n  type Status = Active | Done\nend\n");
+    ("y.march", "Y",
+     "mod Y do\n  type Status = Active | Done\n  fn main() do Active end\nend\n");
+  ] in
+  let ctors = List.filter (fun (r : TC.ref_record) -> r.ref_kind = `Ctor) refs in
+  Alcotest.(check bool) "Y.main's Active resolves to Y.Active, not X.Active" true
+    (List.exists (fun (r : TC.ref_record) ->
+         r.callee = "Y.Active" && r.caller = "Y.main") ctors);
+  Alcotest.(check bool) "no false X.Active reference from Y.main" false
+    (List.exists (fun (r : TC.ref_record) ->
+         r.callee = "X.Active" && r.caller = "Y.main") ctors)
+
+(** An unreferenced declaration must resolve to an empty caller list, not an
+    error — consistent with the "no results" UX elsewhere in [forge search]. *)
+let test_no_references_is_empty_not_error () =
+  let refs = check_refs [
+    ("a.march", "A", "mod A do\n  fn unused() do 1 end\n  fn main() do 2 end\nend\n");
+  ] in
+  let tbl = Search.references_of_list
+      (List.map (fun (r : TC.ref_record) ->
+           { Search.callee = r.callee; caller = r.caller;
+             kind = Search.ref_kind_to_string r.ref_kind;
+             file = r.ref_file; line = r.ref_line })
+          refs) in
+  Alcotest.(check int) "unused fn has zero recorded callers" 0
+    (List.length (Search.callers_of { (sample_index ()) with Search.references = tbl } "A.unused"))
+
 (* ------------------------------------------------------------------ *)
 (* Test suite registration                                             *)
 (* ------------------------------------------------------------------ *)
@@ -548,6 +585,10 @@ let references_tests = [
                                     `Quick, test_index_from_json_missing_references;
   "search_callers merges bare-name matches across modules",
                                     `Quick, test_search_callers_bare_name_merges_modules;
+  "ambiguous ctor ref prefers current module",
+                                    `Quick, test_ambiguous_ctor_ref_prefers_current_module;
+  "no references is empty not error",
+                                    `Quick, test_no_references_is_empty_not_error;
 ]
 
 let () =

--- a/test/test_search.ml
+++ b/test/test_search.ml
@@ -100,6 +100,33 @@ let test_qualified_let_const_not_call_ref () =
   Alcotest.(check bool) "B.some_const (a DLet, not a DFn) never recorded as Call" false
     (List.exists (fun (r : TC.ref_record) -> r.callee = "B.some_const") calls)
 
+(** A qualified interface-method call (`Show2.show(x)`) must still be
+    recorded as a [`Call] reference. [prebind_interface_decl] binds an
+    interface method's dot-qualified name ("Iface.method") directly into
+    [env.vars] — a THIRD source of qualified names, independent of both
+    [Ast.DMod] exports and registry [ExFn] entries (the two sources
+    [qual_fn_names] was originally populated from). Pins the fix that
+    registers interface-method qualified names into [qual_fn_names] too, so
+    the [DLet]-exclusion gate (see [test_qualified_let_const_not_call_ref])
+    doesn't also swallow this genuine function call as a false negative. *)
+let test_qualified_iface_method_call_ref () =
+  let refs = check_refs [
+    ("b.march", "B",
+     "mod B do\n\
+     \  interface Show2(a) do\n\
+     \    fn show: a -> String\n\
+     \  end\n\
+     \  impl Show2(Int) do\n\
+     \    fn show(x) do \"n\" end\n\
+     \  end\n\
+      end\n");
+    ("a.march", "A", "mod A do\n  fn main() do Show2.show(5) end\nend\n");
+  ] in
+  let calls = List.filter (fun (r : TC.ref_record) -> r.ref_kind = `Call) refs in
+  Alcotest.(check bool) "Show2.show interface-method call recorded" true
+    (List.exists (fun (r : TC.ref_record) ->
+         r.callee = "Show2.show" && r.caller = "A.main") calls)
+
 (* ------------------------------------------------------------------ *)
 (* Build a small in-memory index for search tests                     *)
 (* ------------------------------------------------------------------ *)
@@ -390,9 +417,11 @@ let integration_tests = [
 ]
 
 let references_tests = [
-  "same-module call",         `Quick, test_call_ref_same_module;
-  "cross-module call",        `Quick, test_call_ref_cross_module;
-  "qualified let-const excluded", `Quick, test_qualified_let_const_not_call_ref;
+  "same-module call",              `Quick, test_call_ref_same_module;
+  "cross-module call",             `Quick, test_call_ref_cross_module;
+  "qualified let-const excluded",  `Quick, test_qualified_let_const_not_call_ref;
+  "qualified interface-method call recorded",
+                                    `Quick, test_qualified_iface_method_call_ref;
 ]
 
 let () =

--- a/test/test_search.ml
+++ b/test/test_search.ml
@@ -153,6 +153,20 @@ let test_ctor_ref_qualified_cross_module () =
     (List.exists (fun (r : TC.ref_record) ->
          r.callee = "B.Full" && r.caller = "A.main") ctors)
 
+(** A qualified type annotation (`w: B.Widget`) must be recorded as a
+    [`TypeRef] reference. Bare (unqualified) type annotations are an
+    explicitly accepted out-of-scope gap for this task — see the
+    [Ast.TyCon] hook in [surface_ty]. *)
+let test_typeref_qualified_recorded () =
+  let refs = check_refs [
+    ("b.march", "B", "mod B do\n  type Widget = Widget(Int)\nend\n");
+    ("a.march", "A", "mod A do\n  fn make(w: B.Widget) do w end\nend\n");
+  ] in
+  let tyrefs = List.filter (fun (r : TC.ref_record) -> r.ref_kind = `TypeRef) refs in
+  Alcotest.(check bool) "B.Widget annotation recorded" true
+    (List.exists (fun (r : TC.ref_record) ->
+         r.callee = "B.Widget" && r.caller = "A.make") tyrefs)
+
 (* ------------------------------------------------------------------ *)
 (* Build a small in-memory index for search tests                     *)
 (* ------------------------------------------------------------------ *)
@@ -451,6 +465,8 @@ let references_tests = [
   "ctor use recorded",             `Quick, test_ctor_ref_recorded;
   "qualified cross-module ctor use recorded",
                                     `Quick, test_ctor_ref_qualified_cross_module;
+  "qualified type-annotation recorded",
+                                    `Quick, test_typeref_qualified_recorded;
 ]
 
 let () =


### PR DESCRIPTION
## Summary

- Adds `forge search --callers NAME`: reverse-reference search for the March compiler. Given a function, constructor, or qualified type, finds every resolved call/use/reference to it — using the typechecker's own name resolution, not a textual/grep heuristic.
- The typechecker (`lib/typecheck/typecheck.ml`) now records every resolved function call (`EVar`), constructor use (`ECon`), and qualified type-annotation reference (`TyCon`) during typechecking, as `(callee, caller, kind, file, line)`.
- `forge search`'s existing index (`lib/search/search.ml`) gains a `references` table built from that data, persisted in the same JSON cache (version bumped, with stale-cache detection so old caches auto-rebuild).
- CLI wiring in `forge/lib/cmd_search.ml`/`forge/bin/main.ml` exposes it as `--callers`, reusing the existing `--json`/`--plain`/`--rebuild`/`--limit` machinery.

Design spec: `docs/superpowers/specs/2026-08-01-forge-search-reverse-references-design.md`
Implementation plan: `docs/superpowers/plans/2026-08-01-forge-search-callers.md`
Progress record: `specs/progress/2026-08-01-forge-search-callers-reverse-reference-search.md`, `specs/progress/2026-08-01-forge-search-callers-final-review-fixes.md`
Known follow-up (filed, intentionally out of scope): `specs/todos/2026-08-01-forge-search-callers-interface-impl-typeref-gap.md` — qualified type references inside interface method signatures / impl headers are not tracked (no enclosing function to attribute them to; deliberately untracked rather than misattributed).

Built via subagent-driven development: 7 tasks, each independently reviewed with fix loops where findings surfaced (two rounds on the call-reference hook, one each on the constructor and type-reference hooks), followed by a final whole-branch review that caught 2 Critical + 5 Important cross-task issues (stale-cache handling, `current_decl` leaking across unrelated functions for non-fn-body references, prelude/synthetic-module qualification, name-shadowing false positives, LSP/JIT env reset, `--limit` handling, duplicate results) — all fixed and re-reviewed clean in one fix wave.

## Test plan

- [x] `scripts/run-tests.sh` (full suite): all green except one known Slow test, `adversarial-regressions` #39 (`MARCH_SANITIZE=1` sanitized-binary timeout) — reproduced this is a **machine-wide ASAN environment issue, not a regression**: a trivial unrelated `clang -fsanitize=address` "return 0" C program also hangs under current load on this box. Confirmed unrelated to this branch by the final review (the diff touches no runtime/sanitizer/codegen code).
- [x] `test_search.exe`: 46/46 (including the new `references` test group covering call/ctor/type-ref recording, ambiguous same-name-constructor resolution, shadowing, stale-cache handling, and JSON round-trip)
- [x] `test_forge.exe`: 133/133 (including new `--callers`/`--limit`/cache-staleness CLI tests)
- [x] Manual smoke test: `forge search --callers NAME` verified against a real multi-package `forge.toml` project in `--plain`, `--json`, and no-match modes