### PR TITLE
fix: unbreak main on Linux, and implement --cap-sandbox there with seccomp-bpf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,16 @@ git log is authoritative for exact commits.
   the binary chooses whether to compile it in, and the profile grants exactly
   what the program does, so it constrains escalation beyond the program's
   intended behaviour, not the behaviour itself. Off by default; default builds
-  are unchanged. macOS only: on Linux the compiler **rejects the flag**
-  rather than emitting a binary that would refuse to start, and points at
-  `forge cap run` instead.
+  are unchanged. Implemented on both major platforms: macOS via a
+  deny-default Seatbelt profile, Linux via an in-process seccomp-bpf filter
+  installed unprivileged through `PR_SET_NO_NEW_PRIVS` — which matters
+  because Linux is where servers actually run. Denied syscalls return
+  `EPERM`, so a withheld capability surfaces as a March `Err` rather than a
+  crash. `IO.Network`, `IO.Process` and `IO.FileWrite` are enforced;
+  `IO.FileRead` is not, because seccomp filters syscall numbers and scalar
+  arguments, never pointer contents, so it cannot tell which path is being
+  opened (path scoping needs Landlock). Installation failure is fatal —
+  running uncontained after being asked to contain is worse than not trying.
 
 - **`forge cap run [--allow-only CAPS] BINARY`: run a compiled binary under an
   OS-enforced capability sandbox.** The policy is imposed from outside, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,9 @@ git log is authoritative for exact commits.
   the binary chooses whether to compile it in, and the profile grants exactly
   what the program does, so it constrains escalation beyond the program's
   intended behaviour, not the behaviour itself. Off by default; default builds
-  are unchanged. macOS only; on other platforms it refuses rather than
-  installing a filter weaker than it claims.
+  are unchanged. macOS only: on Linux the compiler **rejects the flag**
+  rather than emitting a binary that would refuse to start, and points at
+  `forge cap run` instead.
 
 - **`forge cap run [--allow-only CAPS] BINARY`: run a compiled binary under an
   OS-enforced capability sandbox.** The policy is imposed from outside, so

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -3063,6 +3063,21 @@ let compile filename =
                  Baseline mirrors forge/lib/cap_sandbox.ml's sbpl_baseline;
                  the two are kept in step by test/test_cap_sandbox_profile.ml. *)
               if not !cap_sandbox then ""
+              else if link_is_linux then begin
+                (* Fail at COMPILE time rather than emitting a binary that
+                   exits 70 on first run.  The Linux runtime branch refuses
+                   (self-sandboxing needs in-process seccomp-bpf, which is
+                   not implemented), so accepting the flag here would hand
+                   the user a binary that cannot start — with no warning
+                   until they run it. *)
+                Printf.eprintf
+                  "march: --cap-sandbox is not supported for Linux targets \
+                   (self-imposed sandboxing needs in-process seccomp-bpf, \
+                   not yet implemented).\n\
+                   \  Use `forge cap run --allow-only <caps> <binary>` for \
+                   external enforcement, which is stronger anyway.\n";
+                exit 2
+              end
               else begin
                 (* Filter to THIS module's own functions.  Using the whole
                    closure table unions in every linked stdlib function and

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -3063,21 +3063,6 @@ let compile filename =
                  Baseline mirrors forge/lib/cap_sandbox.ml's sbpl_baseline;
                  the two are kept in step by test/test_cap_sandbox_profile.ml. *)
               if not !cap_sandbox then ""
-              else if link_is_linux then begin
-                (* Fail at COMPILE time rather than emitting a binary that
-                   exits 70 on first run.  The Linux runtime branch refuses
-                   (self-sandboxing needs in-process seccomp-bpf, which is
-                   not implemented), so accepting the flag here would hand
-                   the user a binary that cannot start — with no warning
-                   until they run it. *)
-                Printf.eprintf
-                  "march: --cap-sandbox is not supported for Linux targets \
-                   (self-imposed sandboxing needs in-process seccomp-bpf, \
-                   not yet implemented).\n\
-                   \  Use `forge cap run --allow-only <caps> <binary>` for \
-                   external enforcement, which is stronger anyway.\n";
-                exit 2
-              end
               else begin
                 (* Filter to THIS module's own functions.  Using the whole
                    closure table unions in every linked stdlib function and
@@ -3104,12 +3089,24 @@ let compile filename =
                 if holds "IO.FileWrite" then Buffer.add_string b "(allow file-write*)";
                 if holds "IO.Network"   then Buffer.add_string b "(allow network*)";
                 if holds "IO.Process"   then Buffer.add_string b "(allow process-fork)";
+                (* Per-capability DENY flags, consumed by the Linux
+                   seccomp-bpf builder in runtime/march_runtime.c.  Emitted on
+                   both platforms so the two backends are driven by one
+                   decision rather than two copies of it. *)
+                let deny name held =
+                  if held then "" else " -DMARCH_CAP_DENY_" ^ name in
+                let deny_flags =
+                  deny "NET"   (holds "IO.Network")
+                  ^ deny "EXEC"  (holds "IO.Process")
+                  ^ deny "WRITE" (holds "IO.FileWrite")
+                in
                 (* Filename.quote the ALREADY-quoted C literal so the shell
                    hands clang a real string; without the inner quotes the
                    macro expands as bare SBPL tokens and the runtime will not
                    compile. *)
                 " -DMARCH_CAP_PROFILE="
                 ^ Filename.quote ("\"" ^ Buffer.contents b ^ "\"")
+                ^ deny_flags
               end in
             let strip_flag =
               (* Capability-by-absence (specs/2026-08-03-forge-cap-audit-design.md
@@ -4111,7 +4108,7 @@ let () =
                      "<path.so>  Pre-compiled FFI shim .so to dlopen in interpreter mode");
     ("--check",      Arg.Set do_check,    " Typecheck only — parse, resolve imports, typecheck, then exit (no codegen or eval)");
     ("--dump-caps",  Arg.Set dump_caps,   " Print the module's inferred IO-capability set as JSON, then exit");
-    ("--cap-sandbox", Arg.Set cap_sandbox, " Embed a self-imposed capability sandbox applied at startup (opt-in; macOS only)");
+    ("--cap-sandbox", Arg.Set cap_sandbox, " Embed a self-imposed capability sandbox applied at startup (opt-in; macOS Seatbelt / Linux seccomp-bpf)");
     ("--check-json", Arg.Set check_json,  " Emit diagnostics as NDJSON to stdout (for tooling such as forge fix)");
     ("--no-measure-axioms", Arg.Clear measure_axioms, " Reflect @[measure] functions symbolically instead of axiomatising them (skips datatype/quantifier reasoning and the soundness gate)");
     ("--refine-report", Arg.Set refine_report,

--- a/runtime/march_runtime.c
+++ b/runtime/march_runtime.c
@@ -1691,12 +1691,169 @@ void march_sandbox_install(void) {
         exit(70);
     }
 }
+#elif defined(__linux__)
+
+/* Linux: an in-process seccomp-bpf filter, installed unprivileged via
+ * PR_SET_NO_NEW_PRIVS.  Denied syscalls return EPERM rather than killing the
+ * process, matching the macOS behaviour where a withheld capability surfaces
+ * as a March `Err` the program can handle instead of a crash.
+ *
+ * The compiler passes one -D per WITHHELD capability class (MARCH_CAP_DENY_*),
+ * derived from the same own-capability set as the macOS profile.
+ *
+ * What is enforced here, and what is not:
+ *   IO.Network    -> socket/socketpair denied            ENFORCED
+ *   IO.Process    -> execve/execveat denied              ENFORCED
+ *                    (NOT clone/fork: the scheduler needs threads)
+ *   IO.FileWrite  -> openat with write flags, plus the
+ *                    unambiguous mutators, denied        ENFORCED
+ *   IO.FileRead   -> NOT enforced: seccomp filters syscall numbers and
+ *                    scalar args, never pointer contents, so it cannot tell
+ *                    which PATH is being opened.  Path scoping needs
+ *                    Landlock; until then read stays advisory here, exactly
+ *                    as it is on macOS (where dyld forces it).  Do not claim
+ *                    otherwise.
+ */
+#include <linux/audit.h>
+#include <linux/filter.h>
+#include <linux/seccomp.h>
+#include <stddef.h>
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+
+#if defined(__x86_64__)
+#define MARCH_AUDIT_ARCH AUDIT_ARCH_X86_64
+#elif defined(__aarch64__)
+#define MARCH_AUDIT_ARCH AUDIT_ARCH_AARCH64
+#else
+#define MARCH_AUDIT_ARCH 0
+#endif
+
+/* seccomp_data: nr@0, arch@4, ip@8, args[6]@16 (8 bytes each, LE). */
+#define SD_NR   offsetof(struct seccomp_data, nr)
+#define SD_ARCH offsetof(struct seccomp_data, arch)
+#define SD_ARG2 (offsetof(struct seccomp_data, args) + 2 * 8)
+
+/* O_WRONLY|O_RDWR|O_CREAT|O_TRUNC|O_APPEND — any of these makes an open a
+ * write.  Spelled numerically: the values are identical on x86_64 and
+ * aarch64, and pulling in fcntl.h here would fight the runtime's own
+ * _GNU_SOURCE ordering. */
+#define MARCH_O_WRITE_MASK (01 | 02 | 0100 | 01000 | 02000)
+
+#define MAX_FILTER 96
+
+void march_sandbox_install(void) {
+    struct sock_filter f[MAX_FILTER];
+    size_t n = 0;
+
+    /* Refuse to run on a foreign arch rather than installing a filter whose
+     * syscall numbers mean something else. */
+    if (MARCH_AUDIT_ARCH == 0) {
+        fprintf(stderr,
+                "march: --cap-sandbox: unsupported architecture; refusing to "
+                "run uncontained\n");
+        exit(70);
+    }
+
+    /* arch guard: a mismatch (e.g. a 32-bit compat call) is denied, not
+     * allowed — allowing it would let a caller re-enter through the other
+     * syscall table. */
+    f[n++] = (struct sock_filter)BPF_STMT(BPF_LD | BPF_W | BPF_ABS, SD_ARCH);
+    f[n++] = (struct sock_filter)BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K,
+                                          MARCH_AUDIT_ARCH, 1, 0);
+    f[n++] = (struct sock_filter)BPF_STMT(
+        BPF_RET | BPF_K, SECCOMP_RET_ERRNO | (EPERM & SECCOMP_RET_DATA));
+    f[n++] = (struct sock_filter)BPF_STMT(BPF_LD | BPF_W | BPF_ABS, SD_NR);
+
+/* Two instructions per denied syscall: "if nr == X fall through to the
+ * ERRNO return, else skip it". Fixed offsets, so no second pass. */
+#define DENY_NR(nr_)                                                          \
+    do {                                                                      \
+        f[n++] = (struct sock_filter)BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K,       \
+                                              (nr_), 0, 1);                    \
+        f[n++] = (struct sock_filter)BPF_STMT(                                 \
+            BPF_RET | BPF_K, SECCOMP_RET_ERRNO | (EPERM & SECCOMP_RET_DATA));  \
+    } while (0)
+
+#ifdef MARCH_CAP_DENY_NET
+    DENY_NR(__NR_socket);
+    DENY_NR(__NR_socketpair);
+#endif
+
+#ifdef MARCH_CAP_DENY_EXEC
+    DENY_NR(__NR_execve);
+#ifdef __NR_execveat
+    DENY_NR(__NR_execveat);
+#endif
+#endif
+
+#ifdef MARCH_CAP_DENY_WRITE
+    /* Unambiguous mutators.  Legacy numbers exist only on some arches
+     * (aarch64 has no open/unlink/rename/mkdir/rmdir/chmod), hence the
+     * per-syscall guards. */
+#ifdef __NR_unlink
+    DENY_NR(__NR_unlink);
+#endif
+    DENY_NR(__NR_unlinkat);
+#ifdef __NR_rename
+    DENY_NR(__NR_rename);
+#endif
+#ifdef __NR_renameat
+    DENY_NR(__NR_renameat);
+#endif
+    DENY_NR(__NR_renameat2);
+#ifdef __NR_mkdir
+    DENY_NR(__NR_mkdir);
+#endif
+    DENY_NR(__NR_mkdirat);
+#ifdef __NR_rmdir
+    DENY_NR(__NR_rmdir);
+#endif
+#ifdef __NR_truncate
+    DENY_NR(__NR_truncate);
+#endif
+    DENY_NR(__NR_ftruncate);
+#ifdef __NR_chmod
+    DENY_NR(__NR_chmod);
+#endif
+    DENY_NR(__NR_fchmodat);
+#endif /* MARCH_CAP_DENY_WRITE */
+
+#undef DENY_NR
+
+#ifdef MARCH_CAP_DENY_WRITE
+    /* openat is both the read and the write path, so it is filtered on its
+     * flags argument rather than its number.  Placed LAST so the accumulator
+     * can be clobbered without reloading nr for later checks. */
+    f[n++] = (struct sock_filter)BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K,
+                                          __NR_openat, 0, 3);
+    f[n++] = (struct sock_filter)BPF_STMT(BPF_LD | BPF_W | BPF_ABS, SD_ARG2);
+    f[n++] = (struct sock_filter)BPF_JUMP(BPF_JMP | BPF_JSET | BPF_K,
+                                          MARCH_O_WRITE_MASK, 0, 1);
+    f[n++] = (struct sock_filter)BPF_STMT(
+        BPF_RET | BPF_K, SECCOMP_RET_ERRNO | (EPERM & SECCOMP_RET_DATA));
+#endif
+
+    f[n++] = (struct sock_filter)BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW);
+
+    struct sock_fprog prog = { .len = (unsigned short)n, .filter = f };
+
+    if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0 ||
+        prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &prog) != 0) {
+        /* Fail CLOSED.  Installation genuinely can fail — seccomp is
+         * unavailable under qemu user emulation, and a restrictive outer
+         * profile can reject the prctl — and running uncontained after the
+         * operator asked for containment is the worst outcome. */
+        fprintf(stderr,
+                "march: capability sandbox failed to install (%s); refusing to "
+                "run uncontained\n",
+                strerror(errno));
+        exit(70);
+    }
+}
+
 #else
 void march_sandbox_install(void) {
-    /* Linux self-sandboxing needs an in-process seccomp-bpf filter; the
-     * mount-namespace allow-list forge uses externally is unavailable to a
-     * process sandboxing itself post-exec. Refuse rather than install a filter
-     * that enforces less than the profile claims. */
     fprintf(stderr,
             "march: --cap-sandbox is not implemented on this platform; use "
             "`forge cap run --allow-only ...` for external enforcement\n");

--- a/specs/todos/2026-08-03-cap-sandbox-remaining.md
+++ b/specs/todos/2026-08-03-cap-sandbox-remaining.md
@@ -12,14 +12,13 @@ are what is left, all narrow.
   contained. The exfiltration path (outbound connect) IS enforced today. Low
   priority.
 
-- [ ] **`--cap-sandbox` on Linux is rejected at compile time.** Self-sandboxing
-  there needs an in-process seccomp-bpf filter; the mount-namespace allow-list
-  forge uses externally is unavailable to a process sandboxing itself
-  post-exec. The flag now exits 2 at COMPILE time pointing at `forge cap run`,
-  rather than accepting the flag and emitting a binary that exits 70 on first
-  run — a trap found only when CI executed the test on Linux for the first
-  time. Build the real thing only if there is demand for deployed Linux
-  binaries that self-contain without a supervisor.
+- [ ] **`IO.FileRead` under the Linux self-sandbox needs Landlock.** seccomp
+  filters syscall numbers and scalar args, never pointer contents, so it cannot
+  tell WHICH path an `openat` targets — read scoping is therefore not enforced
+  by `--cap-sandbox` on Linux (write is, via the O_* flag bits, which are
+  scalar). Landlock closes this; `forge cap run` already scopes reads
+  externally via a mount-namespace allow-list. Until then `IO.FileRead` is
+  advisory for the self-imposed variant on BOTH platforms.
 
 - [ ] **Two SBPL baselines can drift.** `forge/lib/cap_sandbox.ml`'s
   `sbpl_baseline` and `bin/main.ml`'s `cap_sandbox_define` construct the same

--- a/specs/todos/2026-08-03-cap-sandbox-remaining.md
+++ b/specs/todos/2026-08-03-cap-sandbox-remaining.md
@@ -12,12 +12,14 @@ are what is left, all narrow.
   contained. The exfiltration path (outbound connect) IS enforced today. Low
   priority.
 
-- [ ] **`--cap-sandbox` on Linux refuses.** Self-sandboxing there needs an
-  in-process seccomp-bpf filter; the mount-namespace allow-list forge uses
-  externally is unavailable to a process sandboxing itself post-exec. It
-  currently exits with a pointer to `forge cap run` rather than installing a
-  filter weaker than the profile claims. Build only if there is demand for
-  deployed Linux binaries that self-contain without a supervisor.
+- [ ] **`--cap-sandbox` on Linux is rejected at compile time.** Self-sandboxing
+  there needs an in-process seccomp-bpf filter; the mount-namespace allow-list
+  forge uses externally is unavailable to a process sandboxing itself
+  post-exec. The flag now exits 2 at COMPILE time pointing at `forge cap run`,
+  rather than accepting the flag and emitting a binary that exits 70 on first
+  run — a trap found only when CI executed the test on Linux for the first
+  time. Build the real thing only if there is demand for deployed Linux
+  binaries that self-contain without a supervisor.
 
 - [ ] **Two SBPL baselines can drift.** `forge/lib/cap_sandbox.ml`'s
   `sbpl_baseline` and `bin/main.ml`'s `cap_sandbox_define` construct the same

--- a/test/test_cap_strip.ml
+++ b/test/test_cap_strip.ml
@@ -225,14 +225,15 @@ let compile_sandboxed src_text out_bin =
          compiler_exe (Filename.quote out_bin) (Filename.quote src)
          (Filename.quote log))
   in
-  if rc <> 0 then begin
-    let ic = open_in log in
-    let tail = really_input_string ic (in_channel_length ic) in
-    close_in ic;
-    Alcotest.failf "--cap-sandbox compile failed (rc=%d):\n%s" rc tail
-  end;
+  let ic = open_in log in
+  let out = really_input_string ic (in_channel_length ic) in
+  close_in ic;
   Sys.remove src;
-  Sys.remove log
+  Sys.remove log;
+  (* Return the exit code rather than failing here, so each platform can
+     assert the behaviour that is correct FOR IT: macOS embeds a profile,
+     Linux rejects the flag outright. *)
+  (rc, out)
 
 let sb_net_src =
   {|
@@ -247,31 +248,58 @@ mod SbNetApp do
 end
 |}
 
+(* On Linux the #else runtime branch compiles, so MARCH_CAP_PROFILE is never
+   REFERENCED and the profile string never lands in the binary — the
+   macOS-shaped assertions below do not apply there.  Chasing that difference
+   is what surfaced the real bug: --cap-sandbox used to be accepted on Linux
+   and produced a binary that exits 70 on first run, with no warning at build
+   time. *)
+let is_macos = Sys.file_exists "/usr/lib/dyld"
+
 let test_cap_sandbox_profile_is_module_specific () =
   let pure_bin = Filename.temp_file "sb_pure" ".bin" in
   let net_bin = Filename.temp_file "sb_net" ".bin" in
-  compile_sandboxed pure_src pure_bin;
-  compile_sandboxed sb_net_src net_bin;
-  Alcotest.(check bool) "pure binary embeds a deny-default profile" true
-    (binary_contains pure_bin "deny default");
-  Alcotest.(check bool) "net binary embeds a deny-default profile" true
-    (binary_contains net_bin "deny default");
-  (* The discriminating assertion: a pure program must NOT be granted
-     network, or the profile is the app-invariant union. *)
-  Alcotest.(check bool) "pure binary is NOT granted network" false
-    (binary_contains pure_bin "allow network");
-  Alcotest.(check bool) "net binary IS granted network" true
-    (binary_contains net_bin "allow network");
-  (* And both must still run: a sandbox that breaks the program is not
-     enforcement. *)
-  let rc_p, out_p = run_capture pure_bin in
-  Alcotest.(check int) "sandboxed pure program exits 0" 0 rc_p;
-  Alcotest.(check string) "sandboxed pure program still prints" "2\n" out_p;
-  let rc_n, out_n = run_capture net_bin in
-  Alcotest.(check int) "sandboxed net program exits 0" 0 rc_n;
-  Alcotest.(check string) "granted network still binds" "BOUND\n" out_n;
-  Sys.remove pure_bin;
-  Sys.remove net_bin
+  let rc_p, out_p = compile_sandboxed pure_src pure_bin in
+  if not is_macos then begin
+    (* Linux: the compiler must REJECT the flag rather than emit a binary
+       that cannot start. *)
+    Alcotest.(check bool) "--cap-sandbox is rejected at compile time" true
+      (rc_p <> 0);
+    Alcotest.(check bool) "the rejection names the external alternative" true
+      (let re = Str.regexp_string "forge cap run" in
+       try
+         ignore (Str.search_forward re out_p 0);
+         true
+       with Not_found -> false)
+  end
+  else begin
+    if rc_p <> 0 then
+      Alcotest.failf "--cap-sandbox compile failed (rc=%d):\n%s" rc_p out_p;
+    let rc_n, out_n_log = compile_sandboxed sb_net_src net_bin in
+    if rc_n <> 0 then
+      Alcotest.failf "--cap-sandbox compile failed (rc=%d):\n%s" rc_n out_n_log;
+    Alcotest.(check bool) "pure binary embeds a deny-default profile" true
+      (binary_contains pure_bin "deny default");
+    Alcotest.(check bool) "net binary embeds a deny-default profile" true
+      (binary_contains net_bin "deny default");
+    (* The discriminating assertion: a pure program must NOT be granted
+       network, or the profile is the app-invariant union. *)
+    Alcotest.(check bool) "pure binary is NOT granted network" false
+      (binary_contains pure_bin "allow network");
+    Alcotest.(check bool) "net binary IS granted network" true
+      (binary_contains net_bin "allow network");
+    (* And both must still run: a sandbox that breaks the program is not
+       enforcement. *)
+    let rc_run_p, out_run_p = run_capture pure_bin in
+    Alcotest.(check int) "sandboxed pure program exits 0" 0 rc_run_p;
+    Alcotest.(check string) "sandboxed pure program still prints" "2\n"
+      out_run_p;
+    let rc_run_n, out_run_n = run_capture net_bin in
+    Alcotest.(check int) "sandboxed net program exits 0" 0 rc_run_n;
+    Alcotest.(check string) "granted network still binds" "BOUND\n" out_run_n;
+    (try Sys.remove net_bin with Sys_error _ -> ())
+  end;
+  (try Sys.remove pure_bin with Sys_error _ -> ())
 
 let tests =
   tests

--- a/test/test_cap_strip.ml
+++ b/test/test_cap_strip.ml
@@ -248,58 +248,57 @@ mod SbNetApp do
 end
 |}
 
-(* On Linux the #else runtime branch compiles, so MARCH_CAP_PROFILE is never
-   REFERENCED and the profile string never lands in the binary — the
-   macOS-shaped assertions below do not apply there.  Chasing that difference
-   is what surfaced the real bug: --cap-sandbox used to be accepted on Linux
-   and produced a binary that exits 70 on first run, with no warning at build
-   time. *)
+(* Both platforms now enforce, by different mechanisms: macOS embeds an SBPL
+   profile string, Linux builds a seccomp-bpf filter from -DMARCH_CAP_DENY_*
+   flags (no profile string appears in the binary there).  The behavioural
+   assertion — a withheld capability is actually refused — is the same on
+   both, so it is the one asserted here; the profile-string checks stay
+   macOS-only because they inspect a macOS-specific artifact. *)
 let is_macos = Sys.file_exists "/usr/lib/dyld"
 
 let test_cap_sandbox_profile_is_module_specific () =
   let pure_bin = Filename.temp_file "sb_pure" ".bin" in
   let net_bin = Filename.temp_file "sb_net" ".bin" in
   let rc_p, out_p = compile_sandboxed pure_src pure_bin in
-  if not is_macos then begin
-    (* Linux: the compiler must REJECT the flag rather than emit a binary
-       that cannot start. *)
-    Alcotest.(check bool) "--cap-sandbox is rejected at compile time" true
-      (rc_p <> 0);
-    Alcotest.(check bool) "the rejection names the external alternative" true
-      (let re = Str.regexp_string "forge cap run" in
-       try
-         ignore (Str.search_forward re out_p 0);
-         true
-       with Not_found -> false)
-  end
-  else begin
-    if rc_p <> 0 then
-      Alcotest.failf "--cap-sandbox compile failed (rc=%d):\n%s" rc_p out_p;
-    let rc_n, out_n_log = compile_sandboxed sb_net_src net_bin in
-    if rc_n <> 0 then
-      Alcotest.failf "--cap-sandbox compile failed (rc=%d):\n%s" rc_n out_n_log;
+  if rc_p <> 0 then
+    Alcotest.failf "--cap-sandbox compile failed (rc=%d):\n%s" rc_p out_p;
+  let rc_n, out_n_log = compile_sandboxed sb_net_src net_bin in
+  if rc_n <> 0 then
+    Alcotest.failf "--cap-sandbox compile failed (rc=%d):\n%s" rc_n out_n_log;
+  if is_macos then begin
     Alcotest.(check bool) "pure binary embeds a deny-default profile" true
       (binary_contains pure_bin "deny default");
-    Alcotest.(check bool) "net binary embeds a deny-default profile" true
-      (binary_contains net_bin "deny default");
     (* The discriminating assertion: a pure program must NOT be granted
        network, or the profile is the app-invariant union. *)
     Alcotest.(check bool) "pure binary is NOT granted network" false
       (binary_contains pure_bin "allow network");
     Alcotest.(check bool) "net binary IS granted network" true
-      (binary_contains net_bin "allow network");
-    (* And both must still run: a sandbox that breaks the program is not
-       enforcement. *)
-    let rc_run_p, out_run_p = run_capture pure_bin in
-    Alcotest.(check int) "sandboxed pure program exits 0" 0 rc_run_p;
-    Alcotest.(check string) "sandboxed pure program still prints" "2\n"
-      out_run_p;
-    let rc_run_n, out_run_n = run_capture net_bin in
-    Alcotest.(check int) "sandboxed net program exits 0" 0 rc_run_n;
-    Alcotest.(check string) "granted network still binds" "BOUND\n" out_run_n;
-    (try Sys.remove net_bin with Sys_error _ -> ())
+      (binary_contains net_bin "allow network")
   end;
-  (try Sys.remove pure_bin with Sys_error _ -> ())
+  (* Behaviour, on every platform: the sandbox must neither break a granted
+     capability nor permit a withheld one. *)
+  let rc_run_p, out_run_p = run_capture pure_bin in
+  Alcotest.(check int) "sandboxed pure program exits 0" 0 rc_run_p;
+  Alcotest.(check string) "sandboxed pure program still prints" "2\n" out_run_p;
+  let rc_run_n, out_run_n = run_capture net_bin in
+  Alcotest.(check int) "sandboxed net program exits 0" 0 rc_run_n;
+  Alcotest.(check string) "granted network still binds" "BOUND\n" out_run_n;
+  (try Sys.remove pure_bin with Sys_error _ -> ());
+  (try Sys.remove net_bin with Sys_error _ -> ())
+
+(* Why there is NO "sandbox denies X" test driven from March source:
+   the profile is derived from the program's OWN inferred capabilities, so it
+   grants exactly what the program does — a program that calls file_write is
+   granted IO.FileWrite by construction and cannot be refused it.  That is the
+   documented limitation of the self-imposed variant (it constrains escalation
+   BEYOND the program's behaviour, not the behaviour itself), not a gap in
+   coverage.  Actual denial is verified at the C level against the seccomp
+   filter itself; see the Linux block in runtime/march_runtime.c.
+
+   What IS assertable from here, and what these tests cover:
+   - the granted set is module-specific (a pure program is not handed network);
+   - the sandbox does not BREAK a program that stays within its capabilities,
+     on either platform's mechanism. *)
 
 let tests =
   tests


### PR DESCRIPTION
Follow-up to #163. Two things: it unbreaks `main` on Linux, and it implements the self-imposed sandbox there properly.

## `main` is currently red on ubuntu

#163 was squash-merged before the last fix landed, so `cap_strip 3` fails on Linux. The immediate cause is that the test asserted a macOS-specific artifact (an embedded SBPL profile string) that Linux has no reason to contain.

## The real gap underneath it

`--cap-sandbox` was accepted on Linux and produced a binary that **exits 70 on first run** — clean build, no warning, failure in production. My first pass fixed that by rejecting the flag at compile time. That was the wrong call: **Linux is where servers run**, so a self-imposed sandbox that doesn't work there doesn't work anywhere that matters.

So it's now implemented: an in-process **seccomp-bpf** filter, installed unprivileged via `PR_SET_NO_NEW_PRIVS`. Denied syscalls return `EPERM` rather than killing the process, matching the macOS behaviour where a withheld capability surfaces as a March `Err` the program can handle.

The compiler emits one `-DMARCH_CAP_DENY_*` per withheld class, derived from the same own-capability set that drives the macOS profile — both backends follow one decision rather than two copies of it.

| capability | enforced on Linux? | how |
|---|---|---|
| `IO.Network` | **yes** | `socket`, `socketpair` |
| `IO.Process` | **yes** | `execve`, `execveat` — *not* `clone`, the scheduler needs threads |
| `IO.FileWrite` | **yes** | `openat` filtered on its `O_*` flag bits, plus the unambiguous mutators |
| `IO.FileRead` | **no** | seccomp filters syscall numbers and scalar args, never pointer contents, so it cannot tell which *path* is opened. Needs Landlock; filed. |

That last row is stated rather than papered over — `forge cap run` already scopes reads externally via a mount-namespace allow-list, and `IO.FileRead` stays advisory for the self-imposed variant on both platforms until Landlock lands.

## Verification

Against the real filter source, natively on arm64 Linux (this host's amd64 containers run under qemu, where seccomp returns `EINVAL` — itself why install failure must be handled):

- **nothing withheld** → socket OK, write OK, exec OK
- **network + write withheld** → socket DENIED, write DENIED, **read still OK**, `mmap` OK, threads OK, process alive
- **only `IO.Process` withheld** → exec DENIED, socket and write still OK

Plus: a March binary cross-compiled to `linux/amd64` links the filter in; macOS `cap_strip` 4/4 unchanged; `run_eval` and the compiler quick suite green; `doc-lint` clean.

**Install failure is fatal.** Running uncontained after the operator asked for containment is the worst available outcome.

## One test removed

I wrote a test asserting a self-sandboxed program is denied a write it performs. That is impossible by construction: the profile is derived from the program's own inferred capabilities, so it grants exactly what the program does. The test is replaced by a comment explaining why such an assertion cannot exist — the self-imposed variant constrains escalation *beyond* the program's behaviour, not the behaviour itself. Actual denial is verified at the C level against the filter.
