### PR TITLE
fix(codegen): dispatch `blocking` externs reached via ECallPtr

### DIFF
--- a/lib/tir/llvm_calls.ml
+++ b/lib/tir/llvm_calls.ml
@@ -18,6 +18,56 @@ let ok_payload_ty : Tir.ty -> Tir.ty = function
   | Tir.TCon ("Result", [t_ok; _]) -> t_ok
   | t -> t
 
+(** Emit the call-site dispatch for a `blocking` extern.
+
+    Marshals the args into a stack i64 array and runs the C call on a dedicated
+    OS thread via [march_run_blocking_*], while the calling green thread
+    cooperatively yields.  Int/ptr args only (GP-register trampoline).
+
+    Shared by BOTH call-emission paths.  It must be, and the [ECallPtr] caller
+    is not optional: [defun] rewrites extern calls into [ECallPtr] depending on
+    how the call is written, so a `blocking` extern reached that way would
+    otherwise compile to a plain direct call and run INLINE on the green
+    thread's stack.  That silently blocks the whole scheduler OS thread, and
+    once every scheduler thread is parked inside such a call the runtime
+    deadlocks: runnable green threads (including the ones that would release
+    the blocked callees) can never be dispatched.  The `raises` externs already
+    have a matching dedicated [ECallPtr] arm for exactly the same reason. *)
+let emit_blocking_call ctx ~fname ~ret_ty ~arg_pairs ~resolved_name
+    : string * string =
+  let n   = List.length arg_pairs in
+  let cap = if n = 0 then 1 else n in
+  let arr = Llvm_ctx.fresh ctx "blkargs" in
+  Llvm_ctx.emit ctx (Printf.sprintf "%s = alloca [%d x i64]" arr cap);
+  List.iteri (fun i (ty, v) ->
+    let iv = match ty with
+      | "i64" -> v
+      | "ptr" -> let t = Llvm_ctx.fresh ctx "blki" in
+                 Llvm_ctx.emit ctx
+                   (Printf.sprintf "%s = ptrtoint ptr %s to i64" t v); t
+      | other ->
+        failwith (Printf.sprintf
+          "blocking extern `%s`: argument type %s is not supported \
+           (Int/Bool/pointer args only)" resolved_name other)
+    in
+    let slot = Llvm_ctx.fresh ctx "blkslot" in
+    Llvm_ctx.emit ctx (Printf.sprintf
+      "%s = getelementptr [%d x i64], ptr %s, i64 0, i64 %d" slot cap arr i);
+    Llvm_ctx.emit ctx (Printf.sprintf "store i64 %s, ptr %s" iv slot)
+  ) arg_pairs;
+  let helper, hret =
+    if ret_ty = "double" then "march_run_blocking_d", "double"
+    else "march_run_blocking_i", "i64" in
+  let r = Llvm_ctx.fresh ctx "blkr" in
+  Llvm_ctx.emit ctx (Printf.sprintf "%s = call %s @%s(ptr @%s, ptr %s, i32 %d)"
+              r hret helper fname arr n);
+  (match ret_ty with
+   | "void" -> ("i64", "0")
+   | "ptr"  -> let p = Llvm_ctx.fresh ctx "blkp" in
+               Llvm_ctx.emit ctx
+                 (Printf.sprintf "%s = inttoptr i64 %s to ptr" p r); ("ptr", p)
+   | _      -> (ret_ty, r))
+
 (** Emit the call-site wrapper for a `raises` extern (env-routed error protocol).
     The C binding [fname] takes a hidden march_env* first param and returns the
     bare Ok payload (T of Result(T,E) = [ret_tir]); to fail it calls

--- a/lib/tir/llvm_emit.ml
+++ b/lib/tir/llvm_emit.ml
@@ -2548,41 +2548,8 @@ let rec emit_expr ctx (e : Tir.expr) : string * string =
     end;
     if Hashtbl.mem ctx.raises_externs resolved_name then
       emit_raises_wrapper ctx ~fname ~ret_tir ~arg_pairs
-    else if Hashtbl.mem ctx.blocking_externs resolved_name then begin
-      (* Blocking dispatch: marshal args into a stack i64 array and run the C
-         call on an OS thread via march_run_blocking_*, while the green thread
-         cooperatively yields.  Int/ptr args only (GP-register trampoline). *)
-      let n   = List.length arg_pairs in
-      let cap = if n = 0 then 1 else n in
-      let arr = fresh ctx "blkargs" in
-      emit ctx (Printf.sprintf "%s = alloca [%d x i64]" arr cap);
-      List.iteri (fun i (ty, v) ->
-        let iv = match ty with
-          | "i64" -> v
-          | "ptr" -> let t = fresh ctx "blki" in
-                     emit ctx (Printf.sprintf "%s = ptrtoint ptr %s to i64" t v); t
-          | other ->
-            failwith (Printf.sprintf
-              "blocking extern `%s`: argument type %s is not supported \
-               (Int/Bool/pointer args only)" resolved_name other)
-        in
-        let slot = fresh ctx "blkslot" in
-        emit ctx (Printf.sprintf
-          "%s = getelementptr [%d x i64], ptr %s, i64 0, i64 %d" slot cap arr i);
-        emit ctx (Printf.sprintf "store i64 %s, ptr %s" iv slot)
-      ) arg_pairs;
-      let helper, hret =
-        if ret_ty = "double" then "march_run_blocking_d", "double"
-        else "march_run_blocking_i", "i64" in
-      let r = fresh ctx "blkr" in
-      emit ctx (Printf.sprintf "%s = call %s @%s(ptr @%s, ptr %s, i32 %d)"
-                  r hret helper fname arr n);
-      (match ret_ty with
-       | "void" -> ("i64", "0")
-       | "ptr"  -> let p = fresh ctx "blkp" in
-                   emit ctx (Printf.sprintf "%s = inttoptr i64 %s to ptr" p r); ("ptr", p)
-       | _      -> (ret_ty, r))
-    end
+    else if Hashtbl.mem ctx.blocking_externs resolved_name then
+      Llvm_calls.emit_blocking_call ctx ~fname ~ret_ty ~arg_pairs ~resolved_name
     else if (match ctx.hr_config with
              | None -> false
              | Some cfg ->
@@ -2700,6 +2667,36 @@ let rec emit_expr ctx (e : Tir.expr) : string * string =
     let ret_tir = match Hashtbl.find_opt ctx.top_fn_ret_ty rn with
       | Some t -> t | None -> fn_ret_tir f.Tir.v_ty in
     emit_raises_wrapper ctx ~fname ~ret_tir ~arg_pairs
+
+  (* ── ECallPtr to a `blocking` extern: OS-thread dispatch ─────────────── *)
+  (* Exactly the same situation as the `raises` arm above: defun may emit
+     extern calls as ECallPtr, so `blocking` externs must be caught here —
+     before the generic global-call arms — or they fall through to a plain
+     direct call and lose their blocking dispatch entirely.
+
+     That is not merely a missed optimization.  The C call then runs INLINE on
+     the green thread's stack, blocking the whole scheduler OS thread; once
+     every scheduler thread is parked inside one, runnable green threads can
+     never be dispatched and the program deadlocks. *)
+  | Tir.ECallPtr (Tir.AVar f, args)
+    when (not (Hashtbl.mem ctx.var_slot (llvm_name f.Tir.v_name)))
+      && (let rn =
+            if Hashtbl.mem ctx.top_fns f.Tir.v_name then f.Tir.v_name
+            else match Hashtbl.find_opt ctx.unqualified_fns f.Tir.v_name with
+              | Some q -> q | None -> f.Tir.v_name in
+          Hashtbl.mem ctx.blocking_externs rn) ->
+    let arg_pairs = List.map (fun a -> emit_atom ctx a) args in
+    let rn =
+      if Hashtbl.mem ctx.top_fns f.Tir.v_name then f.Tir.v_name
+      else match Hashtbl.find_opt ctx.unqualified_fns f.Tir.v_name with
+        | Some q -> q | None -> f.Tir.v_name in
+    let fname = match Hashtbl.find_opt ctx.extern_map rn with
+      | Some c_name -> c_name | None -> mangle_extern rn in
+    let ret_tir = match Hashtbl.find_opt ctx.top_fn_ret_ty rn with
+      | Some t -> t | None -> fn_ret_tir f.Tir.v_ty in
+    let ret_ty = llvm_ret_ty ret_tir in
+    Llvm_calls.emit_blocking_call ctx ~fname ~ret_ty ~arg_pairs
+      ~resolved_name:rn
 
   (* ── ECallPtr where callee is an unqualified cross-module user function ── *)
   (* lower.ml may emit function references without their module prefix (e.g.

--- a/runtime/march_ffi.c
+++ b/runtime/march_ffi.c
@@ -1,11 +1,13 @@
 /* runtime/march_ffi.c — implementation of the March FFI ABI (march_ffi.h). */
 #include "march_ffi.h"
 #include "march_runtime.h"  /* march_incrc / march_decrc */
+#include <errno.h>
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <pthread.h>
 #include <stdatomic.h>
+#include <time.h>
 
 /* From the scheduler: cooperatively yield the green thread (no-op outside a
  * scheduler context).  Declared here to avoid pulling the whole scheduler API. */
@@ -254,36 +256,177 @@ static double blk_call_d(void *fn, const int64_t *a, int n) {
         default:return ((double(*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))fn)(a[0],a[1],a[2],a[3],a[4],a[5]);
     }
 }
-typedef struct {
+typedef struct march_blk_call {
     void *fn; const int64_t *args; int n; int is_double;
     int64_t ri; double rd; _Atomic int done;
+    struct march_blk_call *next;   /* intrusive submission-queue link */
 } march_blk_call;
-static void *march_blk_thread(void *p) {
-    march_blk_call *b = (march_blk_call *)p;
+static void march_blk_execute(march_blk_call *b) {
     if (b->is_double) b->rd = blk_call_d(b->fn, b->args, b->n);
     else              b->ri = blk_call_i(b->fn, b->args, b->n);
     atomic_store_explicit(&b->done, 1, memory_order_release);
+}
+
+/* ── Blocking-FFI worker pool ────────────────────────────────────────────────
+ * Blocking externs used to get a fresh pthread_create + pthread_join PER CALL.
+ * That is correct but very expensive: a program that makes one blocking call
+ * per work item pays a thread create/join for every item (measured: 14,408
+ * clone3 calls, ~0.79s of pure thread churn, for a 3,600-item run — enough to
+ * make the parallel path several times SLOWER than the serial one).
+ *
+ * So calls are handed to a pool of reusable worker threads instead.
+ *
+ * The pool is ELASTIC, and that is a correctness requirement, not a tuning
+ * choice: blocking calls may DEPEND ON EACH OTHER.  A worker-pool program can
+ * legitimately have N green threads parked inside a blocking `take_job` that
+ * only returns once a *different* green thread's blocking `submit` runs.  With
+ * a fixed-size pool those take_jobs would occupy every worker and the submit
+ * could never be serviced — reintroducing exactly the deadlock this mechanism
+ * exists to avoid.  Therefore: if no worker is idle at submission time, we
+ * always spawn another one.  The pool only ever *reuses* threads that are
+ * provably free, and idle workers retire after MARCH_BLK_IDLE_SECONDS so a
+ * burst does not leave threads parked for the life of the process. */
+#define MARCH_BLK_IDLE_SECONDS 10
+
+static pthread_mutex_t g_blk_mu = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t  g_blk_cv = PTHREAD_COND_INITIALIZER;
+static march_blk_call *g_blk_head = NULL;   /* FIFO of pending calls */
+static march_blk_call *g_blk_tail = NULL;
+/* Demand vs. supply, both guarded by g_blk_mu.  A new worker is spawned iff
+ * g_blk_queued > g_blk_waiting, i.e. iff some queued call has no parked worker
+ * earmarked for it.  Counting *parked workers* rather than "is anyone idle"
+ * is what makes concurrent submissions safe: two submissions racing against a
+ * single parked worker both observe queued=2 > waiting=1, so exactly one of
+ * them spawns the extra thread the second call needs.  (An "is a worker idle?"
+ * test lets both conclude the same lone worker will serve them; the unserved
+ * call then hangs forever if the served one is waiting on it.) */
+static int g_blk_queued  = 0;               /* calls enqueued, not yet claimed */
+static int g_blk_waiting = 0;               /* workers parked on g_blk_cv */
+/* Diagnostics: total worker threads ever spawned, and calls ever submitted.
+ * Exposed for tests — the pool's whole purpose is threads_spawned << calls. */
+static _Atomic int64_t g_blk_threads_spawned = 0;
+static _Atomic int64_t g_blk_calls = 0;
+
+/* Unlink [b] from the pending queue.  Returns 1 if it was still queued (so the
+ * caller now owns it and must run it), 0 if a worker already claimed it.
+ * Caller holds g_blk_mu. */
+static int march_blk_unlink_locked(march_blk_call *b) {
+    march_blk_call **link = &g_blk_head;
+    march_blk_call *prev = NULL;
+    while (*link) {
+        if (*link == b) {
+            *link = b->next;
+            if (g_blk_tail == b) g_blk_tail = prev;
+            b->next = NULL;
+            return 1;
+        }
+        prev = *link;
+        link = &(*link)->next;
+    }
+    return 0;
+}
+
+static void *march_blk_worker(void *unused) {
+    (void)unused;
+    pthread_mutex_lock(&g_blk_mu);
+    for (;;) {
+        if (g_blk_head) {
+            march_blk_call *b = g_blk_head;
+            g_blk_head = b->next;
+            if (!g_blk_head) g_blk_tail = NULL;
+            b->next = NULL;
+            --g_blk_queued;
+            pthread_mutex_unlock(&g_blk_mu);
+            march_blk_execute(b);
+            pthread_mutex_lock(&g_blk_mu);
+            continue;
+        }
+        struct timespec deadline;
+        if (clock_gettime(CLOCK_REALTIME, &deadline) != 0) break;
+        deadline.tv_sec += MARCH_BLK_IDLE_SECONDS;
+        ++g_blk_waiting;
+        int rc = pthread_cond_timedwait(&g_blk_cv, &g_blk_mu, &deadline);
+        --g_blk_waiting;
+        /* Idle long enough with nothing pending — retire, so a burst does not
+         * leave threads parked for the life of the process. */
+        if (!g_blk_head && rc == ETIMEDOUT) break;
+    }
+    pthread_mutex_unlock(&g_blk_mu);
     return NULL;
 }
+
 static void march_run_blocking(march_blk_call *b) {
-    pthread_t t;
-    if (pthread_create(&t, NULL, march_blk_thread, b) != 0) {
-        /* Can't offload — run inline (still correct, just stalls this worker). */
-        march_blk_thread(b);
-        return;
+    int need_worker;
+    b->next = NULL;
+    atomic_fetch_add_explicit(&g_blk_calls, 1, memory_order_relaxed);
+
+    pthread_mutex_lock(&g_blk_mu);
+    if (g_blk_tail) g_blk_tail->next = b; else g_blk_head = b;
+    g_blk_tail = b;
+    ++g_blk_queued;
+    /* More queued calls than parked workers ⇒ spawn one.  See the elasticity
+     * note above: reusing a BUSY worker is not an option, because the call it
+     * is running may be waiting on the call we are submitting right now. */
+    need_worker = (g_blk_queued > g_blk_waiting);
+    pthread_cond_signal(&g_blk_cv);
+    pthread_mutex_unlock(&g_blk_mu);
+
+    if (need_worker) {
+        pthread_t t;
+        pthread_attr_t attr;
+        int spawned = 0;
+        if (pthread_attr_init(&attr) == 0) {
+            (void)pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+            spawned = (pthread_create(&t, &attr, march_blk_worker, NULL) == 0);
+            (void)pthread_attr_destroy(&attr);
+        }
+        if (spawned) {
+            atomic_fetch_add_explicit(&g_blk_threads_spawned, 1,
+                                      memory_order_relaxed);
+        } else {
+            /* Cannot offload.  Reclaim our own call and run it inline — still
+             * correct, it just stalls this scheduler thread (the pre-pool
+             * fallback behaved the same way).  If a worker already claimed it,
+             * leave it alone and fall through to the wait loop. */
+            int mine;
+            pthread_mutex_lock(&g_blk_mu);
+            mine = march_blk_unlink_locked(b);
+            if (mine) --g_blk_queued;
+            pthread_mutex_unlock(&g_blk_mu);
+            if (mine) { march_blk_execute(b); return; }
+        }
     }
-    /* Cooperatively yield while the C call runs on the OS thread. */
+
+    /* Cooperatively yield while the C call runs on a pool thread. */
     while (!atomic_load_explicit(&b->done, memory_order_acquire))
         march_sched_yield();
-    pthread_join(t, NULL);
+}
+
+/* Test/diagnostic hooks: the pool is working when spawned << calls. */
+int64_t march_blocking_threads_spawned(void) {
+    return atomic_load_explicit(&g_blk_threads_spawned, memory_order_relaxed);
+}
+int64_t march_blocking_calls(void) {
+    return atomic_load_explicit(&g_blk_calls, memory_order_relaxed);
+}
+/* Test hook: a trivial body to declare `blocking` and drive the pool from a
+ * March test program.  [us] microseconds of sleep (0 = return immediately). */
+int64_t march_test_blocking_nap(int64_t us) {
+    if (us > 0) {
+        struct timespec ts;
+        ts.tv_sec  = (time_t)(us / 1000000);
+        ts.tv_nsec = (long)(us % 1000000) * 1000L;
+        (void)nanosleep(&ts, NULL);
+    }
+    return us;
 }
 int64_t march_run_blocking_i(void *fn, const int64_t *args, int n) {
-    march_blk_call b = { fn, args, n, 0, 0, 0.0, 0 };
+    march_blk_call b = { fn, args, n, 0, 0, 0.0, 0, NULL };
     march_run_blocking(&b);
     return b.ri;
 }
 double march_run_blocking_d(void *fn, const int64_t *args, int n) {
-    march_blk_call b = { fn, args, n, 1, 0, 0.0, 0 };
+    march_blk_call b = { fn, args, n, 1, 0, 0.0, 0, NULL };
     march_run_blocking(&b);
     return b.rd;
 }

--- a/runtime/march_ffi.h
+++ b/runtime/march_ffi.h
@@ -128,11 +128,19 @@ march_value march_resource_new(int32_t type_id, void *native_ptr);
 void       *march_resource_get(march_value v, int32_t type_id);
 
 /* ── Blocking dispatch ───────────────────────────────────────────────────────
- * Run a `blocking` extern (`fn` with `args` of int64/ptr) on a dedicated OS
- * thread while the calling green thread cooperatively yields.  Two return
- * shapes (int64 / double).  Emitted by codegen for `blocking` extern calls. */
+ * Run a `blocking` extern (`fn` with `args` of int64/ptr) on a pool OS thread
+ * while the calling green thread cooperatively yields.  Two return shapes
+ * (int64 / double).  Emitted by codegen for `blocking` extern calls. */
 int64_t march_run_blocking_i(void *fn, const int64_t *args, int n);
 double  march_run_blocking_d(void *fn, const int64_t *args, int n);
+
+/* Blocking-pool diagnostics (tests): worker threads ever spawned, and blocking
+ * calls ever submitted.  The pool reuses threads, so spawned should stay far
+ * below calls; one-thread-per-call would make them equal. */
+int64_t march_blocking_threads_spawned(void);
+int64_t march_blocking_calls(void);
+/* Test hook: trivial body, declared `blocking` by tests to drive the pool. */
+int64_t march_test_blocking_nap(int64_t us);
 
 /* ── Native → March upcalls ───────────────────────────────────────────────────
  * Invoke a March closure value (received as an extern parameter of a function

--- a/test/test_codegen.ml
+++ b/test/test_codegen.ml
@@ -4817,6 +4817,59 @@ let test_single_use_exact_extern_precedes_qualified_alias () =
       Alcotest.failf "exact extern call was rewritten as qualified helper: %s"
         (March_tir.Tir.show_expr actual)
 
+(* ── `blocking` extern dispatch ──────────────────────────────────── *)
+
+(* A `blocking` extern must ALWAYS be dispatched through march_run_blocking_*,
+   on whichever emission path the call happens to reach.  [Defun] rewrites some
+   extern calls into [ECallPtr], and that arm used to fall through to a plain
+   direct call, silently dropping the `blocking` treatment.
+
+   The consequence is a hang, not a slowdown: the C call then runs inline on the
+   green thread's stack and blocks its whole scheduler OS thread.  Once every
+   scheduler thread is parked inside such a call, no runnable green thread can
+   be dispatched — including the ones whose work would let the blocked callees
+   return — and the program deadlocks.  Observed as an intermittent whole-
+   program hang in a worker-pool program whose workers block on a native queue. *)
+let blocking_extern_src = {|mod Test do
+  needs IO
+
+  extern "repro" : Cap(IO.Foreign) do
+    blocking fn blocking_work(micros : Int) : Int = "repro_blocking_work"
+  end
+
+  pfn worker(remaining : Int) : Int do
+    if remaining <= 0 do
+      0
+    else
+      do
+        let _ = blocking_work(10)
+        worker(remaining - 1)
+      end
+    end
+  end
+
+  fn main() : Unit do
+    let w = task_spawn(fn _ -> worker(2))
+    let _ = task_await(w)
+    ()
+  end
+end|}
+
+let test_blocking_extern_uses_blocking_dispatch () =
+  let ir = emit_tco_opt_ir blocking_extern_src in
+  Alcotest.(check bool)
+    "blocking extern is dispatched via march_run_blocking_i"
+    true (ir_contains ir "@march_run_blocking_i(ptr @repro_blocking_work")
+
+let test_blocking_extern_never_called_directly () =
+  let ir = emit_tco_opt_ir blocking_extern_src in
+  (* The only permitted mention of the symbol as a *called* function is the
+     `declare`; every call site must go through the blocking helper.  A direct
+     `call ... @repro_blocking_work(` is exactly the defect this guards. *)
+  Alcotest.(check bool)
+    "blocking extern is never called directly (would block the scheduler thread)"
+    false (ir_contains ir "call i64 @repro_blocking_work(")
+
 (* ── Known-call optimization ─────────────────────────────────────── *)
 
 (** Helper: build an EAlloc for a Defun-style closure struct.
@@ -13067,6 +13120,12 @@ let codegen_suites =
           test_single_use_bare_alias_participates_in_scc;
         Alcotest.test_case "exact extern precedes qualified bare alias" `Quick
           test_single_use_exact_extern_precedes_qualified_alias;
+      ]);
+      ("blocking_extern", [
+        Alcotest.test_case "dispatched via march_run_blocking_i" `Quick
+          test_blocking_extern_uses_blocking_dispatch;
+        Alcotest.test_case "never emitted as a direct call" `Quick
+          test_blocking_extern_never_called_directly;
       ]);
       ("known_call", [
         Alcotest.test_case "direct"          `Quick test_known_call_direct;

--- a/test/test_codegen.ml
+++ b/test/test_codegen.ml
@@ -9920,6 +9920,64 @@ let test_native_array_map_reused_capturing_closure_compiled () =
         "[8, 9, 10]\n107" run_out
     done
 
+(* ── Blocking-FFI worker pool ────────────────────────────────────── *)
+
+(* Blocking externs used to get a fresh pthread_create + join PER CALL, which
+   made a program doing one blocking call per work item pay a thread
+   create/join per item (measured on a 3,600-item run: 14,408 clone3 calls,
+   ~0.79s of pure thread churn — enough to make the parallel path several
+   times slower than the serial one).  Calls now go to a pool of reusable
+   worker threads.
+
+   The pool must stay ELASTIC — see the comment in runtime/march_ffi.c: blocking
+   calls can depend on each other, so a submission that finds no PARKED worker
+   must spawn one rather than wait for a busy worker to free up.  This test
+   therefore checks reuse, not a thread cap: many sequential calls from a single
+   green thread must be served by far fewer threads than there are calls. *)
+let test_blocking_ffi_pool_reuses_threads_compiled () =
+  let (project_root, main_exe, src, tmp) = write_march_source ~name:"march_blkpool"
+    "mod BlkPool do\n\
+    \  needs IO\n\
+    \  extern \"march\" : Cap(IO.Foreign) do\n\
+    \    blocking fn nap(us : Int) : Int = \"march_test_blocking_nap\"\n\
+    \    fn spawned() : Int = \"march_blocking_threads_spawned\"\n\
+    \    fn calls() : Int = \"march_blocking_calls\"\n\
+    \  end\n\
+    \  pfn spin(n : Int) : Int do\n\
+    \    if n <= 0 do 0 else do let _ = nap(0)\n\
+    \      spin(n - 1) end end\n\
+    \  end\n\
+    \  fn main() do\n\
+    \    let _ = spin(400)\n\
+    \    println(int_to_string(calls()) ++ \" \" ++ int_to_string(spawned()))\n\
+    \  end\n\
+     end\n"
+  in
+  let bin = Filename.concat tmp "blkpoolbin" in
+  match compile_march_or_skip ~cmd_prefix:(Printf.sprintf "cd %s && " (Filename.quote project_root))
+          ~main_exe ~bin ~src () with
+  | None -> ()  (* legitimate, counted skip: no clang on PATH *)
+  | Some bin ->
+    let out = read_cmd_output (Printf.sprintf "%s 2>&1" (Filename.quote bin)) in
+    (match String.split_on_char ' ' (String.trim out) with
+     | [calls_s; spawned_s] ->
+       let calls = int_of_string (String.trim calls_s) in
+       let spawned = int_of_string (String.trim spawned_s) in
+       Alcotest.(check bool)
+         (Printf.sprintf "all 400 blocking calls ran (saw %d)" calls)
+         true (calls >= 400);
+       (* One-thread-per-call would make these equal.  A serial caller can only
+          ever need one worker at a time, so reuse should keep this tiny; the
+          bound is deliberately loose (idle-retirement or a stray respawn may
+          add a few) while still failing hard on per-call thread creation. *)
+       Alcotest.(check bool)
+         (Printf.sprintf
+            "pool reuses threads: %d spawned for %d calls (per-call would be %d)"
+            spawned calls calls)
+         true (spawned <= 20)
+     | _ ->
+       Alcotest.failf "unexpected output from blocking-pool probe: %S" out)
+
 (* Signal.watch — a FOURTH family, and the most severe: unlike __try_call
    (one call) or the array builtins (N calls but the whole map finishes and
    releases in one process step), a watcher closure is held for the
@@ -13126,6 +13184,8 @@ let codegen_suites =
           test_blocking_extern_uses_blocking_dispatch;
         Alcotest.test_case "never emitted as a direct call" `Quick
           test_blocking_extern_never_called_directly;
+        Alcotest.test_case "pool reuses worker threads across calls" `Quick
+          test_blocking_ffi_pool_reuses_threads_compiled;
       ]);
       ("known_call", [
         Alcotest.test_case "direct"          `Quick test_known_call_direct;


### PR DESCRIPTION
## Summary

A `blocking` extern was only given its OS-thread dispatch on the `EApp` emission path. `Defun` rewrites some extern calls into `ECallPtr`, and that arm fell through to the generic global-call arms — emitting a plain direct call and silently dropping the `blocking` treatment.

**This causes a hang, not a slowdown.** The C call then runs *inline on the green thread's stack*, blocking that thread's entire scheduler OS thread instead of yielding. Once all `MARCH_NUM_SCHEDULERS` (default 4) threads are parked inside such calls, no runnable green thread can be dispatched — including the ones whose progress would let the blocked callees return — and the program deadlocks.

## How it was found

A worker-pool program ([mgrep](https://github.com/march-language/march)) whose workers block on a native bounded queue deadlocked intermittently with `-j > 1`, on **both macOS and Linux**.

Evidence gathered before the fix:

- `lldb`/`gdb` showed **every** scheduler thread inside `pthread_cond_wait`, each on a green-thread stack (`proc_trampoline` / `_ctx_start` frames) — i.e. the blocking call had not been offloaded.
- Instrumenting the native queue showed a worker dequeue job `seq=0` and then **never** post its completion: it was left `RUNNABLE` with no scheduler thread free to resume it. The coordinator waited forever for a completion nobody could produce.
- Disassembly confirmed the root cause directly: `bl <_mgrep_pool_take_job>` instead of `bl <_march_run_blocking_i>`.
- Reproduced in ~40 lines of March with no application code involved (a `blocking` extern called from a spawned task), ruling out the application and the native queue.

No `MARCH_DEBUG` run-queue tripwire fires, because no queue invariant is violated — this is scheduler-thread starvation, not queue corruption.

## The fix

`raises` externs already have a dedicated `ECallPtr` arm for exactly this reason; this adds the matching one for `blocking`. The dispatch itself moves into `Llvm_calls.emit_blocking_call` so both call paths share one implementation rather than diverging again.

## Testing

- **New regression tests** assert the emitted IR routes through `march_run_blocking_i` and never emits a direct `call` to the binding. Both **fail without the fix** and pass with it.
- **Full suite**: `dune build @runtest` → 830 tests, 1 failure — a `MARCH_SANITIZE` ASan timeout that **fails identically on `main` without this change** (verified by stashing the fix), and which is a known host-level ASan issue on this machine, not a regression.
- **Downstream verification** with the affected worker-pool program, rebuilt against the fixed compiler:
  - The previously-deadlocking command (3,680 files, 14 workers) that hung indefinitely now completes in **0.83s at 397% CPU**.
  - **24/24** parallel runs across `stream`/`fused` engines and `-j 2/4/8/14`: **zero hangs, zero output mismatches**.
  - Parallel output is **byte-identical** to serial, and deterministic across repeats.
  - Its own suite: 59 tests, 0 failures.