### PR TITLE
perf(runtime): serve `blocking` externs from a reusable worker pool

### DIFF
--- a/runtime/march_ffi.c
+++ b/runtime/march_ffi.c
@@ -1,11 +1,13 @@
 /* runtime/march_ffi.c — implementation of the March FFI ABI (march_ffi.h). */
 #include "march_ffi.h"
 #include "march_runtime.h"  /* march_incrc / march_decrc */
+#include <errno.h>
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <pthread.h>
 #include <stdatomic.h>
+#include <time.h>
 
 /* From the scheduler: cooperatively yield the green thread (no-op outside a
  * scheduler context).  Declared here to avoid pulling the whole scheduler API. */
@@ -254,36 +256,177 @@ static double blk_call_d(void *fn, const int64_t *a, int n) {
         default:return ((double(*)(int64_t,int64_t,int64_t,int64_t,int64_t,int64_t))fn)(a[0],a[1],a[2],a[3],a[4],a[5]);
     }
 }
-typedef struct {
+typedef struct march_blk_call {
     void *fn; const int64_t *args; int n; int is_double;
     int64_t ri; double rd; _Atomic int done;
+    struct march_blk_call *next;   /* intrusive submission-queue link */
 } march_blk_call;
-static void *march_blk_thread(void *p) {
-    march_blk_call *b = (march_blk_call *)p;
+static void march_blk_execute(march_blk_call *b) {
     if (b->is_double) b->rd = blk_call_d(b->fn, b->args, b->n);
     else              b->ri = blk_call_i(b->fn, b->args, b->n);
     atomic_store_explicit(&b->done, 1, memory_order_release);
+}
+
+/* ── Blocking-FFI worker pool ────────────────────────────────────────────────
+ * Blocking externs used to get a fresh pthread_create + pthread_join PER CALL.
+ * That is correct but very expensive: a program that makes one blocking call
+ * per work item pays a thread create/join for every item (measured: 14,408
+ * clone3 calls, ~0.79s of pure thread churn, for a 3,600-item run — enough to
+ * make the parallel path several times SLOWER than the serial one).
+ *
+ * So calls are handed to a pool of reusable worker threads instead.
+ *
+ * The pool is ELASTIC, and that is a correctness requirement, not a tuning
+ * choice: blocking calls may DEPEND ON EACH OTHER.  A worker-pool program can
+ * legitimately have N green threads parked inside a blocking `take_job` that
+ * only returns once a *different* green thread's blocking `submit` runs.  With
+ * a fixed-size pool those take_jobs would occupy every worker and the submit
+ * could never be serviced — reintroducing exactly the deadlock this mechanism
+ * exists to avoid.  Therefore: if no worker is idle at submission time, we
+ * always spawn another one.  The pool only ever *reuses* threads that are
+ * provably free, and idle workers retire after MARCH_BLK_IDLE_SECONDS so a
+ * burst does not leave threads parked for the life of the process. */
+#define MARCH_BLK_IDLE_SECONDS 10
+
+static pthread_mutex_t g_blk_mu = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t  g_blk_cv = PTHREAD_COND_INITIALIZER;
+static march_blk_call *g_blk_head = NULL;   /* FIFO of pending calls */
+static march_blk_call *g_blk_tail = NULL;
+/* Demand vs. supply, both guarded by g_blk_mu.  A new worker is spawned iff
+ * g_blk_queued > g_blk_waiting, i.e. iff some queued call has no parked worker
+ * earmarked for it.  Counting *parked workers* rather than "is anyone idle"
+ * is what makes concurrent submissions safe: two submissions racing against a
+ * single parked worker both observe queued=2 > waiting=1, so exactly one of
+ * them spawns the extra thread the second call needs.  (An "is a worker idle?"
+ * test lets both conclude the same lone worker will serve them; the unserved
+ * call then hangs forever if the served one is waiting on it.) */
+static int g_blk_queued  = 0;               /* calls enqueued, not yet claimed */
+static int g_blk_waiting = 0;               /* workers parked on g_blk_cv */
+/* Diagnostics: total worker threads ever spawned, and calls ever submitted.
+ * Exposed for tests — the pool's whole purpose is threads_spawned << calls. */
+static _Atomic int64_t g_blk_threads_spawned = 0;
+static _Atomic int64_t g_blk_calls = 0;
+
+/* Unlink [b] from the pending queue.  Returns 1 if it was still queued (so the
+ * caller now owns it and must run it), 0 if a worker already claimed it.
+ * Caller holds g_blk_mu. */
+static int march_blk_unlink_locked(march_blk_call *b) {
+    march_blk_call **link = &g_blk_head;
+    march_blk_call *prev = NULL;
+    while (*link) {
+        if (*link == b) {
+            *link = b->next;
+            if (g_blk_tail == b) g_blk_tail = prev;
+            b->next = NULL;
+            return 1;
+        }
+        prev = *link;
+        link = &(*link)->next;
+    }
+    return 0;
+}
+
+static void *march_blk_worker(void *unused) {
+    (void)unused;
+    pthread_mutex_lock(&g_blk_mu);
+    for (;;) {
+        if (g_blk_head) {
+            march_blk_call *b = g_blk_head;
+            g_blk_head = b->next;
+            if (!g_blk_head) g_blk_tail = NULL;
+            b->next = NULL;
+            --g_blk_queued;
+            pthread_mutex_unlock(&g_blk_mu);
+            march_blk_execute(b);
+            pthread_mutex_lock(&g_blk_mu);
+            continue;
+        }
+        struct timespec deadline;
+        if (clock_gettime(CLOCK_REALTIME, &deadline) != 0) break;
+        deadline.tv_sec += MARCH_BLK_IDLE_SECONDS;
+        ++g_blk_waiting;
+        int rc = pthread_cond_timedwait(&g_blk_cv, &g_blk_mu, &deadline);
+        --g_blk_waiting;
+        /* Idle long enough with nothing pending — retire, so a burst does not
+         * leave threads parked for the life of the process. */
+        if (!g_blk_head && rc == ETIMEDOUT) break;
+    }
+    pthread_mutex_unlock(&g_blk_mu);
     return NULL;
 }
+
 static void march_run_blocking(march_blk_call *b) {
-    pthread_t t;
-    if (pthread_create(&t, NULL, march_blk_thread, b) != 0) {
-        /* Can't offload — run inline (still correct, just stalls this worker). */
-        march_blk_thread(b);
-        return;
+    int need_worker;
+    b->next = NULL;
+    atomic_fetch_add_explicit(&g_blk_calls, 1, memory_order_relaxed);
+
+    pthread_mutex_lock(&g_blk_mu);
+    if (g_blk_tail) g_blk_tail->next = b; else g_blk_head = b;
+    g_blk_tail = b;
+    ++g_blk_queued;
+    /* More queued calls than parked workers ⇒ spawn one.  See the elasticity
+     * note above: reusing a BUSY worker is not an option, because the call it
+     * is running may be waiting on the call we are submitting right now. */
+    need_worker = (g_blk_queued > g_blk_waiting);
+    pthread_cond_signal(&g_blk_cv);
+    pthread_mutex_unlock(&g_blk_mu);
+
+    if (need_worker) {
+        pthread_t t;
+        pthread_attr_t attr;
+        int spawned = 0;
+        if (pthread_attr_init(&attr) == 0) {
+            (void)pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+            spawned = (pthread_create(&t, &attr, march_blk_worker, NULL) == 0);
+            (void)pthread_attr_destroy(&attr);
+        }
+        if (spawned) {
+            atomic_fetch_add_explicit(&g_blk_threads_spawned, 1,
+                                      memory_order_relaxed);
+        } else {
+            /* Cannot offload.  Reclaim our own call and run it inline — still
+             * correct, it just stalls this scheduler thread (the pre-pool
+             * fallback behaved the same way).  If a worker already claimed it,
+             * leave it alone and fall through to the wait loop. */
+            int mine;
+            pthread_mutex_lock(&g_blk_mu);
+            mine = march_blk_unlink_locked(b);
+            if (mine) --g_blk_queued;
+            pthread_mutex_unlock(&g_blk_mu);
+            if (mine) { march_blk_execute(b); return; }
+        }
     }
-    /* Cooperatively yield while the C call runs on the OS thread. */
+
+    /* Cooperatively yield while the C call runs on a pool thread. */
     while (!atomic_load_explicit(&b->done, memory_order_acquire))
         march_sched_yield();
-    pthread_join(t, NULL);
+}
+
+/* Test/diagnostic hooks: the pool is working when spawned << calls. */
+int64_t march_blocking_threads_spawned(void) {
+    return atomic_load_explicit(&g_blk_threads_spawned, memory_order_relaxed);
+}
+int64_t march_blocking_calls(void) {
+    return atomic_load_explicit(&g_blk_calls, memory_order_relaxed);
+}
+/* Test hook: a trivial body to declare `blocking` and drive the pool from a
+ * March test program.  [us] microseconds of sleep (0 = return immediately). */
+int64_t march_test_blocking_nap(int64_t us) {
+    if (us > 0) {
+        struct timespec ts;
+        ts.tv_sec  = (time_t)(us / 1000000);
+        ts.tv_nsec = (long)(us % 1000000) * 1000L;
+        (void)nanosleep(&ts, NULL);
+    }
+    return us;
 }
 int64_t march_run_blocking_i(void *fn, const int64_t *args, int n) {
-    march_blk_call b = { fn, args, n, 0, 0, 0.0, 0 };
+    march_blk_call b = { fn, args, n, 0, 0, 0.0, 0, NULL };
     march_run_blocking(&b);
     return b.ri;
 }
 double march_run_blocking_d(void *fn, const int64_t *args, int n) {
-    march_blk_call b = { fn, args, n, 1, 0, 0.0, 0 };
+    march_blk_call b = { fn, args, n, 1, 0, 0.0, 0, NULL };
     march_run_blocking(&b);
     return b.rd;
 }

--- a/runtime/march_ffi.h
+++ b/runtime/march_ffi.h
@@ -128,11 +128,19 @@ march_value march_resource_new(int32_t type_id, void *native_ptr);
 void       *march_resource_get(march_value v, int32_t type_id);
 
 /* ── Blocking dispatch ───────────────────────────────────────────────────────
- * Run a `blocking` extern (`fn` with `args` of int64/ptr) on a dedicated OS
- * thread while the calling green thread cooperatively yields.  Two return
- * shapes (int64 / double).  Emitted by codegen for `blocking` extern calls. */
+ * Run a `blocking` extern (`fn` with `args` of int64/ptr) on a pool OS thread
+ * while the calling green thread cooperatively yields.  Two return shapes
+ * (int64 / double).  Emitted by codegen for `blocking` extern calls. */
 int64_t march_run_blocking_i(void *fn, const int64_t *args, int n);
 double  march_run_blocking_d(void *fn, const int64_t *args, int n);
+
+/* Blocking-pool diagnostics (tests): worker threads ever spawned, and blocking
+ * calls ever submitted.  The pool reuses threads, so spawned should stay far
+ * below calls; one-thread-per-call would make them equal. */
+int64_t march_blocking_threads_spawned(void);
+int64_t march_blocking_calls(void);
+/* Test hook: trivial body, declared `blocking` by tests to drive the pool. */
+int64_t march_test_blocking_nap(int64_t us);
 
 /* ── Native → March upcalls ───────────────────────────────────────────────────
  * Invoke a March closure value (received as an extern parameter of a function

--- a/test/test_codegen.ml
+++ b/test/test_codegen.ml
@@ -9920,6 +9920,64 @@ let test_native_array_map_reused_capturing_closure_compiled () =
         "[8, 9, 10]\n107" run_out
     done
 
+(* ── Blocking-FFI worker pool ────────────────────────────────────── *)
+
+(* Blocking externs used to get a fresh pthread_create + join PER CALL, which
+   made a program doing one blocking call per work item pay a thread
+   create/join per item (measured on a 3,600-item run: 14,408 clone3 calls,
+   ~0.79s of pure thread churn — enough to make the parallel path several
+   times slower than the serial one).  Calls now go to a pool of reusable
+   worker threads.
+
+   The pool must stay ELASTIC — see the comment in runtime/march_ffi.c: blocking
+   calls can depend on each other, so a submission that finds no PARKED worker
+   must spawn one rather than wait for a busy worker to free up.  This test
+   therefore checks reuse, not a thread cap: many sequential calls from a single
+   green thread must be served by far fewer threads than there are calls. *)
+let test_blocking_ffi_pool_reuses_threads_compiled () =
+  let (project_root, main_exe, src, tmp) = write_march_source ~name:"march_blkpool"
+    "mod BlkPool do\n\
+    \  needs IO\n\
+    \  extern \"march\" : Cap(IO.Foreign) do\n\
+    \    blocking fn nap(us : Int) : Int = \"march_test_blocking_nap\"\n\
+    \    fn spawned() : Int = \"march_blocking_threads_spawned\"\n\
+    \    fn calls() : Int = \"march_blocking_calls\"\n\
+    \  end\n\
+    \  pfn spin(n : Int) : Int do\n\
+    \    if n <= 0 do 0 else do let _ = nap(0)\n\
+    \      spin(n - 1) end end\n\
+    \  end\n\
+    \  fn main() do\n\
+    \    let _ = spin(400)\n\
+    \    println(int_to_string(calls()) ++ \" \" ++ int_to_string(spawned()))\n\
+    \  end\n\
+     end\n"
+  in
+  let bin = Filename.concat tmp "blkpoolbin" in
+  match compile_march_or_skip ~cmd_prefix:(Printf.sprintf "cd %s && " (Filename.quote project_root))
+          ~main_exe ~bin ~src () with
+  | None -> ()  (* legitimate, counted skip: no clang on PATH *)
+  | Some bin ->
+    let out = read_cmd_output (Printf.sprintf "%s 2>&1" (Filename.quote bin)) in
+    (match String.split_on_char ' ' (String.trim out) with
+     | [calls_s; spawned_s] ->
+       let calls = int_of_string (String.trim calls_s) in
+       let spawned = int_of_string (String.trim spawned_s) in
+       Alcotest.(check bool)
+         (Printf.sprintf "all 400 blocking calls ran (saw %d)" calls)
+         true (calls >= 400);
+       (* One-thread-per-call would make these equal.  A serial caller can only
+          ever need one worker at a time, so reuse should keep this tiny; the
+          bound is deliberately loose (idle-retirement or a stray respawn may
+          add a few) while still failing hard on per-call thread creation. *)
+       Alcotest.(check bool)
+         (Printf.sprintf
+            "pool reuses threads: %d spawned for %d calls (per-call would be %d)"
+            spawned calls calls)
+         true (spawned <= 20)
+     | _ ->
+       Alcotest.failf "unexpected output from blocking-pool probe: %S" out)
+
 (* Signal.watch — a FOURTH family, and the most severe: unlike __try_call
    (one call) or the array builtins (N calls but the whole map finishes and
    releases in one process step), a watcher closure is held for the
@@ -13126,6 +13184,8 @@ let codegen_suites =
           test_blocking_extern_uses_blocking_dispatch;
         Alcotest.test_case "never emitted as a direct call" `Quick
           test_blocking_extern_never_called_directly;
+        Alcotest.test_case "pool reuses worker threads across calls" `Quick
+          test_blocking_ffi_pool_reuses_threads_compiled;
       ]);
       ("known_call", [
         Alcotest.test_case "direct"          `Quick test_known_call_direct;


### PR DESCRIPTION
> **Stacked on #168** — base is `fix/blocking-extern-callptr-dispatch`, so this diff shows only the runtime changes. Retarget to `main` once #168 merges.

Two commits, both about the cost of a `blocking` extern call.

## 1. Serve blocking externs from a reusable worker pool

Every call did its own `pthread_create` + `pthread_join`. On a 3,600-file search making 14,400 blocking calls:

| | before | after |
|---|---:|---:|
| `clone3` calls | **14,408** | **12** |
| time in thread creation | **0.79s** | **0.6ms** |

**The pool is elastic, and that is correctness, not tuning.** Blocking calls can depend on each other: N green threads can be parked in a blocking `take_job` that only returns once a *different* green thread's blocking `submit` runs. A fixed-size pool would let those `take_job`s occupy every worker so the `submit` is never serviced — reintroducing the deadlock #168 fixes. A submission that finds no **parked** worker always spawns one; idle workers retire after 10s.

Worth a reviewer's eye: spawning is decided by `queued > waiting` (demand vs. parked supply), **not** "is any worker idle". The latter is racy and deadlocked immediately in testing — two concurrent submissions see the same lone idle worker, neither spawns, and the call that worker doesn't take hangs forever if the one it does take waits on it.

## 2. Park the caller instead of spinning

The calling green thread sat in `while (!done) march_sched_yield()`, staying permanently runnable so the scheduler re-dispatched it (a full `swapcontext`) for the whole duration of the C call — ~0.59s of user CPU and ~28k context switches on that same run.

**Park-only is not sufficient, and measuring is what showed it.** When every green thread parks, `sched_loop` drops into its 1ms idle `nanosleep`, so a wake waits up to a millisecond. Park-always cut user CPU 0.74s → 0.28s but inflated wall time **0.60s → 3.18s at 17% CPU**. So: bounded spin, then park. The bound was swept (median wall, 5 runs):

| spins | 8 | 32 | 64 | 256 | 1024 |
|---|---:|---:|---:|---:|---:|
| wall | 0.45s | **0.29s** | 0.32s | 0.41s | 0.50s |

**Lifetime hazard handled:** the call struct lives on the *caller's stack* and the caller may return the instant it sees `done`, so the worker reads the waiter **before** running the call, never after. The scheduler's wake-permit closes the wake-before-park window.

## Combined effect

On the benchmark that motivated this (3,600 files, 4 workers, fused engine): **0.64s → 0.29s**, user CPU 0.74s → 0.37s, and the parallel path is faster than serial instead of slower. With a matching downstream change (non-blocking fast paths so uncontended queue ops never leave the green thread) the same workload reaches **0.17s**, beating its pre-pool baseline of 0.24s.

## Testing

- New test asserts threads-spawned ≪ calls-made; forcing the per-call path makes it report *400 spawned for 400 calls* and fail, while the pool serves all 400 with **one** thread.
- `dune build @runtest`: the only failure is the `MARCH_SANITIZE` ASan timeout that **also fails on `main` without these changes** (verified by stashing) — a known host-level ASan issue.
- `clang -std=c11 -Wall -Wextra -Werror -pthread -fsyntax-only` clean.
- Downstream (mgrep): 18/18 parallel runs on macOS and 18/18 on Linux across both engines and `-j 2/4/8/14` — zero hangs, output byte-identical to serial; ASan+UBSan native queue checks clean.