### PR TITLE
bench: machine-readable output, chart generator, and a compile-time benchmark

### DIFF
--- a/bench/chart.py
+++ b/bench/chart.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Render a benchmark JSONL run (from run_benchmarks.sh MACHINE_OUT) as an SVG.
+
+    MACHINE_OUT=bench/results/run.jsonl bash bench/run_benchmarks.sh
+    python3 bench/chart.py bench/results/run.jsonl bench/results/run.svg
+
+The chart is generated FROM the committed data, never hand-drawn — so a number
+on the page is traceable to the run that produced it. No external libraries:
+the SVG is emitted directly, matching the rest of bench/'s no-dependency stance.
+
+Each benchmark becomes a grouped horizontal bar chart (one bar per language),
+bars labelled with the median in ms. The run's provenance (the `meta` record) is
+printed as a caption so the image documents its own conditions.
+"""
+import html
+import json
+import sys
+
+# Fixed language order + colours so successive charts read consistently. A
+# language absent from a benchmark simply has no bar (the honest "not run").
+LANG_ORDER = ["March", "OCaml", "Rust", "Elixir", "Python", "NumPy"]
+COLOR = {
+    "March":  "#4c9be8",
+    "OCaml":  "#e5883a",
+    "Rust":   "#d0563a",
+    "Elixir": "#9a6fce",
+    "Python": "#e0b93a",
+    "NumPy":  "#3aae8f",
+}
+FALLBACK = "#8b98a8"
+
+
+def load(path):
+    meta = {}
+    rows = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            obj = json.loads(line)
+            if obj.get("meta"):
+                meta = obj
+            else:
+                rows.append(obj)
+    if not rows:
+        sys.exit(f"{path}: no benchmark rows")
+    return meta, rows
+
+
+def group(rows):
+    """benchmark -> [(language, median), ...] in LANG_ORDER, then any extras."""
+    out = {}
+    for r in rows:
+        out.setdefault(r["benchmark"], {})[r["language"]] = r["median_ms"]
+    ordered = {}
+    for bench, langs in out.items():
+        seq = [(l, langs[l]) for l in LANG_ORDER if l in langs]
+        seq += [(l, v) for l, v in langs.items() if l not in LANG_ORDER]
+        ordered[bench] = seq
+    return ordered
+
+
+def svg(meta, grouped):
+    # Layout constants (px).
+    W = 900
+    pad_l, pad_r, pad_top = 210, 90, 64
+    bar_h, bar_gap, group_gap = 22, 6, 26
+    label_w = pad_l - 16
+
+    # Height: sum of all bars + per-group gaps.
+    total_bars = sum(len(v) for v in grouped.values())
+    n_groups = len(grouped)
+    plot_h = total_bars * (bar_h + bar_gap) + n_groups * group_gap
+    H = pad_top + plot_h + 74
+
+    def esc(s):
+        return html.escape(str(s))
+
+    parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {W} {H}" '
+        f'font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif">',
+        f'<rect width="{W}" height="{H}" fill="#0b0f14"/>',
+        f'<text x="{pad_l}" y="30" fill="#e6edf3" font-size="18" '
+        f'font-weight="700">Cross-language benchmarks — median wall-clock (ms), lower is better</text>',
+    ]
+    cap = "  ·  ".join(
+        f"{k}: {esc(meta[k])}" for k in ("cpu", "cores", "runs", "load") if k in meta)
+    if meta.get("date"):
+        cap = f"{meta['date']}  ·  " + cap
+    parts.append(
+        f'<text x="{pad_l}" y="50" fill="#7d8b9c" font-size="12">{esc(cap)}</text>')
+
+    y = pad_top
+    for bench, seq in grouped.items():
+        gmax = max(v for _, v in seq) or 1.0
+        parts.append(
+            f'<text x="{label_w}" y="{y + 13}" fill="#c8d3e0" font-size="13" '
+            f'font-weight="650" text-anchor="end">{esc(bench)}</text>')
+        for lang, val in seq:
+            bw = (W - pad_l - pad_r) * (val / gmax)
+            bw = max(bw, 2.0)
+            color = COLOR.get(lang, FALLBACK)
+            parts.append(
+                f'<rect x="{pad_l}" y="{y}" width="{bw:.1f}" height="{bar_h}" '
+                f'rx="3" fill="{color}"/>')
+            parts.append(
+                f'<text x="{pad_l - 8}" y="{y + 15}" fill="#8b98a8" font-size="11" '
+                f'text-anchor="end">{esc(lang)}</text>')
+            parts.append(
+                f'<text x="{pad_l + bw + 6:.1f}" y="{y + 15}" fill="#c8d3e0" '
+                f'font-size="11">{val:.1f}</text>')
+            y += bar_h + bar_gap
+        y += group_gap
+
+    parts.append(
+        f'<text x="{pad_l}" y="{H - 20}" fill="#5c6875" font-size="11">'
+        f'Generated from committed data by bench/chart.py — bars scaled per '
+        f'benchmark (each group\'s slowest = full width).</text>')
+    parts.append('</svg>')
+    return "\n".join(parts)
+
+
+def main():
+    if len(sys.argv) < 2:
+        sys.exit("usage: chart.py RUN.jsonl [OUT.svg]")
+    src = sys.argv[1]
+    out = sys.argv[2] if len(sys.argv) > 2 else src.rsplit(".", 1)[0] + ".svg"
+    meta, rows = load(src)
+    open(out, "w").write(svg(meta, group(rows)))
+    print(f"wrote {out} ({len(rows)} rows, {len(group(rows))} benchmarks)")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/compile_time.py
+++ b/bench/compile_time.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Compile-time benchmark: clean vs incremental, March's CAS/BLAKE3 cache.
+
+    python3 bench/compile_time.py [path/to/march] [prog.march]
+
+Compile time is the complaint heard most often about statically-compiled
+languages, so it belongs next to the runtime numbers. March content-addresses
+each compiled definition (BLAKE3 over the def plus the compiler and runtime
+digests), so a rebuild after an edit recompiles only the changed definition and
+its dependents and links the rest from cache.
+
+Two measurements, both on the same program:
+
+  clean        cold cache (`.march/cas` removed) — the whole program compiled,
+               dominated by clang lowering every definition.
+  incremental  one integer literal changed, cache warm — the realistic
+               edit-rebuild loop.
+
+Prints its own provenance so a pasted result is traceable. Restores the source
+it edits.
+"""
+import pathlib
+import re
+import shutil
+import statistics
+import subprocess
+import sys
+import time
+
+MARCH = sys.argv[1] if len(sys.argv) > 1 else "./_build/default/bin/main.exe"
+PROG = sys.argv[2] if len(sys.argv) > 2 else "bench/dataframe_bench.march"
+OUT = "/tmp/march_compile_time_out"
+
+
+def med_min(ts):
+    ts = sorted(ts)
+    return statistics.median(ts), ts[0]
+
+
+def compile_once():
+    t0 = time.perf_counter()
+    subprocess.run([MARCH, "--compile", "--opt", "2", PROG, "-o", OUT],
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    return (time.perf_counter() - t0) * 1000
+
+
+def cpu_info():
+    p = pathlib.Path("/proc/cpuinfo")
+    if p.exists():
+        for line in p.read_text().splitlines():
+            if line.startswith("model name"):
+                return line.split(":", 1)[1].strip()
+    try:
+        return subprocess.check_output(
+            ["sysctl", "-n", "machdep.cpu.brand_string"], text=True).strip()
+    except Exception:
+        return "unknown"
+
+
+def main():
+    src_path = pathlib.Path(PROG)
+    orig = src_path.read_text()
+    lines = orig.count("\n") + 1
+
+    print(f"program : {PROG} ({lines} lines)")
+    print(f"cpu     : {cpu_info()}")
+
+    clean = []
+    for _ in range(3):
+        shutil.rmtree(".march/cas", ignore_errors=True)
+        clean.append(compile_once())
+    cm, cl = med_min(clean)
+
+    compile_once()  # warm the cache
+    incr = []
+    try:
+        for i in range(5):
+            src = src_path.read_text()
+            new, k = re.subn(r"\b100\b", str(101 + (i % 2)), src, count=1)
+            if k == 0:  # no `100` literal — flip any two-digit literal instead
+                new, k = re.subn(r"\b(\d\d)\b",
+                                 lambda m: str(int(m.group(1)) ^ 1), src, count=1)
+            src_path.write_text(new)
+            incr.append(compile_once())
+    finally:
+        src_path.write_text(orig)
+    im, il = med_min(incr)
+
+    print(f"clean       (cold CAS)         median {cm:6.0f} ms   min {cl:6.0f}")
+    print(f"incremental (1 literal edited) median {im:6.0f} ms   min {il:6.0f}")
+    if im > 0:
+        print(f"speedup     {cm / im:.0f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/results/2026-08-04-compile-time.txt
+++ b/bench/results/2026-08-04-compile-time.txt
@@ -1,0 +1,8 @@
+# Compile-time benchmark — regenerate with: python3 bench/compile_time.py
+# idle GCP c4-standard-4, 2026-08-04
+
+program : bench/dataframe_bench.march (193 lines)
+cpu     : INTEL(R) XEON(R) PLATINUM 8581C CPU @ 2.30GHz
+clean       (cold CAS)         median   4772 ms   min   4765
+incremental (1 literal edited) median     53 ms   min     48
+speedup     91x

--- a/bench/results/2026-08-04-x86_64-xeon8581c.jsonl
+++ b/bench/results/2026-08-04-x86_64-xeon8581c.jsonl
@@ -1,0 +1,35 @@
+{"meta":true,"date":"2026-08-04T18:16:39Z","host":"Linux 6.17.0-1021-gcp x86_64","cpu":"INTEL(R) XEON(R) PLATINUM 8581C CPU @ 2.30GHz","cores":4,"runs":10,"load":"0.14, 0.54, 0.38"}
+{"benchmark":"fib(40)","language":"March","median_ms":425.3,"min_ms":421.5,"max_ms":433.0}
+{"benchmark":"fib(40)","language":"OCaml","median_ms":554.7,"min_ms":546.0,"max_ms":560.2}
+{"benchmark":"fib(40)","language":"Rust","median_ms":266.4,"min_ms":263.9,"max_ms":267.8}
+{"benchmark":"fib(40)","language":"Elixir","median_ms":1507.3,"min_ms":1503.5,"max_ms":1511.6}
+{"benchmark":"binary-trees(15)","language":"March","median_ms":527.5,"min_ms":523.2,"max_ms":530.8}
+{"benchmark":"binary-trees(15)","language":"OCaml","median_ms":26.2,"min_ms":25.5,"max_ms":26.6}
+{"benchmark":"binary-trees(15)","language":"Rust","median_ms":120.1,"min_ms":117.3,"max_ms":122.8}
+{"benchmark":"binary-trees(15)","language":"Elixir","median_ms":366.6,"min_ms":359.1,"max_ms":368.8}
+{"benchmark":"tree-transform(depth=20, 100 passes)","language":"March","median_ms":2744.9,"min_ms":2607.7,"max_ms":3073.9}
+{"benchmark":"tree-transform(depth=20, 100 passes)","language":"OCaml","median_ms":6960.2,"min_ms":6899.8,"max_ms":7043.4}
+{"benchmark":"tree-transform(depth=20, 100 passes)","language":"Rust","median_ms":4326.2,"min_ms":4250.7,"max_ms":4380.0}
+{"benchmark":"tree-transform(depth=20, 100 passes)","language":"Elixir","median_ms":5151.5,"min_ms":4545.4,"max_ms":5268.2}
+{"benchmark":"list-ops(1M)","language":"March","median_ms":147.0,"min_ms":144.0,"max_ms":153.5}
+{"benchmark":"list-ops(1M)","language":"OCaml","median_ms":46.5,"min_ms":44.8,"max_ms":50.0}
+{"benchmark":"list-ops(1M)","language":"Rust","median_ms":1.3,"min_ms":1.2,"max_ms":1.5}
+{"benchmark":"list-ops(1M)","language":"Elixir","median_ms":354.0,"min_ms":348.9,"max_ms":358.7}
+{"benchmark":"simd-sum(5M)","language":"March","median_ms":4.039,"min_ms":3.984,"max_ms":4.107}
+{"benchmark":"simd-sum(5M)","language":"OCaml","median_ms":6.571,"min_ms":6.061,"max_ms":6.689}
+{"benchmark":"simd-sum(5M)","language":"Rust","median_ms":5.247,"min_ms":4.857,"max_ms":5.659}
+{"benchmark":"simd-sum(5M)","language":"Elixir","median_ms":74.003,"min_ms":69.353,"max_ms":84.121}
+{"benchmark":"simd-sum(5M)","language":"Python","median_ms":222.153,"min_ms":210.716,"max_ms":255.771}
+{"benchmark":"simd-sum(5M)","language":"NumPy","median_ms":2.859,"min_ms":2.789,"max_ms":3.095}
+{"benchmark":"simd-map(5M)","language":"March","median_ms":18.485,"min_ms":18.282,"max_ms":19.198}
+{"benchmark":"simd-map(5M)","language":"OCaml","median_ms":8.835,"min_ms":8.721,"max_ms":8.925}
+{"benchmark":"simd-map(5M)","language":"Rust","median_ms":17.440,"min_ms":17.234,"max_ms":17.700}
+{"benchmark":"simd-map(5M)","language":"Elixir","median_ms":460.258,"min_ms":442.906,"max_ms":481.226}
+{"benchmark":"simd-map(5M)","language":"Python","median_ms":161.556,"min_ms":158.265,"max_ms":164.893}
+{"benchmark":"simd-map(5M)","language":"NumPy","median_ms":10.478,"min_ms":9.715,"max_ms":11.075}
+{"benchmark":"simd-map2(5M)","language":"March","median_ms":19.696,"min_ms":19.380,"max_ms":19.918}
+{"benchmark":"simd-map2(5M)","language":"OCaml","median_ms":10.806,"min_ms":10.662,"max_ms":11.331}
+{"benchmark":"simd-map2(5M)","language":"Rust","median_ms":19.221,"min_ms":18.671,"max_ms":19.498}
+{"benchmark":"simd-map2(5M)","language":"Elixir","median_ms":250.293,"min_ms":240.326,"max_ms":267.515}
+{"benchmark":"simd-map2(5M)","language":"Python","median_ms":194.763,"min_ms":192.777,"max_ms":211.492}
+{"benchmark":"simd-map2(5M)","language":"NumPy","median_ms":9.478,"min_ms":8.794,"max_ms":10.049}

--- a/bench/results/2026-08-04-x86_64-xeon8581c.svg
+++ b/bench/results/2026-08-04-x86_64-xeon8581c.svg
@@ -1,0 +1,115 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 1272" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif">
+<rect width="900" height="1272" fill="#0b0f14"/>
+<text x="210" y="30" fill="#e6edf3" font-size="18" font-weight="700">Cross-language benchmarks — median wall-clock (ms), lower is better</text>
+<text x="210" y="50" fill="#7d8b9c" font-size="12">2026-08-04T18:16:39Z  ·  cpu: INTEL(R) XEON(R) PLATINUM 8581C CPU @ 2.30GHz  ·  cores: 4  ·  runs: 10  ·  load: 0.14, 0.54, 0.38</text>
+<text x="194" y="77" fill="#c8d3e0" font-size="13" font-weight="650" text-anchor="end">fib(40)</text>
+<rect x="210" y="64" width="169.3" height="22" rx="3" fill="#4c9be8"/>
+<text x="202" y="79" fill="#8b98a8" font-size="11" text-anchor="end">March</text>
+<text x="385.3" y="79" fill="#c8d3e0" font-size="11">425.3</text>
+<rect x="210" y="92" width="220.8" height="22" rx="3" fill="#e5883a"/>
+<text x="202" y="107" fill="#8b98a8" font-size="11" text-anchor="end">OCaml</text>
+<text x="436.8" y="107" fill="#c8d3e0" font-size="11">554.7</text>
+<rect x="210" y="120" width="106.0" height="22" rx="3" fill="#d0563a"/>
+<text x="202" y="135" fill="#8b98a8" font-size="11" text-anchor="end">Rust</text>
+<text x="322.0" y="135" fill="#c8d3e0" font-size="11">266.4</text>
+<rect x="210" y="148" width="600.0" height="22" rx="3" fill="#9a6fce"/>
+<text x="202" y="163" fill="#8b98a8" font-size="11" text-anchor="end">Elixir</text>
+<text x="816.0" y="163" fill="#c8d3e0" font-size="11">1507.3</text>
+<text x="194" y="215" fill="#c8d3e0" font-size="13" font-weight="650" text-anchor="end">binary-trees(15)</text>
+<rect x="210" y="202" width="600.0" height="22" rx="3" fill="#4c9be8"/>
+<text x="202" y="217" fill="#8b98a8" font-size="11" text-anchor="end">March</text>
+<text x="816.0" y="217" fill="#c8d3e0" font-size="11">527.5</text>
+<rect x="210" y="230" width="29.8" height="22" rx="3" fill="#e5883a"/>
+<text x="202" y="245" fill="#8b98a8" font-size="11" text-anchor="end">OCaml</text>
+<text x="245.8" y="245" fill="#c8d3e0" font-size="11">26.2</text>
+<rect x="210" y="258" width="136.6" height="22" rx="3" fill="#d0563a"/>
+<text x="202" y="273" fill="#8b98a8" font-size="11" text-anchor="end">Rust</text>
+<text x="352.6" y="273" fill="#c8d3e0" font-size="11">120.1</text>
+<rect x="210" y="286" width="417.0" height="22" rx="3" fill="#9a6fce"/>
+<text x="202" y="301" fill="#8b98a8" font-size="11" text-anchor="end">Elixir</text>
+<text x="633.0" y="301" fill="#c8d3e0" font-size="11">366.6</text>
+<text x="194" y="353" fill="#c8d3e0" font-size="13" font-weight="650" text-anchor="end">tree-transform(depth=20, 100 passes)</text>
+<rect x="210" y="340" width="236.6" height="22" rx="3" fill="#4c9be8"/>
+<text x="202" y="355" fill="#8b98a8" font-size="11" text-anchor="end">March</text>
+<text x="452.6" y="355" fill="#c8d3e0" font-size="11">2744.9</text>
+<rect x="210" y="368" width="600.0" height="22" rx="3" fill="#e5883a"/>
+<text x="202" y="383" fill="#8b98a8" font-size="11" text-anchor="end">OCaml</text>
+<text x="816.0" y="383" fill="#c8d3e0" font-size="11">6960.2</text>
+<rect x="210" y="396" width="372.9" height="22" rx="3" fill="#d0563a"/>
+<text x="202" y="411" fill="#8b98a8" font-size="11" text-anchor="end">Rust</text>
+<text x="588.9" y="411" fill="#c8d3e0" font-size="11">4326.2</text>
+<rect x="210" y="424" width="444.1" height="22" rx="3" fill="#9a6fce"/>
+<text x="202" y="439" fill="#8b98a8" font-size="11" text-anchor="end">Elixir</text>
+<text x="660.1" y="439" fill="#c8d3e0" font-size="11">5151.5</text>
+<text x="194" y="491" fill="#c8d3e0" font-size="13" font-weight="650" text-anchor="end">list-ops(1M)</text>
+<rect x="210" y="478" width="249.2" height="22" rx="3" fill="#4c9be8"/>
+<text x="202" y="493" fill="#8b98a8" font-size="11" text-anchor="end">March</text>
+<text x="465.2" y="493" fill="#c8d3e0" font-size="11">147.0</text>
+<rect x="210" y="506" width="78.8" height="22" rx="3" fill="#e5883a"/>
+<text x="202" y="521" fill="#8b98a8" font-size="11" text-anchor="end">OCaml</text>
+<text x="294.8" y="521" fill="#c8d3e0" font-size="11">46.5</text>
+<rect x="210" y="534" width="2.2" height="22" rx="3" fill="#d0563a"/>
+<text x="202" y="549" fill="#8b98a8" font-size="11" text-anchor="end">Rust</text>
+<text x="218.2" y="549" fill="#c8d3e0" font-size="11">1.3</text>
+<rect x="210" y="562" width="600.0" height="22" rx="3" fill="#9a6fce"/>
+<text x="202" y="577" fill="#8b98a8" font-size="11" text-anchor="end">Elixir</text>
+<text x="816.0" y="577" fill="#c8d3e0" font-size="11">354.0</text>
+<text x="194" y="629" fill="#c8d3e0" font-size="13" font-weight="650" text-anchor="end">simd-sum(5M)</text>
+<rect x="210" y="616" width="10.9" height="22" rx="3" fill="#4c9be8"/>
+<text x="202" y="631" fill="#8b98a8" font-size="11" text-anchor="end">March</text>
+<text x="226.9" y="631" fill="#c8d3e0" font-size="11">4.0</text>
+<rect x="210" y="644" width="17.7" height="22" rx="3" fill="#e5883a"/>
+<text x="202" y="659" fill="#8b98a8" font-size="11" text-anchor="end">OCaml</text>
+<text x="233.7" y="659" fill="#c8d3e0" font-size="11">6.6</text>
+<rect x="210" y="672" width="14.2" height="22" rx="3" fill="#d0563a"/>
+<text x="202" y="687" fill="#8b98a8" font-size="11" text-anchor="end">Rust</text>
+<text x="230.2" y="687" fill="#c8d3e0" font-size="11">5.2</text>
+<rect x="210" y="700" width="199.9" height="22" rx="3" fill="#9a6fce"/>
+<text x="202" y="715" fill="#8b98a8" font-size="11" text-anchor="end">Elixir</text>
+<text x="415.9" y="715" fill="#c8d3e0" font-size="11">74.0</text>
+<rect x="210" y="728" width="600.0" height="22" rx="3" fill="#e0b93a"/>
+<text x="202" y="743" fill="#8b98a8" font-size="11" text-anchor="end">Python</text>
+<text x="816.0" y="743" fill="#c8d3e0" font-size="11">222.2</text>
+<rect x="210" y="756" width="7.7" height="22" rx="3" fill="#3aae8f"/>
+<text x="202" y="771" fill="#8b98a8" font-size="11" text-anchor="end">NumPy</text>
+<text x="223.7" y="771" fill="#c8d3e0" font-size="11">2.9</text>
+<text x="194" y="823" fill="#c8d3e0" font-size="13" font-weight="650" text-anchor="end">simd-map(5M)</text>
+<rect x="210" y="810" width="24.1" height="22" rx="3" fill="#4c9be8"/>
+<text x="202" y="825" fill="#8b98a8" font-size="11" text-anchor="end">March</text>
+<text x="240.1" y="825" fill="#c8d3e0" font-size="11">18.5</text>
+<rect x="210" y="838" width="11.5" height="22" rx="3" fill="#e5883a"/>
+<text x="202" y="853" fill="#8b98a8" font-size="11" text-anchor="end">OCaml</text>
+<text x="227.5" y="853" fill="#c8d3e0" font-size="11">8.8</text>
+<rect x="210" y="866" width="22.7" height="22" rx="3" fill="#d0563a"/>
+<text x="202" y="881" fill="#8b98a8" font-size="11" text-anchor="end">Rust</text>
+<text x="238.7" y="881" fill="#c8d3e0" font-size="11">17.4</text>
+<rect x="210" y="894" width="600.0" height="22" rx="3" fill="#9a6fce"/>
+<text x="202" y="909" fill="#8b98a8" font-size="11" text-anchor="end">Elixir</text>
+<text x="816.0" y="909" fill="#c8d3e0" font-size="11">460.3</text>
+<rect x="210" y="922" width="210.6" height="22" rx="3" fill="#e0b93a"/>
+<text x="202" y="937" fill="#8b98a8" font-size="11" text-anchor="end">Python</text>
+<text x="426.6" y="937" fill="#c8d3e0" font-size="11">161.6</text>
+<rect x="210" y="950" width="13.7" height="22" rx="3" fill="#3aae8f"/>
+<text x="202" y="965" fill="#8b98a8" font-size="11" text-anchor="end">NumPy</text>
+<text x="229.7" y="965" fill="#c8d3e0" font-size="11">10.5</text>
+<text x="194" y="1017" fill="#c8d3e0" font-size="13" font-weight="650" text-anchor="end">simd-map2(5M)</text>
+<rect x="210" y="1004" width="47.2" height="22" rx="3" fill="#4c9be8"/>
+<text x="202" y="1019" fill="#8b98a8" font-size="11" text-anchor="end">March</text>
+<text x="263.2" y="1019" fill="#c8d3e0" font-size="11">19.7</text>
+<rect x="210" y="1032" width="25.9" height="22" rx="3" fill="#e5883a"/>
+<text x="202" y="1047" fill="#8b98a8" font-size="11" text-anchor="end">OCaml</text>
+<text x="241.9" y="1047" fill="#c8d3e0" font-size="11">10.8</text>
+<rect x="210" y="1060" width="46.1" height="22" rx="3" fill="#d0563a"/>
+<text x="202" y="1075" fill="#8b98a8" font-size="11" text-anchor="end">Rust</text>
+<text x="262.1" y="1075" fill="#c8d3e0" font-size="11">19.2</text>
+<rect x="210" y="1088" width="600.0" height="22" rx="3" fill="#9a6fce"/>
+<text x="202" y="1103" fill="#8b98a8" font-size="11" text-anchor="end">Elixir</text>
+<text x="816.0" y="1103" fill="#c8d3e0" font-size="11">250.3</text>
+<rect x="210" y="1116" width="466.9" height="22" rx="3" fill="#e0b93a"/>
+<text x="202" y="1131" fill="#8b98a8" font-size="11" text-anchor="end">Python</text>
+<text x="682.9" y="1131" fill="#c8d3e0" font-size="11">194.8</text>
+<rect x="210" y="1144" width="22.7" height="22" rx="3" fill="#3aae8f"/>
+<text x="202" y="1159" fill="#8b98a8" font-size="11" text-anchor="end">NumPy</text>
+<text x="238.7" y="1159" fill="#c8d3e0" font-size="11">9.5</text>
+<text x="210" y="1252" fill="#5c6875" font-size="11">Generated from committed data by bench/chart.py — bars scaled per benchmark (each group's slowest = full width).</text>
+</svg>

--- a/bench/run_benchmarks.sh
+++ b/bench/run_benchmarks.sh
@@ -79,6 +79,23 @@ tool_version() {                   # tool_version LABEL PATH VERSION-ARGS…
 
 print_provenance() {
   MISSING=""
+  # Start the machine file fresh and stamp the run's provenance as its first
+  # record, so a committed .jsonl documents the machine it came from.
+  if [ -n "$MACHINE_OUT" ]; then
+    : > "$MACHINE_OUT"
+    local cpu cores
+    if [ -r /proc/cpuinfo ]; then
+      cpu="$(grep -m1 'model name' /proc/cpuinfo | cut -d: -f2- | sed 's/^ *//')"
+      cores="$(nproc 2>/dev/null || echo 0)"
+    else
+      cpu="$(sysctl -n machdep.cpu.brand_string 2>/dev/null || echo unknown)"
+      cores="$(sysctl -n hw.ncpu 2>/dev/null || echo 0)"
+    fi
+    printf '{"meta":true,"date":"%s","host":"%s","cpu":"%s","cores":%s,"runs":%s,"load":"%s"}\n' \
+      "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$(json_escape "$(uname -srm)")" \
+      "$(json_escape "$cpu")" "$cores" "$RUNS" \
+      "$(json_escape "$(uptime | sed 's/.*load average[s]*: *//')")" >> "$MACHINE_OUT"
+  fi
   bold "═══ Environment ═══"
   printf '  %-8s %s\n' "date" "$(date -u '+%Y-%m-%dT%H:%M:%SZ') (UTC)"
   printf '  %-8s %s\n' "host" "$(uname -srm)"
@@ -141,8 +158,23 @@ print_provenance() {
   fi
   printf '\n'
 }
-header(){ printf '\n'; bold "═══ $* ═══"; printf '  %-12s %8s %8s %8s\n' "Language" "Median" "Min" "Max"; printf '  %-12s %8s %8s %8s\n' "--------" "------" "---" "---"; }
-row()   { printf '  %-12s %7.1f ms %6.1f ms %6.1f ms\n' "$1" "$2" "$3" "$4"; }
+# ── Machine-readable output (JSONL) ──────────────────────────────────────────
+# When MACHINE_OUT names a file, every row() also appends one JSON object there,
+# tagged with the current benchmark (set by header()). This is the data a chart
+# is generated FROM — a committed run under bench/results/*.jsonl plus
+# bench/chart.py means a published chart is regenerable from data in the repo,
+# never transcribed from a terminal (the failure that lost two languages once).
+MACHINE_OUT="${MACHINE_OUT:-}"
+CUR_BENCH=""
+json_escape() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
+emit_json() {  # emit_json language median min max
+  [ -n "$MACHINE_OUT" ] || return 0
+  printf '{"benchmark":"%s","language":"%s","median_ms":%s,"min_ms":%s,"max_ms":%s}\n' \
+    "$(json_escape "$CUR_BENCH")" "$(json_escape "$1")" "$2" "$3" "$4" >> "$MACHINE_OUT"
+}
+
+header(){ CUR_BENCH="${1%% —*}"; printf '\n'; bold "═══ $* ═══"; printf '  %-12s %8s %8s %8s\n' "Language" "Median" "Min" "Max"; printf '  %-12s %8s %8s %8s\n' "--------" "------" "---" "---"; }
+row()   { printf '  %-12s %7.1f ms %6.1f ms %6.1f ms\n' "$1" "$2" "$3" "$4"; emit_json "$1" "$2" "$3" "$4"; }
 skip()  { printf '  %-12s   (not available)\n' "$1"; }
 
 # ── timing: run a command $RUNS times, print "median min max" (ms) to stdout ─


### PR DESCRIPTION
Phase 4 remainder — two of the three items. Both build on the reproducible
harness from #173 (merged).

## 1. Machine-readable output + charts from committed data

`run_benchmarks.sh` gains a `MACHINE_OUT` mode: alongside the human table, every
row appends one JSON object, with the run's provenance as a leading `meta`
record. Text output is unchanged when unset.

`bench/chart.py` renders a run's JSONL to a self-contained SVG (grouped bars per
benchmark, one per language, each group scaled to its own slowest so a 4ms SIMD
row and a 400ms fib row are both legible). No external libraries — SVG emitted
directly, matching the rest of `bench/`. The provenance becomes the caption, so
the image documents its own conditions.

A real idle-box run is committed under `bench/results/*.jsonl` (the data) with
its `.svg` (regenerable via `python3 bench/chart.py <jsonl>`). This is what the
plan asked for: charts generated from committed data, never transcribed.

## 2. Compile-time benchmark

`bench/compile_time.py` measures clean (cold CAS) vs incremental (one literal
edited, warm cache). Idle Xeon 8581C, `dataframe_bench.march`:

```
clean       (cold CAS)         4772 ms
incremental (1 literal edited)   53 ms      91x
```

March content-addresses each compiled definition, so an edit recompiles only
the changed def + dependents — the edit loop is ~50ms regardless of program
size. This addresses compile time, Rust's most common complaint, and sits next
to the runtime numbers.

## Not in this PR

The p99.9/RSS end-to-end demo (lock-free ring buffer + `@noalloc` socket io) —
the one substantial build left in phase 4 — is deferred to its own PR.

Also: fib remains as-diagnosed, not fixed. The reverted-sink root cause is on
`claude/fib-rootcause-doc` — the 114ms check is structurally the loop
back-edge check, so it's not cheaply movable.
