### PR TITLE
feat(caps): per-module capability attribution — name the module that does the IO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ git log is authoritative for exact commits.
 
 ### Added
 
+- **`forge cap inspect` now says WHICH module uses each capability.** The
+  report gained an "Attributed to" section: `IO.FileRead   Conduit.Store`
+  instead of only "this binary reads files". This is what makes it possible to
+  ask whether a capability came from your code or from a dependency — the
+  whole-program union could never distinguish them.
+
+  Attribution is computed before inlining, which is the only point where it is
+  correct: by codegen time a small dependency function has been folded into
+  its caller, so attributing there credits the dependency's IO to the
+  application — a false clean bill for the dependency. A capability reached
+  through a stdlib wrapper is attributed to the module that called the
+  wrapper, not to the wrapper, so `File.read` does not become the answer for
+  every dependency in the program.
+
+  A capability reached only through an indirect (closure) call has no
+  statically known callee and is reported as *unattributed* rather than
+  silently omitted. Also available as `attribution` in `--json` output.
+
 - **Path-scoped capabilities: `needs IO.FileRead("/etc/myapp")`.** A module
   can narrow a filesystem capability to a directory subtree instead of
   declaring all-or-nothing access. A literal path outside the declared scope

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -356,6 +356,37 @@ let stdlib_span_files (decls : March_ast.Ast.decl list) : string list =
   go decls;
   Hashtbl.fold (fun f () acc -> f :: acc) seen []
 
+(** The module names a batch of stdlib declarations defines.
+
+    Feeds [Cap_attrib.attribute]'s [~transparent] set, so a capability reached
+    through a stdlib wrapper is attributed to the dependency that called the
+    wrapper rather than to the wrapper. Derived from the declarations actually
+    loaded — like [stdlib_span_files] — rather than from a hand-maintained
+    name list, which is exactly the thing that drifts (see the correction
+    history on [Resolver.stdlib_module_names]).
+
+    [DMod] is the only declaration form that introduces a module name, so the
+    catch-all below cannot hide one; nested modules are reached through
+    [DMod]'s own inner list. Note prelude.march is deliberately unwrapped into
+    global scope by [load_stdlib_file], so its members are bare-named and
+    invisible here — a capability used only by a prelude function is
+    attributed to the entry module. *)
+let stdlib_module_names (decls : March_ast.Ast.decl list) : string list =
+  let seen = Hashtbl.create 64 in
+  let rec go prefix ds =
+    List.iter
+      (function
+        | March_ast.Ast.DMod (name, _, inner, _) ->
+          let name = name.March_ast.Ast.txt in
+          let q = if prefix = "" then name else prefix ^ "." ^ name in
+          Hashtbl.replace seen q ();
+          go q inner
+        | _ -> ())
+      ds
+  in
+  go "" decls;
+  Hashtbl.fold (fun n () acc -> n :: acc) seen []
+
 (** Typecheck [stdlib_decls] once and cache the resulting environment, so a
     combined check/compile can seed pass 1 from it (via
     [Typecheck.check_module_core]'s [?seed_env]) instead of re-typechecking
@@ -2516,6 +2547,20 @@ let compile filename =
     (* Save pre-opt TIR so we can hash __rpc_stub base functions that the
        inliner may eliminate before the CAS hash step below. *)
     let pre_opt_tir = tir in
+    (* Per-module capability attribution MUST be taken here, before the
+       inliner runs: it folds a dependency's small function into its caller
+       and the module boundary is gone by emission time, so attributing then
+       would credit the dependency's IO to the application.  Pruned first so
+       a dependency feature nothing calls contributes no owner row — that is
+       what makes "use one function of a library" cost only that function's
+       capabilities.  Both passes are pure, so this observes the pipeline
+       without perturbing it. *)
+    let cap_attrib =
+      let stdlib_mods = stdlib_module_names stdlib_decls in
+      March_tir.Cap_attrib.attribute
+        ~transparent:(fun m -> List.mem m stdlib_mods)
+        (March_tir.Dce.prune_unreachable pre_opt_tir)
+    in
     let tir =
       if !opt_enabled then
         March_tir.Opt.run
@@ -2813,7 +2858,7 @@ let compile filename =
         else
           (* Cache miss (or stale artifact / failed copy): emit LLVM IR,
              call clang, then cache the binary *)
-          let ir = March_tir.Llvm_emit.emit_module ~fast_math:!fast_math ~pmap_threshold:!pmap_threshold ~target ~hot_reload:(hr_config ()) ~impl_hashes:hr_impl_hashes ~remote_impl_hashes:rpc_impl_hashes ~remote_sig_hashes:remote_sig_hashes ~emit_main:(not !compile_so) tir in
+          let ir = March_tir.Llvm_emit.emit_module ~fast_math:!fast_math ~pmap_threshold:!pmap_threshold ~target ~hot_reload:(hr_config ()) ~impl_hashes:hr_impl_hashes ~remote_impl_hashes:rpc_impl_hashes ~remote_sig_hashes:remote_sig_hashes ~emit_main:(not !compile_so) ~cap_attrib tir in
           stamp "llvm-emit";
           let oc = open_out ll_file in
           output_string oc ir;
@@ -3574,7 +3619,7 @@ let compile filename =
             end
           ) pre_fns
         in
-        let ir = March_tir.Llvm_emit.emit_module ~fast_math:!fast_math ~pmap_threshold:!pmap_threshold ~target ~hot_reload:(hr_config ()) ~impl_hashes:hr_impl_hashes ~remote_impl_hashes:rpc_impl_hashes ~remote_sig_hashes:remote_sig_hashes2 ~emit_main:(not !compile_so) tir in
+        let ir = March_tir.Llvm_emit.emit_module ~fast_math:!fast_math ~pmap_threshold:!pmap_threshold ~target ~hot_reload:(hr_config ()) ~impl_hashes:hr_impl_hashes ~remote_impl_hashes:rpc_impl_hashes ~remote_sig_hashes:remote_sig_hashes2 ~emit_main:(not !compile_so) ~cap_attrib tir in
         let oc = open_out ll_file in
         output_string oc ir;
         close_out oc;

--- a/forge/lib/cap_binary.ml
+++ b/forge/lib/cap_binary.ml
@@ -6,6 +6,7 @@ type build_kind = Dead_stripped | Unstripped | Symbols_removed
 type t = {
   caps : string list;
   markers : string list;
+  attribution : (string * string) list;
   rt_symbols : string list;
   build : build_kind;
   manifest : string option;
@@ -81,6 +82,48 @@ let markers_of_symbols syms =
     syms
   |> List.sort_uniq String.compare
 
+(* ── attribution channel ────────────────────────────────────────────── *)
+
+(* Per-module attribution markers, [__march_capfrom_<CAP>__<OWNER>].  The
+   prefix deliberately shares no prefix with [marker_prefix] (they diverge at
+   the 12th character), so [markers_of_symbols] above cannot mistake one of
+   these for a flat marker and decode "IO_FileRead__BigLib" as a capability.
+
+   Capability paths never contain "__", so the FIRST "__" in the remainder is
+   the separator even when the owner module itself contains one. *)
+let attrib_prefix = "__march_capfrom_"
+
+let split_on_double_underscore s =
+  let n = String.length s in
+  let rec go i =
+    if i + 1 >= n then None
+    else if s.[i] = '_' && s.[i + 1] = '_' then
+      Some (String.sub s 0 i, String.sub s (i + 2) (n - i - 2))
+    else go (i + 1)
+  in
+  go 0
+
+let attribution_of_symbols syms =
+  List.filter_map
+    (fun sym ->
+      let sym = strip_underscore sym in
+      if not (has_prefix attrib_prefix sym) then None
+      else
+        let rest =
+          String.sub sym
+            (String.length attrib_prefix)
+            (String.length sym - String.length attrib_prefix)
+        in
+        match split_on_double_underscore rest with
+        (* The owner is emitted verbatim (dots and all — LLVM global names
+           permit them), so it needs no unmangling.  Mangling it would be
+           irreversible: a module named My_Mod and a nested module My.Mod
+           would share one encoding. *)
+        | Some (cap, owner) when owner <> "" -> Some (unmangle_cap cap, owner)
+        | _ -> None)
+    syms
+  |> List.sort_uniq compare
+
 (* ── manifest channel ───────────────────────────────────────────────── *)
 
 let manifest_magic = "MARCHCAP\x01"
@@ -139,6 +182,7 @@ let read path : (t, string) result =
             in
             let syms = read_symbols path in
             let markers = markers_of_symbols syms in
+            let attribution = attribution_of_symbols syms in
             let rt_symbols =
               List.filter_map
                 (fun s ->
@@ -192,9 +236,9 @@ let read path : (t, string) result =
                 (* Reporting the full symbol set as "capabilities" would be
                    the app-invariance failure; report the build kind and no
                    cap list. Markers, if present, are still trustworthy. *)
-                Ok { caps = markers; markers; rt_symbols; build; manifest }
+                Ok { caps = markers; markers; attribution; rt_symbols; build; manifest }
             | Symbols_removed ->
-                Ok { caps = []; markers; rt_symbols; build; manifest }
+                Ok { caps = []; markers; attribution; rt_symbols; build; manifest }
             | Dead_stripped ->
                 let caps =
                   if markers <> [] then markers
@@ -203,4 +247,4 @@ let read path : (t, string) result =
                       rt_symbols
                     |> List.sort_uniq String.compare
                 in
-                Ok { caps; markers; rt_symbols; build; manifest }))
+                Ok { caps; markers; attribution; rt_symbols; build; manifest }))

--- a/forge/lib/cap_binary.mli
+++ b/forge/lib/cap_binary.mli
@@ -22,6 +22,20 @@ type build_kind =
 type t = {
   caps : string list;        (** normalized; markers preferred, symbols as fallback *)
   markers : string list;     (** cap paths recovered from [__march_cap_*] globals *)
+  attribution : (string * string) list;
+      (** [(cap_path, owner_module)] from [__march_capfrom_*] globals: which
+          module's code performs the IO, so a capability can be traced to the
+          dependency that introduced it rather than only to the program.
+
+          Computed by the compiler BEFORE inlining ([March_tir.Cap_attrib]) —
+          by emission time a small dependency function has been folded into
+          its caller and would be credited to the application instead.
+
+          A cap in [markers] with no row here is UNATTRIBUTED, not
+          unattributable-to-anyone: indirect calls through closures have no
+          statically known callee. Report that difference; do not present an
+          empty owner set as "nothing uses it". Binaries built by a
+          pre-attribution compiler have this empty entirely. *)
   rt_symbols : string list;  (** cap-bearing runtime symbols present *)
   build : build_kind;
   manifest : string option;  (** raw JSON; [None] when absent *)

--- a/forge/lib/cmd_cap.ml
+++ b/forge/lib/cmd_cap.ml
@@ -413,20 +413,57 @@ let render_report ~bin (t : Cap_binary.t) =
          \  the compiler's knowledge and is not covered by this report.\n"
          (if blocking then ", includes blocking externs" else ""));
   end;
+  (* Per-module attribution: which module's code actually performs the IO.
+     Only meaningful when the capability list itself is meaningful, so it is
+     suppressed for the build kinds whose caps are withheld above. *)
+  if t.Cap_binary.build = Cap_binary.Dead_stripped
+     && t.Cap_binary.attribution <> [] then begin
+    Buffer.add_string buf "\nAttributed to\n";
+    List.iter
+      (fun cap ->
+         let owners =
+           List.filter_map
+             (fun (c, o) -> if c = cap then Some o else None)
+             t.Cap_binary.attribution
+           |> List.sort_uniq String.compare
+         in
+         if owners <> [] then
+           Buffer.add_string buf
+             (Printf.sprintf "  %-22s%s\n" cap (String.concat ", " owners)))
+      non_foreign;
+    (* A capability with no owner row is unattributed, NOT unused — an
+       indirect call through a closure has no statically known callee.
+       Saying so is the difference between a gap and a clean bill. *)
+    let unattributed =
+      List.filter
+        (fun c ->
+           not (List.exists (fun (c', _) -> c' = c) t.Cap_binary.attribution))
+        non_foreign
+    in
+    if unattributed <> [] then
+      Buffer.add_string buf
+        (Printf.sprintf
+           "  (unattributed: %s — reached only through indirect calls, whose\n\
+           \   callee is not statically known)\n"
+           (String.concat ", " unattributed))
+  end;
   Buffer.add_string buf
     (Printf.sprintf "\nbuild: %s    coverage: %s\n"
        (build_str t.Cap_binary.build)
        (coverage_str (coverage_of t)));
   (* Say what this does and does not cover.  This is the SOUND check — it is
      read after codegen, so it sees capabilities reached through stdlib and
-     dependency code that a source-level audit misses — but it answers about
-     the whole program, so it cannot show which dependency is responsible.
-     `forge audit` answers that, less soundly. Neither subsumes the other. *)
+     dependency code that a source-level audit misses.  Since attribution
+     landed it can also name the module responsible, but only the module that
+     directly calls the builtin: a dependency reaching IO through a stdlib
+     wrapper is attributed to that wrapper.  `forge audit` answers the
+     per-package question from source, less soundly. Neither subsumes the
+     other. *)
   Buffer.add_string buf
     "\nnote: read from the built artifact, so this covers capabilities reached\n\
-    \      through stdlib and dependency code as well as your own. It is a\n\
-    \      whole-program union: it cannot attribute a capability to a specific\n\
-    \      dependency — `forge audit` does that from source.\n";
+    \      through stdlib and dependency code as well as your own. Attribution\n\
+    \      names the module that directly calls the capability — code reaching\n\
+    \      it through a stdlib wrapper is attributed to the wrapper.\n";
   Buffer.contents buf
 
 let render_json ~bin (t : Cap_binary.t) =
@@ -436,6 +473,10 @@ let render_json ~bin (t : Cap_binary.t) =
         ("binary", `String bin);
         ("caps", strs t.Cap_binary.caps);
         ("markers", strs t.Cap_binary.markers);
+        ("attribution",
+         `List (List.map (fun (c, o) ->
+             `Assoc [ ("cap", `String c); ("module", `String o) ])
+             t.Cap_binary.attribution));
         ("rt_symbols", strs t.Cap_binary.rt_symbols);
         ("build", `String (build_str t.Cap_binary.build));
         ("coverage", `String (coverage_str (coverage_of t)));

--- a/forge/test/test_cap_inspect.ml
+++ b/forge/test/test_cap_inspect.ml
@@ -9,10 +9,10 @@ open March_forge
 (* A current-compiler binary carries markers for the caps it holds; [markers]
    defaults to [caps] so fixtures model that.  Pass ~markers:[] explicitly to
    model a pre-marker or non-March binary. *)
-let mk ?(caps = []) ?markers ?(rt_symbols = [])
+let mk ?(caps = []) ?markers ?(rt_symbols = []) ?(attribution = [])
     ?(build = Cap_binary.Dead_stripped) () =
   let markers = match markers with Some m -> m | None -> caps in
-  { Cap_binary.caps; markers; rt_symbols; build; manifest = None }
+  { Cap_binary.caps; markers; attribution; rt_symbols; build; manifest = None }
 
 let test_deny_uses_lattice_subsumption () =
   let t = mk ~caps:[ "IO.FileRead" ] () in

--- a/lib/tir/cap_attrib.ml
+++ b/lib/tir/cap_attrib.ml
@@ -1,0 +1,121 @@
+(* Per-module capability attribution.  See cap_attrib.mli for why this is a
+   pre-inline TIR pass rather than a codegen side effect, and for why
+   transparent (stdlib) modules are seen through rather than reported. *)
+
+module SSet = Set.Make (String)
+
+(* March builtin name → capability, via the same name→C-symbol table codegen
+   uses.  Resolved through [c_symbol_of_march_name], NOT [mangle_extern]:
+   the latter records into the marker accumulator, and an analysis that
+   walks unreachable-at-emit code would mark capabilities the binary never
+   references. *)
+let cap_of_call (name : string) : string option =
+  March_caps.Cap_symbols.cap_of_symbol
+    (Llvm_builtins.c_symbol_of_march_name name)
+
+(* One walk collecting both halves: the capabilities this body reaches
+   directly, and the functions it calls (for the reverse call graph). *)
+let rec walk (caps, callees) (e : Tir.expr) =
+  match e with
+  | Tir.EApp (v, _) ->
+    let n = v.Tir.v_name in
+    let caps =
+      match cap_of_call n with Some c -> SSet.add c caps | None -> caps
+    in
+    (caps, SSet.add n callees)
+  | Tir.ELet (_, rhs, body) -> walk (walk (caps, callees) rhs) body
+  | Tir.ESeq (a, b) -> walk (walk (caps, callees) a) b
+  | Tir.ECase (_, branches, default) ->
+    let acc =
+      List.fold_left (fun a (br : Tir.branch) -> walk a br.Tir.br_body)
+        (caps, callees) branches
+    in
+    (match default with Some d -> walk acc d | None -> acc)
+  (* A lambda lifted into an inner fn_def is still the enclosing module's
+     code, so its uses belong to the same owner. *)
+  | Tir.ELetRec (fns, body) ->
+    let acc =
+      List.fold_left (fun a (fd : Tir.fn_def) -> walk a fd.Tir.fn_body)
+        (caps, callees) fns
+    in
+    walk acc body
+  (* ECallPtr is an indirect call with no statically known callee — see the
+     .mli on why it yields no row rather than a guess. *)
+  | Tir.ECallPtr _
+  | Tir.EAtom _ | Tir.ETuple _ | Tir.ERecord _ | Tir.EField _ | Tir.EUpdate _
+  | Tir.EAlloc _ | Tir.EStackAlloc _ | Tir.EFree _ | Tir.EReuse _
+  | Tir.EIncRC _ | Tir.EDecRC _ | Tir.EAtomicIncRC _ | Tir.EAtomicDecRC _ ->
+    (caps, callees)
+
+let attribute ?(transparent = fun _ -> false) (m : Tir.tir_module) :
+    (string * string) list =
+  (* lower.ml strips the entry file-module's name from its own declarations,
+     so an unprefixed function is the entry module's.  Dependency modules
+     keep their prefix (verified: @BigLib.load survives to emitted IR). *)
+  let entry = if m.Tir.tm_name = "" then "main" else m.Tir.tm_name in
+  let owner_of fn_name =
+    match Hot_reload.module_of_name fn_name with "" -> entry | o -> o
+  in
+  (* The entry module is the program itself; seeing through it would leave a
+     capability with nowhere to land. *)
+  let is_transparent owner = owner <> entry && transparent owner in
+
+  let direct : (string, SSet.t) Hashtbl.t = Hashtbl.create 64 in
+  let callers : (string, string list) Hashtbl.t = Hashtbl.create 256 in
+  let defined : (string, unit) Hashtbl.t = Hashtbl.create 256 in
+  List.iter
+    (fun (fn : Tir.fn_def) -> Hashtbl.replace defined fn.Tir.fn_name ())
+    m.Tir.tm_fns;
+  List.iter
+    (fun (fn : Tir.fn_def) ->
+       let caps, callees = walk (SSet.empty, SSet.empty) fn.Tir.fn_body in
+       if not (SSet.is_empty caps) then
+         Hashtbl.replace direct fn.Tir.fn_name caps;
+       SSet.iter
+         (fun callee ->
+            if Hashtbl.mem defined callee then
+              Hashtbl.replace callers callee
+                (fn.Tir.fn_name
+                 :: Option.value ~default:[] (Hashtbl.find_opt callers callee)))
+         callees)
+    m.Tir.tm_fns;
+
+  (* Nearest non-transparent owner, walking the reverse call graph.  A
+     dependency that reads a file through File.read is the responsible party;
+     attributing it to the stdlib wrapper would report the same owner for
+     every dependency in the program and answer nobody's question. *)
+  let responsible_owners fn_name =
+    if not (is_transparent (owner_of fn_name)) then [ owner_of fn_name ]
+    else begin
+      let seen = Hashtbl.create 16 in
+      let found = ref SSet.empty in
+      let rec go n =
+        if not (Hashtbl.mem seen n) then begin
+          Hashtbl.replace seen n ();
+          List.iter
+            (fun c ->
+               let o = owner_of c in
+               if is_transparent o then go c else found := SSet.add o !found)
+            (Option.value ~default:[] (Hashtbl.find_opt callers n))
+        end
+      in
+      go fn_name;
+      (* Nothing outside the transparent set reaches it — every caller is
+         stdlib, or it is reached only indirectly.  Naming the stdlib module
+         is then the honest answer rather than dropping the row. *)
+      if SSet.is_empty !found then [ owner_of fn_name ]
+      else SSet.elements !found
+    end
+  in
+
+  let seen : (string * string, unit) Hashtbl.t = Hashtbl.create 32 in
+  Hashtbl.iter
+    (fun fn_name caps ->
+       let owners = responsible_owners fn_name in
+       SSet.iter
+         (fun cap ->
+            List.iter (fun o -> Hashtbl.replace seen (cap, o) ()) owners)
+         caps)
+    direct;
+  Hashtbl.fold (fun k () acc -> k :: acc) seen []
+  |> List.sort_uniq compare

--- a/lib/tir/cap_attrib.mli
+++ b/lib/tir/cap_attrib.mli
@@ -1,0 +1,57 @@
+(** Per-module capability attribution: WHICH module's code performs the IO.
+
+    The flat [__march_cap_*] markers say a binary reads files. They cannot say
+    whether the reading code is yours or a dependency's, and that is the
+    question a per-dependency capability budget has to answer.
+
+    [attribute] pairs each capability with the March module whose function
+    body contains the call, so codegen can emit [__march_capfrom_CAP__OWNER]
+    alongside the flat markers.
+
+    {2 Why this is a TIR pass and not a codegen side effect}
+
+    The obvious implementation — record the module being emitted when
+    [Llvm_builtins.mangle_extern] resolves a cap-bearing symbol — is wrong,
+    and wrong in the dangerous direction. By emission time the inliner has
+    folded small dependency functions into their callers, so a dependency's
+    [file_read] appears inside the application's [main] and would be
+    attributed to the application. That reports a clean dependency and a
+    dirty app: exactly backwards for deciding whether to trust a dep.
+
+    Measured, not assumed: a two-line [BigLib.load] calling [file_read]
+    leaves no trace of [BigLib] in the emitted IR at all — the call site
+    lands in [@march_main].
+
+    So this runs over the pre-[Opt.run] TIR, where module prefixes still
+    exist, and after reachability pruning, so a dependency feature the
+    program never calls contributes nothing here either. *)
+
+val attribute :
+  ?transparent:(string -> bool) -> Tir.tir_module -> (string * string) list
+(** [attribute m] returns sorted, de-duplicated [(cap_path, owner_module)]
+    pairs — e.g. [("IO.FileRead", "BigLib")].
+
+    [transparent] names modules to see THROUGH rather than report — in
+    practice the stdlib. Without it, a dependency that reads a file via
+    [File.read] is attributed to [File], and since most dependencies reach IO
+    through stdlib wrappers, every capability in a real program lands on a
+    handful of stdlib modules and the report answers nobody's question.
+    Measured before this existed: a dep calling [File.read] produced
+    [IO.FileRead ← File].
+
+    When the direct owner is transparent, the reverse call graph is walked to
+    the nearest non-transparent callers, and the capability is attributed to
+    each of them. The entry module is never treated as transparent — seeing
+    through it would leave the capability nowhere to land. If nothing outside
+    the transparent set reaches the call at all, the transparent module is
+    reported rather than the row dropped.
+
+    The owner is the module prefix of the enclosing function's TIR name.
+    [lower.ml] strips the entry file-module's own name from its declarations,
+    so its functions are unprefixed; those are attributed to [m.tm_name].
+
+    Only direct calls ([Tir.EApp]) are attributed. An indirect call through a
+    closure ([Tir.ECallPtr]) has no statically known callee, so it yields no
+    row — the flat marker still reports the capability, it just carries no
+    owner. Consumers must therefore treat "flat caps minus attributed caps"
+    as unattributed rather than as absent. *)

--- a/lib/tir/dune
+++ b/lib/tir/dune
@@ -1,6 +1,6 @@
 (library
  (name march_tir)
- (modules tir_names rc_types tir pp lower_types lower_state lower_match lower_decls lower_actor lower_tests lower mono defun borrow perceus perceus_liveness perceus_elide perceus_fbip perceus_scrut repr drop escape llvm_ctx llvm_builtins llvm_eq llvm_data llvm_case llvm_calls llvm_tco llvm_toplevel llvm_repl llvm_emit js_emit purity fold simplify inline single_use_inline dce cprop opt fusion known_call policy_dce beta_adt join_points hot_reload collision_set dispatch_registry llvm_dispatch native_map_inline vectorize_check vectorize_mark)
+ (modules tir_names rc_types tir pp lower_types lower_state lower_match lower_decls lower_actor lower_tests lower mono defun borrow perceus perceus_liveness perceus_elide perceus_fbip perceus_scrut repr drop escape llvm_ctx llvm_builtins llvm_eq llvm_data llvm_case llvm_calls llvm_tco llvm_toplevel llvm_repl llvm_emit js_emit cap_attrib purity fold simplify inline single_use_inline dce cprop opt fusion known_call policy_dce beta_adt join_points hot_reload collision_set dispatch_registry llvm_dispatch native_map_inline vectorize_check vectorize_mark)
  (libraries march_ast march_typecheck march_modules march_caps)
  (foreign_stubs (language c) (names native_triple_stub))
 )

--- a/lib/tir/llvm_builtins.ml
+++ b/lib/tir/llvm_builtins.ml
@@ -1480,3 +1480,15 @@ let mangle_extern (name : string) : string =
   match Hashtbl.find_opt mangle_extern_tbl name with
   | Some c -> Hashtbl.replace called_syms c (); c
   | None -> Hashtbl.replace called_syms name (); name
+
+(** [mangle_extern] without the [called_syms] side effect: same March-name →
+    C-symbol resolution, including the identity fallthrough.
+
+    Analyses that ask "what symbol WOULD this name resolve to?" must use this
+    rather than [mangle_extern].  Recording a symbol that emission never
+    actually referenced would mark a capability in a binary that does not use
+    it — the app-invariance trap the marker scheme exists to avoid. *)
+let c_symbol_of_march_name (name : string) : string =
+  match Hashtbl.find_opt mangle_extern_tbl name with
+  | Some c -> c
+  | None -> name

--- a/lib/tir/llvm_emit.ml
+++ b/lib/tir/llvm_emit.ml
@@ -3958,10 +3958,11 @@ let emit_main_wrapper = Llvm_toplevel.emit_main_wrapper
 let emit_preamble = Llvm_toplevel.emit_preamble
 
 let emit_module ?fast_math ?pmap_threshold ?target ?hot_reload ?impl_hashes
-    ?remote_impl_hashes ?remote_sig_hashes ?emit_main (m : Tir.tir_module) : string =
+    ?remote_impl_hashes ?remote_sig_hashes ?emit_main ?cap_attrib
+    (m : Tir.tir_module) : string =
   Llvm_toplevel.emit_module ~emit_expr
     ?fast_math ?pmap_threshold ?target ?hot_reload ?impl_hashes
-    ?remote_impl_hashes ?remote_sig_hashes ?emit_main m
+    ?remote_impl_hashes ?remote_sig_hashes ?emit_main ?cap_attrib m
 
 type repl_globals = Llvm_repl.repl_globals
 let emit_repl_globals_decl = Llvm_repl.emit_repl_globals_decl

--- a/lib/tir/llvm_toplevel.ml
+++ b/lib/tir/llvm_toplevel.ml
@@ -580,6 +580,7 @@ let emit_module ~emit_expr
     ?(remote_impl_hashes=(Hashtbl.create 0 : (string, string) Hashtbl.t))
     ?(remote_sig_hashes=(Hashtbl.create 0 : (string, string) Hashtbl.t))
     ?(emit_main=true)
+    ?(cap_attrib=([] : (string * string) list))
     (m : Tir.tir_module) : string =
   (* type defs are threaded via ctx.type_defs (set below); reset the
      repr-consistency audit per module emission. *)
@@ -1209,18 +1210,58 @@ let emit_module ~emit_expr
             @ l)
      |> List.sort_uniq String.compare
    in
+   let mangle_cap c = String.map (fun ch -> if ch = '.' then '_' else ch) c in
+   (* Per-module attribution (see cap_attrib.mli).  Computed pre-inline by the
+      driver and handed in, because by the time we are here the inliner has
+      already dissolved the module boundaries this needs.
+
+      Filtered against [caps]: attribution is computed on the pre-opt TIR, so
+      a call site that cprop/fold later proves dead would otherwise be
+      reported as a capability the final binary does not have.  Intersecting
+      guarantees the owner rows are a subset of the flat markers.
+
+      A flat cap with no owner row is UNATTRIBUTED, not absent — indirect
+      calls through closures have no statically known callee.  Consumers
+      compute that difference themselves rather than reading a sentinel. *)
+   let attrib =
+     cap_attrib
+     |> List.filter (fun (cap, owner) ->
+            owner <> "" && List.mem cap caps)
+     |> List.sort_uniq compare
+   in
    if caps <> [] then begin
-     let mangle_cap c = String.map (fun ch -> if ch = '.' then '_' else ch) c in
      List.iter
        (fun cap ->
           Buffer.add_string out
             (Printf.sprintf "@__march_cap_%s = constant i8 1\n"
                (mangle_cap cap)))
        caps;
+     (* Distinct prefix, NOT a longer @__march_cap_ name: the forge reader
+        matches that prefix and takes the whole remainder as the cap path, so
+        @__march_cap_IO_FileRead__BigLib would decode as a bogus capability
+        named "IO_FileRead__BigLib".  "__march_capfrom_" shares no prefix with
+        "__march_cap_" (they differ at the 12th character).  Cap paths never
+        contain "__", so splitting the remainder on the FIRST "__" recovers
+        (cap, owner) unambiguously.
+
+        The OWNER is emitted verbatim — LLVM global names permit dots, and
+        mangling them would be irreversible: a module named My_Mod and a
+        nested module My.Mod would collide on one encoding. *)
+     List.iter
+       (fun (cap, owner) ->
+          Buffer.add_string out
+            (Printf.sprintf "@__march_capfrom_%s__%s = constant i8 1\n"
+               (mangle_cap cap) owner))
+       attrib;
      let refs =
        List.map
          (fun cap -> Printf.sprintf "ptr @__march_cap_%s" (mangle_cap cap))
          caps
+       @ List.map
+           (fun (cap, owner) ->
+              Printf.sprintf "ptr @__march_capfrom_%s__%s" (mangle_cap cap)
+                owner)
+           attrib
      in
      Buffer.add_string out
        (Printf.sprintf

--- a/specs/progress/2026-08-04-per-module-cap-attribution.md
+++ b/specs/progress/2026-08-04-per-module-cap-attribution.md
@@ -1,0 +1,102 @@
+# Per-module capability attribution
+
+Shipped 2026-08-04. `forge cap inspect` now reports which module's code
+performs each capability's IO, not only that the binary performs it.
+
+    Capabilities — ./myapp
+      IO.Console              [march_print]
+      IO.FileRead             [march_file_read]
+
+    Attributed to
+      IO.Console            MyApp
+      IO.FileRead           StdDep
+
+## Why this had to be a pre-inline TIR pass
+
+The obvious implementation is a codegen side effect: `Llvm_builtins.mangle_extern`
+already records every cap-bearing C symbol it resolves, and `emit_fn` already
+sets `ctx.cur_emit_fn`, so pairing them looks like a two-line change.
+
+It is wrong, and wrong in the dangerous direction. Measured before writing any
+code: a two-line `BigLib.load` calling `file_read`, called from `main`, leaves
+**no trace of `BigLib` in the emitted IR at all** — the inliner folds it into
+the caller and the `march_file_read` call site lands in `@march_main`. Codegen
+attribution would report that the *application* reads files and the dependency
+does not: a false clean bill for exactly the party you are inspecting.
+
+So `Cap_attrib.attribute` runs on the pre-`Opt.run` TIR, where module prefixes
+still exist (verified: `@BigLib.load` survives to emitted IR when the function
+is too large to inline), over a `Dce.prune_unreachable` copy, so a dependency
+feature nothing calls contributes no owner row.
+
+Both passes are pure, so this observes the pipeline without perturbing it.
+
+## The stdlib-wrapper problem, and the transparent-module walk
+
+First working version reported `IO.FileRead ← File` for a dependency that read
+a file through the stdlib's `File.read`. Since most dependencies reach IO
+through a stdlib wrapper, every capability in a real program landed on a
+handful of stdlib modules — a report that names the same owner regardless of
+which dependency is responsible answers nobody's question, and would have made
+the per-dependency budgets this feature exists to enable impossible.
+
+`attribute ~transparent` therefore walks the reverse call graph through stdlib
+modules to the nearest non-stdlib callers. The transparent set is derived from
+the stdlib declarations actually loaded (`stdlib_module_names` in `bin/main.ml`,
+mirroring `stdlib_span_files`), **not** from a hand-maintained name list —
+`Resolver.stdlib_module_names` is the cautionary example, having carried
+`Depot*` names that ship in a third-party package and a mis-cased `URI` that
+was never a module.
+
+The entry module is never transparent; seeing through it would leave a
+capability with nowhere to land.
+
+## Marker encoding
+
+`@__march_capfrom_<CAP>__<OWNER>`, pinned in `@llvm.used` like the flat
+markers so `-dead_strip` cannot drop them.
+
+Two encoding decisions that are load-bearing:
+
+- The prefix is **not** a longer `__march_cap_` name. `Cap_binary` matches that
+  prefix and takes the whole remainder as the capability path, so
+  `@__march_cap_IO_FileRead__BigLib` would decode as a bogus capability named
+  `IO_FileRead__BigLib`. `__march_capfrom_` diverges at the 12th character.
+  Pinned by a test.
+- The owner is emitted **verbatim**, dots and all (LLVM global names permit
+  them). Mangling `.`→`_` would be irreversible: a module named `My_Mod` and a
+  nested module `My.Mod` would share one encoding.
+
+Capability paths never contain `__`, so splitting the remainder on the first
+`__` recovers `(cap, owner)` unambiguously.
+
+## Known limits
+
+- **Indirect calls are unattributed.** `ECallPtr` has no statically known
+  callee. The flat marker still reports the capability; the report names it as
+  unattributed rather than omitting it, because an empty owner set must not
+  read as "nothing uses it".
+- **`prelude.march` is invisible.** `load_stdlib_file` unwraps it into global
+  scope, so its members are bare-named and indistinguishable from the entry
+  module's. A capability used only by a prelude function is attributed to the
+  entry module.
+- **Attribution is per-module, not per-package.** Mapping modules to packages
+  is forge's job (it already does this in `cap_package.ml`) and is the next
+  step toward per-dependency capability budgets in `forge.toml`.
+- **Over-approximation is filtered, not prevented.** Attribution is computed
+  pre-opt, so a call site that `cprop`/`fold` later proves dead would be
+  reported. Emission intersects the owner rows against the flat marker set, so
+  the owners are always a subset of the capabilities the binary actually has.
+
+## Where the code is
+
+- `lib/tir/cap_attrib.ml` / `.mli` — the analysis
+- `lib/tir/llvm_toplevel.ml` — marker emission (alongside the flat markers)
+- `lib/tir/llvm_builtins.ml` — `c_symbol_of_march_name`, the side-effect-free
+  twin of `mangle_extern` (recording there would mark capabilities the binary
+  never references)
+- `bin/main.ml` — `stdlib_module_names`, and the pre-`Opt.run` call site
+- `forge/lib/cap_binary.ml` — the `attribution` channel
+- `forge/lib/cmd_cap.ml` — the "Attributed to" section and JSON field
+- `test/test_cap_markers.ml` — four cases, each measured in its failing state
+  before the fix

--- a/test/test_cap_markers.ml
+++ b/test/test_cap_markers.ml
@@ -117,3 +117,145 @@ let tests =
     Alcotest.test_case "no marker for unused capability" `Slow
       test_marker_absent_for_unused_cap;
   ]
+
+(* ── Per-module attribution (lib/tir/cap_attrib.ml) ──────────────────────
+   The flat marker says the binary reads files; @__march_capfrom_ says WHOSE
+   code does the reading.  Each case below is a route by which attribution
+   was measured to go wrong, or would go wrong under the obvious
+   implementation. *)
+
+let attrib_inlined_src =
+  {|
+mod AttribApp do
+  mod Dep do
+    needs IO.FileRead
+    fn slurp(p : String) : String do
+      match file_read(p) do
+        Ok(s)  -> s
+        Err(_) -> ""
+      end
+    end
+  end
+  fn main() : () do
+    println(Dep.slurp("/etc/hosts"))
+  end
+end
+|}
+
+let test_attributed_to_dep_not_app_despite_inlining () =
+  (* The load-bearing case.  [Dep.slurp] is small enough that the inliner
+     folds it into main and no trace of [Dep] survives to the emitted IR —
+     measured.  Attributing at codegen time would therefore credit the
+     dependency's file read to the application: a clean bill for the
+     dependency and a false one for the app, which is the wrong direction for
+     every decision this feature exists to support.  Attribution is taken
+     pre-inline precisely so this says Dep. *)
+  let ir = emit_ir attrib_inlined_src in
+  Alcotest.(check bool) "IO.FileRead attributed to Dep" true
+    (contains ir "@__march_capfrom_IO_FileRead__Dep");
+  Alcotest.(check bool) "IO.FileRead NOT attributed to the app" false
+    (contains ir "@__march_capfrom_IO_FileRead__AttribApp")
+
+let attrib_stdlib_wrapper_src =
+  {|
+mod WrapApp do
+  mod Dep do
+    needs IO.FileRead
+    fn slurp(p : String) : String do
+      match File.read(p) do
+        Ok(s)  -> s
+        Err(_) -> ""
+      end
+    end
+  end
+  fn main() : () do
+    println(Dep.slurp("/etc/hosts"))
+  end
+end
+|}
+
+let test_stdlib_wrapper_is_seen_through () =
+  (* Before the transparent-module walk this reported [File] — and since most
+     dependencies reach IO through a stdlib wrapper, every capability in a
+     real program landed on a handful of stdlib modules.  A report that names
+     the same owner regardless of which dependency is responsible answers
+     nobody's question, so stdlib is walked through to the caller. *)
+  let ir = emit_ir attrib_stdlib_wrapper_src in
+  Alcotest.(check bool) "attributed to the calling module" true
+    (contains ir "@__march_capfrom_IO_FileRead__Dep");
+  Alcotest.(check bool) "NOT attributed to the stdlib wrapper" false
+    (contains ir "@__march_capfrom_IO_FileRead__File")
+
+let attrib_unused_feature_src =
+  {|
+mod PartialApp do
+  mod Dep do
+    needs IO.FileRead
+    fn add(a : Int, b : Int) : Int do
+      a + b
+    end
+    fn slurp(p : String) : String do
+      match file_read(p) do
+        Ok(s)  -> s
+        Err(_) -> ""
+      end
+    end
+  end
+  fn main() : () do
+    println(Int.to_string(Dep.add(2, 3)))
+  end
+end
+|}
+
+let test_unused_feature_contributes_nothing () =
+  (* Using one function of a module must not import the capabilities of the
+     functions you did not call — neither the flat marker nor an owner row.
+     Attribution runs after reachability pruning so that stays true. *)
+  let ir = emit_ir attrib_unused_feature_src in
+  Alcotest.(check bool) "no IO.FileRead marker at all" false
+    (contains ir "@__march_cap_IO_FileRead");
+  Alcotest.(check bool) "no IO.FileRead owner row either" false
+    (contains ir "@__march_capfrom_IO_FileRead")
+
+let test_attribution_prefix_cannot_be_read_as_a_flat_marker () =
+  (* forge's Cap_binary matches the "__march_cap_" prefix and takes the whole
+     remainder as the capability path.  An attribution marker spelled
+     @__march_cap_IO_FileRead__Dep would decode as a bogus capability named
+     "IO_FileRead__Dep", so the two prefixes must diverge before that point. *)
+  let ir = emit_ir attrib_inlined_src in
+  Alcotest.(check bool) "attribution markers do not start with __march_cap_"
+    false
+    (contains ir "@__march_cap_IO_FileRead__")
+
+let tests =
+  tests
+  @ [
+      Alcotest.test_case "attributed to the dep despite inlining" `Slow
+        test_attributed_to_dep_not_app_despite_inlining;
+      Alcotest.test_case "stdlib wrapper is seen through" `Slow
+        test_stdlib_wrapper_is_seen_through;
+      Alcotest.test_case "unused feature contributes no owner row" `Slow
+        test_unused_feature_contributes_nothing;
+      Alcotest.test_case "attribution prefix is not a flat-marker prefix" `Slow
+        test_attribution_prefix_cannot_be_read_as_a_flat_marker;
+    ]
+
+let test_indirect_call_is_unattributed_not_absent () =
+  (* [direct_pass_src] invokes file_read through a closure, so no statically
+     known callee exists and attribution genuinely cannot see it.  The FLAT
+     marker still must — the two channels complement each other, and a
+     capability that is real but unattributed must never look like an absent
+     one.  Measured: `forge cap inspect` renders this as an explicit
+     "unattributed" line rather than an empty owner set. *)
+  let ir = emit_ir direct_pass_src in
+  Alcotest.(check bool) "flat marker still reports the capability" true
+    (contains ir "@__march_cap_IO_FileRead");
+  Alcotest.(check bool) "but no owner row is invented" false
+    (contains ir "@__march_capfrom_IO_FileRead")
+
+let tests =
+  tests
+  @ [
+      Alcotest.test_case "indirect call is unattributed, not absent" `Slow
+        test_indirect_call_is_unattributed_not_absent;
+    ]


### PR DESCRIPTION
`forge cap inspect` now reports **which module's code** performs each capability's IO, not only that the binary performs it.

```
Capabilities — ./myapp
  IO.Console              [march_print]
  IO.FileRead             [march_file_read]

Attributed to
  IO.Console            MyApp
  IO.FileRead           StdDep
```

This is the prerequisite for per-dependency capability budgets: the whole-program union could say "this binary reads files" but never whether the reading code was yours or a dependency's.

## Why this is a pre-inline TIR pass

The obvious implementation is a codegen side effect — `mangle_extern` already records every cap-bearing C symbol it resolves, and `emit_fn` already tracks the current function, so pairing them looks like a two-line change.

It is wrong, and wrong in the dangerous direction. Measured before writing any code: a two-line `BigLib.load` calling `file_read`, called from `main`, leaves **no trace of `BigLib` in the emitted IR at all** — the inliner folds it into the caller and the `march_file_read` call site lands in `@march_main`. Codegen attribution would report that the *application* reads files and the dependency does not: a false clean bill for exactly the party you are inspecting.

So attribution runs on the pre-`Opt.run` TIR, where module prefixes still exist, over a `Dce.prune_unreachable` copy so a dependency feature nothing calls contributes no owner row. Both passes are pure.

## The stdlib-wrapper problem

The first working version reported `IO.FileRead ← File` for a dependency reading through the stdlib's `File.read`. Since most dependencies reach IO through a stdlib wrapper, every capability in a real program landed on a handful of stdlib modules — a report naming the same owner regardless of which dependency is responsible answers nobody's question.

`attribute ~transparent` walks the reverse call graph through stdlib to the nearest non-stdlib callers. The transparent set is derived from the stdlib declarations actually loaded, **not** a hand-maintained list — `Resolver.stdlib_module_names` is the cautionary example, having carried `Depot*` names that ship in a third-party package and a mis-cased `URI` that was never a module.

## Honest gaps

- **Indirect calls are unattributed, not omitted.** A closure call has no statically known callee. The flat marker still reports the capability and the output says so explicitly — an empty owner set must never read as "nothing uses it".
- **`prelude.march` is invisible** (unwrapped into global scope, so bare-named); its capabilities land on the entry module.
- **Per-module, not per-package.** Mapping modules to packages is forge's job and is the next step.

## Marker encoding

`@__march_capfrom_<CAP>__<OWNER>`, pinned in `@llvm.used` so `-dead_strip` cannot drop it. Two load-bearing decisions, both pinned by tests:

- The prefix diverges from `__march_cap_` before the 12th character. `Cap_binary` matches that prefix and takes the whole remainder as the cap path, so `@__march_cap_IO_FileRead__BigLib` would decode as a bogus capability named `IO_FileRead__BigLib`.
- The owner is emitted **verbatim** — mangling `.`→`_` would make `My_Mod` and `My.Mod` share one encoding.

## Testing

Four attribution cases plus the unattributed case in `test/test_cap_markers.ml`, each measured in its failing state before the fix. Full suite: 830 tests, one failure — `adversarial-regressions.040` (ASAN), which is environmental: a trivial unrelated `clang -fsanitize=address` C program also hangs >2min on this box under load 21.9. `check-docs.sh` and the pagefind index check both pass; forge's own suites pass.
