### PR TITLE
docs: document OS-level capability enforcement (forge cap run, --cap-sandbox)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,18 @@ git log is authoritative for exact commits.
   an exact current-module match. Genuinely ambiguous references, where the
   current package owns none of the candidates, still error.
 
+### Documentation
+
+- **OS-level capability enforcement is now documented.** The capabilities guide
+  gains an "OS-level enforcement" section covering `forge cap run` (an
+  externally imposed sandbox) and `--cap-sandbox` (a deny-default profile a
+  binary installs on itself at startup — macOS Seatbelt / Linux seccomp-bpf,
+  fail-closed), with the honest defense-in-depth framing and the per-platform
+  advisory caveats. The capability-audit and tooling pages cross-link to it and
+  distinguish *reading* a binary's authority (`forge cap inspect`) from
+  *enforcing* it, and the `forge cap` tooling reference now lists the
+  `coverage`, `inspect`, and `run` subcommands alongside `query`.
+
 ### Added
 
 - **`forge audit --inferred`: infer each dependency's capability set from its

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -478,7 +478,43 @@ end
 
 ## Runtime behaviour
 
-All `Cap(X)` values are **runtime-erased**. They compile to `null` in LLVM IR and to `VUnit` in the interpreter. No allocation, no indirection, no overhead. Enforcement is purely at compile time.
+All `Cap(X)` values are **runtime-erased**. They compile to `null` in LLVM IR and to `VUnit` in the interpreter. No allocation, no indirection, no overhead. Enforcement of the capability *types* is purely at compile time — but a compiled binary can additionally turn its declared set into a kernel-enforced sandbox at startup; see [OS-level enforcement](#os-level-enforcement--sandboxing-the-compiled-binary) below.
+
+---
+
+## OS-level enforcement — sandboxing the compiled binary
+
+Capability *types* are checked at compile time and then erased (above). That verifies your March code, but it says nothing about what the process may do once it is running: an `extern` C call, a `dlopen`, or a raw syscall is past the point the compiler can see. This is the [`IO.Foreign`](#ioforeign--calling-unverified-c) boundary, and the gap [`forge audit`]({{ site.baseurl }}/docs/capability-audit/#what-this-does-and-does-not-prove) is explicit about not closing. March can close it at the OS level, turning the declared capability set into an actual confinement.
+
+There are two mechanisms — one imposed on the process from outside, one built into it.
+
+### `forge cap run` — externally imposed (the stronger one)
+
+`forge cap run` launches a binary under a sandbox that *forge* installs before the program gets control:
+
+```
+$ forge cap run ./build/myapp                        # policy from the binary's own claim
+$ forge cap run --allow-only IO.Console ./untrusted   # policy YOU choose
+```
+
+For a binary you do **not** trust, pass `--allow-only`: deriving the policy from the binary's own claim only tells you what it admits to, which is worthless against code trying to hide. Where a capability cannot be enforced by the platform's available primitive, `forge cap run` reports it as **advisory** per capability rather than pretending to enforce it. This is the stronger of the two mechanisms, because the launcher — not the code being confined — chooses the policy.
+
+### `--cap-sandbox` — self-imposed (defense in depth)
+
+Compiling with `--cap-sandbox` embeds a **deny-default** profile, derived from *this program's own* declared capabilities, that the binary installs on itself at startup before any user code runs:
+
+```
+$ march --compile --cap-sandbox -o build/myapp app.march
+```
+
+- **macOS** — a Seatbelt (SBPL) profile via `sandbox_init()`. Deny-default, then each declared capability opens a specific hole: `IO.FileWrite` allows writes (narrowed to the path scopes you declared, otherwise blanket), `IO.Network` allows sockets, `IO.Process` allows fork. `IO.FileRead` is **advisory** here — dyld must map system libraries before any user code exists, so the baseline allows reads unconditionally and a scoped read rule would be decorative.
+- **Linux** — an unprivileged in-process **seccomp-bpf** filter (`PR_SET_NO_NEW_PRIVS` + `PR_SET_SECCOMP`). One syscall class is denied per *withheld* capability: no `IO.Network` blocks `socket`/`socketpair`, no `IO.Process` blocks `execve`/`execveat`, no `IO.FileWrite` blocks the write path — denied calls return `EPERM`. `IO.FileRead` is not enforced here either, because seccomp filters syscall *numbers*, not paths; path-scoped reads come from `forge cap run`'s mount namespace instead.
+
+Installation **fails closed**: if the sandbox cannot be installed, the program refuses to run rather than continue unconfined.
+
+`--cap-sandbox` is **opt-in defense-in-depth**, not a guarantee against a hostile *publisher* — whoever builds the binary chooses whether to compile it in, so a malicious author simply omits it. Its purpose is a binary *you* built and trust, deployed somewhere `forge` is not the launcher — under systemd, a supervisor, a container entrypoint — the exact case `forge cap run` cannot reach. When you control the launcher, prefer `forge cap run`.
+
+Because both mechanisms confine the **whole process**, they bound even the code the compiler cannot see — `extern` C, `dlopen`, raw syscalls. They are the enforcement counterpart to [`forge cap inspect`]({{ site.baseurl }}/docs/capability-audit/#auditing-a-compiled-binary): `inspect` *reads* what a binary holds; these *enforce* what it may do.
 
 ---
 

--- a/docs/capability-audit.md
+++ b/docs/capability-audit.md
@@ -199,12 +199,26 @@ Use both. `forge audit` tells you which dependency changed and does so before
 anything is built; `forge cap inspect` tells you what the artifact you are about
 to ship actually carries.
 
+### Reading is not enforcing
+
+Both commands on this page *read* — they report authority, they do not restrain
+it. The rows above marked "bounds nothing" (`IO.Foreign`, raw syscalls, an
+undeclared builtin call) are a limit of *reading a declaration or a symbol
+table*, not a limit of what March can enforce. To turn the declared set into an
+actual OS-level confinement — one that bounds even `extern` C and raw syscalls
+because it confines the whole process — see [OS-level
+enforcement]({{ site.baseurl }}/docs/capabilities/#os-level-enforcement--sandboxing-the-compiled-binary):
+`forge cap run` (a sandbox forge installs around the binary) and `--cap-sandbox`
+(a deny-default profile the binary installs on itself at startup).
+
 ---
 
 ## See also
 
 - [Capabilities]({{ site.baseurl }}/docs/capabilities/) — the language feature
-  these tools report on
+  these tools report on, including
+  [OS-level enforcement]({{ site.baseurl }}/docs/capabilities/#os-level-enforcement--sandboxing-the-compiled-binary)
+  (`forge cap run`, `--cap-sandbox`) that turns a declared set into a real sandbox
 - [Safety by Construction]({{ site.baseurl }}/docs/safety-by-construction/) —
   how capabilities sit alongside the other safety axes
 - [FFI]({{ site.baseurl }}/docs/ffi/) — the `extern` boundary, and why analysis

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -585,6 +585,22 @@ Example output for a project with a typestate database handle:
 
 This gives you a top-level map of what your codebase touches and what resource lifecycles it manages — useful during code review, security audits, or onboarding a new contributor.
 
+`forge cap coverage` reports which of the capabilities your project holds are exercised by tests and which are not — a `Covered` / `Uncovered` list and an `N/M capabilities covered (X%)` summary — so a capability that no test ever drives is easy to spot.
+
+### Reading and enforcing a compiled binary
+
+The subcommands above read source. Two more work on a built artifact:
+
+```sh
+forge cap inspect ./build/myapp                          # what capabilities does this binary hold?
+forge cap inspect ./build/myapp --deny IO.Network         # fail if it holds IO.Network (repeatable)
+forge cap inspect ./build/myapp --allow-only IO.Console    # fail if it holds anything outside this set
+forge cap run ./build/myapp                               # run it under a sandbox forge installs
+forge cap run --allow-only IO.Console ./untrusted          # run untrusted code with a policy YOU choose
+```
+
+`forge cap inspect` cross-checks capability markers the compiler emitted, capability-bearing runtime symbols that survived dead-stripping, and an embedded manifest when present; `--deny`/`--allow-only` are **fail-closed** (they fail on a binary whose coverage is not full, and foreign code requires `--allow-foreign`). `forge cap run` is the enforcing counterpart — it launches the binary under an OS sandbox before the program gets control. Both are covered in depth on the [Capability Audit](capability-audit.md) page and under [OS-level enforcement]({{ site.baseurl }}/docs/capabilities/#os-level-enforcement--sandboxing-the-compiled-binary); a binary can also sandbox *itself* at startup when compiled with `march --compile --cap-sandbox`.
+
 ---
 
 ## Dependency Management

--- a/specs/lang/capabilities.md
+++ b/specs/lang/capabilities.md
@@ -468,7 +468,43 @@ end
 
 ## Runtime behaviour
 
-All `Cap(X)` values are **runtime-erased**. They compile to `null` in LLVM IR and to `VUnit` in the interpreter. No allocation, no indirection, no overhead. Enforcement is purely at compile time.
+All `Cap(X)` values are **runtime-erased**. They compile to `null` in LLVM IR and to `VUnit` in the interpreter. No allocation, no indirection, no overhead. Enforcement of the capability *types* is purely at compile time — but a compiled binary can additionally turn its declared set into a kernel-enforced sandbox at startup; see [OS-level enforcement](#os-level-enforcement--sandboxing-the-compiled-binary) below.
+
+---
+
+## OS-level enforcement — sandboxing the compiled binary
+
+Capability *types* are checked at compile time and then erased (above). That verifies your March code, but it says nothing about what the process may do once it is running: an `extern` C call, a `dlopen`, or a raw syscall is past the point the compiler can see. This is the [`IO.Foreign`](#ioforeign--calling-unverified-c) boundary, and the gap [`forge audit`]({{ site.baseurl }}/docs/capability-audit/#what-this-does-and-does-not-prove) is explicit about not closing. March can close it at the OS level, turning the declared capability set into an actual confinement.
+
+There are two mechanisms — one imposed on the process from outside, one built into it.
+
+### `forge cap run` — externally imposed (the stronger one)
+
+`forge cap run` launches a binary under a sandbox that *forge* installs before the program gets control:
+
+```
+$ forge cap run ./build/myapp                        # policy from the binary's own claim
+$ forge cap run --allow-only IO.Console ./untrusted   # policy YOU choose
+```
+
+For a binary you do **not** trust, pass `--allow-only`: deriving the policy from the binary's own claim only tells you what it admits to, which is worthless against code trying to hide. Where a capability cannot be enforced by the platform's available primitive, `forge cap run` reports it as **advisory** per capability rather than pretending to enforce it. This is the stronger of the two mechanisms, because the launcher — not the code being confined — chooses the policy.
+
+### `--cap-sandbox` — self-imposed (defense in depth)
+
+Compiling with `--cap-sandbox` embeds a **deny-default** profile, derived from *this program's own* declared capabilities, that the binary installs on itself at startup before any user code runs:
+
+```
+$ march --compile --cap-sandbox -o build/myapp app.march
+```
+
+- **macOS** — a Seatbelt (SBPL) profile via `sandbox_init()`. Deny-default, then each declared capability opens a specific hole: `IO.FileWrite` allows writes (narrowed to the path scopes you declared, otherwise blanket), `IO.Network` allows sockets, `IO.Process` allows fork. `IO.FileRead` is **advisory** here — dyld must map system libraries before any user code exists, so the baseline allows reads unconditionally and a scoped read rule would be decorative.
+- **Linux** — an unprivileged in-process **seccomp-bpf** filter (`PR_SET_NO_NEW_PRIVS` + `PR_SET_SECCOMP`). One syscall class is denied per *withheld* capability: no `IO.Network` blocks `socket`/`socketpair`, no `IO.Process` blocks `execve`/`execveat`, no `IO.FileWrite` blocks the write path — denied calls return `EPERM`. `IO.FileRead` is not enforced here either, because seccomp filters syscall *numbers*, not paths; path-scoped reads come from `forge cap run`'s mount namespace instead.
+
+Installation **fails closed**: if the sandbox cannot be installed, the program refuses to run rather than continue unconfined.
+
+`--cap-sandbox` is **opt-in defense-in-depth**, not a guarantee against a hostile *publisher* — whoever builds the binary chooses whether to compile it in, so a malicious author simply omits it. Its purpose is a binary *you* built and trust, deployed somewhere `forge` is not the launcher — under systemd, a supervisor, a container entrypoint — the exact case `forge cap run` cannot reach. When you control the launcher, prefer `forge cap run`.
+
+Because both mechanisms confine the **whole process**, they bound even the code the compiler cannot see — `extern` C, `dlopen`, raw syscalls. They are the enforcement counterpart to [`forge cap inspect`]({{ site.baseurl }}/docs/capability-audit/#auditing-a-compiled-binary): `inspect` *reads* what a binary holds; these *enforce* what it may do.
 
 ---
 


### PR DESCRIPTION
`--cap-sandbox` (self-imposed macOS Seatbelt / Linux seccomp-bpf sandbox) and `forge cap run` (externally imposed) shipped but were **entirely undocumented** — zero mentions across `docs/`. This fills the gap.

## What changed
- **`docs/capabilities.md` + `specs/lang/capabilities.md` (reference twin):** new **OS-level enforcement** section covering both mechanisms:
  - `forge cap run` — sandbox forge installs around the binary; `--allow-only` for untrusted code; advisory caps reported honestly. The stronger mechanism (the launcher picks the policy).
  - `--cap-sandbox` — deny-default profile the binary installs on itself at startup. macOS: SBPL via `sandbox_init()` (FileRead advisory — dyld needs unconditional read). Linux: unprivileged seccomp-bpf, one syscall class denied per *withheld* capability (`socket`/`execve`/write path → `EPERM`), **fail-closed**. Framed as opt-in defense-in-depth (a hostile publisher just omits it).
  - Both confine the whole process, so they bound even `extern` C / raw syscalls — the enforcement counterpart to `forge cap inspect`'s *reading*.
- **`docs/capability-audit.md`:** a "Reading is not enforcing" note closing the `IO.Foreign` 'bounds nothing' gap at the OS level, plus a See-also link.
- **`docs/tooling.md`:** the `forge cap` reference now lists `coverage`, `inspect`, and `run` (previously only `query`). Also corrected `coverage`'s description — it reports **test** coverage of capabilities, not enforcement coverage (verified against `forge/lib/cmd_cap.ml`).
- **CHANGELOG:** `### Documentation` entry.

All facts verified against source (`bin/main.ml` cap_sandbox_define, `runtime/march_runtime.c` seccomp/SBPL builders, `forge/lib/cmd_cap.ml`, `forge/bin/main.ml` cap subcommand wiring). `scripts/check-docs.sh` passes.