### PR TITLE
feat(caps): --cap-strict — `needs` as a hard ceiling, checked against emitted code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,29 @@ git log is authoritative for exact commits.
 
 ### Added
 
+- **`--cap-strict`: `needs` as a hard ceiling.** Opt-in build gate — every
+  module's emitted code must stay within that module's own `needs`
+  declarations, or the build fails naming the module.
+
+  This closes a gap that was wider than the known one. `needs` was documented
+  as a floor that capability-passing code could not go under, with direct
+  builtin calls a warning rather than an error. Measured, a *stdlib-mediated*
+  call (`File.write(…)`) produced **no diagnostic at all** — not even the
+  warning — because the import check walks `use` declarations and stdlib
+  modules are ambiently available without one. That is the most common route
+  in real code.
+
+  The check runs against emitted code rather than as another source-level
+  walk, so every route — direct builtin, stdlib wrapper, builtin passed as a
+  value — collapses into one rule that re-routing through a helper cannot
+  evade. It applies per-module, so **a dependency that declares
+  `needs IO.Console` and reads `/etc/passwd` fails the build**, without that
+  dependency having opted in to anything.
+
+  A capability that cannot be attributed to any module fails the check rather
+  than passing it. `IO.Foreign` is excluded (extern blocks are already an
+  error when undeclared), and FFI remains outside what any of this can see.
+
 - **`forge cap inspect` now says WHICH module uses each capability.** The
   report gained an "Attributed to" section: `IO.FileRead   Conduit.Store`
   instead of only "this binary reads files". This is what makes it possible to

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -869,6 +869,7 @@ let own_caps_of_this_module typecheck_env (m : March_ast.Ast.module_) : string l
   |> List.sort String.compare
 
 let cap_sandbox    = ref false   (* --cap-sandbox: embed a self-imposed capability sandbox profile *)
+let cap_strict     = ref false   (* --cap-strict: `needs` is a hard ceiling, checked against attributed use *)
 let check_json     = ref false   (* --check-json: emit diagnostics as NDJSON to stdout *)
 let emit_core_ast_file = ref None  (* --emit-core-ast <file>: dump desugared core AST + verdict + diagnostics as JSON to stdout *)
 let measure_axioms = ref true    (* --no-measure-axioms: reflect @[measure]s symbolically *)
@@ -1830,6 +1831,7 @@ let compile filename =
               (* --cap-sandbox changes the emitted binary (a -D define), so a
                  non-sandboxed cached artifact must never satisfy it. *)
               @ (if !cap_sandbox then ["capsandbox"] else [])
+              @ (if !cap_strict then ["capstrict"] else [])
               @ cross_sysroot_tag
               @ (if !signing_pubkey <> "" then ["spk:" ^ !signing_pubkey] else [])) in
         let ch = March_cas.Cas.compilation_hash src_hash ~target:target_label ~flags:cas_flags in
@@ -2561,6 +2563,51 @@ let compile filename =
         ~transparent:(fun m -> List.mem m stdlib_mods)
         (March_tir.Dce.prune_unreachable pre_opt_tir)
     in
+    (* --cap-strict: `needs` as a hard ceiling.  Deliberately checked here,
+       against attributed use, rather than by a fifth source-level AST walk.
+       The four existing walks in Typecheck do NOT cover the same routes —
+       measured, a stdlib-mediated `File.write` produced no diagnostic at all,
+       because Check 4 walks `DUse` declarations and stdlib modules are
+       ambiently available without one.  Emitted code collapses all routes
+       into one rule and cannot be evaded by re-routing through a helper.
+
+       Runs BEFORE the CAS artifact lookup below, so a warm cache cannot
+       skip it; "capstrict" is also in cas_flags so a strict build never
+       reuses an artifact produced without the check. *)
+    if !cap_strict then begin
+      let flat_caps =
+        List.sort_uniq compare (List.map fst cap_attrib)
+        @ own_caps_of_this_module typecheck_env desugared
+        |> List.sort_uniq compare
+      in
+      (* The entry module is unwrapped by desugar (~is_entry:true), so it has
+         no DMod and never lands in [module_caps]; its `needs` accumulate in
+         [mod_needs] instead. Attribution names it by [tm_name], so bind the
+         two together or every entry-module capability reads as undeclared —
+         which is what the first run of this check did to a module that had
+         correctly declared its need. *)
+      let module_caps =
+        (pre_opt_tir.March_tir.Tir.tm_name,
+         typecheck_env.March_typecheck.Typecheck.mod_needs)
+        :: typecheck_env.March_typecheck.Typecheck.module_caps
+      in
+      let violations =
+        March_caps.Cap_ceiling.check ~module_caps ~attribution:cap_attrib
+          ~caps:flat_caps
+      in
+      if violations <> [] then begin
+        List.iter
+          (fun v ->
+             Printf.eprintf "-- CAPABILITY CEILING --\n%s\n\n"
+               (March_caps.Cap_ceiling.describe v))
+          violations;
+        Printf.eprintf
+          "--cap-strict: %d capability ceiling violation(s). Every module's \
+           emitted code must stay within its own `needs`.\n%!"
+          (List.length violations);
+        exit 1
+      end
+    end;
     let tir =
       if !opt_enabled then
         March_tir.Opt.run
@@ -2841,6 +2888,7 @@ let compile filename =
               (* --cap-sandbox changes the emitted binary (a -D define), so a
                  non-sandboxed cached artifact must never satisfy it. *)
               @ (if !cap_sandbox then ["capsandbox"] else [])
+              @ (if !cap_strict then ["capstrict"] else [])
               @ cross_sysroot_tag
               @ (if !signing_pubkey <> "" then ["spk:" ^ !signing_pubkey] else [])) in
         let ch = March_cas.Cas.compilation_hash mod_hash ~target:target_label ~flags:cas_flags in
@@ -4276,6 +4324,7 @@ let () =
     ("--ffi-so",     Arg.String (fun p -> March_eval.Eval.ffi_shim_so := Some p),
                      "<path.so>  Pre-compiled FFI shim .so to dlopen in interpreter mode");
     ("--check",      Arg.Set do_check,    " Typecheck only — parse, resolve imports, typecheck, then exit (no codegen or eval)");
+    ("--cap-strict", Arg.Set cap_strict, " Treat `needs` as a hard ceiling: fail the build if any module's emitted code uses a capability it does not declare");
     ("--cap-sandbox", Arg.Set cap_sandbox, " Embed a self-imposed capability sandbox applied at startup (opt-in; macOS Seatbelt / Linux seccomp-bpf)");
     ("--check-json", Arg.Set check_json,  " Emit diagnostics as NDJSON to stdout (for tooling such as forge fix)");
     ("--no-measure-axioms", Arg.Clear measure_axioms, " Reflect @[measure] functions symbolically instead of axiomatising them (skips datatype/quantifier reasoning and the soundness gate)");

--- a/lib/caps/cap_ceiling.ml
+++ b/lib/caps/cap_ceiling.ml
@@ -1,0 +1,52 @@
+(* `needs` as a hard ceiling, checked against attributed use.
+   See cap_ceiling.mli for why this is not another source-level AST walk. *)
+
+type violation =
+  | Undeclared of { cap : string; owner : string }
+  | Unattributed of { cap : string }
+
+(* Emitted from the presence of extern blocks, not from an attributed call
+   site, so these have no owner by construction.  Typecheck's Check 5 already
+   errors when an extern's capability is undeclared; treating them as
+   unattributed here would report a violation on every FFI-using program. *)
+let is_foreign c = c = "IO.Foreign" || c = "IO.Foreign.Blocking"
+
+let declared_for module_caps owner =
+  match List.assoc_opt owner module_caps with Some l -> l | None -> []
+
+let covered module_caps ~owner ~cap =
+  List.exists
+    (fun need -> Cap_lattice.cap_subsumes need cap)
+    (declared_for module_caps owner)
+
+let check ~module_caps ~attribution ~caps =
+  let attribution = List.filter (fun (c, _) -> not (is_foreign c)) attribution in
+  let undeclared =
+    List.filter_map
+      (fun (cap, owner) ->
+         if covered module_caps ~owner ~cap then None
+         else Some (Undeclared { cap; owner }))
+      attribution
+  in
+  (* A capability nobody can be held responsible for.  Fail-closed: see the
+     .mli — an unattributable capability is the one an attacker would route
+     through, so it must not certify. *)
+  let unattributed =
+    List.filter_map
+      (fun cap ->
+         if is_foreign cap then None
+         else if List.exists (fun (c, _) -> c = cap) attribution then None
+         else Some (Unattributed { cap }))
+      caps
+  in
+  List.sort_uniq compare (undeclared @ unattributed)
+
+let describe = function
+  | Undeclared { cap; owner } ->
+    Printf.sprintf
+      "module `%s` uses `%s` but does not declare `needs %s`" owner cap cap
+  | Unattributed { cap } ->
+    Printf.sprintf
+      "`%s` is used but cannot be attributed to any module — it is reached \
+       only through indirect calls, whose callee is not statically known"
+      cap

--- a/lib/caps/cap_ceiling.mli
+++ b/lib/caps/cap_ceiling.mli
@@ -1,0 +1,65 @@
+(** `needs` as a hard ceiling, checked against attributed use.
+
+    {2 Why this is not another source walk}
+
+    The source-level checks in [Typecheck] each cover one route to a
+    capability, and measured, they do not cover the same set:
+
+    - a direct builtin call ([file_write "…"]) is a WARNING (Check 1b);
+    - a stdlib-mediated call ([File.write "…"]) produced NO diagnostic at all,
+      because Check 4 walks [DUse] declarations and stdlib modules are
+      ambiently available without one;
+    - an import of a user module that declares [needs] is an ERROR (Check 4);
+    - an [extern] block is an ERROR (Check 5).
+
+    So the most common route in real code was also the silent one. Closing it
+    with a fifth AST walk would repeat the failure that produced the first
+    four: this codebase has shipped five separate capability decl-walks whose
+    catch-all arm silently skipped a declaration form.
+
+    This check instead runs over what codegen actually emitted, via
+    [March_tir.Cap_attrib]. All three call routes collapse into one rule,
+    and re-routing a call through a helper or a wrapper cannot evade it.
+
+    {2 The rule}
+
+    For every module [M]: every capability attributed to [M] must be subsumed
+    by one of [M]'s own [needs] declarations.
+
+    Because attribution charges stdlib-mediated IO to the CALLING module
+    rather than to the stdlib wrapper, this asks nothing of the standard
+    library's own declarations — the module that called [File.write] is the
+    one required to declare [needs IO.FileWrite]. *)
+
+type violation =
+  | Undeclared of { cap : string; owner : string }
+      (** [owner]'s emitted code uses [cap], which none of its [needs]
+          declarations subsumes. *)
+  | Unattributed of { cap : string }
+      (** The program uses [cap] but no module can be held responsible for it
+          — it is reached only through indirect calls, whose callee is not
+          statically known.
+
+          This is a violation rather than a pass. A capability the analysis
+          cannot attribute is precisely the one an attacker would route
+          through, so certifying it would make the check worthless exactly
+          where it matters most. *)
+
+val check :
+  module_caps:(string * string list) list ->
+  attribution:(string * string) list ->
+  caps:string list ->
+  violation list
+(** [module_caps] is each module's declared [needs]; a module absent from it
+    has declared none. [caps] is the program's flat capability set — the
+    marker channel — used to find capabilities with no owner row.
+
+    [IO.Foreign] and [IO.Foreign.Blocking] are excluded: they are emitted from
+    the presence of [extern] blocks rather than from an attributed call site,
+    so they have no owner by construction, and Typecheck's Check 5 already
+    errors when an extern's capability is undeclared.
+
+    Results are sorted and de-duplicated for deterministic diagnostics. *)
+
+val describe : violation -> string
+(** One-line rendering, without span or severity decoration. *)

--- a/lib/caps/dune
+++ b/lib/caps/dune
@@ -1,6 +1,6 @@
 (library
  (name march_caps)
- (modules cap_lattice cap_symbols cap_scope))
+ (modules cap_lattice cap_symbols cap_scope cap_ceiling))
 
 ; Emitter: regenerates runtime/march_cap_lattice.{h,c} from the OCaml
 ; Cap_lattice.hierarchy source of truth.  See emit_c_table.ml for the

--- a/lib/tir/cap_attrib.ml
+++ b/lib/tir/cap_attrib.ml
@@ -13,22 +13,38 @@ let cap_of_call (name : string) : string option =
   March_caps.Cap_symbols.cap_of_symbol
     (Llvm_builtins.c_symbol_of_march_name name)
 
+(* A builtin can also appear as a VALUE rather than a call — [apply1(file_read,
+   p)] passes it as an atom, and only later does defun synthesize the apply
+   wrapper that calls it.  Measured: without this, such a program emitted an
+   IO.FileRead marker with NO owner row, so the module that handed out the
+   capability escaped attribution entirely.  Charging it to the module that
+   passes the value is right: that module is the one granting the authority. *)
+let atom_cap (a : Tir.atom) : string option =
+  match a with
+  | Tir.AVar v -> cap_of_call v.Tir.v_name
+  | Tir.ADefRef _ | Tir.ALit _ -> None
+
+let add_atoms caps atoms =
+  List.fold_left
+    (fun acc a -> match atom_cap a with Some c -> SSet.add c acc | None -> acc)
+    caps atoms
+
 (* One walk collecting both halves: the capabilities this body reaches
    directly, and the functions it calls (for the reverse call graph). *)
 let rec walk (caps, callees) (e : Tir.expr) =
   match e with
-  | Tir.EApp (v, _) ->
+  | Tir.EApp (v, args) ->
     let n = v.Tir.v_name in
     let caps =
       match cap_of_call n with Some c -> SSet.add c caps | None -> caps
     in
-    (caps, SSet.add n callees)
+    (add_atoms caps args, SSet.add n callees)
   | Tir.ELet (_, rhs, body) -> walk (walk (caps, callees) rhs) body
   | Tir.ESeq (a, b) -> walk (walk (caps, callees) a) b
-  | Tir.ECase (_, branches, default) ->
+  | Tir.ECase (scrut, branches, default) ->
     let acc =
       List.fold_left (fun a (br : Tir.branch) -> walk a br.Tir.br_body)
-        (caps, callees) branches
+        (add_atoms caps [ scrut ], callees) branches
     in
     (match default with Some d -> walk acc d | None -> acc)
   (* A lambda lifted into an inner fn_def is still the enclosing module's
@@ -39,13 +55,26 @@ let rec walk (caps, callees) (e : Tir.expr) =
         (caps, callees) fns
     in
     walk acc body
-  (* ECallPtr is an indirect call with no statically known callee — see the
-     .mli on why it yields no row rather than a guess. *)
-  | Tir.ECallPtr _
-  | Tir.EAtom _ | Tir.ETuple _ | Tir.ERecord _ | Tir.EField _ | Tir.EUpdate _
-  | Tir.EAlloc _ | Tir.EStackAlloc _ | Tir.EFree _ | Tir.EReuse _
-  | Tir.EIncRC _ | Tir.EDecRC _ | Tir.EAtomicIncRC _ | Tir.EAtomicDecRC _ ->
-    (caps, callees)
+  (* ECallPtr's CALLEE is not statically known — that is the residual gap the
+     .mli documents — but its atoms are still scanned, so a builtin handed to
+     it as an argument is attributed. *)
+  | Tir.ECallPtr (f, args) -> (add_atoms caps (f :: args), callees)
+  | Tir.EAtom a -> (add_atoms caps [ a ], callees)
+  | Tir.ETuple atoms -> (add_atoms caps atoms, callees)
+  | Tir.ERecord fields -> (add_atoms caps (List.map snd fields), callees)
+  | Tir.EField (a, _) -> (add_atoms caps [ a ], callees)
+  | Tir.EUpdate (a, fields) ->
+    (add_atoms caps (a :: List.map snd fields), callees)
+  | Tir.EAlloc (_, atoms) | Tir.EStackAlloc (_, atoms) ->
+    (add_atoms caps atoms, callees)
+  | Tir.EReuse (a, _, atoms) -> (add_atoms caps (a :: atoms), callees)
+  (* RC ops and EFree only ever carry an already-bound local, never a
+     top-level function name, but scanning them costs nothing and keeps this
+     match exhaustive-by-construction rather than by a catch-all — the shape
+     that has repeatedly hidden a missed case in this codebase's cap walks. *)
+  | Tir.EFree a | Tir.EIncRC a | Tir.EDecRC a
+  | Tir.EAtomicIncRC a | Tir.EAtomicDecRC a ->
+    (add_atoms caps [ a ], callees)
 
 let attribute ?(transparent = fun _ -> false) (m : Tir.tir_module) :
     (string * string) list =

--- a/specs/progress/2026-08-04-cap-ceiling-strict.md
+++ b/specs/progress/2026-08-04-cap-ceiling-strict.md
@@ -1,0 +1,102 @@
+# `--cap-strict`: `needs` as a hard ceiling
+
+Shipped 2026-08-04. Opt-in build gate: every module's emitted code must stay
+within that module's own `needs` declarations.
+
+```
+$ march --cap-strict --compile -o app app.march
+-- CAPABILITY CEILING --
+module `HostileDep` uses `IO.FileRead` but does not declare `needs IO.FileRead`
+
+--cap-strict: 1 capability ceiling violation(s).
+```
+
+## The hole this closes was bigger than believed
+
+The premise going in was "direct builtin calls are a warning, not an error."
+Measured, the routes to a capability do not agree with each other:
+
+| route | before |
+|---|---|
+| direct builtin `file_write(…)` | warning (Check 1b) |
+| **stdlib `File.write(…)`** | **nothing at all** |
+| builtin passed as a value, called indirectly | nothing |
+| user module via `use` | error (Check 4) |
+| `extern` block | error (Check 5) |
+
+The stdlib route — the most common one in real code — produced **zero**
+diagnostics, because Check 4 walks `DUse` declarations and stdlib modules are
+ambiently available without one. `mod M` calling `File.write` with no `needs`
+at all typechecked silently, rc=0.
+
+So flipping Check 1b to an error would have closed the smaller hole and left
+the larger one open, at the cost of a fifth source-level AST walk — in a
+codebase that has already shipped five capability decl-walks whose catch-all
+arm silently skipped a declaration form.
+
+## The rule
+
+For every module M: every capability attributed to M must be subsumed by one
+of M's own `needs`.
+
+Checked against `March_tir.Cap_attrib` output — emitted code — so all routes
+collapse into one rule and re-routing a call through a helper or a wrapper
+cannot evade it. Because attribution charges stdlib-mediated IO to the calling
+module, this asks nothing of the standard library's own declarations: the
+module that called `File.write` is the one required to declare
+`needs IO.FileWrite`. The "20 stdlib needs" question never enters the path.
+
+## Why it does not need the dependency to opt in
+
+March dependencies are distributed as source, so attribution is computed from
+the consumer's own build of the dependency's code. The check runs on every
+module in the program, including dependencies that never heard of the flag.
+
+Measured end to end: a dependency declaring only `needs IO.Console` whose
+`greet` reads `/etc/passwd` builds clean today (rc=0, one non-blocking
+warning) and fails under `--cap-strict` (rc=1), naming `HostileDep`.
+
+That is the difference between a `needs` declaration you trust and one you
+check.
+
+## Two bugs found by testing, not by reading
+
+- **The entry module always read as undeclared.** Desugar unwraps the entry
+  module (`~is_entry:true`), so it has no `DMod` and never lands in
+  `module_caps`; its `needs` accumulate in `mod_needs`. The first run of the
+  check reported a violation against a module that had correctly declared the
+  capability. Fixed by binding `(tm_name, mod_needs)` into the map.
+- **The fail-closed rule was dead code.** A builtin passed as a *value*
+  (`apply1(file_read, p)`) is a TIR *atom*, not an `EApp`, so the walk saw
+  nothing and emitted an `IO.FileRead` marker with no owner — and strict
+  passed it. `Cap_attrib` now scans atoms in every position, charging the
+  capability to the module that hands out the authority. This is the right
+  answer on the merits, not just a way to make the check fire.
+
+The second one is the reason the walk is now exhaustive over `Tir.expr` by
+construction rather than ending in a catch-all.
+
+## Caching
+
+`--cap-strict` is in `cas_flags` at BOTH sites, and the check runs before the
+CAS artifact lookup. Verified: a non-strict build that populates the cache,
+followed by a strict build of the same source, still fails (rc=1, 2
+violations) rather than being served the cached artifact — the
+`--refine-report`-on-a-warm-CAS failure mode.
+
+## Where the code is
+
+- `lib/caps/cap_ceiling.ml` / `.mli` — the rule, with `Undeclared` and
+  fail-closed `Unattributed` violations
+- `lib/tir/cap_attrib.ml` — atom scanning (the value-passing route)
+- `bin/main.ml` — `--cap-strict`, the pre-CAS call site, `cas_flags`
+- `test/test_cap_ceiling.ml` — 7 unit tests for the rule (including both
+  subsumption directions) and 6 end-to-end tests, one per route plus the
+  dependency case and two accept cases
+
+## Open
+
+See `specs/todos/2026-08-04-cap-ceiling-follow-ups.md` — notably an
+un-root-caused inconsistency where `println` does not trip Check 1b in a plain
+function body while `file_exists` does, no `forge cap inspect --strict`
+(binaries do not carry per-module declarations), and no migration autofix.

--- a/specs/todos/2026-08-04-cap-ceiling-follow-ups.md
+++ b/specs/todos/2026-08-04-cap-ceiling-follow-ups.md
@@ -1,0 +1,62 @@
+# `--cap-strict` capability ceiling — follow-ups
+
+Shipped 2026-08-04: `--cap-strict` checks each module's attributed capability
+use against its own `needs`. See
+`specs/progress/2026-08-04-cap-ceiling-strict.md`.
+
+- [ ] **`println` does not trip Check 1b in a plain function body, but
+  `file_exists` does.** Found while sizing the ceiling work, NOT root-caused.
+  Both are in `builtin_cap_table`, both are collected by `calls_in_expr`
+  (which does descend into match arms), `declared_needs` is empty in both
+  cases, and no `IO.Console` exemption exists anywhere in `typecheck.ml`.
+
+  Measured, same module and same shape:
+
+  ```march
+  mod P3 do
+    fn emit(s : String) : () do println(s) end          -- NO warning
+    fn touch(p : String) : Bool do
+      match file_exists(p) do true -> true  false -> false end   -- warns
+    end
+  end
+  ```
+
+  A test at `test/test_compiler.ml:3291` asserts `IO.Console` DOES warn for
+  actor handler bodies, so the diagnostic is not globally suppressed. This
+  inconsistency is invisible under `--cap-strict` (which derives from emitted
+  code and correctly requires `needs IO.Console`), but it means the default
+  build's warnings are not a reliable preview of what strict will demand.
+
+- [ ] **`ECallPtr`'s callee is still not statically known.** The atom scan now
+  attributes a builtin handed out as a value, which closed the common case,
+  but a capability reached only through a genuinely dynamic dispatch — a
+  closure selected at runtime from a table — has no owner. `Cap_ceiling`
+  reports these as `Unattributed` and fails closed.
+
+  Not yet verified: whether any construct in real March code actually produces
+  an `Unattributed` row today. The unit test covers the rule; there is no
+  end-to-end witness, so that path is currently exercised by construction
+  only. Worth finding a real witness or establishing that none exists.
+
+- [ ] **`--cap-strict` is compile-only, not available to `--check`.** The
+  check needs TIR, and `--check` stops after typecheck, so editors and
+  `forge check` cannot preview ceiling violations. Either lower far enough
+  under a flag, or accept that strict is a build gate and say so in the docs.
+
+- [ ] **No `forge cap inspect --strict`.** The artifact carries per-module
+  attribution markers and the compiler knows each module's `needs`, but the
+  binary does not carry the declarations, so the ceiling cannot currently be
+  re-checked from an artifact alone. Embedding declared needs per module in
+  the manifest blob would let a consumer verify a ceiling on a binary they did
+  not build.
+
+- [ ] **Migration story.** `--cap-strict` rejects most existing code, including
+  this repo's own `examples/`, because `needs IO.Console` is almost never
+  declared. The existing `warning_with_fix`/`FInsert` machinery already emits
+  the right autofix for Check 1b; wiring a `forge fix`-style bulk apply driven
+  by ceiling violations would make adoption mechanical rather than manual.
+
+- [ ] **Per-dependency budgets in `forge.toml`** (the original motivation) are
+  now unblocked: attribution names the module and the ceiling check proves the
+  module stays inside its declaration. What remains is the module→package
+  mapping, which `forge/lib/cap_package.ml` already computes from source.

--- a/test/dune
+++ b/test/dune
@@ -11,7 +11,7 @@
 (library
  (name march_test_compiler)
  (wrapped false)
- (modules test_compiler test_cap_strip test_cap_symbols test_cap_markers test_cap_package test_cap_scope)
+ (modules test_compiler test_cap_strip test_cap_symbols test_cap_markers test_cap_package test_cap_scope test_cap_ceiling)
  (libraries march_test_helpers march_lexer march_parser march_ast march_desugar march_typecheck march_refinecheck march_errors march_effects march_eval march_tir march_repl march_debug march_scheduler march_cas march_caps march_modules march_resolver march_forge march_lint alcotest str unix threads.posix))
 
 (library

--- a/test/test_cap_ceiling.ml
+++ b/test/test_cap_ceiling.ml
@@ -1,0 +1,264 @@
+(* `needs` as a hard ceiling (lib/caps/cap_ceiling.ml + --cap-strict).
+
+   The unit tests pin the rule; the end-to-end tests pin the ROUTES, which is
+   the part that actually matters — the source-level checks this replaces were
+   measured to disagree with each other about which routes they cover. *)
+
+module C = March_caps.Cap_ceiling
+
+let violations_pp = Alcotest.list Alcotest.string
+let describe l = List.map C.describe l
+
+let test_covered_by_exact_declaration () =
+  Alcotest.check violations_pp "no violation" []
+    (describe
+       (C.check
+          ~module_caps:[ ("M", [ "IO.FileRead" ]) ]
+          ~attribution:[ ("IO.FileRead", "M") ]
+          ~caps:[ "IO.FileRead" ]))
+
+let test_covered_by_a_broader_declaration () =
+  (* The ceiling is a lattice test, not string equality: IO.FileSystem
+     subsumes IO.FileRead, so declaring the parent covers the child. *)
+  Alcotest.check violations_pp "parent covers child" []
+    (describe
+       (C.check
+          ~module_caps:[ ("M", [ "IO.FileSystem" ]) ]
+          ~attribution:[ ("IO.FileRead", "M") ]
+          ~caps:[ "IO.FileRead" ]))
+
+let test_narrower_declaration_does_not_cover () =
+  (* And not the other way around — declaring IO.FileRead must NOT license a
+     write.  Getting the subsumption direction backwards here would make the
+     ceiling admit strictly more than it claims. *)
+  Alcotest.(check int) "one violation" 1
+    (List.length
+       (C.check
+          ~module_caps:[ ("M", [ "IO.FileRead" ]) ]
+          ~attribution:[ ("IO.FileWrite", "M") ]
+          ~caps:[ "IO.FileWrite" ]))
+
+let test_undeclared_module_is_a_violation () =
+  Alcotest.(check int) "module with no needs at all" 1
+    (List.length
+       (C.check ~module_caps:[] ~attribution:[ ("IO.FileRead", "M") ]
+          ~caps:[ "IO.FileRead" ]))
+
+let test_each_module_is_judged_on_its_own_needs () =
+  (* The whole point: A's declaration must not license B's use.  A check that
+     unioned the program's needs would pass this and report nothing, which is
+     exactly the whole-program-union blindness this replaces. *)
+  let vs =
+    C.check
+      ~module_caps:[ ("A", [ "IO.FileRead" ]); ("B", [ "IO.Console" ]) ]
+      ~attribution:[ ("IO.FileRead", "A"); ("IO.FileRead", "B") ]
+      ~caps:[ "IO.FileRead" ]
+  in
+  Alcotest.(check int) "only B violates" 1 (List.length vs);
+  Alcotest.(check bool) "and B is named" true
+    (List.exists
+       (fun v ->
+         match v with C.Undeclared { owner; _ } -> owner = "B" | _ -> false)
+       vs)
+
+let test_unattributed_capability_fails_closed () =
+  (* A capability nobody can be held responsible for must NOT certify.  It is
+     precisely the one an attacker would route through. *)
+  Alcotest.(check int) "unattributed is a violation" 1
+    (List.length
+       (C.check ~module_caps:[] ~attribution:[] ~caps:[ "IO.FileRead" ]))
+
+let test_foreign_is_excluded () =
+  (* IO.Foreign comes from the presence of extern blocks, not an attributed
+     call site, so it has no owner by construction; Typecheck's Check 5
+     already errors when an extern's cap is undeclared.  Treating it as
+     unattributed would fire on every FFI-using program. *)
+  Alcotest.check violations_pp "no violation for foreign" []
+    (describe
+       (C.check ~module_caps:[] ~attribution:[]
+          ~caps:[ "IO.Foreign"; "IO.Foreign.Blocking" ]))
+
+let unit_tests =
+  [
+    Alcotest.test_case "exact declaration covers" `Quick
+      test_covered_by_exact_declaration;
+    Alcotest.test_case "broader declaration covers" `Quick
+      test_covered_by_a_broader_declaration;
+    Alcotest.test_case "narrower declaration does NOT cover" `Quick
+      test_narrower_declaration_does_not_cover;
+    Alcotest.test_case "module with no needs violates" `Quick
+      test_undeclared_module_is_a_violation;
+    Alcotest.test_case "each module judged on its own needs" `Quick
+      test_each_module_is_judged_on_its_own_needs;
+    Alcotest.test_case "unattributed fails closed" `Quick
+      test_unattributed_capability_fails_closed;
+    Alcotest.test_case "IO.Foreign excluded" `Quick test_foreign_is_excluded;
+  ]
+
+(* ── End to end: --cap-strict over each ROUTE to a capability ───────────
+   Exe-relative for the same reason as test_cap_strip.ml. *)
+
+let compiler_exe =
+  let exe_dir = Filename.dirname Sys.executable_name in
+  Filename.concat exe_dir "../bin/main.exe"
+
+let compile_strict src_text =
+  if not (Sys.file_exists compiler_exe) then
+    Alcotest.failf "compiler not found at %s" compiler_exe;
+  let src = Filename.temp_file "cap_ceiling" ".march" in
+  let oc = open_out src in
+  output_string oc src_text;
+  close_out oc;
+  let out = Filename.temp_file "cap_ceiling" ".out" in
+  let bin = Filename.temp_file "cap_ceiling" ".bin" in
+  let rc =
+    Sys.command
+      (Printf.sprintf "%s --cap-strict --compile -o %s %s > %s 2>&1"
+         (Filename.quote compiler_exe) (Filename.quote bin)
+         (Filename.quote src) (Filename.quote out))
+  in
+  let ic = open_in out in
+  let s = really_input_string ic (in_channel_length ic) in
+  close_in ic;
+  List.iter (fun f -> try Sys.remove f with Sys_error _ -> ()) [ src; out; bin ];
+  (rc, s)
+
+let rejects name src =
+  let rc, out = compile_strict src in
+  if rc = 0 then
+    Alcotest.failf "%s should have failed --cap-strict but compiled" name;
+  if
+    not
+      (let re = Str.regexp_string "CAPABILITY CEILING" in
+       match Str.search_forward re out 0 with
+       | _ -> true
+       | exception Not_found -> false)
+  then Alcotest.failf "%s failed, but not for the ceiling reason:\n%s" name out
+
+let accepts name src =
+  let rc, out = compile_strict src in
+  if rc <> 0 then Alcotest.failf "%s should compile but did not:\n%s" name out
+
+(* Route 1: a direct builtin call.  Warning-only without --cap-strict. *)
+let test_direct_builtin_route () =
+  rejects "direct builtin call"
+    {|
+mod CeilDirect do
+  needs IO.Console
+  fn main() : () do
+    match file_write("/tmp/x", "d") do
+      Ok(_)  -> println("ok")
+      Err(_) -> println("e")
+    end
+  end
+end
+|}
+
+(* Route 2: through a stdlib wrapper.  THE hole this closes — measured, this
+   produced NO diagnostic at all before, not even a warning, because
+   Typecheck's Check 4 walks `use` declarations and stdlib modules are
+   ambiently available without one. *)
+let test_stdlib_route_was_completely_silent () =
+  rejects "stdlib-mediated call"
+    {|
+mod CeilStdlib do
+  needs IO.Console
+  fn main() : () do
+    match File.write("/tmp/x", "d") do
+      Ok(_)  -> println("ok")
+      Err(_) -> println("e")
+    end
+  end
+end
+|}
+
+(* Route 3: a builtin handed out as a VALUE and invoked indirectly. *)
+let test_builtin_as_value_route () =
+  rejects "builtin passed as a value"
+    {|
+mod CeilValue do
+  needs IO.Console
+  fn apply1(f : (String) -> a, p : String) : a do
+    f(p)
+  end
+  fn main() : () do
+    match apply1(file_read, "/etc/hosts") do
+      Ok(_)  -> println("ok")
+      Err(_) -> println("e")
+    end
+  end
+end
+|}
+
+(* A DEPENDENCY exceeding its own ceiling, in a program whose entry module is
+   itself clean.  This is the supply-chain case, and the reason the check is
+   per-module: the whole-program union cannot see it, and the dependency never
+   opted in to anything. *)
+let test_dependency_exceeding_its_own_ceiling () =
+  rejects "dependency exceeds its declared needs"
+    {|
+mod CeilApp do
+  needs IO.Console
+  mod Dep do
+    needs IO.Console
+    fn greet(n : String) : String do
+      match file_read("/etc/passwd") do
+        Ok(s)  -> s
+        Err(_) -> "hello " ++ n
+      end
+    end
+  end
+  fn main() : () do
+    println(Dep.greet("world"))
+  end
+end
+|}
+
+let test_a_correctly_declared_program_compiles () =
+  (* The check must be satisfiable.  A test suite of only REJECT cases cannot
+     tell a working ceiling from one that rejects everything. *)
+  accepts "fully declared program"
+    {|
+mod CeilOkay do
+  needs IO.Console
+  needs IO.FileWrite
+  fn main() : () do
+    match File.write("/tmp/x", "d") do
+      Ok(_)  -> println("ok")
+      Err(_) -> println("e")
+    end
+  end
+end
+|}
+
+let test_parent_declaration_satisfies_the_ceiling () =
+  accepts "IO.FileSystem covers a write"
+    {|
+mod CeilParent do
+  needs IO.Console
+  needs IO.FileSystem
+  fn main() : () do
+    match File.write("/tmp/x", "d") do
+      Ok(_)  -> println("ok")
+      Err(_) -> println("e")
+    end
+  end
+end
+|}
+
+let tests =
+  unit_tests
+  @ [
+      Alcotest.test_case "route: direct builtin call" `Slow
+        test_direct_builtin_route;
+      Alcotest.test_case "route: stdlib wrapper (was silent)" `Slow
+        test_stdlib_route_was_completely_silent;
+      Alcotest.test_case "route: builtin passed as a value" `Slow
+        test_builtin_as_value_route;
+      Alcotest.test_case "dependency exceeding its own ceiling" `Slow
+        test_dependency_exceeding_its_own_ceiling;
+      Alcotest.test_case "correctly declared program compiles" `Slow
+        test_a_correctly_declared_program_compiles;
+      Alcotest.test_case "parent capability satisfies the ceiling" `Slow
+        test_parent_declaration_satisfies_the_ceiling;
+    ]

--- a/test/test_cap_markers.ml
+++ b/test/test_cap_markers.ml
@@ -240,22 +240,22 @@ let tests =
         test_attribution_prefix_cannot_be_read_as_a_flat_marker;
     ]
 
-let test_indirect_call_is_unattributed_not_absent () =
-  (* [direct_pass_src] invokes file_read through a closure, so no statically
-     known callee exists and attribution genuinely cannot see it.  The FLAT
-     marker still must — the two channels complement each other, and a
-     capability that is real but unattributed must never look like an absent
-     one.  Measured: `forge cap inspect` renders this as an explicit
-     "unattributed" line rather than an empty owner set. *)
+let test_builtin_passed_as_a_value_is_attributed () =
+  (* [direct_pass_src] hands file_read to apply1 as a VALUE; defun only later
+     synthesizes the wrapper that calls it, so an EApp-only walk saw nothing
+     and the capability was emitted with no owner at all — the module handing
+     out the authority escaped attribution entirely.  Measured before the
+     atom scan was added.  Charging it to the module that passes the value is
+     the right answer: that module is the one granting the capability. *)
   let ir = emit_ir direct_pass_src in
-  Alcotest.(check bool) "flat marker still reports the capability" true
+  Alcotest.(check bool) "flat marker reports the capability" true
     (contains ir "@__march_cap_IO_FileRead");
-  Alcotest.(check bool) "but no owner row is invented" false
-    (contains ir "@__march_capfrom_IO_FileRead")
+  Alcotest.(check bool) "and it now has an owner" true
+    (contains ir "@__march_capfrom_IO_FileRead__")
 
 let tests =
   tests
   @ [
-      Alcotest.test_case "indirect call is unattributed, not absent" `Slow
-        test_indirect_call_is_unattributed_not_absent;
+      Alcotest.test_case "builtin passed as a value is attributed" `Slow
+        test_builtin_passed_as_a_value_is_attributed;
     ]

--- a/test/test_compiler.ml
+++ b/test/test_compiler.ml
@@ -11155,6 +11155,7 @@ let compiler_suites =
       ("cap_markers", Test_cap_markers.tests);
       ("cap_package", Test_cap_package.tests);
       ("cap_scope", Test_cap_scope.tests);
+      ("cap_ceiling", Test_cap_ceiling.tests);
       ( "match_diagnostics",
         [
           Alcotest.test_case "or-pattern binding accepted" `Quick


### PR DESCRIPTION
Opt-in build gate: every module's emitted code must stay within that module's own `needs`, or the build fails naming the module.

```
$ march --cap-strict --compile -o app app.march
-- CAPABILITY CEILING --
module `HostileDep` uses `IO.FileRead` but does not declare `needs IO.FileRead`

--cap-strict: 1 capability ceiling violation(s).
```

## The hole was wider than the known one

The premise going in was "direct builtin calls are a warning, not an error." Measured, the routes to a capability do not agree with each other:

| route | before |
|---|---|
| direct builtin `file_write(…)` | warning (Check 1b) |
| **stdlib `File.write(…)`** | **nothing at all** |
| builtin passed as a value, called indirectly | nothing |
| user module via `use` | error (Check 4) |
| `extern` block | error (Check 5) |

The stdlib route — the most common in real code — produced **zero** diagnostics, because Check 4 walks `DUse` declarations and stdlib modules are ambiently available without one. `mod M` calling `File.write` with no `needs` at all typechecked silently at rc=0.

So flipping Check 1b to an error would have closed the smaller hole and left the larger one open, at the cost of a fifth source-level AST walk — in a codebase that has already shipped five capability decl-walks whose catch-all arm silently skipped a declaration form.

## The rule

For every module M: every capability attributed to M must be subsumed by one of M's own `needs`.

Checked against emitted code (`Cap_attrib`), so every route collapses into one rule that re-routing through a helper cannot evade. Because attribution charges stdlib-mediated IO to the *calling* module, this asks nothing of the standard library's own declarations — the "20 stdlib needs" question never enters the path.

## It does not need the dependency to opt in

March dependencies ship as source, so attribution is computed from the consumer's own build. Measured end to end: a dependency declaring only `needs IO.Console` whose `greet` reads `/etc/passwd` builds clean today (rc=0, one non-blocking warning) and **fails under `--cap-strict`** (rc=1), naming `HostileDep` — without that dependency having opted in to anything.

That is the difference between a `needs` declaration you trust and one you check.

## Two bugs found by testing, not by reading

- **The entry module always read as undeclared.** Desugar unwraps it (`~is_entry:true`), so it has no `DMod` and never enters `module_caps`; its needs accumulate in `mod_needs`. The first run reported a violation against a module that had correctly declared the capability.
- **The fail-closed rule was dead code.** A builtin passed as a *value* (`apply1(file_read, p)`) is a TIR *atom*, not an `EApp`, so the walk saw nothing and strict passed a program whose binary carried the marker. `Cap_attrib` now scans atoms in every position, charging the capability to the module handing out the authority — right on the merits, not just a way to make the check fire. The walk is now exhaustive over `Tir.expr` by construction rather than ending in a catch-all.

## Caching

`--cap-strict` is in `cas_flags` at both sites and the check runs before the CAS lookup. Verified a non-strict build that populates the cache, followed by a strict build of the same source, still fails rather than being served the cached artifact.

## Honest limits

- **Compile-only.** The check needs TIR; `--check` stops after typecheck, so editors cannot preview violations.
- **No `forge cap inspect --strict`.** Binaries carry attribution markers but not per-module declarations, so the ceiling cannot yet be re-checked from an artifact alone.
- **`--cap-strict` rejects most existing code**, including this repo's `examples/`, because `needs IO.Console` is almost never declared. No bulk autofix yet.
- **FFI is still outside all of this.** `IO.Foreign` is excluded from the check; extern blocks are already an error when undeclared.
- **An un-root-caused inconsistency found in passing:** `println` does not trip Check 1b in a plain function body while `file_exists` does, with no `IO.Console` exemption anywhere in `typecheck.ml`. Filed, not fixed — it means default-build warnings are not a reliable preview of what strict demands.

All filed in `specs/todos/2026-08-04-cap-ceiling-follow-ups.md`.

## Testing

7 unit tests for the rule (including both subsumption directions — reversing it would make the ceiling admit more than it claims) and 6 end-to-end tests: one per route, the dependency case, and two accept cases so the suite can tell a working ceiling from one that rejects everything.

Full suite: 830 tests, one failure — `adversarial-regressions.040` (ASAN), environmental and pre-existing: a trivial unrelated `clang -fsanitize=address` C program also hangs >2min on this box under load. `check-docs.sh`, the pagefind index check, and forge's five suites all pass.
