### PR TITLE
fix: NativeArray.set_int/set_float FBIP in-place update at rc==1 (stops per-op leak)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,21 @@ git log is authoritative for exact commits.
 
 ### Fixed
 
+- **`NativeArray.set_int` / `set_float` no longer leak (or churn) a copy per
+  call when the array is uniquely owned.** The C runtime's
+  `native_int_arr_set` / `native_float_arr_set` are passed their array under
+  the owned/consumed convention, but they only ever allocated a fresh backing
+  array, `memcpy`'d, and returned it — without ever releasing the consumed
+  input. A hot loop threading the result forward (last-use, RC=1) leaked one
+  copy per op: a 2M-op `set_int` loop on an 8-element array ramped to ~190 MB
+  RSS (linear in ops) while the same loop without it held ~2.7 MB flat. They
+  now reuse the backing array in place when it is uniquely owned (rc == 1) —
+  O(1) and flat RSS — and preserve copy-on-write (allocate, copy, then release
+  the consumed reference) only when the array is shared (rc > 1), so an aliased
+  array is never mutated out from under its alias. This is the same FBIP
+  in-place-at-unique-ownership story March already applies to ADT reuse.
+  Compiled-only (the interpreter uses a different NativeArray backend).
+
 - **`cap no_panic` no longer rejects a division guarded by a boolean
   condition.** `if p > 0 && d > 0 do n / d else 0 end` was reported as a
   possible division by zero, as was every other guard containing `&&` or `||`

--- a/runtime/march_runtime.c
+++ b/runtime/march_runtime.c
@@ -5116,11 +5116,37 @@ int64_t native_int_arr_get(void *arr, int64_t i) {
     return *(int64_t *)((char *)arr + NATIVE_ARR_HDR + i * 8);
 }
 
+/* FBIP in-place update at unique ownership.
+ *
+ * [arr] is passed under the owned/consumed convention — native_int_arr_set is
+ * absent from borrow.ml's extern_borrow_table, so Perceus transfers one
+ * reference into this call and emits no dec_rc after it. This function
+ * therefore owns exactly one reference to [arr] and is responsible for
+ * releasing it.
+ *
+ * When that reference is the ONLY one (rc == 1, the same unique-ownership
+ * predicate LLVM-generated FBIP `reuse … as …` uses, which also reads ->rc as
+ * a plain non-atomic load — safe precisely because a unique owner has no
+ * concurrent observer), we mutate the backing array in place and hand our
+ * reference straight to the result: O(1), no allocation, no copy, no free.
+ * That is what keeps a threaded-forward set_int accumulator flat in RSS
+ * instead of leaking (or churning) a fresh 8-element copy on every call.
+ *
+ * When the array is SHARED (rc > 1) an alias may still observe it, so
+ * copy-on-write MUST be preserved: allocate a fresh array, copy, write the new
+ * value, then release our owned reference (march_decrc drops our count; the
+ * alias keeps its own). The rc == 1 gate also excludes interned/immortal
+ * arrays (rc >= MARCH_RC_IMMORTAL), which are never mutated in place. */
 void *native_int_arr_set(void *arr, int64_t i, int64_t val) {
+    if (IS_HEAP_PTR(arr) && ((march_hdr *)arr)->rc == 1) {
+        *(int64_t *)((char *)arr + NATIVE_ARR_HDR + i * 8) = val;
+        return arr;
+    }
     int64_t len = native_int_arr_length(arr);
     void *new_arr = native_arr_alloc(len);
     memcpy((char *)new_arr + NATIVE_ARR_HDR, (char *)arr + NATIVE_ARR_HDR, (size_t)(len * 8));
     *(int64_t *)((char *)new_arr + NATIVE_ARR_HDR + i * 8) = val;
+    march_decrc(arr);
     return new_arr;
 }
 
@@ -5282,11 +5308,19 @@ double native_float_arr_get(void *arr, int64_t i) {
     double v; memcpy(&v, (char *)arr + NATIVE_ARR_HDR + i * 8, 8); return v;
 }
 
+/* In-place-at-rc==1 FBIP update — see native_int_arr_set above for the full
+ * ownership contract (identical: owned/consumed arg, unique-owner mutates in
+ * place, shared array copies-on-write then releases our reference). */
 void *native_float_arr_set(void *arr, int64_t i, double val) {
+    if (IS_HEAP_PTR(arr) && ((march_hdr *)arr)->rc == 1) {
+        memcpy((char *)arr + NATIVE_ARR_HDR + i * 8, &val, 8);
+        return arr;
+    }
     int64_t len = native_float_arr_length(arr);
     void *new_arr = native_arr_alloc(len);
     memcpy((char *)new_arr + NATIVE_ARR_HDR, (char *)arr + NATIVE_ARR_HDR, (size_t)(len * 8));
     memcpy((char *)new_arr + NATIVE_ARR_HDR + i * 8, &val, 8);
+    march_decrc(arr);
     return new_arr;
 }
 

--- a/specs/progress/2026-08-04-nativearray-set-int-fbip-in-place.md
+++ b/specs/progress/2026-08-04-nativearray-set-int-fbip-in-place.md
@@ -1,0 +1,82 @@
+# NativeArray.set_int / set_float: FBIP in-place update at unique ownership
+
+Closes the first bullet of
+`specs/todos/2026-08-04-compiled-backend-nativearray-set-int-queue-retain-memory.md`
+(the `set_int` copy-per-op leak). The `Queue` and `RingBuf` bullets of that
+todo are left open — see "Queue: diagnosed, not fixed" below.
+
+## Diagnosis (compiled, `--compile --opt 2`, peak RSS via `/usr/bin/time -l`)
+
+A 2M-op loop whose only per-op heap op is `NativeArray.set_int` on an
+8-element array, threaded forward (last-use, RC=1):
+
+| ops   | RSS before | RSS after |
+|-------|-----------:|----------:|
+| 500k  |      48 MB |    2.6 MB |
+| 1M    |      94 MB |    2.6 MB |
+| 2M    |     187 MB |    2.6 MB |
+| 4M    |     371 MB |    2.6 MB |
+| 8M    |     740 MB |    2.6 MB |
+
+Before the fix RSS was perfectly **linear** in ops (~93 bytes/op) — that is a
+**true leak** (case (a) in the todo's taxonomy), not an allocator high-water
+mark. Root cause: `native_int_arr_set` / `native_float_arr_set`
+(`runtime/march_runtime.c`) are passed their array under the **owned/consumed**
+convention — they are absent from `borrow.ml`'s `extern_borrow_table`, so
+Perceus transfers one reference into the call and emits **no `dec_rc` after
+it** (confirmed via `MARCH_DUMP_TXT=perceus`). But the C code only allocated a
+fresh backing array, `memcpy`'d, and returned it — it never released the
+consumed input. One 8-element array leaked per call.
+
+## Fix
+
+Reuse the backing array **in place when it is uniquely owned** (`rc == 1`, the
+same predicate LLVM-generated FBIP `reuse … as …` uses, read as a plain
+non-atomic load — safe because a unique owner has no concurrent observer):
+O(1), no allocation, no copy → flat RSS. When the array is **shared**
+(`rc > 1`) copy-on-write is preserved (allocate, copy, write) and the consumed
+reference is released with `march_decrc` — so an aliased array is never
+mutated out from under its alias. This is the same FBIP in-place-at-unique-
+ownership story March already applies to ADT reuse.
+
+Correctness-critical: the `rc == 1` gate is what makes it safe. It also
+excludes interned/immortal arrays (`rc >= MARCH_RC_IMMORTAL`).
+
+## Tests (compiled-only — the interpreter uses a different NativeArray backend)
+
+`test/test_codegen.ml`, group `native_arrays`:
+- `…set_int_alias_cow_compiled` — aliases the array (rc>1) and asserts the
+  alias reads the ORIGINAL (0), the result reads the mutation (99). In-place
+  mutation here would corrupt the alias.
+- `…set_int_inplace_churn_compiled` — 2M-op rc==1 churn, asserts the final
+  sum (15999964). Would crash / read freed memory / diverge if in-place reuse
+  ever freed a still-live array.
+
+Full suite green (compiler 711, eval 256, codegen 546). The stdlib
+`MARCH_SANITIZE` adversarial test could not run: ASAN hangs in
+`FindDynamicShadowStart` on this macOS build even for a trivial hello-world
+(hangs before `main`), an environmental clang/OS issue independent of March —
+so it is not a usable check here. Memory-safety evidence instead: correctness
+preserved, the alias test, and `march_decrc`'s RC-underflow abort not firing
+across 2M+ ops.
+
+## Queue: diagnosed, not fixed (separate root cause)
+
+The todo's `Queue` bullet is **also a true leak** (linear: 33→475 MB over
+500k→8M ops), not the allocator high-water the todo speculated. But it is a
+**distinct root cause** and is left for a focused follow-up:
+
+- Plain persistent-list cons/uncons churn and a tuple-in-`Option` churn are
+  both **flat** (~2.7 MB) — so it is not general List/tuple RC.
+- An **inline** two-list ADT push/pop churn is **flat** — so it is not the
+  two-list-ADT shape either.
+- The leak appears only across the **stdlib `Queue` function boundary**
+  (`push_front`/`pop_front`). The post-Perceus TIR of `pop_front`'s hot branch
+  allocates a **join-point closure** (`$jp_clo…`, ~32 bytes) and captures it
+  into a sibling `$jp_clo` that is `reuse`d-and-`dec_rc`'d; the captured
+  closure FV appears not to be reclaimed. 67 MB / 2M ≈ 33 bytes/op ≈ exactly
+  one leaked closure box per op.
+
+That is a join-point-closure RC / materialization issue in the nested-match
+lowering, high blast radius, and unrelated to the `set_int` C-runtime bug — so
+it was not folded into this change.

--- a/test/test_codegen.ml
+++ b/test/test_codegen.ml
@@ -9920,6 +9920,82 @@ let test_native_array_map_reused_capturing_closure_compiled () =
         "[8, 9, 10]\n107" run_out
     done
 
+(* ── NativeArray.set_int FBIP in-place-at-rc==1 ──────────────────────────
+   native_int_arr_set / native_float_arr_set (runtime/march_runtime.c) take
+   their array under the owned/consumed convention (absent from borrow.ml's
+   extern_borrow_table, so Perceus emits no dec_rc after the call). They used
+   to *always* allocate a fresh backing array, memcpy, and return it —
+   WITHOUT ever releasing the consumed input. A hot loop threading the result
+   forward (last-use, rc==1) leaked one copy per op: a 2M-op set_int loop on
+   an 8-element array ramped to ~190MB RSS (linear in ops) while the same loop
+   without set_int held ~2.7MB flat.
+
+   Fixed by reusing the backing array in place when it is uniquely owned
+   (rc==1) — O(1), flat RSS — and preserving copy-on-write + releasing the
+   consumed reference only when the array is shared (rc>1). These two tests
+   pin BOTH halves of that contract; the correctness bug they guard is
+   compiled-only (the interpreter has a different NativeArray backend). *)
+
+(* rc>1 (aliased): the array is still live after set_int, so copy-on-write
+   MUST be preserved — the alias must observe the ORIGINAL, not the mutation. *)
+let test_native_array_set_int_alias_cow_compiled () =
+  let (project_root, main_exe, src, tmp) = write_march_source ~name:"march_setalias"
+    "mod SetAlias do\n\
+    \  fn main() : Unit do\n\
+    \    let a = NativeArray.make_int(4, 0)\n\
+    \    let b = NativeArray.set_int(a, 0, 99)\n\
+    \    -- a is read AFTER set_int -> aliased (rc>1) -> must be unchanged.\n\
+    \    println(int_to_string(NativeArray.get_int(a, 0)))\n\
+    \    println(int_to_string(NativeArray.get_int(b, 0)))\n\
+    \  end\n\
+     end\n"
+  in
+  let bin = Filename.concat tmp "setaliasbin" in
+  match compile_march_or_skip ~cmd_prefix:(Printf.sprintf "cd %s && " (Filename.quote project_root))
+          ~main_exe ~bin ~src () with
+  | None -> ()  (* legitimate, counted skip: no clang on PATH *)
+  | Some bin ->
+    let run_out = read_cmd_output (Printf.sprintf "%s 2>&1" (Filename.quote bin)) in
+    Alcotest.(check string)
+      "set_int on a SHARED (rc>1) array must copy-on-write: the alias reads 0 \
+       (unchanged original), the result reads 99 — in-place mutation here \
+       would corrupt the alias"
+      "0\n99" run_out
+
+(* rc==1 (unique, threaded forward): the in-place path must produce the SAME
+   final array as a copy would. A long churn loop that would crash / read
+   freed memory / diverge if in-place reuse ever freed a still-live array;
+   the value is the sum of the 8 last writes per position. *)
+let test_native_array_set_int_inplace_churn_compiled () =
+  let (project_root, main_exe, src, tmp) = write_march_source ~name:"march_setchurn"
+    "mod SetChurn do\n\
+    \  fn go(arr, i : Int, n : Int) : Int do\n\
+    \    if i >= n do\n\
+    \      NativeArray.sum_int(arr)\n\
+    \    else\n\
+    \      let arr2 = NativeArray.set_int(arr, i % 8, i)\n\
+    \      go(arr2, i + 1, n)\n\
+    \    end\n\
+    \  end\n\
+    \  fn main() : Unit do\n\
+    \    let arr = NativeArray.make_int(8, 0)\n\
+    \    println(int_to_string(go(arr, 0, 2000000)))\n\
+    \  end\n\
+     end\n"
+  in
+  let bin = Filename.concat tmp "setchurnbin" in
+  match compile_march_or_skip ~cmd_prefix:(Printf.sprintf "cd %s && " (Filename.quote project_root))
+          ~main_exe ~bin ~src () with
+  | None -> ()  (* legitimate, counted skip: no clang on PATH *)
+  | Some bin ->
+    let run_out = read_cmd_output (Printf.sprintf "%s 2>&1" (Filename.quote bin)) in
+    (* last write to position p is the largest i<2_000_000 with i%8==p:
+       1999992..1999999; their sum is 15999964. *)
+    Alcotest.(check string)
+      "set_int threaded forward at rc==1 mutates in place and stays correct \
+       over 2M ops (final array = sum of the last 8 writes)"
+      "15999964" run_out
+
 (* ── Blocking-FFI worker pool ────────────────────────────────────── *)
 
 (* Blocking externs used to get a fresh pthread_create + join PER CALL, which
@@ -13561,6 +13637,10 @@ let codegen_suites =
             test_try_call_panic_with_capture_no_double_free_compiled;
           Alcotest.test_case "NativeArray.map_int: reused capturing closure not freed mid-map (20x)" `Quick
             test_native_array_map_reused_capturing_closure_compiled;
+          Alcotest.test_case "NativeArray.set_int: aliased (rc>1) array is copy-on-write, not mutated" `Quick
+            test_native_array_set_int_alias_cow_compiled;
+          Alcotest.test_case "NativeArray.set_int: rc==1 in-place churn stays correct over 2M ops (flat RSS)" `Quick
+            test_native_array_set_int_inplace_churn_compiled;
           Alcotest.test_case "Signal.watch: capturing handler survives repeated delivery (25x)" `Quick
             test_signal_watch_capturing_handler_repeated_delivery_compiled;
         ] );


### PR DESCRIPTION
## Summary

`NativeArray.set_int` / `set_float` leaked one backing-array copy per call when the array was uniquely owned — a **true leak**, not allocator high-water. A 2M-op `set_int` loop on an 8-element array threaded forward (last-use, rc==1) ramped to **~190MB RSS, linear in ops**, while the same loop without it held ~2.7MB flat. This nicked March's flat-RSS headline claim.

Refs `specs/todos/2026-08-04-compiled-backend-nativearray-set-int-queue-retain-memory.md` (the `set_int` bullet).

## Root cause

`native_int_arr_set` / `native_float_arr_set` (`runtime/march_runtime.c`) are passed their array under the **owned/consumed** convention — they are absent from `borrow.ml`'s `extern_borrow_table`, so Perceus transfers one reference into the call and emits **no `dec_rc` after it** (confirmed via `MARCH_DUMP_TXT=perceus`). But the C code only allocated a fresh array, `memcpy`'d, and returned it — never releasing the consumed input.

## Fix (FBIP in-place at unique ownership)

- **rc == 1** (uniquely owned): mutate the backing array in place, hand the reference to the result. O(1), no alloc, no copy, no free → flat RSS.
- **rc > 1** (shared): preserve copy-on-write (allocate, copy, write) then `march_decrc` the consumed reference, so an aliased array is never mutated out from under its alias.

Same FBIP in-place-at-unique-ownership story March already applies to ADT reuse.

## Measurements (compiled `--opt 2`, peak RSS via `/usr/bin/time -l`)

| ops | before | after |
|-----|-------:|------:|
| 500k | 48 MB | 2.6 MB |
| 1M | 94 MB | 2.6 MB |
| 2M | 187 MB | 2.6 MB |
| 4M | 371 MB | 2.6 MB |
| 8M | 740 MB | 2.6 MB |

Output value unchanged (15999964 at 2M); alias probe reads 0 / 99 (copy-on-write preserved).

## Tests

`test/test_codegen.ml`, `native_arrays` group (compiled-only — interpreter uses a different backend):
- **alias/rc>1**: aliases the array, asserts the alias reads the original (0) and the result the mutation (99).
- **rc==1 churn**: 2M-op in-place churn, asserts the final sum — would crash / read freed memory / diverge if in-place reuse ever freed a live array.

Full suite green (compiler 711, eval 256, codegen 546). The stdlib `MARCH_SANITIZE` test could not run: **ASAN hangs in `FindDynamicShadowStart` on this macOS build even for a trivial hello-world** (hangs before `main`), an environmental clang/OS issue independent of March. Memory-safety evidence instead: correctness preserved, the alias test, and `march_decrc`'s RC-underflow abort not firing across 2M+ ops.

## Queue (todo's second bullet): diagnosed, NOT fixed here

Also a **true leak** (linear, 33→475 MB over 500k→8M ops) — not the allocator high-water the todo guessed — but a **distinct root cause**, left for a focused follow-up. Plain list churn, tuple-in-`Option` churn, and an inline two-list ADT churn are all flat; the leak appears only across the stdlib `Queue` function boundary. `pop_front`'s hot-branch TIR allocates a **join-point closure** (~32 bytes) captured into a sibling `$jp_clo` that is `reuse`d-and-`dec_rc`'d, and the captured FV appears unreclaimed (67 MB / 2M ≈ one closure box/op). That is a join-point-closure RC issue in nested-match lowering, high blast radius, unrelated to the set_int C-runtime bug. Details in the progress note.