### PR TITLE
fix(test): skip ASAN golden gate under CrowdStrike Falcon on macOS

### DIFF
--- a/specs/lang/golden/sanitize.sh
+++ b/specs/lang/golden/sanitize.sh
@@ -23,6 +23,14 @@ if [ ! -x "$bin" ]; then
   exit 2
 fi
 
+if [ "$(uname -s)" = "Darwin" ] && pgrep -qf 'com\.crowdstrike\.falcon\.Agent' 2>/dev/null; then
+  echo "SKIP: CrowdStrike Falcon (EndpointSecurity system extension) detected on this Mac." >&2
+  echo "Falcon's syscall interception hangs ASAN's shadow-memory mmap setup on every binary," >&2
+  echo "even a no-op 'printf' program — this is environmental, not a golden regression." >&2
+  echo "Run this gate on a host without Falcon (e.g. CI) instead." >&2
+  exit 0
+fi
+
 export ASAN_OPTIONS="detect_leaks=0:halt_on_error=1"
 export MARCH_STDLIB="${MARCH_STDLIB:-$root/stdlib}"
 


### PR DESCRIPTION
## Summary
- `specs/lang/golden/sanitize.sh` hangs on any Mac running CrowdStrike Falcon: Falcon's EndpointSecurity syscall interception deadlocks against ASAN's shadow-memory `mmap` setup, reproducible with a trivial no-op `printf` binary — nothing to do with compiler correctness.
- Without a guard, the gate burns all 46 goldens through a 25s timeout each before reporting spurious "SANITIZER FAIL" results.
- Adds a Darwin-only check for the Falcon agent process; if detected, the gate prints why and exits 0 instead of running.

## Test plan
- [x] Ran the patched script locally with `MARCH_BIN=/bin/echo` on a Falcon-managed Mac — guard fires immediately, prints the reason, exits 0, no goldens attempted.
- [x] Verified the underlying hang independently: a bare `clang -fsanitize=address` "hello world" binary hangs at `FindDynamicShadowStart` on this machine, confirming the Falcon/ASAN interaction rather than a march-specific issue.
- [ ] CI (no Falcon present) should still run the gate normally — not exercised here since it only affects Falcon-managed hosts.