### PR TITLE
fix(codegen): ~H misread non-IOList ADTs as IOList (XSS + SIGSEGV)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,34 @@ git log is authoritative for exact commits.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`~H` misread non-IOList ADTs as IOLists — unescaped output and a SIGSEGV.**
+  `march_html_auto_escape` ended by assuming any constructor with `tag >= 0` was
+  an `IOList` and flattening it verbatim. Constructor tags are numbered per type
+  from 0, so every ADT aliased `IOList`'s `Empty|Str|Segments`: a tag-1
+  constructor had its `String` field emitted **raw and unescaped**, a tag-2
+  constructor crashed walking field 0 as a cons list, and a tag-0 constructor
+  rendered empty. The widest case needed no custom type at all: `Cons` is tag 1
+  with the element in field 0, so interpolating a plain `List(String)` emitted
+  its head element raw and unescaped. `Option`/`Result` were not exempt — only `Some(x)` is
+  niche-optimised, so `Err("<b>")` leaked its payload unescaped and `Ok(...)`
+  was silently dropped. `Html.raw` content was also discarded whenever another
+  module declared a type named `Safe`. The interpreter was correct throughout;
+  this was compiled-only. The escaper now dispatches on the argument's static
+  type in `llvm_emit` rather than guessing from a heap tag. A hole whose type is
+  unresolved (a value reaching it through a closure stored in a container) is
+  stringified rather than flattened, since nothing at runtime can tell an
+  `IOList` from an ADT there; that makes a genuine `IOList` partial at such a
+  hole render `#<tag:N>` instead of its markup, which is a real but narrow
+  regression accepted over leaving an XSS and a crash in place.
+
+  Note one visible consequence: a user ADT interpolated into `~H` now renders as
+  `#<tag:N>` compiled, where the interpreter renders `Point(1, 2)`. That is a
+  pre-existing gap in compiled `to_string` (it has no constructor-name
+  metadata), now reachable from templates; tracked in
+  `specs/todos/2026-08-05-compiled-to-string-adt-ctor-names.md`.
+
 ### Added
 
 - **`forge cap inspect --strict`** re-checks the capability ceiling on a

--- a/lib/tir/llvm_emit.ml
+++ b/lib/tir/llvm_emit.ml
@@ -1568,8 +1568,57 @@ let rec emit_expr ctx (e : Tir.expr) : string * string =
     emit ctx (Printf.sprintf "%s = load ptr, ptr %s" r fp);
     ("ptr", r)
 
+  (* Every OTHER type: the runtime's polymorphic dispatch is only safe for the
+     three representations it can actually recognise — a low-bit-tagged
+     immediate, a MARCH_STRING_TAG string, and a genuine IOList.  Its final
+     arm ("Constructor with tag >= 0: treat as IOList") is a guess, and it is
+     wrong for every user ADT: constructor tags are numbered per type from 0,
+     so `B(String)` (tag 1) was read as `IOList.Str` and its field emitted RAW
+     AND UNESCAPED, and `C(_, _)` (tag 2) was read as `IOList.Segments` and
+     its field walked as a cons list — a segfault.  Decide it here instead,
+     where the static TIR type is still known, and only route to the runtime
+     the cases it genuinely handles.  Anything else — user ADTs, records,
+     tuples, and the `Safe`-name-collision case that falls through the arm
+     above — goes through `march_value_to_string` first, then escapes the
+     resulting real String. *)
   | Tir.EApp (f, [a]) when f.Tir.v_name = "html_auto_escape" ->
+    let runtime_safe =
+      match atom_tir_ty a with
+      | Tir.TString | Tir.TInt | Tir.TFloat | Tir.TBool -> true
+      | Tir.TCon ("IOList", _) -> true
+      (* An unresolved type variable is the genuinely undecidable case, and it
+         is NOT hypothetical: a value reaching this hole through a closure
+         stored in a container (defunctionalized dispatch, e.g.
+         `Bx(Cons(fn x -> ~H"<p>${x}</p>", Nil))`) is not specialised by mono
+         and arrives as TVar.  Neither answer is right for it — an IOList
+         wants flattening, an ADT must not be flattened, and nothing at
+         runtime can tell them apart, which is the whole defect.
+
+         So choose the failure that is not a vulnerability: stringify.  A
+         genuine IOList partial reaching a polymorphic hole renders as
+         `#<tag:2>` instead of its markup — visibly wrong, and a real
+         regression for that (rare) pattern.  Routing it to the runtime
+         instead would leave a tag-1 ADT emitting its String field raw and
+         unescaped, and a tag-2 ADT segfaulting.  A wrong-looking page beats
+         an XSS and a crash.
+
+         Fixing this properly means giving the runtime a way to identify the
+         type — march_hdr.pad is free for non-record ADTs and could carry a
+         type id — which is out of scope here; see
+         specs/todos/2026-08-05-boxed-adt-type-id.md. *)
+      | Tir.TVar _ -> false
+      | _ -> false
+    in
     let v = emit_atom_as ctx "ptr" a in
+    let v =
+      if runtime_safe then v
+      else begin
+        let s = fresh ctx "hae_str" in
+        emit ctx
+          (Printf.sprintf "%s = call ptr @march_value_to_string(ptr %s)" s v);
+        s
+      end
+    in
     let r = fresh ctx "hae" in
     emit ctx (Printf.sprintf "%s = call ptr @march_html_auto_escape(ptr %s)" r v);
     ("ptr", r)

--- a/runtime/march_extras.c
+++ b/runtime/march_extras.c
@@ -2434,7 +2434,32 @@ void *march_html_auto_escape(void *v) {
         free(out);
         return r;
     }
-    /* Constructor with tag >= 0: treat as IOList and flatten verbatim. */
+    /* Constructor with tag >= 0.  This USED to assume "it must be an IOList"
+       and flatten it verbatim, which was a guess the runtime cannot make:
+       constructor tags are numbered per type starting at 0, so every user ADT
+       aliases IOList's Empty|Str|Segments.  tag-1 ADTs had field 0 emitted raw
+       and unescaped (XSS); tag-2 ADTs had field 0 walked as a cons list
+       (SIGSEGV); tag-0 ADTs rendered empty.
+
+       llvm_emit now decides this from the argument's static TIR type and only
+       routes genuine IOLists here, so reaching this arm with a non-IOList
+       means a caller reintroduced the polymorphic path.  Fail loudly rather
+       than silently emitting unescaped bytes — the emitter is the real fix,
+       this is defense in depth.
+
+       Note the limit of this guard: IOList has three constructors, so tags
+       0..2 remain genuinely ambiguous here and cannot be rejected. Only a tag
+       of 3 or more is PROVABLY not an IOList. That is exactly why the real
+       fix has to live in the emitter, where the type is known. */
+    if (((march_hdr *)v)->tag > 2) {
+        fprintf(stderr,
+                "march_html_auto_escape: refusing to flatten constructor tag "
+                "%d as an IOList (IOList has only tags 0..2). Pass a String, "
+                "an immediate, or a real IOList; see the html_auto_escape "
+                "dispatch in lib/tir/llvm_emit.ml.\n",
+                ((march_hdr *)v)->tag);
+        abort();
+    }
     int64_t sz = mh_iolist_size(v);
     char *buf = (char *)malloc((size_t)(sz + 1));
     mh_iolist_copy(v, buf, 0);

--- a/specs/plans/2026-08-05-contextual-autoescaping.md
+++ b/specs/plans/2026-08-05-contextual-autoescaping.md
@@ -1,0 +1,958 @@
+# Contextual Auto-Escaping for `~H` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `~H`'s single context-blind escaper with a table-driven contextual escaper that picks the correct encoding for PCDATA, attribute, URL, CSS and script contexts — resolved entirely at compile time, with compile-time diagnostics for interpolations that cannot be made safe.
+
+**Architecture:** A declarative transition table (`specs/security/html-contexts.tbl`) is the single source of truth. A codegen step emits both an OCaml table (`lib/ctxesc/table_data.ml`) and a March table (`stdlib/ctx_table.march`) from it. The desugarer walks the static chunks of a `~H` sigil through the automaton at compile time and emits a *direct, monomorphic escaper call* per hole — no runtime automaton, no accumulator. This is sound because the paper establishes that an interpolation is a single transition whose successor context depends only on the predecessor context, never on the interpolated value, and because March's `~H` has no in-template control flow (no `if`/`for`), so there are no join points and no fixed point to compute.
+
+**Tech Stack:** OCaml 5.3.0 / dune, March stdlib, C runtime (escapers), alcotest.
+
+## Source
+
+Samuel, Palmer, Summa & Grayson, *Compile-time Security Analysis and Optimization of Sensitive String Producers* (Temper Systems), arXiv:2605.16561v1. Sections 4.6 (substitutions) and the transition-table figures are the normative reference for table semantics.
+
+## Global Constraints
+
+- OCaml switch is `march`. **Never** prefix commands with `eval $(opam env ...)`.
+- Run tests with `scripts/run-tests.sh` (not bare `dune runtest` — stale RPC daemons block runs).
+- Every feature commit must add a `CHANGELOG.md` bullet under `## [Unreleased]`. **This plan file is the `specs/` record for all of it** — no separate `specs/todos/` entry is filed, because Task 0's measured behaviour and root cause are recorded here rather than in a stub. On completion, add one `specs/progress/2026-08-05-contextual-autoescaping.md` summarising what shipped and link back to this file.
+- After changing the desugarer or TIR shape, regenerate TIR snapshots deliberately: `UPDATE_SNAPSHOTS=1 ./_build/default/test/run_snapshots.exe -e`, then review `git diff test/snapshots/` — that diff *is* the review artifact.
+- After editing `runtime/*.c`, build a target that restages the runtime (`dune build --root .`); a targeted `dune build bin/main.exe` does **not** refresh `_build/default/runtime`, and the CAS cache key is computed over the *staged* runtime.
+- **Non-breaking:** the existing `Html.Safe = Safe(String)` and `html_auto_escape` must keep working unchanged for the whole of this plan. New context-indexed types are added *alongside* and the old ones are marked deprecated in docstrings only.
+- Use `forge search` before grepping when looking for March modules/functions/types.
+
+---
+
+## Scope
+
+**In scope (this plan):** HTML plus the subsidiary automata HTML *requires* — URL (for `href`/`src`), CSS (for `<style>` and `style=`), and JS-string (for `<script>` and `on*=` handlers).
+
+**Also in scope, and landing first:** Task 0, an existing XSS and memory-safety defect in `~H` that is unrelated to context-sensitivity but sits in the same code path. It ships on its own branch ahead of the rest.
+
+**Out of scope (follow-up plan, outlined at the end):** the March-side runtime accumulator API (Layer A), generic accumulator-based desugaring for non-`~H` sigils, and standalone `~SQL` / `~SH` sigils.
+
+**Deliberate simplification — no regex engine.** The paper's tables use regular expressions to consume fixed input. Implementing and cross-validating a regex engine in both OCaml and March is disproportionate here. This plan uses a fixed, closed pattern vocabulary sufficient for HTML (see Task 1). If a future content language needs true regex, that is a table-format version bump, not a rewrite.
+
+---
+
+## File Structure
+
+| Path | Responsibility |
+|---|---|
+| `lib/tir/llvm_emit.ml` | **Task 0.** Generalise the `Html.Safe` type-directed dispatch to all types (existing file, lines 1559-1575) |
+| `runtime/march_extras.c` | **Task 0.** Turn the unreachable `tag >= 0 → IOList` fallback into an abort (existing file, lines 2437-2443) |
+| `specs/security/README.md` | Table format spec — the document a security engineer reads |
+| `specs/security/html-contexts.tbl` | **Source of truth.** Declarative transition table |
+| `lib/ctxesc/dune` | New OCaml library `march_ctxesc` |
+| `lib/ctxesc/context.ml` | The 4-tuple context type + escaper-id enum |
+| `lib/ctxesc/tbl_parse.ml` | Parser for the `.tbl` format (no new deps) |
+| `lib/ctxesc/table_data.ml` | **Generated.** The table as OCaml data |
+| `lib/ctxesc/automaton.ml` | `consume_literal`, `consume_interp`, `is_valid_terminal` |
+| `lib/ctxesc/emit_tables.ml` | Emitter executable → `table_data.ml` + `stdlib/ctx_table.march` |
+| `lib/desugar/desugar.ml` | Modify `html_interp_to_iolist` to fold contexts (existing file, ~line 456) |
+| `runtime/march_ctx_escape.c` | The escaper implementations |
+| `stdlib/html.march` | Add `Ctx` type + context-indexed `Safe`; deprecate old |
+| `test/test_ctxesc.ml` | Automaton unit tests |
+| `test/stdlib/test_html_ctx.march` | End-to-end escaping behaviour |
+
+---
+
+## Task 0: Fix the ADT-flattening hole — live XSS + SIGSEGV
+
+> **Land this on its own branch, before Tasks 1–8.** It is independent of the contextual-escaping
+> work and fixes two defects that exist in the shipped compiler today. It is also the reason this
+> plan does not need a separate `specs/todos/` entry: the measured behaviour, the root cause, and
+> the fix are recorded here.
+
+**Files:**
+- Modify: `lib/tir/llvm_emit.ml:1559-1575` (generalise the existing `Safe` special case)
+- Modify: `runtime/march_extras.c:2437-2443` (turn the unreachable fallback into an abort)
+- Test: `test/test_codegen.ml`, plus an interpreter/compiled parity test
+
+### Measured behaviour (2026-08-05, `_build/default/bin/main.exe`)
+
+`march_html_auto_escape` ends with *"Constructor with tag >= 0: treat as IOList and flatten
+verbatim"* and delegates to `mh_iolist_size`/`mh_iolist_copy`
+(`runtime/march_extras.c:2369-2407`), which branch on `tag == 1` → read field 0 as
+`march_string*`, and `tag == 2` → walk field 0 as a cons list. Constructor tags are numbered
+**per type** starting at 0, so any ADT collides with `IOList = Empty | Str(String) |
+Segments(List(IOList))`. Compiled results, all of which are correct when interpreted:
+
+| Interpolated into `~H"<p>${x}</p>"` | Compiled result |
+|---|---|
+| `Point(1, 2)` — tag 0, two fields | `<p></p>` — silently empty |
+| `B("<script>")` — tag 1, String field | `<p><script></p>` — **raw, unescaped: XSS** |
+| `C("xx", "yy")` — tag 2 | **SIGSEGV** (exit 139) |
+| `M2(7, 9)` — tag 2, Int fields | **SIGSEGV** |
+
+**CORRECTED 2026-08-05 by measurement.** This plan originally claimed `Option`/`Result` were
+niche-optimised and therefore safe. That holds only for `Some(x)`. `None`, `Ok` and `Err` are
+ordinary boxed constructors and collided exactly like any user ADT — `Err("<b>")` rendered
+`<p><b></p>`, raw and unescaped. Since `Result` is pervasive, that was the widest instance of
+the bug, not an exempt case.
+
+### The spike is already answered — do not re-run it
+
+`llvm_emit.ml:1543-1558` states the root cause outright: *"every Boxed ADT's constructor tags
+are numbered independently starting at 0, so the runtime has no way to tell a bare tag-0 heap
+cell apart from the other."* The runtime **cannot** decide this. `Html.Safe` was already
+patched at `llvm_emit.ml:1559-1569` by dispatching on the argument's static TIR type. The fix
+is to generalise that existing special case to cover every type, not to add a runtime check.
+
+Note also that the existing `Safe` patch has an escape hatch: when `"Safe"` collides with
+another module's short type name it deliberately falls through to the generic runtime path —
+which is the broken one. Under the generalised dispatch, the unknown/ambiguous case must route
+to `to_string` + escape, so a collision degrades to "renders the ADT" instead of "silently
+empty".
+
+- [ ] **Step 1: Write the failing tests**
+
+In `test/test_codegen.ml`:
+
+```ocaml
+("~H renders a multi-field ADT instead of dropping it", `Quick, fun () ->
+  let out = compile_and_run {|
+    type Point = Point(Int, Int)
+    fn main() do
+      let p = Point(1, 2)
+      IO.puts(IOList.to_string(~H"<p>${p}</p>"))
+    end
+  |} in
+  check_contains out "Point(1, 2)");
+
+("~H escapes a tag-1 ADT string field instead of emitting it raw", `Quick, fun () ->
+  let out = compile_and_run {|
+    type Multi = A | B(String)
+    fn main() do
+      let b = B("<script>")
+      IO.puts(IOList.to_string(~H"<p>${b}</p>"))
+    end
+  |} in
+  check_not_contains out "<script>";
+  check_contains out "&lt;script&gt;");
+
+("~H does not crash on a tag-2 ADT", `Quick, fun () ->
+  let out = compile_and_run {|
+    type Multi = A | B(String) | C(String, String)
+    fn main() do
+      let c = C("xx", "yy")
+      IO.puts(IOList.to_string(~H"<p>${c}</p>"))
+    end
+  |} in
+  check_contains out "xx");
+```
+
+And a parity test in the interpreter/compiled parity group (these are `Slow`-marked in
+`run_stdlib`) asserting the three programs above produce byte-identical output interpreted and
+compiled. The parity framing matters: the interpreter was correct the whole time, so parity is
+the property that would have caught this.
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+scripts/run-tests.sh codegen
+```
+Expected: test 1 FAILs with empty output, test 2 FAILs with raw `<script>`, test 3 **crashes the
+test runner with SIGSEGV**. If the runner aborts rather than reporting, run the third case
+standalone via `--compile` to confirm the signal before proceeding.
+
+- [ ] **Step 3: Generalise the emitter dispatch**
+
+Replace the two `html_auto_escape` cases at `llvm_emit.ml:1559-1575` with a single
+type-directed dispatch on `atom_tir_ty a`:
+
+- `TCon ("Safe", _)`, non-colliding → load field 0, emit verbatim (existing behaviour, keep)
+- `TCon ("IOList", _)` → call `march_html_auto_escape` (its IOList path is correct *when the
+  value really is an IOList*)
+- `TCon ("String", _)` → call the string escaper directly
+- immediates (`Int`, `Float`, `Bool`, `Char`) → existing tagged-ptr coercion path
+- **everything else, including the `Safe`-collision case** → emit `march_to_string(v)` then
+  escape the resulting string. This is the missing arm that currently misreads as an IOList.
+
+Keep the scalar re-tagging comment at `llvm_emit.ml:1531-1542` intact — that hazard is
+unrelated and still live.
+
+- [ ] **Step 4: Turn the runtime fallback into an abort**
+
+In `runtime/march_extras.c:2437-2443`, replace *"Constructor with tag >= 0: treat as IOList and
+flatten verbatim"* with a hard abort carrying the observed tag. After Step 3 this arm is
+unreachable from `~H`; making it loud means a future caller that reintroduces the polymorphic
+path fails immediately instead of silently emitting unescaped bytes. Defense in depth — the
+emitter is the real fix.
+
+- [ ] **Step 5: Rebuild with the runtime restaged, then verify**
+
+The runtime changed, so a targeted `dune build bin/main.exe` is **not** sufficient:
+
+```bash
+dune build --root .
+scripts/run-tests.sh
+```
+Expected: PASS, including the parity tests. Confirm no SIGSEGV in the runner output.
+
+- [ ] **Step 6: Reproduce and cover the `Safe`-collision fallback**
+
+The existing patch at `llvm_emit.ml:1559-1563` deliberately declines to fire when `"Safe"` is a
+same-short-name collision with another module's type, falling through to the generic path — the
+broken one. So `Html.raw` in any program that also defines its own `Safe` type should render
+empty today.
+
+This was read from the code, **not** measured — it needs two modules to trigger, and the probe
+runs in this task were single-module. Build the two-module case, confirm the behaviour, and pin
+it:
+
+```march
+mod Other do
+  type Safe = Safe(Int)
+end
+
+mod CollisionProbe do
+  fn main() do
+    let s = Html.raw("<b>x</b>")
+    IO.puts(IOList.to_string(~H"<p>${s}</p>"))
+  end
+end
+```
+
+Expected before the fix: `<p></p>`. Expected after: `<p><b>x</b></p>`, because the generalised
+dispatch routes the ambiguous case to `march_to_string` + escape rather than to the IOList
+misread — degraded (the wrapper is no longer verbatim) but safe and non-empty.
+
+If the collision case turns out **not** to reproduce, say so in the commit message and delete
+this step's test rather than leaving an assertion that passes for the wrong reason.
+
+- [ ] **Step 7: Sweep forgepm for exposed interpolations**
+
+The exposure is any boxed constructor reaching a `~H` hole: user-defined ADTs with two or more
+constructors, **and** `None` / `Ok` / `Err` (only `Some(x)` is niche-optimised away). Check both. forgepm has 153 `~H` sites. Find the
+ones at risk:
+
+```bash
+forge search --callers to_string
+```
+
+then check each `~H` interpolation in `lib/forgepm/web/pages.march`,
+`lib/forgepm/web/search_island.march`, `lib/forgepm/forgepm_router.march`,
+`lib/forgepm/web/web_router.march` and `lib/forgepm/orgs/org.march` for a hole whose expression
+has a user-defined multi-constructor ADT type.
+
+Any hit is a live XSS or crash in production and must be recorded in `specs/progress/` with the
+file and line. A clean sweep is also a result worth recording — it bounds the incident.
+
+**This is not Task 8.** Task 8 validates the new *contextual* analysis against the whole corpus;
+this step answers the narrower and more urgent question of whether the tag-collision bug is
+currently reachable in deployed code.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/tir/llvm_emit.ml runtime/march_extras.c test/test_codegen.ml test/stdlib
+git commit -m "fix(codegen): ~H misread non-IOList ADTs as IOList (XSS + SIGSEGV)
+
+Constructor tags are per-type, so any user ADT collided with IOList's
+Empty|Str|Segments tags. tag-1 ADTs with a String field were emitted raw
+and unescaped; tag-2 ADTs crashed walking field 0 as a cons list; tag-0
+multi-field ADTs rendered empty. Interpreted output was correct throughout.
+
+Generalises the existing Html.Safe type-directed dispatch in llvm_emit to
+cover all types, and makes the now-unreachable runtime fallback abort."
+```
+
+---
+
+## Task 1: Table format + parser
+
+**Files:**
+- Create: `specs/security/README.md`, `specs/security/html-contexts.tbl`
+- Create: `lib/ctxesc/dune`, `lib/ctxesc/context.ml`, `lib/ctxesc/tbl_parse.ml`
+- Test: `test/test_ctxesc.ml` (new), registered in `test/dune`
+
+**Interfaces:**
+- Produces:
+  ```ocaml
+  (* context.ml *)
+  type state = Pcdata | RcData | TagOpen | TagName | BeforeAttrName | AttrName
+             | AfterAttrName | BeforeAttrValue | AttrValue | AfterAttrValue
+             | Comment | Doctype
+  type element = ElNormal | ElScript | ElStyle | ElTextarea | ElTitle
+  type attr    = AtNormal | AtUrl | AtStyle | AtScript
+  type delim   = DlNone | DlSingle | DlDouble | DlUnquoted | DlDoubleSubst
+  type t = { state : state; element : element; attr : attr; delim : delim }
+  val initial : t
+  type escaper = EscHtml | EscAttr | EscUrlComponent | EscUrlWhole
+               | EscCss | EscJsString | EscNone | EscReject of string
+  val escaper_id : escaper -> int   (* stable ids shared with the C runtime *)
+
+  (* tbl_parse.ml *)
+  type pattern = PLit of string | PClass of char list | PClassPlus of char list
+               | PInterp | PUntil of string
+  type row = { from_pat : Context.t option_pat; pat : pattern;
+               subst : string option; succ : Context.t option_pat;
+               diag : string option }
+  val parse_file : string -> (row list, string) result
+  ```
+
+`DlDoubleSubst` is the paper's substitution mechanism: an unquoted attribute value that we forcibly quoted. It is a distinct delimiter so the automaton knows to emit the closing `"` on exit.
+
+- [ ] **Step 1: Write the format spec**
+
+Create `specs/security/README.md` documenting the `.tbl` grammar. One row per line, `|`-separated, `#` starts a comment:
+
+```
+# from-context | pattern | substitution | successor-context | diagnostic
+# Context is state,element,attr,delim — `*` means "any", and `=` in the
+# successor means "unchanged from the source context".
+pcdata,*,*,*        | lit:"<"       |     | tagopen,=,=,=      |
+pcdata,*,*,*        | interp        |     | =,=,=,=            |
+beforeattrvalue,*,*,unquoted | interp | "\"" | attrvalue,=,=,doublesubst |
+attrname,*,*,*      | interp        |     | =,=,=,=            | Cannot interpolate an attribute name
+```
+
+- [ ] **Step 2: Write the failing parser test**
+
+In `test/test_ctxesc.ml`:
+
+```ocaml
+let test_parse_minimal () =
+  let tmp = Filename.temp_file "tbl" ".tbl" in
+  let oc = open_out tmp in
+  output_string oc "# comment\npcdata,*,*,* | lit:\"<\" |  | tagopen,=,=,= |\n";
+  close_out oc;
+  match March_ctxesc.Tbl_parse.parse_file tmp with
+  | Error e -> Alcotest.failf "parse failed: %s" e
+  | Ok rows ->
+    Alcotest.(check int) "one row" 1 (List.length rows);
+    let r = List.hd rows in
+    Alcotest.(check bool) "literal pattern" true
+      (r.March_ctxesc.Tbl_parse.pat = March_ctxesc.Tbl_parse.PLit "<")
+
+let test_parse_rejects_unknown_state () =
+  let tmp = Filename.temp_file "tbl" ".tbl" in
+  let oc = open_out tmp in
+  output_string oc "notastate,*,*,* | lit:\"<\" |  | pcdata,=,=,= |\n";
+  close_out oc;
+  match March_ctxesc.Tbl_parse.parse_file tmp with
+  | Ok _ -> Alcotest.fail "should have rejected unknown state"
+  | Error e ->
+    Alcotest.(check bool) "names the bad state" true
+      (Astring.String.is_infix ~affix:"notastate" e)
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+```bash
+scripts/run-tests.sh ctxesc
+```
+Expected: FAIL — library `march_ctxesc` does not exist.
+
+- [ ] **Step 4: Implement `context.ml`, `tbl_parse.ml`, `lib/ctxesc/dune`**
+
+`lib/ctxesc/dune`:
+```
+(library
+ (name march_ctxesc)
+ (modules context tbl_parse table_data automaton))
+```
+
+Implement the types in the Interfaces block above. `parse_file` splits on `|`, trims, parses each context field against a fixed name table, and returns `Error` with the offending line number and token for anything unrecognised. **Unknown names must be a hard error, never a silent skip** — a typo'd state name in a security table that silently drops a row is the worst possible failure mode.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+scripts/run-tests.sh ctxesc
+```
+Expected: PASS.
+
+- [ ] **Step 6: Write the real HTML table**
+
+Populate `specs/security/html-contexts.tbl` with the full HTML automaton: PCDATA, tag open/name, attribute name/value in all four delimiter modes, comments, and the `script`/`style`/`textarea`/`title` RCDATA and raw-text elements. Attribute classification (`AtUrl` for `href`/`src`/`action`/`formaction`/`poster`, `AtStyle` for `style`, `AtScript` for `on*`) is assigned on the `attrname → afterattrname` transition.
+
+Rows that must carry a diagnostic (interpolation is unsafe at any encoding):
+- `tagname` — cannot interpolate an element name
+- `attrname` — cannot interpolate an attribute name
+- `comment` — cannot interpolate inside a comment
+- `beforeattrname` — cannot interpolate where an attribute name is expected
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add specs/security lib/ctxesc test/test_ctxesc.ml test/dune
+git commit -m "feat(ctxesc): declarative HTML context transition table + parser"
+```
+
+---
+
+## Task 2: The automaton
+
+**Files:**
+- Create: `lib/ctxesc/automaton.ml`
+- Modify: `test/test_ctxesc.ml`
+
+**Interfaces:**
+- Consumes: `Context.t`, `Tbl_parse.row` from Task 1.
+- Produces:
+  ```ocaml
+  type step_out = {
+    emit : string;          (* the literal text to emit, incl. substitutions *)
+    ctx  : Context.t;
+  }
+  val consume_literal : Context.t -> string -> (step_out, string * int) result
+  (* Error (message, byte_offset_into_literal) *)
+
+  val consume_interp : Context.t -> (Context.escaper * string * Context.t, string) result
+  (* Ok (escaper, substitution_prefix, successor_context) | Error diagnostic *)
+
+  val is_valid_terminal : Context.t -> bool
+  val describe : Context.t -> string   (* for diagnostics: "inside an unquoted attribute value" *)
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `test/test_ctxesc.ml`:
+
+```ocaml
+let ctx_after s =
+  match Automaton.consume_literal Context.initial s with
+  | Ok o -> o.ctx
+  | Error (m, _) -> Alcotest.failf "unexpected error: %s" m
+
+let test_pcdata_stays_pcdata () =
+  Alcotest.(check bool) "plain text" true
+    ((ctx_after "hello world").state = Context.Pcdata)
+
+let test_enters_double_quoted_attr () =
+  let c = ctx_after "<a href=\"" in
+  Alcotest.(check bool) "in attr value" true (c.state = Context.AttrValue);
+  Alcotest.(check bool) "double delim"  true (c.delim = Context.DlDouble);
+  Alcotest.(check bool) "url attr"      true (c.attr  = Context.AtUrl)
+
+let test_script_body_is_js () =
+  let c = ctx_after "<script>" in
+  Alcotest.(check bool) "script element" true (c.element = Context.ElScript)
+
+let test_interp_in_url_attr_picks_url_escaper () =
+  let c = ctx_after "<a href=\"" in
+  match Automaton.consume_interp c with
+  | Ok (esc, _, _) ->
+    Alcotest.(check bool) "url escaper" true (esc = Context.EscUrlWhole)
+  | Error e -> Alcotest.failf "unexpected reject: %s" e
+
+let test_interp_in_attr_name_is_rejected () =
+  let c = ctx_after "<div " in
+  match Automaton.consume_interp c with
+  | Ok _ -> Alcotest.fail "attribute-name interpolation must be rejected"
+  | Error _ -> ()
+
+let test_unquoted_attr_gets_substituted_quote () =
+  let c = ctx_after "<div class=" in
+  match Automaton.consume_interp c with
+  | Ok (_, subst, c') ->
+    Alcotest.(check string) "opening quote substituted" "\"" subst;
+    Alcotest.(check bool) "delim marked substituted" true
+      (c'.delim = Context.DlDoubleSubst)
+  | Error e -> Alcotest.failf "unexpected reject: %s" e
+
+let test_unterminated_tag_is_invalid_terminal () =
+  Alcotest.(check bool) "open tag is not a valid end state" false
+    (Automaton.is_valid_terminal (ctx_after "<div"))
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+scripts/run-tests.sh ctxesc
+```
+Expected: FAIL — `Automaton` unbound.
+
+- [ ] **Step 3: Implement `automaton.ml`**
+
+`consume_literal` walks the string byte by byte, at each position selecting the first table row whose `from_pat` matches the current context and whose `pattern` matches at that position (longest literal first). It accumulates `emit`, applying any `subst`. On no matching row, return `Error` with the byte offset.
+
+`consume_interp` selects the row whose pattern is `PInterp`; if that row carries a `diag`, return `Error diag`. Otherwise return the escaper implied by the successor context, the substitution prefix, and the successor.
+
+When a `DlDoubleSubst` attribute value is exited, `consume_literal` must emit a closing `"` before the whitespace or `>` that ends it.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+scripts/run-tests.sh ctxesc
+```
+Expected: PASS, all seven.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/ctxesc/automaton.ml test/test_ctxesc.ml
+git commit -m "feat(ctxesc): HTML context automaton with substitutions"
+```
+
+---
+
+## Task 3: Escaper implementations in the C runtime
+
+**Files:**
+- Create: `runtime/march_ctx_escape.c`, `runtime/march_ctx_escape.h`
+- Test: `test/test_ctx_escape.c` + a `test/dune` rule modelled on the "HCR capability-lattice C table unit test" at `test/dune:176-191`
+
+**Interfaces:**
+- Produces:
+  ```c
+  /* escaper ids must match Context.escaper_id in lib/ctxesc/context.ml */
+  #define MARCH_ESC_HTML          0
+  #define MARCH_ESC_ATTR          1
+  #define MARCH_ESC_URL_COMPONENT 2
+  #define MARCH_ESC_URL_WHOLE     3
+  #define MARCH_ESC_CSS           4
+  #define MARCH_ESC_JS_STRING     5
+  #define MARCH_ESC_NONE          6
+  void *march_html_escape_ctx(int64_t escaper_id, void *v);
+  ```
+
+Semantics per escaper:
+- `HTML` — `& < > " '` to entities (matches today's behaviour).
+- `ATTR` — as HTML, plus backtick, for IE attribute-delimiter quirks.
+- `URL_COMPONENT` — percent-encode everything outside RFC 3986 unreserved.
+- `URL_WHOLE` — scheme allowlist. `http`, `https`, `mailto`, and scheme-relative or path-relative URLs pass through percent-normalised; **everything else, notably `javascript:` and `data:`, is replaced with `about:invalid#zSoyz`.** This is the fix for the live `href` hole.
+- `CSS` — allow only `[a-zA-Z0-9_.#%-]` and safe string content; replace anything else with `\` + hex escape.
+- `JS_STRING` — JSON-string escaping plus `</`, `<!--`, U+2028, U+2029.
+
+- [ ] **Step 1: Write the failing C test**
+
+`test/test_ctx_escape.c` — a plain C main asserting on each escaper. The critical cases:
+
+```c
+assert_esc(MARCH_ESC_URL_WHOLE, "javascript:alert(1)", "about:invalid#zSoyz");
+assert_esc(MARCH_ESC_URL_WHOLE, "JaVaScRiPt:alert(1)", "about:invalid#zSoyz");
+assert_esc(MARCH_ESC_URL_WHOLE, "  javascript:alert(1)", "about:invalid#zSoyz");
+assert_esc(MARCH_ESC_URL_WHOLE, "java\tscript:alert(1)", "about:invalid#zSoyz");
+assert_esc(MARCH_ESC_URL_WHOLE, "https://example.com/a?b=c", "https://example.com/a?b=c");
+assert_esc(MARCH_ESC_URL_WHOLE, "/relative/path", "/relative/path");
+assert_esc(MARCH_ESC_JS_STRING, "</script>", "\\u003c/script\\u003e");
+assert_esc(MARCH_ESC_ATTR, "a\" onload=\"x", "a&quot; onload=&quot;x");
+assert_esc(MARCH_ESC_CSS, "expression(alert(1))", /* neutralised */ ...);
+```
+
+The scheme check must be done **after** stripping leading whitespace and control characters, and case-insensitively — that is what the three `javascript:` variants above pin.
+
+- [ ] **Step 2: Add the dune rule and run to verify failure**
+
+Add to `test/dune`, mirroring lines 176–191:
+
+```
+; ── contextual escaper unit test ──────────────────────────────────────────
+(rule
+ (targets test_ctx_escape_runner)
+ (deps    test_ctx_escape.c
+          ../runtime/march_ctx_escape.c
+          ../runtime/march_ctx_escape.h)
+ (action  (run %{cc}
+               -std=gnu11 -Wall -Wextra -I../runtime
+               -o %{targets}
+               test_ctx_escape.c ../runtime/march_ctx_escape.c)))
+
+(rule
+ (alias   runtest)
+ (deps    (file test_ctx_escape_runner))
+ (action  (run ./test_ctx_escape_runner)))
+```
+
+```bash
+dune build --root . 2>&1 | head -20
+```
+Expected: FAIL — `march_ctx_escape.c` does not exist.
+
+- [ ] **Step 3: Implement the escapers**
+
+Write `runtime/march_ctx_escape.c`. For the value→string normalisation, reuse the existing immediate/string/IOList handling from `march_html_auto_escape` (`runtime/march_extras.c:2409`) — but **do not copy its `tag >= 0 → treat as IOList` fallback**. That fallback is the XSS-and-SIGSEGV bug measured in Task 0; propagating it into a second escaper would double the blast radius. `march_html_escape_ctx` must never dispatch polymorphically on a heap tag: the caller (Task 5's desugar fold, via Task 0's type-directed emitter dispatch) is responsible for handing it a String, and anything else is a hard abort.
+
+**Task 0 lands before this task**, so the correct dispatch already exists to copy.
+
+- [ ] **Step 4: Run to verify it passes**
+
+```bash
+dune build --root . && ./_build/default/test/test_ctx_escape_runner
+```
+Expected: exit 0, no assertion failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add runtime/march_ctx_escape.c runtime/march_ctx_escape.h test/test_ctx_escape.c test/dune
+git commit -m "feat(runtime): contextual escapers incl. URL scheme allowlist"
+```
+
+---
+
+## Task 4: Wire `html_escape_ctx` into typecheck, TIR and eval
+
+**Files:**
+- Modify: `lib/typecheck/typecheck.ml:2587` (builtin type table)
+- Modify: `lib/tir/llvm_builtins.ml:106-107`, `lib/tir/llvm_emit.ml:1559-1574`, `lib/tir/defun.ml:140`
+- Modify: `lib/eval/eval.ml:4259` (interpreter builtin)
+- Test: `test/test_codegen.ml`, `test/test_eval.ml`
+
+**Interfaces:**
+- Consumes: `march_html_escape_ctx` from Task 3.
+- Produces: a March-visible builtin `html_escape_ctx : Int -> a -> String`, callable from desugared code.
+
+This task mirrors, line for line, the existing wiring of `html_auto_escape` — read all five call sites listed above first; each needs an analogous entry for the two-argument form. Note `llvm_emit.ml:1531-1548` documents a real hazard: the emitter special-cases the call because a scalar `i64` argument must be re-tagged before being passed as a generic `ptr`. The two-argument version has the same hazard on its *second* argument; the first (the escaper id) is a genuine `i64`.
+
+- [ ] **Step 1: Write the failing eval test**
+
+In `test/test_eval.ml`, alongside the existing `html_auto_escape` coverage:
+
+```ocaml
+let test_html_escape_ctx_url () =
+  check_eval_string
+    {| html_escape_ctx(3, "javascript:alert(1)") |}
+    "about:invalid#zSoyz"
+
+let test_html_escape_ctx_attr () =
+  check_eval_string
+    {| html_escape_ctx(1, "a\" onload=\"x") |}
+    "a&quot; onload=&quot;x"
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+scripts/run-tests.sh -q eval
+```
+Expected: FAIL — unbound `html_escape_ctx`.
+
+- [ ] **Step 3: Add the builtin to all five sites**
+
+Typecheck (`typecheck.ml`, next to the `html_auto_escape` entry):
+```ocaml
+("html_escape_ctx", poly1 (fun a -> TArrow (t_int, TArrow (a, t_string))));
+```
+Then `llvm_builtins.ml` declaration, `llvm_emit.ml` emission (including the scalar re-tag path for arg 2), `defun.ml` known-name list, and the `eval.ml` `VBuiltin` case.
+
+- [ ] **Step 4: Run to verify it passes**
+
+```bash
+scripts/run-tests.sh -q eval codegen
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/typecheck lib/tir lib/eval test/test_eval.ml test/test_codegen.ml
+git commit -m "feat: html_escape_ctx builtin wired through typecheck/TIR/eval"
+```
+
+---
+
+## Task 5: Compile-time context folding in the desugarer
+
+**Files:**
+- Modify: `lib/desugar/desugar.ml:456-500` (`html_interp_to_iolist`)
+- Modify: `lib/desugar/dune` (add `march_ctxesc` to libraries)
+- Test: `test/test_codegen.ml` ("~H sigil codegen" group, `test/test_codegen.ml:13385`), `test/stdlib/test_html_ctx.march`
+
+**Interfaces:**
+- Consumes: `Automaton.consume_literal`, `Automaton.consume_interp`, `Context.escaper_id` (Tasks 1–2); `html_escape_ctx` (Task 4); `desugar_expr_error` (`desugar.ml:520`).
+- Produces: `~H` desugars to `IOList.from_strings([...])` where each hole is `html_escape_ctx(<id>, e)` rather than `html_auto_escape(e)`.
+
+This replaces the "Third pass" at `desugar.ml:465-481`. The island and CSRF passes run first and are unchanged; both inject markup that is only valid in PCDATA, so the fold must assert the context is `Pcdata` at those points and emit a diagnostic otherwise.
+
+- [ ] **Step 1: Write the failing codegen tests**
+
+In `test/test_codegen.ml`, in the `"~H sigil codegen"` group:
+
+```ocaml
+("~H picks URL escaper inside href", `Quick, fun () ->
+  let out = compile_and_run {|
+    let url = "javascript:alert(1)"
+    IO.println(IOList.to_string(~H"<a href=\"${url}\">x</a>"))
+  |} in
+  check_contains out "about:invalid#zSoyz";
+  check_not_contains out "javascript:");
+
+("~H quotes an unquoted attribute", `Quick, fun () ->
+  let out = compile_and_run {|
+    let cls = "a b onmouseover=alert(1)"
+    IO.println(IOList.to_string(~H"<div class=${cls}>x</div>"))
+  |} in
+  check_contains out "class=\"a b onmouseover=alert(1)\"");
+
+("~H uses JS escaping inside script", `Quick, fun () ->
+  let out = compile_and_run {|
+    let payload = "</script><script>alert(1)"
+    IO.println(IOList.to_string(~H"<script>var x = \"${payload}\";</script>"))
+  |} in
+  check_not_contains out "</script><script>");
+
+("~H still escapes PCDATA as before", `Quick, fun () ->
+  let out = compile_and_run {|
+    let s = "<b>&"
+    IO.println(IOList.to_string(~H"<p>${s}</p>"))
+  |} in
+  check_contains out "<p>&lt;b&gt;&amp;</p>");
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+scripts/run-tests.sh codegen
+```
+Expected: FAIL — the URL test prints `javascript:alert(1)` (this is the current live vulnerability, now pinned by a test).
+
+- [ ] **Step 3: Implement the fold**
+
+Replace the third pass in `html_interp_to_iolist`:
+
+```ocaml
+let ctx = ref March_ctxesc.Context.initial in
+let parts = List.concat_map (fun part ->
+  match part with
+  | ELit (LitString s, sp) ->
+    (match March_ctxesc.Automaton.consume_literal !ctx s with
+     | Ok o -> ctx := o.ctx; [ELit (LitString o.emit, sp)]
+     | Error (msg, _off) ->
+       desugar_expr_error ~sp msg; [part])
+  | EApp (EVar { txt = "to_string"; _ }, [inner], psp) ->
+    (match March_ctxesc.Automaton.consume_interp !ctx with
+     | Ok (esc, subst, ctx') ->
+       ctx := ctx';
+       let id = March_ctxesc.Context.escaper_id esc in
+       let call =
+         EApp (EVar { txt = "html_escape_ctx"; span = psp },
+               [ELit (LitInt id, psp); inner], psp) in
+       if subst = "" then [call]
+       else [ELit (LitString subst, psp); call]
+     | Error diag ->
+       desugar_expr_error ~sp:psp diag
+         ~hint:(Printf.sprintf "This interpolation is %s, where no escaping can make \
+                                untrusted input safe. Move the dynamic part into a \
+                                value position instead."
+                  (March_ctxesc.Automaton.describe !ctx));
+       [part])
+  | other ->
+    (* island_ssr / CSRF injections: valid only in PCDATA *)
+    if !ctx.March_ctxesc.Context.state <> March_ctxesc.Context.Pcdata then
+      desugar_expr_error ~sp
+        "Template fragments can only be inserted in element content, not inside a tag.";
+    [other]
+) parts in
+if not (March_ctxesc.Automaton.is_valid_terminal !ctx) then
+  desugar_expr_error ~sp
+    "This ~H template does not end in a well-formed state — a tag or attribute is left open."
+```
+
+Preserve the existing unique-span discipline documented at `desugar.ml:483-495` verbatim; the substitution segments are *new* nodes and each needs its own distinct span or the type map will be clobbered.
+
+- [ ] **Step 4: Run to verify they pass**
+
+```bash
+scripts/run-tests.sh codegen
+```
+Expected: PASS, all four.
+
+- [ ] **Step 5: Regenerate TIR snapshots and review the diff**
+
+```bash
+UPDATE_SNAPSHOTS=1 ./_build/default/test/run_snapshots.exe -e
+git diff test/snapshots/
+```
+Expected: `html_auto_escape` calls become `html_escape_ctx` calls with an explicit id. Read every changed line — an id that looks wrong for its context is a security bug, and this diff is where it is visible.
+
+- [ ] **Step 6: Run the full suite**
+
+```bash
+scripts/run-tests.sh
+```
+Expected: PASS. `test/stdlib/test_sigil.march` must still pass unchanged — its PCDATA assertions pin the no-regression property.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/desugar test/test_codegen.ml test/snapshots
+git commit -m "feat(desugar): compile-time contextual escaping for ~H sigils"
+```
+
+---
+
+## Task 6: Context-indexed `Safe`, added alongside the old one
+
+**Files:**
+- Modify: `stdlib/html.march:14` (add, do not change, `Safe`)
+- Test: `test/stdlib/test_html_ctx.march`
+
+**Interfaces:**
+- Produces:
+  ```march
+  type Ctx = CtxPcdata | CtxAttr | CtxUrl | CtxCss | CtxJs
+  type Trusted = Trusted(Ctx, String)
+
+  fn trust(ctx : Ctx, s : String) : Trusted
+  fn untrust(t : Trusted) : String
+  fn trusted_ctx(t : Trusted) : Ctx
+  ```
+
+`Html.Safe`/`Html.raw` keep their exact current behaviour and signatures. Their docstrings gain a deprecation note pointing at `Trusted`, explaining that `Safe` is context-free and therefore trusted everywhere once trusted anywhere. **Do not remove them** — `bastion` is published at 0.2.3 and external consumers may depend on them.
+
+- [ ] **Step 1: Write the failing March test**
+
+`test/stdlib/test_html_ctx.march`:
+
+```march
+mod TestHtmlCtx do
+
+describe "context-indexed trust" do
+  test "trusted markup is inserted verbatim in its own context" do
+    let t = Html.trust(Html.CtxPcdata, "<b>bold</b>")
+    let out = ~H"<p>${t}</p>"
+    assert (IOList.to_string(out) == "<p><b>bold</b></p>")
+  end
+
+  test "trusted PCDATA is NOT trusted in an href" do
+    let t = Html.trust(Html.CtxPcdata, "javascript:alert(1)")
+    let out = ~H"<a href=\"${t}\">x</a>"
+    assert (String.contains(IOList.to_string(out), "about:invalid"))
+  end
+
+  test "legacy Html.raw still works" do
+    let s = Html.raw("<i>x</i>")
+    assert (Html.unwrap(s) == "<i>x</i>")
+  end
+end
+
+end
+```
+
+The second test is the whole point of the change: trust must not be transitive across contexts.
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+scripts/run-tests.sh -q stdlib
+```
+Expected: FAIL — `Html.trust` undefined.
+
+- [ ] **Step 3: Implement `Trusted` in `stdlib/html.march`, and teach `march_html_escape_ctx` about it**
+
+An escaper receiving a `Trusted(ctx, s)` emits `s` verbatim **only** when `ctx` matches the escaper's own context; otherwise it escapes `s` as untrusted.
+
+- [ ] **Step 4: Run to verify it passes**
+
+```bash
+scripts/run-tests.sh -q stdlib
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add stdlib/html.march test/stdlib/test_html_ctx.march
+git commit -m "feat(stdlib): context-indexed Html.Trusted alongside legacy Safe"
+```
+
+---
+
+## Task 7: Codegen wiring, drift guard, and docs
+
+**Files:**
+- Create: `lib/ctxesc/emit_tables.ml`
+- Modify: `lib/ctxesc/dune`, `test/dune`, `CHANGELOG.md`
+- Move: `specs/todos/<this>.md` → `specs/progress/2026-08-05-contextual-autoescaping.md`
+
+Up to this point `table_data.ml` may be hand-written. This task makes the `.tbl` file the real source of truth and adds the anti-drift check, modelled on `lib/caps/emit_c_table.ml` + the freshness rule at `test/dune:176`.
+
+- [ ] **Step 1: Write the emitter**
+
+`lib/ctxesc/emit_tables.ml` — reads `specs/security/html-contexts.tbl`, writes `lib/ctxesc/table_data.ml` and `stdlib/ctx_table.march`. Header comment on both generated files: *"GENERATED — do not edit. Regenerate with `./_build/default/lib/ctxesc/emit_tables.exe`."*
+
+- [ ] **Step 2: Add the freshness rule to `test/dune`**
+
+Regenerate into a temp prefix and diff against the committed copies; fail with the regeneration command in the message if they differ.
+
+- [ ] **Step 3: Verify the guard actually catches drift**
+
+Deliberately edit one row of `specs/security/html-contexts.tbl` without regenerating, run `scripts/run-tests.sh`, and confirm it fails. Revert.
+
+Expected: FAIL before revert, PASS after. A drift guard that has never been seen to fail is not known to work.
+
+- [ ] **Step 4: Update docs and tracking**
+
+- `CHANGELOG.md` under `## [Unreleased]` → `### Fixed`: note that `~H` now escapes by parse context, that `javascript:` URLs in `href` are neutralised, and that unquoted attribute values are auto-quoted. This is a **behaviour change** for existing templates and must be listed as such.
+- `specs/security/README.md`: add the regeneration command.
+- `git mv` the todo file to `specs/progress/`.
+- Run `scripts/check-docs.sh` — it gates CI on stale stdlib module counts, and this plan adds stdlib modules.
+
+- [ ] **Step 5: Full suite + benchmark check**
+
+```bash
+scripts/run-tests.sh
+scripts/check-docs.sh
+```
+
+Then confirm no template-rendering regression, compiled (never interpreted):
+```bash
+march --compile --opt 2 bench/list_ops.march -o /tmp/list_ops && /tmp/list_ops
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/ctxesc test/dune CHANGELOG.md specs
+git commit -m "feat(ctxesc): generate tables from spec file + CI drift guard"
+```
+
+---
+
+## Task 8: Validate against forgepm's 153 real templates
+
+**Files:** none in this repo — this is a validation gate.
+
+forgepm has 153 `~H` sites and exactly one `Html.raw`. It is the only real-world corpus available and the only way to find out how many existing templates the new diagnostics reject.
+
+- [ ] **Step 1: Build forgepm against the new compiler**
+
+```bash
+cd /Users/80197052/code/march && MARCH_LIB_PATH=/Users/80197052/code/forgepm/lib \
+  ./_build/default/bin/main.exe --compile -o /tmp/forgepm_check \
+  /Users/80197052/code/forgepm/lib/forgepm.march
+```
+
+- [ ] **Step 2: Triage every new diagnostic**
+
+For each one, classify: (a) a genuine template bug the analysis correctly caught — fix the template; (b) a table gap — fix the table and add a row-level test in `test_ctxesc.ml`; (c) a false positive from the pattern-vocabulary simplification — record it in `specs/security/README.md` under a "Known limitations" heading.
+
+**Do not silence a diagnostic by widening a table row without a test pinning the widening.** That is how these systems rot.
+
+- [ ] **Step 3: Diff the rendered output of the admin request-detail modal**
+
+That page renders untrusted `user_agent` and `path`. Render it before and after and diff. Expect changed output *only* where the old escaping was wrong.
+
+- [ ] **Step 4: Record findings in `specs/progress/` and commit any table fixes**
+
+---
+
+## Follow-up plan (not in scope here)
+
+**"Runtime accumulator + generic sigils"** — Layer A. Ports the automaton to March (`stdlib/ctx_accumulator.march`, consuming the generated `stdlib/ctx_table.march`), exposes `Acc.new/append_fixed/append_unsafe/collected`, and changes `desugar.ml:741` so non-`~H` sigils receive their static/dynamic *segments* instead of a pre-concatenated string. Two payoffs: an escape hatch for dynamic composition that today has none, and a differential test oracle — the March runtime automaton and the OCaml constant-folder read the same generated tables and must agree on every input, which is a far stronger correctness argument than either has alone.
+
+Note the performance caveat from the design discussion: the runtime accumulator pays a real per-character scan over fixed chunks. It is the substrate and the escape hatch, not the ergonomic front door. `~H` must keep going through the compile-time fold.
+
+---
+
+## Self-Review
+
+**Spec coverage.** Transition tables → Tasks 1, 7. Context tuple → Task 1. Subsidiary automata (URL/CSS/JS) → Tasks 1, 3. Epsilon transitions with substitutions → Tasks 1, 2, 5. Escaper selection + accumulator erasure → Task 5 (erasure is total here, by constant folding). Compile-time diagnostics → Tasks 2, 5. `isValidTerminalContext` → Tasks 2, 5. Merge at join points → **deliberately not implemented**: `~H` has no in-template control flow, so no join points exist. If in-template `if`/`for` is ever added to `~H`, `Automaton.merge` becomes required and this is the gap to close first.
+
+**Type consistency.** `Context.t` field names (`state`/`element`/`attr`/`delim`) are used identically in Tasks 1, 2 and 5. `escaper_id` ids in `context.ml` and the `MARCH_ESC_*` C defines in Task 3 must agree — Task 7's drift guard covers the OCaml↔March pair but **not** the OCaml↔C pair. Add that assertion to Task 3's C test.
+
+**Task ordering.** Task 0 was measured after this plan was first drafted and turned out to be a
+live XSS plus a SIGSEGV in the shipped compiler, independent of everything else here — hence its
+promotion to the front and its own branch. Task 3 then copies its type-directed dispatch rather
+than the broken polymorphic one. Order: 0, then 1 → 2 → 3 → 4 → 5 → 6 → 7 → 8.
+
+**Known risk.** The `Repr` decision of which single-field ADTs are newtype-erased versus Boxed
+is load-bearing for Task 0's dispatch and for Task 6's `Trusted`. A user-defined
+`MySafe(String)` is newtype-erased to a bare String (measured), while `Html.Safe(String)` is
+Boxed — same declared shape, different representation. Task 6 must establish which side
+`Trusted(Ctx, String)` lands on *before* writing the escaper's verbatim-insertion path; a
+two-field constructor is unambiguously Boxed, which is one reason to prefer that shape over a
+phantom-typed single-field wrapper.

--- a/specs/progress/2026-08-05-h-sigil-adt-misread.md
+++ b/specs/progress/2026-08-05-h-sigil-adt-misread.md
@@ -1,0 +1,140 @@
+# `~H` misread non-IOList ADTs as IOLists — XSS + SIGSEGV
+
+**Landed:** 2026-08-05
+**Branch:** `fix/h-sigil-adt-misread` (off `main` @ `079ff744`)
+**Severity:** High — unescaped output and a memory-unsafe read in compiled code
+
+Task 0 of `specs/plans/2026-08-05-contextual-autoescaping.md`, split out and
+landed ahead of the rest because it is independent of contextual escaping and
+was live in the shipped compiler.
+
+## The defect
+
+`march_html_auto_escape` (`runtime/march_extras.c`) ended with:
+
+```c
+/* Constructor with tag >= 0: treat as IOList and flatten verbatim. */
+```
+
+and delegated to `mh_iolist_size` / `mh_iolist_copy`, which branch on the raw
+heap tag: tag 1 reads field 0 as a `march_string*`, tag 2 walks field 0 as a
+cons list. Constructor tags are numbered **per type** starting at 0, so every
+ADT aliases `IOList = Empty | Str(String) | Segments(List(IOList))`.
+
+The runtime cannot resolve this — `llvm_emit.ml:1543-1558` already said so in
+prose while patching the single `Html.Safe` instance of it.
+
+## Measured before/after (compiled; the interpreter was correct throughout)
+
+| Interpolated into `~H"<p>${x}</p>"` | Before | After |
+|---|---|---|
+| `Point(1, 2)` — tag 0, 2 fields | `<p></p>` (empty) | `<p>#&lt;tag:0&gt;</p>` |
+| `B("<script>")` — tag 1, String | `<p><script></p>` **raw, unescaped** | `<p>#&lt;tag:1&gt;</p>` |
+| `C("xx", "yy")` — tag 2 | **SIGSEGV** (exit 139) | `<p>#&lt;tag:2&gt;</p>` |
+| `Err("<b>")` | `<p><b></p>` **raw, unescaped** | `<p>#&lt;tag:1&gt;</p>` |
+| `Ok("<script>")` | `<p></p>` (payload dropped) | `<p>#&lt;tag:0&gt;</p>` |
+| `None` | `<p></p>` | `<p>nil</p>` |
+| `Html.raw(...)` under a `Safe` name collision | `<p></p>` (markup dropped) | escaped, non-empty |
+| `Cons("<script>alert(1)</script>", Nil)` — a plain `List(String)` | `<p><script>alert(1)</script></p>` **raw, unescaped** | `<p>#&lt;tag:1&gt;</p>` |
+| record `{ name: "<script>", .. }` / tuple | `<p></p>` | `<p>#&lt;tag:0&gt;</p>` |
+| `B("<script>")` via a stored closure (TVar) | `<p><script></p>` **raw, unescaped** | `<p>#&lt;tag:1&gt;</p>` |
+| `C(..)` via a stored closure (TVar) | **SIGSEGV** | `<p>#&lt;tag:2&gt;</p>` |
+| `Some("<script>")`, String, IOList, `Html.raw` | correct | unchanged |
+
+**The widest case is a plain `List`.** `Cons` is tag 1 with the element in
+field 0, aliasing `IOList.Str`, so interpolating any `List(String)` emitted its
+**head element raw and unescaped**. That needs no custom ADT and no `Result` —
+just a list in a template.
+
+**`Option`/`Result` were NOT exempt.** The plan originally asserted they were
+niche-optimised and therefore safe. That is true only of `Some(x)`; `None`,
+`Ok` and `Err` are ordinary boxed constructors, and `Err` leaked its payload
+raw and unescaped. Since `Result` is pervasive, this was by far the widest
+instance of the bug — the plan has been corrected.
+
+## The fix
+
+`lib/tir/llvm_emit.ml` — decide from the argument's static TIR type instead of
+letting the runtime guess from a heap tag. `String`, `Int`, `Float`, `Bool` and
+`IOList` still take the runtime path, which genuinely handles them. Everything
+else goes through `march_value_to_string` first and is escaped as a real String.
+
+`TVar` — the unresolved case — also stringifies, and getting there took a
+correction. The first version of this fix kept the runtime path for `TVar`, on
+the stated assumption that mono concretises every ADT interpolation. **That is
+false.** A value reaching the hole through a closure stored in a container is
+not specialised:
+
+```march
+let b = Bx(Cons(fn x -> ~H"<p>${x}</p>", Nil))
+apply_first(b, B("<script>"))
+```
+
+Measured with that first version still in place: `<p><script></p>` — raw and
+unescaped — and the tag-2 case still segfaulted. The hole was entirely unfixed
+for polymorphic sites.
+
+`TVar` is genuinely undecidable: an IOList wants flattening, an ADT must not be
+flattened, and nothing at runtime distinguishes them (`march_value_to_string`
+renders a real IOList as `#<tag:2>`, so it cannot flatten one either). It now
+resolves toward safety — stringify. The accepted cost is that a genuine IOList
+partial reaching a polymorphic hole renders `#<tag:2>` instead of its markup:
+visibly wrong for that (rare) pattern, but not a vulnerability. Pinned as
+`poly_iolist`. The proper fix needs a runtime type id; filed as
+`specs/todos/2026-08-05-boxed-adt-type-id.md`.
+
+`runtime/march_extras.c` — the fallback arm now aborts with the observed tag
+instead of guessing. Note its limit, which is documented at the site: IOList has
+three constructors, so tags 0..2 stay ambiguous and only tag >= 3 is *provably*
+not an IOList. The emitter is the real fix; this is defense in depth.
+
+## Known follow-up
+
+Compiled `march_value_to_string` has no constructor-name metadata, so ADTs
+render `#<tag:N>` where the interpreter renders `Point(1, 2)`. That gap predates
+this work and reproduces with `to_string` alone. Filed as
+`specs/todos/2026-08-05-compiled-to-string-adt-ctor-names.md`;
+`test/native/h_sigil_adt_interp.expected` pins the current output and is
+annotated to be updated when ctor names land.
+
+## Exposure sweep — forgepm
+
+Clean, for both the app and the framework.
+
+**bastion** (`lib/`, worktree copies excluded): 46 `~H`, 28 interpolations, 6
+user multi-constructor ADTs — none reaches an interpolation.
+
+**forgepm**: 153 `~H` sites and 257 interpolations. It declares exactly
+one user multi-constructor ADT (`PublishResult`,
+`lib/forgepm/client/registry.march:9`), which lives in the CLI publish client,
+appears in no file containing `~H`, and is always destructured by `match` before
+rendering. No interpolation references an `Option`/`Result`-typed binding,
+function, or record field (the only such field is `Email.reply_to`, never
+interpolated).
+
+Caveat: this is source-level analysis, not a typechecked sweep — building
+forgepm against this compiler fails with 68 pre-existing errors from bastion
+version drift, unrelated to this change.
+
+## Tests
+
+- `test/native/h_sigil_adt_interp.march` — compile-and-run golden diff over
+  tag-0/1/2 ADTs, `Option`, `Result`, String, IOList, `Html.raw`, and the
+  polymorphic/`TVar` holes (`poly_tag1`, `poly_tag2`, `poly_iolist`). Fails on
+  `main` with exit 139.
+- `test/native/h_sigil_safe_collision.march` — separate file, because declaring
+  a second `Safe` type makes every `Safe` in the program collide and would
+  silently destroy the other test's coverage of the verbatim path. Asserts
+  booleans rather than exact text, since the stringified form embeds a raw tag
+  number that would make a golden diff brittle.
+
+Backends checked: `html_auto_escape` is implemented only in
+`runtime/march_extras.c` and emitted only from `lib/tir/llvm_emit.ml`, so the
+JIT inherits the fix and there is no separate WASM or JS path to patch. The
+interpreter (`lib/eval/eval.ml`) was always correct.
+
+Full suite: 830 tests, 1 failure — `adversarial-regressions 40 MARCH_SANITIZE`,
+an ASAN timeout. Environmental, not this change: a trivial
+`clang -fsanitize=address` C program that only calls `printf` also hangs and is
+SIGKILLed at 30s on this host, which is exactly the check that test's own
+failure message asks for.

--- a/specs/todos/2026-08-05-boxed-adt-type-id.md
+++ b/specs/todos/2026-08-05-boxed-adt-type-id.md
@@ -1,0 +1,62 @@
+# Boxed ADT cells carry no type identity, so the runtime cannot tell types apart
+
+**Filed:** 2026-08-05
+**Priority:** P2 — currently costs correctness (not safety) at polymorphic sites
+
+## The gap
+
+A boxed ADT cell's `march_hdr` is `{ int64_t rc; int32_t tag; int32_t pad; }`
+(`runtime/march_runtime.h:12`). `tag` is the constructor index, numbered **per
+type** from 0. Nothing in the cell says *which type* it belongs to, so at
+runtime `IOList.Str("x")` and `B("x")` are indistinguishable: both are a boxed
+cell with `tag == 1` and one pointer field.
+
+That is the root cause of the `~H` misread fixed in
+`specs/progress/2026-08-05-h-sigil-adt-misread.md`. That fix works by deciding
+from the **static** TIR type in `llvm_emit`, which is the right answer wherever
+a static type exists.
+
+## Where it still bites
+
+It does not exist for an unresolved `TVar` — a value reaching a hole through a
+closure stored in a container, which mono does not specialise:
+
+```march
+let b = Bx(Cons(fn x -> ~H"<p>${x}</p>", Nil))
+apply_first(b, some_value)
+```
+
+Neither answer is correct there: an `IOList` wants flattening, an ADT must not
+be flattened. The `~H` fix resolves it toward safety — stringify — so a genuine
+`IOList` partial reaching a polymorphic hole renders `#<tag:2>` instead of its
+markup. Pinned as `poly_iolist` in `test/native/h_sigil_adt_interp.march`.
+
+`march_value_to_string` has the same problem from the other side: it cannot
+flatten an IOList it is handed generically, because it cannot recognise one.
+
+## Sketch of a fix
+
+`pad` is **free for non-record ADTs** — `march_runtime.c:295` zeroes it, and
+only the record path uses it (as an interned shape id, via
+`march_record_shape_intern`; see `march_extras.c:1875`). So a per-type id could
+be stamped into `pad` at boxed-ADT allocation, letting the runtime answer "is
+this an IOList?" directly.
+
+Costs to weigh before committing to this:
+
+- Every boxed ADT allocation gains a store. Measure against
+  `bench/binary_trees.march` (allocation-heavy) and `bench/tree_transform.march`
+  (Perceus/FBIP), per `specs/benchmarks.md`.
+- `pad` is 32 bits shared with the record shape-id space; the two schemes must
+  not collide. Records and ADTs are disjoint today, but that is an invariant
+  worth asserting rather than assuming.
+- Cross-heap copy (`march_message.c:138`) and the WASM runtime
+  (`march_runtime_wasm.c:432`) both zero `pad` and would need updating.
+
+If this lands, three things get better together: polymorphic `~H` holes become
+correct rather than merely safe, `march_value_to_string` can flatten IOLists,
+and the `tag > 2` abort guard in `march_html_auto_escape` can become an exact
+check instead of the partial one documented at that site.
+
+Related: `specs/todos/2026-08-05-compiled-to-string-adt-ctor-names.md` (a
+constructor-name table would likely share this type-id mechanism).

--- a/specs/todos/2026-08-05-compiled-to-string-adt-ctor-names.md
+++ b/specs/todos/2026-08-05-compiled-to-string-adt-ctor-names.md
@@ -1,0 +1,67 @@
+# Compiled `to_string` renders user ADTs as `#<tag:N>` instead of the constructor
+
+**Filed:** 2026-08-05
+**Priority:** P2 — interpreter/compiled parity gap, not a safety issue
+
+## Symptom
+
+`to_string` on a user-defined ADT disagrees between the interpreter and the
+compiled backend:
+
+```march
+mod TsProbe do
+  type Point = Point(Int, Int)
+  fn main() : Unit do
+    let p = Point(1, 2)
+    println("to_string=" ++ to_string(p))
+  end
+end
+```
+
+```
+interpreted : to_string=Point(1, 2)
+compiled    : to_string=#<tag:0>
+```
+
+Measured 2026-08-05 on `main` @ `079ff744`. Predates and is independent of the
+`~H` ADT fix landed alongside this file — `to_string` alone reproduces it with
+no sigil involved.
+
+## Cause
+
+`march_value_to_string` (the C implementation behind the `to_string` builtin)
+has no constructor-name metadata to consult. It can read a heap cell's tag but
+has no table mapping `(type, tag) -> "Point"`, nor field count/types to recurse
+into, so it prints the raw tag.
+
+## Why it matters now
+
+The `~H` contextual-escaping work made this visible in rendered output.
+`~H"<p>${p}</p>"` used to misread a non-IOList ADT as an IOList (silent empty
+output, raw unescaped emission, or a SIGSEGV — see
+`specs/progress/2026-08-05-h-sigil-adt-misread.md`). The fix routes such values
+through `march_value_to_string`, which is safe and escaped but renders
+`#<tag:N>`.
+
+Two consequences worth fixing:
+
+1. `test/native/h_sigil_adt_interp.expected` currently pins `#<tag:N>` as the
+   compiled output. It is annotated as a known defect, not intended behaviour.
+   **When this is fixed, update that file to the interpreter's rendering.**
+2. The `Html.Safe` short-name-collision path
+   (`test/native/h_sigil_safe_collision.march`) renders the wrapper rather than
+   the markup. Constructor names would at least make that output legible.
+
+## Sketch of a fix
+
+Emit a per-type constructor table (name, arity, field reprs) into the binary and
+have `march_value_to_string` walk it, recursing into fields. The capability
+lattice already has this shape: `lib/caps/cap_lattice.ml` is an OCaml
+source-of-truth with `emit_c_table.ml` generating `runtime/march_cap_lattice.{h,c}`
+and an anti-drift freshness check in `test/dune`. Model the constructor table on
+that rather than inventing a second mechanism.
+
+Note the tag is not globally unique — tags are numbered per type from 0 — so the
+table must be keyed by type identity, which means the emitter has to record
+which type each cell belongs to. That is the same information the `~H` fix uses
+statically, so the two should share a representation if possible.

--- a/test/dune
+++ b/test/dune
@@ -4161,3 +4161,62 @@ printf 'mod CsHelper do\\n\\n  fn double(x : Int) : Int do\\n    x * 2\\n  end\\
 (rule
  (alias runtest)
  (action (diff native/preempt_starvation.expected native_preempt_starvation.out)))
+
+; ── Regression: ~H must not misread a non-IOList ADT as an IOList ─────────
+; Constructor tags are numbered per type, so any user ADT collided with
+; IOList's Empty|Str|Segments tags in march_html_auto_escape's polymorphic
+; fallback: tag-0 ADTs rendered empty, tag-1 ADTs emitted their String field
+; raw and unescaped (XSS), tag-2 ADTs walked field 0 as a cons list (SIGSEGV).
+; The interpreter was always correct, so .expected is the interpreter's output
+; and this rule is an interpreter/compiled parity check.
+(rule
+ (targets native_h_sigil_adt_interp native_h_sigil_adt_interp.out)
+ (deps (file %{exe:../bin/main.exe})
+       (file ../runtime/march_runtime.c) (file ../runtime/march_runtime.h)
+       (file ../runtime/march_scheduler.c) (file ../runtime/march_scheduler.h)
+       (file ../runtime/march_heap.c) (file ../runtime/march_heap.h)
+       (file ../runtime/march_gc.c) (file ../runtime/march_gc.h)
+       (file ../runtime/march_message.c) (file ../runtime/march_message.h)
+       (file ../runtime/march_deque.h)
+       (file ../runtime/march_extras.c) (file ../runtime/march_compress.c)
+       (file ../runtime/base64.c) (file ../runtime/sha1.c)
+       (file native/h_sigil_adt_interp.march))
+ (action
+  (progn
+   (run %{exe:../bin/main.exe} --compile -o native_h_sigil_adt_interp
+        native/h_sigil_adt_interp.march)
+   (with-stdout-to native_h_sigil_adt_interp.out
+        (system "./native_h_sigil_adt_interp")))))
+
+(rule
+ (alias runtest)
+ (action (diff native/h_sigil_adt_interp.expected native_h_sigil_adt_interp.out)))
+
+; ── Regression: Html.raw dropped under a `Safe` short-name collision ──────
+; llvm_emit's verbatim-insertion arm declines to fire when another module also
+; declares a type named `Safe`; that fell through to the IOList misread and
+; rendered `<p></p>`, silently discarding the wrapped markup. Separate file
+; from h_sigil_adt_interp because declaring Other.Safe makes every `Safe` in
+; the program collide.
+(rule
+ (targets native_h_sigil_safe_collision native_h_sigil_safe_collision.out)
+ (deps (file %{exe:../bin/main.exe})
+       (file ../runtime/march_runtime.c) (file ../runtime/march_runtime.h)
+       (file ../runtime/march_scheduler.c) (file ../runtime/march_scheduler.h)
+       (file ../runtime/march_heap.c) (file ../runtime/march_heap.h)
+       (file ../runtime/march_gc.c) (file ../runtime/march_gc.h)
+       (file ../runtime/march_message.c) (file ../runtime/march_message.h)
+       (file ../runtime/march_deque.h)
+       (file ../runtime/march_extras.c) (file ../runtime/march_compress.c)
+       (file ../runtime/base64.c) (file ../runtime/sha1.c)
+       (file native/h_sigil_safe_collision.march))
+ (action
+  (progn
+   (run %{exe:../bin/main.exe} --compile -o native_h_sigil_safe_collision
+        native/h_sigil_safe_collision.march)
+   (with-stdout-to native_h_sigil_safe_collision.out
+        (system "./native_h_sigil_safe_collision")))))
+
+(rule
+ (alias runtest)
+ (action (diff native/h_sigil_safe_collision.expected native_h_sigil_safe_collision.out)))

--- a/test/native/h_sigil_adt_interp.expected
+++ b/test/native/h_sigil_adt_interp.expected
@@ -1,0 +1,17 @@
+tag0=<p>#&lt;tag:0&gt;</p>
+tag1=<p>#&lt;tag:1&gt;</p>
+tag2=<p>#&lt;tag:2&gt;</p>
+nullary=<p>#&lt;tag:0&gt;</p>
+string=<p>&lt;b&gt;x&lt;/b&gt;</p>
+iolist=<p><i>inner</i></p>
+safe=<p><b>bold</b></p>
+some=<p>&lt;script&gt;</p>
+none=<p>nil</p>
+ok=<p>#&lt;tag:0&gt;</p>
+err=<p>#&lt;tag:1&gt;</p>
+list=<p>#&lt;tag:1&gt;</p>
+record=<p>#&lt;tag:0&gt;</p>
+tuple=<p>#&lt;tag:0&gt;</p>
+poly_tag1=<p>#&lt;tag:1&gt;</p>
+poly_tag2=<p>#&lt;tag:2&gt;</p>
+poly_iolist=<p>#&lt;tag:2&gt;</p>

--- a/test/native/h_sigil_adt_interp.march
+++ b/test/native/h_sigil_adt_interp.march
@@ -1,0 +1,122 @@
+-- Regression: `~H` interpolation of a non-IOList ADT misread the value as an
+-- IOList, producing silent data loss, unescaped output, and a SIGSEGV.
+--
+-- `march_html_auto_escape` (runtime/march_extras.c) ended with "Constructor
+-- with tag >= 0: treat as IOList and flatten verbatim" and delegated to
+-- mh_iolist_size / mh_iolist_copy, which branch on the raw heap tag:
+--   tag 1 -> read field 0 as a march_string*
+--   tag 2 -> walk field 0 as a cons list
+-- Constructor tags are numbered PER TYPE starting at 0, so every user ADT
+-- collides with IOList = Empty | Str(String) | Segments(List(IOList)):
+--   tag 0 (Point)      -> rendered as the empty string
+--   tag 1 (B(String))  -> field 0 emitted RAW AND UNESCAPED  (XSS)
+--   tag 2 (C(_, _))    -> field 0 walked as a cons list      (SIGSEGV)
+-- The interpreter was correct throughout.
+--
+-- Fix: llvm_emit dispatches on the argument's static TIR type instead of
+-- letting the runtime guess from a heap tag.  Types the runtime genuinely
+-- recognises (String, immediates, real IOLists) still take the runtime path;
+-- everything else is stringified with march_value_to_string first, then
+-- escaped as a String.
+--
+-- KNOWN SEPARATE DEFECT — the `#<tag:N>` below is NOT intended output.
+-- Compiled `march_value_to_string` has no constructor-name metadata, so it
+-- renders any user ADT as `#<tag:N>` where the interpreter renders
+-- `Point(1, 2)`.  That gap predates this fix and is independent of `~H`:
+-- `to_string(Point(1, 2))` alone already differs the same way on main.  It is
+-- filed separately; see specs/todos/2026-08-05-compiled-to-string-adt-ctor-names.md.
+-- What this test pins is the SECURITY property — the ADT payload is never
+-- emitted raw, and the `<`/`>` that do appear are escaped.  Once ctor names
+-- land, update .expected to the interpreter's rendering.
+
+mod HSigilAdtInterp do
+  type Point = Point(Int, Int)
+  type Multi = A | B(String) | C(String, String)
+  type Box = Bx(List(b))
+
+  -- Reaching the ~H hole through a closure stored in a container: mono cannot
+  -- specialise this, so the hole's TIR type is an unresolved TVar. That is the
+  -- genuinely undecidable case -- an IOList wants flattening, an ADT must not
+  -- be flattened, and nothing at runtime can tell them apart. It resolves to
+  -- "stringify", the failure that is not a vulnerability.
+  pfn apply_first(box, v) do
+    match box do
+    Bx(fs) ->
+      match fs do
+      Cons(f, _) -> f(v)
+      Nil        -> IOList.empty()
+      end
+    end
+  end
+
+  fn main() : Unit do
+    -- tag 0, two fields: was silently empty
+    let p = Point(1, 2)
+    println("tag0=" ++ IOList.to_string(~H"<p>${p}</p>"))
+
+    -- tag 1, String field: was emitted raw and unescaped
+    let b = B("<script>")
+    println("tag1=" ++ IOList.to_string(~H"<p>${b}</p>"))
+
+    -- tag 2: crashed walking field 0 as a cons list
+    let c = C("xx", "yy")
+    println("tag2=" ++ IOList.to_string(~H"<p>${c}</p>"))
+
+    -- tag 2 with non-pointer fields: also crashed
+    let a = A
+    println("nullary=" ++ IOList.to_string(~H"<p>${a}</p>"))
+
+    -- Values that were already correct must stay correct.
+    let s = "<b>x</b>"
+    println("string=" ++ IOList.to_string(~H"<p>${s}</p>"))
+    let nested = ~H"<i>inner</i>"
+    println("iolist=" ++ IOList.to_string(~H"<p>${nested}</p>"))
+    let safe = Html.raw("<b>bold</b>")
+    println("safe=" ++ IOList.to_string(~H"<p>${safe}</p>"))
+
+    -- Option/Result are NOT exempt. Only `Some(x)` is niche-optimised down to
+    -- its payload; `None`, `Ok` and `Err` are ordinary boxed constructors and
+    -- collided with IOList exactly like any user ADT. Measured on main before
+    -- the fix:
+    --   None            -> <p></p>        (empty)
+    --   Ok("<script>")  -> <p></p>        (payload silently dropped)
+    --   Err("<b>")      -> <p><b></p>     (RAW, UNESCAPED -- XSS)
+    -- `Result` is pervasive, so this was the widest instance of the bug.
+    let some : Option(String) = Some("<script>")
+    println("some=" ++ IOList.to_string(~H"<p>${some}</p>"))
+    let none : Option(String) = None
+    println("none=" ++ IOList.to_string(~H"<p>${none}</p>"))
+    let ok : Result(String, String) = Ok("<script>")
+    println("ok=" ++ IOList.to_string(~H"<p>${ok}</p>"))
+    let err : Result(String, String) = Err("<b>")
+    println("err=" ++ IOList.to_string(~H"<p>${err}</p>"))
+
+    -- A bare List is the most realistic instance of all: `Cons` is tag 1 with
+    -- the element in field 0, aliasing `IOList.Str`, so before the fix
+    -- `${some_string_list}` emitted its HEAD ELEMENT raw and unescaped.
+    -- Measured on main: <p><script>alert(1)</script></p>
+    let l = Cons("<script>alert(1)</script>", Nil)
+    println("list=" ++ IOList.to_string(~H"<p>${l}</p>"))
+    let rec = { name: "<script>", age: 3 }
+    println("record=" ++ IOList.to_string(~H"<p>${rec}</p>"))
+    let tup = ("<script>", 7)
+    println("tuple=" ++ IOList.to_string(~H"<p>${tup}</p>"))
+
+    -- Polymorphic (TVar) hole. Before the fix these were NOT covered by
+    -- dispatching on the static type -- an early version of this fix kept the
+    -- runtime path for TVar on the assumption that mono concretises every ADT
+    -- interpolation, and it does not. Measured on main:
+    --   B("<script>") through a closure -> <p><script></p>  RAW, UNESCAPED
+    --   C("xx", "yy")  through a closure -> SIGSEGV
+    let cb = Bx(Cons(fn x -> ~H"<p>${x}</p>", Nil))
+    println("poly_tag1=" ++ IOList.to_string(apply_first(cb, B("<script>"))))
+    let cb2 = Bx(Cons(fn x -> ~H"<p>${x}</p>", Nil))
+    println("poly_tag2=" ++ IOList.to_string(apply_first(cb2, C("xx", "yy"))))
+    -- The accepted cost of failing safe: a genuine IOList partial reaching a
+    -- polymorphic hole is stringified rather than flattened. Visibly wrong,
+    -- but not a vulnerability. Fixing it needs a runtime type id --
+    -- specs/todos/2026-08-05-boxed-adt-type-id.md.
+    let cb3 = Bx(Cons(fn x -> ~H"<p>${x}</p>", Nil))
+    println("poly_iolist=" ++ IOList.to_string(apply_first(cb3, ~H"<i>ok</i>")))
+  end
+end

--- a/test/native/h_sigil_safe_collision.expected
+++ b/test/native/h_sigil_safe_collision.expected
@@ -1,0 +1,2 @@
+dropped=false
+raw=false

--- a/test/native/h_sigil_safe_collision.march
+++ b/test/native/h_sigil_safe_collision.march
@@ -1,0 +1,38 @@
+-- Regression: `Html.raw` content was silently dropped whenever some other
+-- module in the program also declared a type named `Safe`.
+--
+-- llvm_emit's verbatim-insertion arm for `Html.Safe` declines to fire on a
+-- short-name collision (TIR carries only `TCon ("Safe", _)`, so it genuinely
+-- cannot tell Html.Safe from Other.Safe). Before the fix that fell through to
+-- march_html_auto_escape's "tag >= 0 -> treat as IOList" guess, which read the
+-- Boxed Safe cell as an empty IOList: `<p></p>`, with the wrapped markup gone.
+--
+-- It now stringifies and escapes instead. That is degraded — you see the
+-- wrapper rather than the markup, because compiled march_value_to_string has
+-- no constructor-name metadata (see
+-- specs/todos/2026-08-05-compiled-to-string-adt-ctor-names.md) — but it is
+-- never empty and never raw, which is what this test pins.
+--
+-- Deliberately a separate file from h_sigil_adt_interp.march: declaring
+-- `Other.Safe` anywhere in a program makes EVERY `Safe` in it collide, which
+-- would silently destroy that test's coverage of the good verbatim path.
+--
+-- Asserted as booleans, not exact text: the stringified form embeds a raw
+-- constructor tag number that is stable per build but would break a golden
+-- diff on any unrelated tag renumbering.
+
+mod HSigilSafeCollision do
+  fn main() : Unit do
+    let s = Html.raw("<b>x</b>")
+    let out = IOList.to_string(~H"<p>${s}</p>")
+    -- Was `true` before the fix: the markup vanished entirely.
+    println("dropped=" ++ bool_to_string(string_contains(out, "<p></p>")))
+    -- Must never become `true`: that would mean unescaped verbatim insertion
+    -- of a value we could not prove was Html.Safe.
+    println("raw=" ++ bool_to_string(string_contains(out, "<b>x</b>")))
+  end
+
+  mod Other do
+    type Safe = Safe(Int)
+  end
+end


### PR DESCRIPTION
`march_html_auto_escape` ended by assuming any constructor with `tag >= 0` was an `IOList` and flattening it verbatim, delegating to `mh_iolist_size` / `mh_iolist_copy`. Constructor tags are numbered **per type** from 0, so every ADT aliased `IOList`'s `Empty|Str|Segments`.

The interpreter was correct throughout — this was compiled-only.

## Measured before / after

| Interpolated into `~H"<p>${x}</p>"` | Before | After |
|---|---|---|
| `Cons("<script>alert(1)</script>", Nil)` — a plain `List(String)` | `<p><script>alert(1)</script></p>` **raw, unescaped** | `<p>#&lt;tag:1&gt;</p>` |
| `Err("<b>")` | `<p><b></p>` **raw, unescaped** | `<p>#&lt;tag:1&gt;</p>` |
| `B("<script>")` — tag 1, String field | `<p><script></p>` **raw, unescaped** | `<p>#&lt;tag:1&gt;</p>` |
| `B("<script>")` via a stored closure (TVar) | `<p><script></p>` **raw, unescaped** | `<p>#&lt;tag:1&gt;</p>` |
| `C("xx", "yy")` — tag 2 | **SIGSEGV** (exit 139) | `<p>#&lt;tag:2&gt;</p>` |
| `C(..)` via a stored closure (TVar) | **SIGSEGV** | `<p>#&lt;tag:2&gt;</p>` |
| `Point(1, 2)` — tag 0 | `<p></p>` (empty) | `<p>#&lt;tag:0&gt;</p>` |
| `Ok("<script>")` | `<p></p>` (payload dropped) | `<p>#&lt;tag:0&gt;</p>` |
| record / tuple | `<p></p>` | `<p>#&lt;tag:0&gt;</p>` |
| `Html.raw(..)` under a `Safe` name collision | `<p></p>` (markup dropped) | escaped, non-empty |
| `Some(..)`, String, IOList, `Html.raw` | correct | unchanged |

Two things worth flagging about reachability:

- **The widest case needs no custom type.** `Cons` is tag 1 with the element in field 0, so interpolating any `List(String)` emitted its head element raw.
- **`Option`/`Result` are not exempt.** Only `Some(x)` is niche-optimised; `None`, `Ok` and `Err` are ordinary boxed constructors.

## The fix

The runtime cannot decide this — `llvm_emit.ml` already said so in prose while patching the single `Html.Safe` case. This generalises that: dispatch on the argument's static TIR type, keep the runtime path only for `String`, immediates and real `IOList`s, and stringify everything else before escaping.

That includes `TVar`. It is not hypothetical: a value reaching the hole through a closure stored in a container is not specialised by mono, and an earlier version of this fix that trusted the runtime path there still emitted raw output and still segfaulted. `TVar` is genuinely undecidable — an IOList wants flattening, an ADT must not be flattened, and `march_value_to_string` cannot flatten an IOList either — so it resolves toward safety.

**Accepted cost:** a genuine `IOList` partial at a polymorphic hole renders `#<tag:N>` instead of its markup. A wrong-looking page beats an XSS and a crash. The proper fix needs a runtime type id (`march_hdr.pad` is free for non-record ADTs) — filed as `specs/todos/2026-08-05-boxed-adt-type-id.md`.

The runtime fallback now aborts with the observed tag instead of guessing. Its limit is documented at the site: IOList has three constructors, so tags 0..2 stay ambiguous and only `tag >= 3` is provably wrong. The emitter is the real fix; the abort is defense in depth.

## Known follow-up

Compiled `march_value_to_string` has no constructor-name metadata, so ADTs render `#<tag:N>` where the interpreter renders `Point(1, 2)`. That gap **predates this fix** and reproduces with `to_string` alone. Filed as `specs/todos/2026-08-05-compiled-to-string-adt-ctor-names.md`; the `.expected` files are annotated to be updated when ctor names land.

## Exposure sweep

Clean for both the framework and the app — no production XSS or crash from this.

- **bastion** (`lib/`): 46 `~H`, 28 interpolations, 6 user multi-constructor ADTs — none reaches an interpolation.
- **forgepm**: 153 `~H` sites, 257 interpolations. Its one user multi-constructor ADT (`PublishResult`) lives in the CLI publish client, appears in no file containing `~H`, and is always `match`ed before rendering. No interpolation touches an `Option`/`Result`-typed binding, function or field.

Caveat: source-level analysis, not a typechecked sweep — forgepm does not build against this compiler due to 68 pre-existing bastion version-drift errors, unrelated to this change.

## Verification

- `test/native/h_sigil_adt_interp.march` — compile-and-run golden diff over tag-0/1/2 ADTs, `Option`, `Result`, `List`, record, tuple, String, IOList, `Html.raw`, and the polymorphic/`TVar` holes. **Fails on `main` with exit 139.**
- `test/native/h_sigil_safe_collision.march` — separate file, because declaring a second `Safe` type makes every `Safe` in the program collide and would silently destroy the other test's coverage of the verbatim path. Asserts booleans rather than exact text, since the stringified form embeds a raw tag number that would make a golden diff brittle.
- Backends: `html_auto_escape` exists only in `march_extras.c` and is emitted only from `llvm_emit.ml`, so the JIT inherits the fix; no separate WASM or JS path.
- Full suite: 830 tests, 1 failure — `adversarial-regressions 40 MARCH_SANITIZE`, an ASAN timeout. **Environmental, not this change:** a trivial `clang -fsanitize=address` C program that only calls `printf` also hangs and is SIGKILLed at 30s on this host, which is exactly the check that test's own failure message asks for.
- `scripts/check-docs.sh` passes.
- Benchmarks vs `main`, compiled `--opt 2`, best of 3: `tree_transform` 590→600ms, `list_ops` 60→60ms, `binary_trees` 250→260ms — within one 10ms tick of `time -p` resolution, checksums and outputs identical. None of these exercise `~H`, so this is a no-unrelated-regression check rather than a measurement of the changed path.

Task 0 of `specs/plans/2026-08-05-contextual-autoescaping.md`.
