### PR TITLE
docs(site): surface capability-language and effect-system terms in headers

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,5 @@
 title: March Lang
-description: A statically-typed functional language in the ML/Elixir tradition, compiled to native code via LLVM.
+description: A statically-typed, capability-based functional language in the ML/Elixir tradition, with a compile-time effect system and native-code compilation via LLVM.
 baseurl: ""
 url: "https://march-lang.org"
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -5,9 +5,9 @@ nav_order: 5.6
 permalink: /docs/capabilities/
 ---
 
-# Capabilities
+# Capabilities: March's Effect & Capability System
 
-March makes side effects **visible in your types** — zero runtime overhead, enforced at compile time. This guide explains what capabilities are, when to reach for each kind, when to leave them alone, and how they compose.
+March is a **capability-based language**: side effects are **visible in your types** — zero runtime overhead, enforced at compile time. This guide explains what capabilities are, when to reach for each kind, when to leave them alone, and how they compose.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ permalink: /
 
 **Elixir's concurrency model. ML's type safety. Native performance.**
 
-March is a statically-typed functional language built for concurrent and distributed systems — the kind you'd normally reach for Elixir or Erlang to build, but with a static type system, algebraic data types, and compilation to native binaries via LLVM.
+March is a statically-typed, capability-based functional language built for concurrent and distributed systems — the kind you'd normally reach for Elixir or Erlang to build, but with a static type system, a compile-time effect system, algebraic data types, and compilation to native binaries via LLVM.
 
 Write code that reads like Elixir. Get compile-time guarantees that your message protocols are correct, your resources aren't leaked, and your actor supervision trees handle faults the way you expect. Run at native speed with no garbage collector pauses.
 


### PR DESCRIPTION
## Summary
- Site description, homepage subtitle, and the Capabilities page title/H1 now include "capability-based" and "effect system" so those terms appear in the parts of the page (title, meta description, H1) search engines weight most heavily for a query like "capability language."
- No behavioral/code changes — docs content only.

## Test plan
- [x] `./scripts/check-docs.sh` passes