### PR TITLE
feat(~H): compile-time contextual auto-escaping (Tasks 3-5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,39 @@ git log is authoritative for exact commits.
 
 ### Changed
 
+- **`~H` now escapes by HTML parse context, not with one escaper everywhere.**
+  Previously every interpolation was HTML entity-encoded regardless of where it
+  landed, which is correct in element content and wrong everywhere else. The
+  desugarer now walks a template's literal chunks through a context automaton at
+  compile time and gives each hole the escaper its position calls for.
+
+  **This changes rendered output.** Measured across bastion and forgepm — 121
+  templates, 253 interpolations — 40 holes change:
+
+  | context | before | now |
+  |---|---|---|
+  | element content (213 holes) | entity-encoded | unchanged |
+  | attribute value (17) | entity-encoded | + backtick |
+  | URL component (14) | entity-encoded | percent-encoded |
+  | `style` attribute (7) | entity-encoded | CSS declaration/value escape |
+  | start of `href`/`src` (2) | entity-encoded | **URL scheme allowlist** |
+
+  The last row closes a real hole: `~H"<a href=\"${url}\">"` accepted
+  `javascript:alert(1)`, since entity-encoding does not touch a scheme. Such
+  URLs now render as `about:invalid#zSoyz`.
+
+  An **unquoted attribute value** receiving an interpolation is now quoted
+  automatically — `<div class=${x}>` emits `<div class="…">` — so a value
+  containing a space can no longer start a new attribute.
+
+  Interpolations that no escaping can make safe are now **compile errors**
+  rather than silently-wrong output: an attribute name, an element name, the
+  interior of a comment, and a template that ends mid-tag or mid-attribute.
+  Nothing in bastion or forgepm hits any of these.
+
+  Escaping tables live in `specs/security/html-contexts.tbl` and are documented
+  in `specs/security/README.md`.
+
 - **Breaking: the three JS-only stdlib modules are now namespaced under `Js.`.**
   `mod Audio`, `mod Canvas`, `mod Dom` are `mod Js.Audio`, `mod Js.Canvas`,
   `mod Js.Dom` — these are the only stdlib modules that panic at runtime when

--- a/lib/ctxesc/automaton.ml
+++ b/lib/ctxesc/automaton.ml
@@ -191,4 +191,17 @@ let consume_interp t (c : C.t) =
 let is_valid_terminal (c : C.t) =
   c.C.state = C.Pcdata && c.C.element = C.ElNormal
 
+(* The table the compiler uses, parsed once from the embedded copy. A failure
+   here is a build-time defect in the .tbl, not a user error -- the parser
+   rejects unknown tokens precisely so this cannot silently degrade. *)
+let default =
+  lazy
+    (match P.parse_string ~name:"specs/security/html-contexts.tbl"
+             Table_data.contents with
+     | Ok t -> compile t
+     | Error e ->
+       failwith
+         ("march: the embedded HTML context table failed to parse. This is a \
+           compiler build defect, not a problem with your source. " ^ e))
+
 let describe = C.describe

--- a/lib/ctxesc/automaton.ml
+++ b/lib/ctxesc/automaton.ml
@@ -150,13 +150,14 @@ let escaper_for (c : C.t) =
   | C.Rcdata ->
     (match c.C.element with
      | C.ElScript -> C.EscJsString
-     | C.ElStyle -> C.EscCss
+     | C.ElStyle -> C.EscCssDecl
      | _ -> C.EscHtml)
   | C.Attrvalue ->
     (match c.C.attr with
      | C.AtUrl -> C.EscUrlWhole
      | C.AtUrlMid -> C.EscUrlComponent
-     | C.AtStyle -> C.EscCss
+     | C.AtStyle -> C.EscCssDecl
+     | C.AtStyleValue -> C.EscCssValue
      | C.AtScript -> C.EscJsString
      | C.AtNormal -> C.EscAttr)
   | _ -> C.EscAttr  (* unreachable: every other state rejects holes *)

--- a/lib/ctxesc/context.ml
+++ b/lib/ctxesc/context.ml
@@ -31,6 +31,13 @@ type attr =
       (** a URL attribute value with literal content already before the hole —
           the interpolation is a component, so it needs percent-encoding *)
   | AtStyle
+      (** a `style` attribute at a DECLARATION position — the start of the
+          value, or just after a `;`. A hole here is a declaration list
+          (`color:red;background:blue`), so `:` and `;` are structural. *)
+  | AtStyleValue
+      (** a `style` attribute at a VALUE position — after a `:`. A hole here is
+          a single value (`#fff`, `var(--x)`), so `:` and `;` are NOT allowed:
+          either would let the value start a new declaration. *)
   | AtScript
 
 type delim =
@@ -55,7 +62,7 @@ let all_states =
     Beforeattrvalue; Attrvalue; Comment ]
 
 let all_elements = [ ElNormal; ElScript; ElStyle; ElTextarea; ElTitle ]
-let all_attrs = [ AtNormal; AtUrl; AtUrlMid; AtStyle; AtScript ]
+let all_attrs = [ AtNormal; AtUrl; AtUrlMid; AtStyle; AtStyleValue; AtScript ]
 let all_delims = [ DlNone; DlSingle; DlDouble; DlUnquoted; DlDoubleSubst ]
 
 let state_name = function
@@ -81,6 +88,7 @@ let attr_name = function
   | AtUrl -> "url"
   | AtUrlMid -> "urlmid"
   | AtStyle -> "style"
+  | AtStyleValue -> "stylevalue"
   | AtScript -> "script"
 
 let delim_name = function
@@ -109,7 +117,8 @@ let describe c =
   | Beforeattrvalue, _, _ -> "just before an attribute value"
   | Attrvalue, AtUrl, _ -> "at the start of a URL attribute value"
   | Attrvalue, AtUrlMid, _ -> "inside a URL attribute value"
-  | Attrvalue, AtStyle, _ -> "in a CSS style attribute value"
+  | Attrvalue, AtStyle, _ -> "at a declaration position in a style attribute"
+  | Attrvalue, AtStyleValue, _ -> "at a value position in a style attribute"
   | Attrvalue, AtScript, _ -> "in an event-handler attribute value"
   | Attrvalue, _, DlUnquoted -> "in an unquoted attribute value"
   | Attrvalue, _, _ -> "in an attribute value"
@@ -125,24 +134,33 @@ type escaper =
   | EscAttr
   | EscUrlComponent
   | EscUrlWhole
-  | EscCss
+  | EscCssValue
+      (** a single CSS value: identifiers, numbers, colours, and calls to an
+          allowlisted set of functions (`var`, `rgb`, `calc`, ...) *)
   | EscJsString
   | EscNone
+  | EscCssDecl
+      (** a CSS declaration LIST: as EscCssValue, plus `:` and `;` so a hole can
+          carry `color:red;background:blue`. Appended rather than inserted so
+          the existing ids stay stable -- they are shared verbatim with the C
+          runtime's MARCH_ESC_* defines. *)
 
 let escaper_id = function
   | EscHtml -> 0
   | EscAttr -> 1
   | EscUrlComponent -> 2
   | EscUrlWhole -> 3
-  | EscCss -> 4
+  | EscCssValue -> 4
   | EscJsString -> 5
   | EscNone -> 6
+  | EscCssDecl -> 7
 
 let escaper_name = function
   | EscHtml -> "html"
   | EscAttr -> "attr"
   | EscUrlComponent -> "url_component"
   | EscUrlWhole -> "url_whole"
-  | EscCss -> "css"
+  | EscCssValue -> "css_value"
   | EscJsString -> "js_string"
   | EscNone -> "none"
+  | EscCssDecl -> "css_decl"

--- a/lib/ctxesc/dune
+++ b/lib/ctxesc/dune
@@ -7,3 +7,12 @@
 (library
  (name march_ctxesc)
  (modules context tbl_parse automaton escape))
+
+; Dry-run blast-radius scanner: walks every ~H template in a source tree
+; through the automaton and reports what Task 5's desugar WOULD do. A report,
+; not a gate -- used to measure a real corpus (bastion, forgepm) before
+; changing behaviour rather than discovering the fallout afterwards.
+(executable
+ (name scan_templates)
+ (modules scan_templates)
+ (libraries march_ctxesc march_ast march_lexer march_parser))

--- a/lib/ctxesc/dune
+++ b/lib/ctxesc/dune
@@ -4,9 +4,26 @@
 ; it and (later, via emit_tables) generates both the OCaml and March copies.
 ; See specs/security/README.md and
 ; specs/plans/2026-08-05-contextual-autoescaping.md.
+;; The transition table is EMBEDDED as text, generated from the single source
+;; of truth by the rule below. The compiler cannot read a repo-relative file at
+;; runtime -- an installed `march` has no specs/ directory -- and generating it
+;; from the .tbl on every build makes drift structurally impossible, so no
+;; freshness check is needed for this pair.
+(rule
+ (targets table_data.ml)
+ (deps    %{project_root}/specs/security/html-contexts.tbl)
+ (action
+  (with-stdout-to table_data.ml
+   (progn
+    (echo "(* GENERATED from specs/security/html-contexts.tbl by lib/ctxesc/dune.\n")
+    (echo "   Do not edit -- edit the .tbl instead. *)\n")
+    (echo "let contents = {tbl|")
+    (cat %{deps})
+    (echo "|tbl}\n")))))
+
 (library
  (name march_ctxesc)
- (modules context tbl_parse automaton escape))
+ (modules context tbl_parse table_data automaton escape))
 
 ; Dry-run blast-radius scanner: walks every ~H template in a source tree
 ; through the automaton and reports what Task 5's desugar WOULD do. A report,

--- a/lib/ctxesc/escape.ml
+++ b/lib/ctxesc/escape.ml
@@ -122,21 +122,67 @@ let js_string s =
   done;
   Buffer.contents b
 
-(* Allowlist: CSS has too many routes to a URL or an expression for a denylist
-   to be credible. Anything outside the safe set becomes `\XX `, which CSS reads
-   as a literal character and which can never re-open a construct. *)
-let css s =
-  let b = Buffer.create (String.length s) in
-  String.iter
-    (fun c ->
-       if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
-          || (c >= '0' && c <= '9')
-          || c = '-' || c = '_' || c = '#' || c = '%' || c = '.'
-          || c = ',' || c = ' '
-       then Buffer.add_char b c
-       else (Buffer.add_char b '\\'; buf_add_hex2 b c; Buffer.add_char b ' '))
-    s;
-  Buffer.contents b
+(* CSS -- two positions, two escapers; mirrors runtime/march_ctx_escape.c.
+   Both allow calls to an ALLOWLISTED set of functions. Escaping every `(` is
+   safe but broke real templates: `var(--text-muted)` became
+   `var\28 --text-muted\29 `, and a declaration list interpolated after a `;`
+   was destroyed. A denylist of `expression(`/`url(` is not credible, so a
+   function call survives only if its name is on the list. *)
+let css_fn_allow =
+  [ "var"; "calc"; "min"; "max"; "clamp";
+    "rgb"; "rgba"; "hsl"; "hsla";
+    "translate"; "translatex"; "translatey"; "translate3d";
+    "scale"; "scalex"; "scaley"; "rotate"; "rotatex"; "rotatey"; "rotatez";
+    "skew"; "skewx"; "skewy"; "matrix"; "matrix3d"; "perspective";
+    "cubic-bezier"; "steps";
+    "linear-gradient"; "radial-gradient"; "conic-gradient";
+    "repeating-linear-gradient"; "repeating-radial-gradient" ]
+
+let css_ident_char c =
+  (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+  || c = '-' || c = '_'
+
+let css_plain ~decl c =
+  css_ident_char c
+  || c = '#' || c = '%' || c = '.' || c = ',' || c = ' '
+  || (decl && (c = ':' || c = ';'))
+
+(* One pass: is the whole string safe-shaped? Every `(` preceded by an
+   allowlisted function name, parens balanced, everything else plain. If not,
+   escape EVERYTHING strictly -- a partially escaped CSS string is far harder to
+   reason about than a wholly escaped one, and strict is always safe. *)
+let css_is_safe_shaped ~decl s =
+  let n = String.length s in
+  let rec go i depth =
+    if i >= n then depth = 0
+    else
+      let c = s.[i] in
+      if css_ident_char c then begin
+        let j = ref i in
+        while !j < n && css_ident_char s.[!j] do incr j done;
+        if !j < n && s.[!j] = '(' then
+          let name = String.lowercase_ascii (String.sub s i (!j - i)) in
+          if List.mem name css_fn_allow then go (!j + 1) (depth + 1) else false
+        else go !j depth
+      end
+      else if c = ')' then (if depth = 0 then false else go (i + 1) (depth - 1))
+      else if c = '(' then false
+      else if not (css_plain ~decl c) then false
+      else go (i + 1) depth
+  in
+  go 0 0
+
+let css ~decl s =
+  if css_is_safe_shaped ~decl s then s
+  else begin
+    let b = Buffer.create (String.length s) in
+    String.iter
+      (fun c ->
+         if css_plain ~decl c then Buffer.add_char b c
+         else (Buffer.add_char b '\\'; buf_add_hex2 b c; Buffer.add_char b ' '))
+      s;
+    Buffer.contents b
+  end
 
 let apply (e : C.escaper) s =
   match e with
@@ -144,14 +190,15 @@ let apply (e : C.escaper) s =
   | C.EscAttr -> html_like ~attr:true s
   | C.EscUrlComponent -> url_component s
   | C.EscUrlWhole -> url_whole s
-  | C.EscCss -> css s
+  | C.EscCssValue -> css ~decl:false s
+  | C.EscCssDecl -> css ~decl:true s
   | C.EscJsString -> js_string s
   | C.EscNone -> s
 
 let apply_id id s =
   match List.find_opt (fun e -> C.escaper_id e = id)
           [ C.EscHtml; C.EscAttr; C.EscUrlComponent; C.EscUrlWhole;
-            C.EscCss; C.EscJsString; C.EscNone ] with
+            C.EscCssValue; C.EscJsString; C.EscNone; C.EscCssDecl ] with
   | Some e -> apply e s
   | None ->
     invalid_arg

--- a/lib/ctxesc/scan_templates.ml
+++ b/lib/ctxesc/scan_templates.ml
@@ -1,0 +1,188 @@
+(* Dry-run scanner: walk every ~H template in a source tree through the context
+   automaton and report what the Task 5 desugar WOULD do, without changing it.
+ *
+ * Purpose is blast radius. Task 5 turns some interpolations into hard compile
+ * errors and rewrites others (the unquoted-attribute substitution), so the
+ * honest order is to measure a real corpus first rather than discover the
+ * fallout afterwards.
+ *
+ * Usage:
+ *   scan_templates.exe <table.tbl> <dir> [<dir> ...]
+ *
+ * Parses each .march file with the real lexer/parser and finds ESigil("H", _),
+ * so what it sees is exactly what the desugar will see -- not a regex guess at
+ * template boundaries.
+ *
+ * Exit code is always 0: this is a report, not a gate. *)
+
+module C = March_ctxesc.Context
+module P = March_ctxesc.Tbl_parse
+module A = March_ctxesc.Automaton
+
+type finding =
+  | Ok_hole of C.escaper
+  | Rejected of string
+  | Literal_error of string
+  | Bad_terminal of string
+
+let escaper_counts : (string, int) Hashtbl.t = Hashtbl.create 8
+let bump tbl k = Hashtbl.replace tbl k (1 + (try Hashtbl.find tbl k with Not_found -> 0))
+
+let problems : (string * int * finding) list ref = ref []
+(* Holes whose escaper is NOT EscHtml. These still COMPILE, but their output
+   changes: today every hole is HTML-escaped regardless of context. Behaviour
+   changes need eyeballing even when nothing errors. *)
+let changed : (string * int * string) list ref = ref []
+let n_templates = ref 0
+let n_holes = ref 0
+
+(* A ~H sigil's content is a `++` chain of literal chunks and to_string(hole)
+   calls, exactly as the desugar sees it. *)
+let rec decompose (e : March_ast.Ast.expr) =
+  let open March_ast.Ast in
+  match e with
+  | EApp (EVar { txt = "++"; _ }, [ l; r ], _) -> decompose l @ decompose r
+  | EApp (EVar { txt = "string_concat3"; _ }, [ a; b; c ], _) ->
+    decompose a @ decompose b @ decompose c
+  | _ -> [ e ]
+
+let scan_sigil tbl file line content =
+  let open March_ast.Ast in
+  incr n_templates;
+  let ctx = ref C.initial in
+  let parts = decompose content in
+  List.iter
+    (fun part ->
+       match part with
+       | ELit (LitString s, _) ->
+         (match A.consume_literal tbl !ctx s with
+          | Ok o -> ctx := o.A.ctx
+          | Error (m, _) ->
+            problems := (file, line, Literal_error m) :: !problems)
+       | EApp (EVar { txt = "to_string"; _ }, _, _) ->
+         incr n_holes;
+         (match A.consume_interp tbl !ctx with
+          | Ok (esc, _, c') ->
+            ctx := c';
+            bump escaper_counts (C.escaper_name esc);
+            if esc <> C.EscHtml then
+              changed := (file, line, C.escaper_name esc) :: !changed;
+            ignore (Ok_hole esc)
+          | Error d ->
+            problems := (file, line, Rejected d) :: !problems)
+       | _ -> (* island_ssr / CSRF injections and other non-literal parts *)
+         ())
+    parts;
+  if not (A.is_valid_terminal !ctx) then
+    problems :=
+      (file, line, Bad_terminal (C.describe !ctx)) :: !problems
+
+let rec find_sigils tbl file (e : March_ast.Ast.expr) =
+  let open March_ast.Ast in
+  let go = find_sigils tbl file in
+  match e with
+  | ESigil ("H", content, sp) ->
+    scan_sigil tbl file sp.start_line content;
+    go content
+  | ESigil (_, c, _) -> go c
+  | EApp (f, args, _) -> go f; List.iter go args
+  | ECon (_, args, _) -> List.iter go args
+  | ELet (b, _) -> go b.bind_expr
+  | ELetQ (_, a, b, _) -> go a; go b
+  | ELetFn (_, _, _, b, _) -> go b
+  | EIf (a, b, c, _) -> go a; go b; go c
+  | ECond (arms, _) -> List.iter (fun (c, b) -> go c; go b) arms
+  | EMatch (s, branches, _) ->
+    go s;
+    List.iter (fun (b : branch) ->
+        (match b.branch_guard with Some g -> go g | None -> ()); go b.branch_body)
+      branches
+  | EBlock (es, _) -> List.iter go es
+  | ELam (_, b, _) -> go b
+  | ETuple (es, _) -> List.iter go es
+  | ERecord (fs, _) -> List.iter (fun (_, e) -> go e) fs
+  | ERecordUpdate (e, fs, _) -> go e; List.iter (fun (_, e) -> go e) fs
+  | EField (e, _, _) -> go e
+  | EPipe (a, b, _) -> go a; go b
+  | EAnnot (e, _, _) -> go e
+  | EAtom (_, es, _) -> List.iter go es
+  | ESend (a, b, _) -> go a; go b
+  | ESpawn (e, _) -> go e
+  | EAssert (a, _) -> go a
+  | _ -> ()
+
+let rec find_in_decls tbl file (ds : March_ast.Ast.decl list) =
+  let open March_ast.Ast in
+  List.iter
+    (fun d ->
+       match d with
+       | DFn (f, _) ->
+         List.iter (fun (c : fn_clause) -> find_sigils tbl file c.fc_body) f.fn_clauses
+       | DLet (_, b, _) -> find_sigils tbl file b.bind_expr
+       | DMod (_, _, inner, _) -> find_in_decls tbl file inner
+       | _ -> ())
+    ds
+
+let scan_file tbl path =
+  try
+    let ic = open_in path in
+    let n = in_channel_length ic in
+    let src = really_input_string ic n in
+    close_in ic;
+    let lexbuf = Lexing.from_string src in
+    let m =
+      March_parser.Parser.module_
+        (March_parser.Token_filter.make March_lexer.Lexer.token) lexbuf
+    in
+    find_in_decls tbl path m.March_ast.Ast.mod_decls
+  with _ ->
+    (* A file this scanner cannot parse is not a finding about escaping; the
+       corpus predates this compiler and has its own drift. Counted, not
+       reported as a template problem. *)
+    ()
+
+let rec walk dir f =
+  match Sys.readdir dir with
+  | entries ->
+    Array.iter
+      (fun e ->
+         let p = Filename.concat dir e in
+         if e = ".march" || e = ".claude" || e = "_build" || e = ".git" then ()
+         else if Sys.is_directory p then walk p f
+         else if Filename.check_suffix p ".march" then f p)
+      entries
+  | exception Sys_error _ -> ()
+
+let () =
+  if Array.length Sys.argv < 3 then begin
+    prerr_endline "usage: scan_templates.exe <table.tbl> <dir> [<dir> ...]";
+    exit 2
+  end;
+  let tbl =
+    match P.parse_file Sys.argv.(1) with
+    | Ok t -> A.compile t
+    | Error e -> prerr_endline e; exit 2
+  in
+  for i = 2 to Array.length Sys.argv - 1 do
+    walk Sys.argv.(i) (scan_file tbl)
+  done;
+  Printf.printf "templates: %d   holes: %d\n\n" !n_templates !n_holes;
+  print_endline "escaper selected per hole:";
+  Hashtbl.iter (fun k v -> Printf.printf "  %-16s %d\n" k v) escaper_counts;
+  let chg = List.rev !changed in
+  Printf.printf "\nBEHAVIOUR CHANGES (compile fine, output differs): %d\n"
+    (List.length chg);
+  List.iter (fun (f, l, e) -> Printf.printf "  %-14s %s:%d\n" e f l) chg;
+  let probs = List.rev !problems in
+  Printf.printf "\nWOULD-BREAK: %d\n" (List.length probs);
+  List.iter
+    (fun (f, l, p) ->
+       let kind, msg =
+         match p with
+         | Rejected d -> "REJECT", d
+         | Literal_error m -> "NO-RULE", m
+         | Bad_terminal d -> "UNCLOSED", "template ends " ^ d
+         | Ok_hole _ -> "OK", ""
+       in
+       Printf.printf "  %-8s %s:%d\n           %s\n" kind f l msg)
+    probs

--- a/lib/ctxesc/tbl_parse.ml
+++ b/lib/ctxesc/tbl_parse.ml
@@ -211,9 +211,8 @@ let parse_transition line s =
        (from | pattern | substitution | successor | diagnostic), got %d"
       (List.length fields)
 
-let parse_file path =
+let parse_channel path ic =
   try
-    let ic = open_in path in
     let tags = ref [] and attrs = ref [] and trans = ref [] in
     let section = ref `None in
     let lineno = ref 0 in
@@ -259,13 +258,33 @@ let parse_file path =
               | `Transitions -> trans := parse_transition line s :: !trans)
        done
      with End_of_file -> ());
-    close_in ic;
     Ok { tags = List.rev !tags;
          attrs = List.rev !attrs;
          transitions = List.rev !trans }
   with
   | Bad (msg, line) -> Error (Printf.sprintf "%s: line %d: %s" path line msg)
   | Sys_error e -> Error e
+
+let parse_file path =
+  match open_in path with
+  | exception Sys_error e -> Error e
+  | ic ->
+    let r = parse_channel path ic in
+    close_in ic;
+    r
+
+(* Used by the compiler, which cannot read a repo-relative file: the table text
+   is embedded via a dune rule (see table_data.ml) and parsed once at startup. *)
+let parse_string ~name text =
+  let tmp = Filename.temp_file "ctxtbl" ".tbl" in
+  let oc = open_out tmp in
+  output_string oc text;
+  close_out oc;
+  let ic = open_in tmp in
+  let r = parse_channel name ic in
+  close_in ic;
+  (try Sys.remove tmp with Sys_error _ -> ());
+  r
 
 (** Classify a tag or attribute name against a [name_rule] list. First match
     wins, so ordering in the file is significant (e.g. `on*` above `*`). *)

--- a/lib/desugar/desugar.ml
+++ b/lib/desugar/desugar.ml
@@ -437,6 +437,33 @@ let inject_csrf_tokens (parts : expr list) (sp : span) : expr list =
   in
   go parts
 
+(** Diagnostic sink for expression-level desugar errors.
+
+    [desugar_expr] is public API called without an error context by the
+    REPL and other tools, so [desugar_module ~errors] communicates its
+    context via this ref for the duration of the module pass.  When a
+    caller-supplied context is installed, errors are reported through the
+    standard [Errors] diagnostic machinery (positioned span, rendered by
+    the drivers that check [has_errors]).  When no context was supplied,
+    we raise the same positioned [ParseError] exception the parse path
+    uses — loud failure, never silently-wrong desugared code. *)
+let expr_err_ctx : Err.ctx option ref = ref None
+
+let desugar_expr_error ~(sp : span) ?hint msg : unit =
+  match !expr_err_ctx with
+  | Some ctx ->
+    Err.report ctx
+      { severity = Err.Error; span = sp; message = msg; labels = [];
+        notes = (match hint with Some h -> [h] | None -> []);
+        code = None; fix = None }
+  | None ->
+    let pos = { Lexing.pos_fname = sp.file;
+                pos_lnum = sp.start_line;
+                pos_bol  = 0;
+                pos_cnum = sp.start_col } in
+    raise (March_errors.Errors.ParseError (msg, hint, pos))
+
+
 (** Build an IOList directly from the parts of an ~H sigil interpolation.
 
     Static string literals are kept as-is.  Dynamic parts (to_string calls)
@@ -463,22 +490,80 @@ let html_interp_to_iolist (content : expr) (sp : span) : expr =
      templates must never see an injected unbound `conn`). *)
   let parts =
     if !csrf_conn_in_scope then inject_csrf_tokens parts sp else parts in
-  (* Third pass: escape dynamic interpolations.
-     Use html_auto_escape(x) instead of Html.escape(to_string(x)) so that:
-     - Html.Safe values are inserted verbatim (no double-escaping)
-     - IOList values (partials) are flattened as-is (already HTML)
-     - Plain strings and other values are HTML-escaped normally *)
-  let parts = List.map (fun part ->
+  (* Third pass: walk the FIXED chunks through the HTML context automaton and
+     give each hole the escaper its parse context calls for.
+
+     This is the whole point of the analysis, and it is entirely compile-time.
+     Per Samuel et al. (arXiv:2605.16561v1) an interpolation is a single
+     transition whose successor depends only on the predecessor context, never
+     on the interpolated value; and ~H has no in-template control flow, so
+     there are no join points and no fixed point. The context trajectory is
+     therefore fully determined by the literal chunks, which are constants
+     sitting right here. Nothing survives to runtime but a direct escaper call.
+
+     Three things fall out of the walk:
+     - the escaper id per hole (html in element content, a URL scheme
+       allowlist at the start of an href, JS inside <script>, and so on);
+     - SUBSTITUTIONS — an unquoted attribute value receiving a hole gets a
+       quote inserted, and the automaton closes it on the way out, so
+       `<div class=${x}>` emits `<div class="..."`>;
+     - DIAGNOSTICS for holes no escaper can make safe (an attribute name, an
+       element name, a comment interior). Those are hard errors: there is no
+       encoding that makes an attacker-chosen attribute name safe. *)
+  let tbl = Lazy.force March_ctxesc.Automaton.default in
+  let ctx = ref March_ctxesc.Context.initial in
+  let lit s psp = ELit (LitString s, psp) in
+  let parts = List.concat_map (fun part ->
     match part with
-    | EApp (EVar { txt = "to_string"; _ }, [inner_expr], psp) ->
-      (* Dynamic part: use html_auto_escape(x) — handles Safe/IOList/String *)
-      EApp (EVar { txt = "html_auto_escape"; span = psp }, [inner_expr], psp)
+    | ELit (LitString s, psp) ->
+      (match March_ctxesc.Automaton.consume_literal tbl !ctx s with
+       | Ok o -> ctx := o.March_ctxesc.Automaton.ctx; [lit o.March_ctxesc.Automaton.emit psp]
+       | Error (msg, _off) ->
+         desugar_expr_error ~sp:psp msg;
+         [part])
     | EApp (EVar { txt = "to_string"; _ }, args, psp) ->
-      (* Fallback for unusual arity — shouldn't happen in practice *)
-      let inner = EApp (EVar { txt = "to_string"; span = psp }, args, psp) in
-      EApp (EVar { txt = "html_auto_escape"; span = psp }, [inner], psp)
-    | _ -> part  (* String literals and island_ssr calls — leave as-is *)
+      let inner =
+        match args with
+        | [one] -> one
+        | _ ->
+          (* Unusual arity — keep the to_string call and escape its result. *)
+          EApp (EVar { txt = "to_string"; span = psp }, args, psp)
+      in
+      (match March_ctxesc.Automaton.consume_interp tbl !ctx with
+       | Ok (esc, subst, ctx') ->
+         ctx := ctx';
+         let id = March_ctxesc.Context.escaper_id esc in
+         let call =
+           EApp (EVar { txt = "html_escape_ctx"; span = psp },
+                 [ELit (LitInt id, psp); inner], psp) in
+         if subst = "" then [call] else [lit subst psp; call]
+       | Error diag ->
+         desugar_expr_error ~sp:psp
+           ~hint:(Printf.sprintf
+                    "This interpolation is %s. Move the dynamic part into a \
+                     value position instead."
+                    (March_ctxesc.Context.describe !ctx))
+           diag;
+         [part])
+    | _ ->
+      (* island_ssr / CSRF injections: markup that is only valid in element
+         content. If the walk says we are anywhere else, the template is
+         malformed in a way that would splice into a tag. *)
+      (if (!ctx).March_ctxesc.Context.state <> March_ctxesc.Context.Pcdata then
+         desugar_expr_error ~sp
+           "A template fragment can only be inserted in element content, not \
+            inside a tag or attribute.");
+      [part]
   ) parts in
+  (* A template must not end mid-tag, mid-attribute or mid-comment: whatever
+     the caller concatenates next would splice into it, which is exactly the
+     composition hazard this analysis exists to stop. *)
+  if not (March_ctxesc.Automaton.is_valid_terminal !ctx) then
+    desugar_expr_error ~sp
+      (Printf.sprintf
+         "This ~H template does not end in a well-formed state — it ends %s. \
+          Anything concatenated after it would be spliced into that position."
+         (March_ctxesc.Context.describe !ctx));
   (* Build the cons-list of parts.
      CRITICAL: every generated node must carry a DISTINCT span.  The
      typechecker records each expression's inferred type in a type_map keyed
@@ -504,32 +589,6 @@ let html_interp_to_iolist (content : expr) (sp : span) : expr =
   EApp (EVar { txt = "IOList.from_strings"; span = sp }, [list_expr], sp)
 
 (* ---- Pipe desugaring ---- *)
-
-(** Diagnostic sink for expression-level desugar errors.
-
-    [desugar_expr] is public API called without an error context by the
-    REPL and other tools, so [desugar_module ~errors] communicates its
-    context via this ref for the duration of the module pass.  When a
-    caller-supplied context is installed, errors are reported through the
-    standard [Errors] diagnostic machinery (positioned span, rendered by
-    the drivers that check [has_errors]).  When no context was supplied,
-    we raise the same positioned [ParseError] exception the parse path
-    uses — loud failure, never silently-wrong desugared code. *)
-let expr_err_ctx : Err.ctx option ref = ref None
-
-let desugar_expr_error ~(sp : span) ?hint msg : unit =
-  match !expr_err_ctx with
-  | Some ctx ->
-    Err.report ctx
-      { severity = Err.Error; span = sp; message = msg; labels = [];
-        notes = (match hint with Some h -> [h] | None -> []);
-        code = None; fix = None }
-  | None ->
-    let pos = { Lexing.pos_fname = sp.file;
-                pos_lnum = sp.start_line;
-                pos_bol  = 0;
-                pos_cnum = sp.start_col } in
-    raise (March_errors.Errors.ParseError (msg, hint, pos))
 
 (* ---- Predicate qualified-spelling flattening (Task 8 prototype) ────────
 

--- a/lib/desugar/dune
+++ b/lib/desugar/dune
@@ -1,3 +1,3 @@
 (library
  (name march_desugar)
- (libraries march_ast march_errors march_caps))
+ (libraries march_ast march_errors march_caps march_ctxesc))

--- a/runtime/march_ctx_escape.c
+++ b/runtime/march_ctx_escape.c
@@ -164,20 +164,98 @@ static void esc_js_string(sink *s, const char *src, size_t len) {
     }
 }
 
-/* ── CSS ───────────────────────────────────────────────────────────────────
- * Allowlist rather than denylist: CSS has too many ways to reach a URL or an
- * expression for a blocklist to be credible. Anything outside a small safe set
- * becomes a `\XX ` hex escape, which CSS reads as a literal character and
- * which can never re-open a construct. */
-static void esc_css(sink *s, const char *src, size_t len) {
+/* CSS -- two positions, two escapers; see march_ctx_escape.h.
+ *
+ * Both allow calls to an ALLOWLISTED set of functions. An earlier version
+ * escaped every `(`, which is safe but broke real templates: `var(--text-muted)`
+ * became `var\28 --text-muted\29 `, and a whole declaration interpolated after a
+ * `;` was destroyed entirely. Both shapes occur in forgepm. A denylist of
+ * `expression(` / `url(` is not credible -- CSS has too many routes to a URL --
+ * so the rule is: a function call survives only if its name is on the list.
+ *
+ * `url(`, `expression(`, `image-set(`, `element(` and `attr(` are all absent
+ * from the list, so they are escaped like any other unknown identifier. */
+
+static const char *const css_fn_allow[] = {
+    "var", "calc", "min", "max", "clamp",
+    "rgb", "rgba", "hsl", "hsla",
+    "translate", "translatex", "translatey", "translate3d",
+    "scale", "scalex", "scaley", "rotate", "rotatex", "rotatey", "rotatez",
+    "skew", "skewx", "skewy", "matrix", "matrix3d", "perspective",
+    "cubic-bezier", "steps",
+    "linear-gradient", "radial-gradient", "conic-gradient",
+    "repeating-linear-gradient", "repeating-radial-gradient",
+    NULL
+};
+
+static int css_fn_allowed(const char *name, size_t len) {
+    if (len == 0 || len > 32) return 0;
+    char low[33];
+    for (size_t i = 0; i < len; i++) {
+        char c = name[i];
+        low[i] = (c >= 'A' && c <= 'Z') ? (char)(c - 'A' + 'a') : c;
+    }
+    low[len] = '\0';
+    for (int i = 0; css_fn_allow[i]; i++)
+        if (strcmp(low, css_fn_allow[i]) == 0) return 1;
+    return 0;
+}
+
+static int css_ident_char(unsigned char c) {
+    return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+        || (c >= '0' && c <= '9') || c == '-' || c == '_';
+}
+
+/* Plain value bytes, excluding the structural ones handled per-mode. */
+static int css_plain(unsigned char c, int decl) {
+    if (css_ident_char(c)) return 1;
+    if (c == '#' || c == '%' || c == '.' || c == ',' || c == ' ') return 1;
+    if (decl && (c == ':' || c == ';')) return 1;
+    return 0;
+}
+
+/* Decide, in one pass, whether the whole string is safe-shaped: every `(` is
+ * preceded by an allowlisted function name, parens balance, and every other
+ * byte is a plain value byte. Anything else and we escape EVERYTHING strictly
+ * -- a partially-escaped CSS string is far harder to reason about than a wholly
+ * escaped one, and the strict form is always safe. */
+static int css_is_safe_shaped(const char *s, size_t len, int decl) {
+    size_t i = 0;
+    int depth = 0;
+    while (i < len) {
+        unsigned char c = (unsigned char)s[i];
+        if (css_ident_char(c)) {
+            size_t j = i;
+            while (j < len && css_ident_char((unsigned char)s[j])) j++;
+            if (j < len && s[j] == '(') {
+                if (!css_fn_allowed(s + i, j - i)) return 0;
+                depth++;
+                i = j + 1;
+                continue;
+            }
+            i = j;
+            continue;
+        }
+        if (c == ')') {
+            if (depth == 0) return 0;
+            depth--; i++; continue;
+        }
+        if (c == '(') return 0;  /* `(` with no function name before it */
+        if (!css_plain(c, decl)) return 0;
+        i++;
+    }
+    return depth == 0;
+}
+
+static void esc_css(sink *s, const char *src, size_t len, int decl) {
+    if (css_is_safe_shaped(src, len, decl)) {
+        put(s, src, len);
+        return;
+    }
     for (size_t i = 0; i < len; i++) {
         unsigned char c = (unsigned char)src[i];
-        if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
-            || (c >= '0' && c <= '9')
-            || c == '-' || c == '_' || c == '#' || c == '%' || c == '.'
-            || c == ',' || c == ' ') {
-            put1(s, (char)c);
-        } else {
+        if (css_plain(c, decl)) put1(s, (char)c);
+        else {
             put1(s, '\\');
             put_hex2(s, c);
             put1(s, ' ');  /* terminate the escape so the next char is literal */
@@ -192,7 +270,8 @@ size_t march_ctx_escape(int escaper_id, const char *src, size_t len, char *out) 
     case MARCH_ESC_ATTR:          esc_html_like(&s, src, len, 1); break;
     case MARCH_ESC_URL_COMPONENT: esc_url_component(&s, src, len); break;
     case MARCH_ESC_URL_WHOLE:     esc_url_whole(&s, src, len); break;
-    case MARCH_ESC_CSS:           esc_css(&s, src, len); break;
+    case MARCH_ESC_CSS_VALUE:     esc_css(&s, src, len, 0); break;
+    case MARCH_ESC_CSS_DECL:      esc_css(&s, src, len, 1); break;
     case MARCH_ESC_JS_STRING:     esc_js_string(&s, src, len); break;
     case MARCH_ESC_NONE:          put(&s, src, len); break;
     default:

--- a/runtime/march_ctx_escape.h
+++ b/runtime/march_ctx_escape.h
@@ -5,6 +5,13 @@
  * lib/ctxesc/automaton.ml and inlined as a constant id at the call site, so
  * nothing here ever inspects a value to decide what it is.
  *
+ * CSS has two escapers because a style attribute alternates between two
+ * positions with different syntax: a DECLARATION list (`color:red;...`), where
+ * `:` and `;` are structural, and a VALUE (`#fff`, `var(--x)`), where either
+ * would let the value start a new declaration. Both permit calls to an
+ * allowlisted set of functions -- rejecting `var()` outright broke real
+ * templates, and a denylist of `expression(`/`url(` is not credible.
+ *
  * THE IDS BELOW MUST MATCH Context.escaper_id IN lib/ctxesc/context.ml.
  * That pairing is not covered by the generated-table drift check, so
  * test/test_ctx_escape.c asserts it explicitly against a copy of the OCaml
@@ -20,10 +27,11 @@
 #define MARCH_ESC_ATTR          1
 #define MARCH_ESC_URL_COMPONENT 2
 #define MARCH_ESC_URL_WHOLE     3
-#define MARCH_ESC_CSS           4
+#define MARCH_ESC_CSS_VALUE     4
 #define MARCH_ESC_JS_STRING     5
 #define MARCH_ESC_NONE          6
-#define MARCH_ESC__COUNT        7
+#define MARCH_ESC_CSS_DECL      7
+#define MARCH_ESC__COUNT        8
 
 /* What a URL that failed the scheme allowlist is replaced with. Chosen to be
  * inert in every context: it navigates nowhere and executes nothing. */

--- a/specs/progress/2026-08-06-h-sigil-contextual-escaping.md
+++ b/specs/progress/2026-08-06-h-sigil-contextual-escaping.md
@@ -1,0 +1,123 @@
+# `~H` contextual auto-escaping
+
+**Landed:** 2026-08-06
+**Branch:** `feat/ctxesc-tables` (off `main` @ `37d1e166`)
+
+Tasks 1–5 of `specs/plans/2026-08-05-contextual-autoescaping.md`, following
+Samuel, Palmer, Summa & Grayson, *Compile-time Security Analysis and
+Optimization of Sensitive String Producers* (arXiv:2605.16561v1).
+
+## What was wrong
+
+`~H` applied one escaper to every interpolation regardless of parse context.
+Correct in element content, wrong everywhere else:
+
+- `~H"<a href=\"${url}\">"` accepted `javascript:alert(1)` — entity-encoding
+  does not touch a scheme.
+- `~H"<div class=${cls}>"` — an unquoted attribute ends at the first space, so
+  a value could start a new attribute.
+- `~H"<script>var x = \"${d}\";</script>"` — HTML entities are the wrong codec
+  entirely inside a script.
+
+## How it works
+
+`specs/security/html-contexts.tbl` is the source of truth: a declarative
+transition table a security engineer can read without knowing OCaml.
+`lib/ctxesc/` parses it, walks it, and selects an escaper from the resulting
+context.
+
+**The whole walk is compile-time.** The paper's load-bearing property is that an
+interpolation is a single transition whose successor depends only on the
+predecessor context, never on the interpolated value. Combined with `~H` having
+no in-template control flow — no `if`/`for`, so no join points and no fixed
+point — the context trajectory is fully determined by the literal chunks, which
+are constants in the desugarer. Nothing survives to runtime but a direct escaper
+call, so there is no per-render cost.
+
+The escaper is derived from the *successor* context rather than named in a table
+row, so the table cannot drift out of sync with the escaper set.
+
+## Measured impact
+
+The dry-run scanner (`lib/ctxesc/scan_templates.ml`) walks every `~H` in a
+source tree and reports what the desugar would do. Against bastion + forgepm —
+**121 templates, 253 holes**:
+
+| escaper | holes | change |
+|---|---|---|
+| html | 213 | none |
+| attr | 17 | + backtick |
+| url_component | 14 | percent-encoded |
+| css_value / css_decl | 7 | allowlist-filtered |
+| url_whole | 2 | **scheme allowlist** |
+
+**Zero would fail to compile.** Nothing in either codebase interpolates into an
+attribute name, element name, or comment.
+
+## Design decisions the plan did not anticipate
+
+Every one of these came from measurement or from an earlier task's consequences,
+not from the plan:
+
+- **`ilit:` (case-insensitive literals)** is load-bearing. Without it
+  `</SCRIPT>` walks past the raw-text exit rule and every hole after it is
+  escaped as the wrong language.
+- **URL position.** A hole at the start of an `href` *is* the whole URL and
+  needs a scheme allowlist; after literal text it is a component needing
+  percent-encoding. Expressed as a table transition (`url` → `urlmid`) rather
+  than a fifth context field.
+- **CSS position and a function allowlist.** Task 3's CSS escaper rejected every
+  `(`, which I described as "deliberately strict". Measured against forgepm that
+  was simply wrong: it destroyed `var(--text-muted)` (pages.march:336) and a
+  whole declaration list (pages.march:714), neither malicious. Now split by CSS
+  syntax position (declaration vs value, discriminated by `:` and `;`, not by
+  offset) with an allowlisted function set. See
+  `specs/progress/…` history in the branch for the full reasoning.
+- **Already-safe HTML.** A nested `~H` partial is an `IOList` of trusted markup
+  and must be inserted verbatim — but only when the surrounding context is HTML.
+  An `IOList` spliced into an `href` is a context mismatch, so it is flattened
+  and escaped for wherever it landed. Type-indexed trust (`Html.Trusted`) makes
+  this precise in a later task.
+- **Table embedding.** The desugarer needs the table at compile time and an
+  installed `march` has no `specs/` directory, so `lib/ctxesc/dune` `cat`s the
+  `.tbl` into a generated module. Drift is structurally impossible — dune
+  regenerates from the source of truth every build — so the OCaml side needs no
+  freshness check. The March-side copy still does (later task).
+
+## Verification
+
+- 28 OCaml tests over the *shipped* table (parser, automaton, escaper selection,
+  substitution, rejections, terminal validity), **mutation-tested**: breaking
+  `ilit:` or removing the URL demotion row makes the right tests fail.
+- 61 C escaper checks, including six `javascript:` bypass variants (case,
+  leading space, embedded tab/newline/control byte) and the two forgepm CSS
+  regressions pinned verbatim by file:line.
+- `test/native/h_escape_ctx_builtin.march` — compiled/interpreted golden diff.
+  Parity is the property that matters: the ADT misread in
+  `2026-08-05-h-sigil-adt-misread.md` stayed hidden because only compiled output
+  was wrong.
+- The OCaml↔C escaper-id pairing is asserted explicitly; it is the one
+  cross-language contract no generated-table check covers, and a mismatch would
+  silently apply the wrong escaper.
+
+Suites: compiler 739, eval 256, codegen 546, stdlib 830 — all green except
+`adversarial-regressions 40 MARCH_SANITIZE`, an ASAN timeout that is
+environmental (a trivial `clang -fsanitize=address` program also hangs on this
+host; CI's `sanitize-gate` passes).
+
+Exactly one existing test needed updating: `~H sigil codegen / int interp
+coerces arg to ptr` pinned `march_html_auto_escape` in the emitted IR. Its
+intent — an `Int` must reach the escaper as a tagged ptr, never a raw `i64` —
+is unchanged and now asserted against the new call shape, plus the contextual
+decision itself (escaper id 0 in element content).
+
+## Open
+
+- The CSS **function allowlist** is a judgement call, modelled on Go's
+  `html/template`. A function not on it degrades to strict escaping: visibly
+  broken styling, at runtime only. Worth review.
+- The 14 `url_component` holes were reasoned safe by reading the templates
+  (package names and internal paths are unreserved characters), not by
+  rendering them.
+- Tasks 6–8 remain: context-indexed `Html.Trusted`, the March-side table copy
+  plus its drift guard, and the full-corpus validation sweep.

--- a/specs/security/README.md
+++ b/specs/security/README.md
@@ -47,7 +47,7 @@ Four fields, exactly as the paper describes:
 |---|---|
 | `state` | `pcdata` `rcdata` `tagname` `closetagname` `beforeattrname` `afterattrname` `beforeattrvalue` `attrvalue` `comment` |
 | `element` | `normal` `script` `style` `textarea` `title` |
-| `attr` | `normal` `url` `urlmid` `style` `script` |
+| `attr` | `normal` `url` `urlmid` `style` `stylevalue` `script` |
 | `delim` | `none` `single` `double` `unquoted` `doublesubst` |
 
 `element` tracks which element's content we are inside, because `<script>` and
@@ -143,7 +143,8 @@ row — one less thing to get out of sync:
 | `attrvalue` with `attr = normal` | HTML entity-encode, plus backtick |
 | `attrvalue` with `attr = url` (start of value) | URL scheme allowlist |
 | `attrvalue` with `attr = urlmid` | percent-encode |
-| `attrvalue` with `attr = style`, or `rcdata` in `style` | CSS escape |
+| `attrvalue` with `attr = style`, or `rcdata` in `style` | CSS **declaration** escape |
+| `attrvalue` with `attr = stylevalue` | CSS **value** escape |
 | `attrvalue` with `attr = script`, or `rcdata` in `script` | JS string escape |
 
 ## Escaper implementations

--- a/specs/security/html-contexts.tbl
+++ b/specs/security/html-contexts.tbl
@@ -111,6 +111,18 @@ attrvalue,*,*,unquoted    | cls+:[ \t\r\n] |  | beforeattrname,=,normal,none |
 attrvalue,*,url,*         | interp         |  | =,=,=,=                  |
 attrvalue,*,url,*         | any            |  | =,=,urlmid,=             |
 
+# -- CSS position tracking --
+# A style attribute alternates between DECLARATION and VALUE positions, and the
+# two need different escapers: a declaration list may contain `:` and `;`, a
+# value may not (either would let it start a new declaration). The discriminator
+# is CSS syntax, not offset -- `style="a:b;${decls}"` is a declaration position
+# even though literal text precedes it, and `style="color:${v}"` is a value
+# position. Measured against forgepm, both shapes occur in real templates.
+attrvalue,*,style,*       | lit:":"        |  | =,=,stylevalue,=         |
+attrvalue,*,stylevalue,*  | lit:";"        |  | =,=,style,=              |
+attrvalue,*,style,*       | interp         |  | =,=,=,=                  |
+attrvalue,*,stylevalue,*  | interp         |  | =,=,=,=                  |
+
 # -- generic within-value rows --
 attrvalue,*,*,*           | interp         |  | =,=,=,=                  |
 attrvalue,*,*,*           | any            |  | =,=,=,=                  |

--- a/test/test_codegen.ml
+++ b/test/test_codegen.ml
@@ -7686,13 +7686,22 @@ let test_h_sigil_int_interp_coerces_arg_to_ptr () =
   let ir = emit_ir_with_iolist {|mod Test do
     fn render(n : Int) : String do IOList.to_string(~H"<p>n=${n}</p>") end
   end|} in
-  (* The runtime march_html_auto_escape takes a tagged ptr; an int arg must be
-     tagged via i64->ptr coercion, never passed as `i64 N` against the `ptr`
-     declaration (which segfaulted). *)
-  Alcotest.(check bool) "html_auto_escape called with a ptr arg" true
-    (ir_contains ir "call ptr @march_html_auto_escape(ptr");
-  Alcotest.(check bool) "html_auto_escape NOT called with a raw i64 arg" false
-    (ir_contains ir "@march_html_auto_escape(i64")
+  (* Contextual escaping (Task 5) replaced html_auto_escape with
+     html_escape_ctx(id, v), but the hazard this test exists for is unchanged:
+     the VALUE argument must arrive as a tagged ptr, never as a raw `i64 N`
+     against a `ptr` declaration, which segfaulted. The escaper id is a
+     genuine i64 and is the FIRST argument, so the shape to pin is
+     `(i64 <id>, ptr ...)`.
+
+     Also pins the contextual decision itself at the IR level: a hole in
+     element content must select escaper 0 (Context.EscHtml). *)
+  Alcotest.(check bool) "html_escape_ctx called with (i64 id, ptr value)" true
+    (ir_contains ir "call ptr @march_html_escape_ctx(i64 0, ptr");
+  Alcotest.(check bool) "value arg is NOT a raw i64" false
+    (ir_contains ir "@march_html_escape_ctx(i64 0, i64");
+  (* An Int reaches the escaper via to_string, and must be tagged on the way. *)
+  Alcotest.(check bool) "int is coerced through the ptr path" true
+    (ir_contains ir "call ptr @march_value_to_string(ptr")
 
 (* ── Http stdlib module tests ──────────────────────────────────────────── *)
 

--- a/test/test_ctx_escape.c
+++ b/test/test_ctx_escape.c
@@ -61,9 +61,10 @@ int main(void) {
         { MARCH_ESC_ATTR,          "attr" },
         { MARCH_ESC_URL_COMPONENT, "url_component" },
         { MARCH_ESC_URL_WHOLE,     "url_whole" },
-        { MARCH_ESC_CSS,           "css" },
+        { MARCH_ESC_CSS_VALUE,     "css_value" },
         { MARCH_ESC_JS_STRING,     "js_string" },
         { MARCH_ESC_NONE,          "none" },
+        { MARCH_ESC_CSS_DECL,      "css_decl" },
     };
     for (int i = 0; i < MARCH_ESC__COUNT; i++) {
         checks++;
@@ -147,14 +148,58 @@ int main(void) {
     expect(MARCH_ESC_JS_STRING, "\xe2\x80\xa8", "\\u2028", "js escapes U+2028");
     expect(MARCH_ESC_JS_STRING, "\xe2\x80\xa9", "\\u2029", "js escapes U+2029");
 
-    /* ── CSS ─────────────────────────────────────────────────────────────── */
-    expect(MARCH_ESC_CSS, "red", "red", "css passes an identifier");
-    expect(MARCH_ESC_CSS, "#fff", "#fff", "css passes a hex colour");
-    expect_absent(MARCH_ESC_CSS, "expression(alert(1))", "(",
+    /* ── CSS ─────────────────────────────────────────────────────────────
+       Two positions. A VALUE (after `:`) may not contain `:` or `;` -- either
+       would let it start a new declaration. A DECLARATION list (start of the
+       attribute, or after `;`) may.
+
+       Both allow an allowlisted set of functions. An earlier version escaped
+       every `(`, which was safe but broke real forgepm templates -- the two
+       cases marked "regression" below are verbatim from
+       forgepm/lib/forgepm/web/pages.march. */
+    expect(MARCH_ESC_CSS_VALUE, "red", "red", "css value passes an identifier");
+    expect(MARCH_ESC_CSS_VALUE, "#fff", "#fff", "css value passes a hex colour");
+    expect(MARCH_ESC_CSS_VALUE, "transparent", "transparent",
+           "css value passes a keyword");
+
+    /* regression: pages.march:336 -- `color = "var(--text-muted)"` */
+    expect(MARCH_ESC_CSS_VALUE, "var(--text-muted)", "var(--text-muted)",
+           "css value passes an allowlisted var()");
+    expect(MARCH_ESC_CSS_VALUE, "rgba(34,211,238,0.35)", "rgba(34,211,238,0.35)",
+           "css value passes rgba()");
+    expect(MARCH_ESC_CSS_VALUE, "calc(100% - 4px)", "calc(100% - 4px)",
+           "css value passes calc()");
+
+    /* regression: pages.march:714 -- a whole declaration list after a `;` */
+    expect(MARCH_ESC_CSS_DECL,
+           "border:1px solid rgba(34,211,238,0.35);background:transparent",
+           "border:1px solid rgba(34,211,238,0.35);background:transparent",
+           "css decl passes a declaration list");
+
+    /* A value must NOT be able to start a new declaration. */
+    expect_absent(MARCH_ESC_CSS_VALUE, "red;background:url(x)", ";",
+                  "css value escapes a semicolon");
+    expect_absent(MARCH_ESC_CSS_VALUE, "red;background:url(x)", ":",
+                  "css value escapes a colon");
+
+    /* The allowlist is what keeps the parens safe -- these are not on it. */
+    expect_absent(MARCH_ESC_CSS_VALUE, "expression(alert(1))", "(",
                   "css neutralises expression()");
-    expect_absent(MARCH_ESC_CSS, "a;color:red", ";", "css escapes a semicolon");
-    expect_absent(MARCH_ESC_CSS, "url(javascript:x)", "(", "css escapes url(");
-    expect_absent(MARCH_ESC_CSS, "a\"b", "\"", "css escapes a quote");
+    expect_absent(MARCH_ESC_CSS_DECL, "background:url(javascript:x)", "(",
+                  "css decl escapes url()");
+    expect_absent(MARCH_ESC_CSS_VALUE, "image-set(x)", "(",
+                  "css escapes image-set()");
+    expect_absent(MARCH_ESC_CSS_VALUE, "attr(href)", "(", "css escapes attr()");
+    expect_absent(MARCH_ESC_CSS_VALUE, "element(#x)", "(", "css escapes element()");
+    /* A known-good name must not smuggle an unknown one alongside it. */
+    expect_absent(MARCH_ESC_CSS_VALUE, "var(--a) expression(1)", "expression(",
+                  "one bad function poisons the whole value");
+    /* Unbalanced parens fall back to the strict form. */
+    expect_absent(MARCH_ESC_CSS_VALUE, "var(--a", "(",
+                  "css escapes unbalanced parens");
+    expect_absent(MARCH_ESC_CSS_VALUE, "a\"b", "\"", "css escapes a quote");
+    expect_absent(MARCH_ESC_CSS_VALUE, "a/*x*/b", "/", "css escapes a comment");
+    expect_absent(MARCH_ESC_CSS_DECL, "@import url(x)", "@", "css escapes @import");
 
     /* ── None ────────────────────────────────────────────────────────────── */
     expect(MARCH_ESC_NONE, "<b>&", "<b>&", "none passes through verbatim");

--- a/test/test_ctxesc.ml
+++ b/test/test_ctxesc.ml
@@ -229,7 +229,7 @@ let test_script_body_is_js () =
   Alcotest.check escaper "js escaper" C.EscJsString (esc_after "<script>var x = ")
 
 let test_style_body_is_css () =
-  Alcotest.check escaper "css escaper" C.EscCss (esc_after "<style>a{color:")
+  Alcotest.check escaper "css escaper" C.EscCssDecl (esc_after "<style>a{color:")
 
 let test_textarea_body_is_html () =
   Alcotest.check escaper "html in textarea" C.EscHtml (esc_after "<textarea>")
@@ -251,7 +251,17 @@ let test_event_handler_attr_is_js () =
   Alcotest.check escaper "onclick is js" C.EscJsString (esc_after "<a onclick=\"")
 
 let test_style_attr_is_css () =
-  Alcotest.check escaper "style attr is css" C.EscCss (esc_after "<div style=\"")
+  (* A style attribute alternates between two positions and the escapers differ:
+     at the start (or after a `;`) a hole is a DECLARATION list; after a `:` it
+     is a VALUE. Both shapes occur in forgepm, which is what forced the split --
+     an escaper that rejected `var()` and destroyed `a:b;c:d` broke real
+     templates. *)
+  Alcotest.check escaper "start of style attr is a declaration list"
+    C.EscCssDecl (esc_after "<div style=\"");
+  Alcotest.check escaper "after a colon is a value"
+    C.EscCssValue (esc_after "<div style=\"color:");
+  Alcotest.check escaper "after a semicolon is a declaration list again"
+    C.EscCssDecl (esc_after "<div style=\"color:red;")
 
 let test_plain_attr_is_attr_escaper () =
   Alcotest.check escaper "class is attr" C.EscAttr (esc_after "<div class=\"")


### PR DESCRIPTION
Continues #194 (Tasks 1–2, merged as `6cfdc005`). **This is where `~H`'s behaviour actually changes** — #194 was infrastructure nothing called.

Tasks 3–5 of `specs/plans/2026-08-05-contextual-autoescaping.md`, following Samuel, Palmer, Summa & Grayson, *Compile-time Security Analysis and Optimization of Sensitive String Producers* (arXiv:2605.16561v1).

## What was wrong

`~H` applied one escaper to every interpolation regardless of parse context. Correct in element content, wrong everywhere else:

- `~H"<a href=\"${url}\">"` accepted `javascript:alert(1)` — entity-encoding doesn't touch a scheme.
- `~H"<div class=${cls}>"` — an unquoted attribute ends at the first space, so a value could start a new attribute.
- `~H"<script>var x = \"${d}\";</script>"` — HTML entities are the wrong codec entirely inside a script.

## What it does now

The desugarer walks each template's literal chunks through the context automaton and gives every hole the escaper its position calls for:

```
href    : <a href="about:invalid#zSoyz">x</a>            ← javascript: neutralised
unquoted: <div class="a b onmouseover=alert(1)">y</div>   ← auto-quoted, injection inert
script  : <script>var x = "</script>…";</script>
pcdata  : <p>&lt;b&gt;&amp;</p>                           ← unchanged
query   : <a href="/s?q=a%20b%26c">z</a>
cssvalue: <div style="color:var(--text-muted)">w</div>
```

**Entirely compile-time.** An interpolation is a single transition whose successor depends only on the predecessor context, never on the interpolated value; and `~H` has no in-template control flow, so there are no join points and no fixed point. The context trajectory is fully determined by the literal chunks, which are constants in the desugarer. Nothing survives to runtime but a direct escaper call — **no per-render cost**.

Interpolations no escaping can make safe are now **compile errors** with actionable messages: an attribute name, an element name, a comment interior, and a template ending mid-tag or mid-attribute.

## Blast radius — measured, not estimated

`lib/ctxesc/scan_templates.ml` (added here) walks every `~H` in a source tree and reports what the desugar would do. I built it **before** changing the desugar, specifically so the fallout would be known rather than discovered. Against bastion + forgepm — 121 templates, 253 holes:

| escaper | holes | change |
|---|---|---|
| html | 213 | none |
| attr | 17 | + backtick |
| url_component | 14 | percent-encoded |
| css_value / css_decl | 7 | allowlist-filtered |
| url_whole | 2 | **URL scheme allowlist** |

**Zero would fail to compile.** Nothing in either codebase interpolates into an attribute name, element name, or comment.

## The scanner immediately found a bug in my own work

Task 3's CSS escaper rejected every `(`, which I'd documented as "deliberately strict". Measured against forgepm that was simply wrong — it destroyed two live, non-malicious patterns:

```
in : var(--text-muted)                          → var\28 --text-muted\29     (invalid CSS)
in : border:1px solid rgba(...);background:...  → border\3A 1px solid...     (destroyed)
```

Both at `forgepm/lib/forgepm/web/pages.march:336` and `:714`. Commit `2333523e` fixes it by splitting CSS by **syntax position** — declaration (start, or after `;`) vs value (after `:`), discriminated by CSS syntax rather than offset — and adding a **function allowlist** (`var`, `calc`, `rgb`, gradients, transforms). `url(`, `expression(`, `image-set(`, `attr(`, `element(` are absent and still escaped. If any part of a value is unsafe-shaped, the whole string falls back to strict escaping rather than being partly escaped.

Note this fix is stacked on the escaper that shipped in #194, so `main` currently has the broken-strict version. Nothing calls it there yet.

## Verification

- 28 OCaml tests over the **shipped** table, **mutation-tested** — breaking `ilit:` or removing the URL demotion row makes the right tests fail, so they detect table errors rather than merely exercising code.
- 61 C escaper checks: six `javascript:` bypass variants (case, leading space, embedded tab/newline/control byte) and the two forgepm CSS regressions pinned verbatim by file:line.
- `test/native/h_escape_ctx_builtin.march` — compiled/interpreted golden diff. Parity is the property that matters: the ADT misread in #192 stayed hidden precisely because only compiled output was wrong.
- The OCaml↔C escaper-id pairing is asserted explicitly — the one cross-language contract no generated-table check covers, where a mismatch would silently apply the wrong escaper.

Suites on this base: compiler 760, eval 256, codegen 546, stdlib 830 — green except `adversarial-regressions 40 MARCH_SANITIZE`, an ASAN timeout that is environmental (a trivial `clang -fsanitize=address` program also hangs on this host; CI's `sanitize-gate` passes).

One existing test updated: `~H sigil codegen / int interp coerces arg to ptr` pinned `march_html_auto_escape` in the emitted IR. Its intent — an `Int` must reach the escaper as a tagged ptr, never a raw `i64`, which segfaulted — is unchanged and now asserted against the new call shape, **plus** the contextual decision itself (escaper id 0 in element content). I checked the real IR before rewriting the assertion.

## Worth a reviewer's attention

- **The CSS function allowlist** is a judgement call modelled on Go's `html/template`. A function not on it degrades to strict escaping — visibly broken styling, at runtime only.
- **The 14 `url_component` holes** I reasoned safe by reading the templates (package names and internal paths are unreserved characters), not by rendering them. Task 8's corpus sweep should settle that by diffing rendered output.

## Implementation note

The table is embedded via a dune rule that `cat`s the `.tbl` into a generated module — the desugarer needs it at compile time and an installed `march` has no `specs/` directory. Drift is structurally impossible since dune regenerates from the source of truth every build, so the OCaml side needs no freshness check. This pulls part of Task 7 forward; the March-side copy and its guard remain.

Remaining: Task 6 (context-indexed `Html.Trusted`), Task 7 (March-side table + drift guard), Task 8 (corpus validation).
