### PR TITLE
test(ctxesc): render-diff the corpus — Task 8 validation

### DIFF
--- a/lib/ctxesc/scan_templates.ml
+++ b/lib/ctxesc/scan_templates.ml
@@ -18,6 +18,39 @@
 module C = March_ctxesc.Context
 module P = March_ctxesc.Tbl_parse
 module A = March_ctxesc.Automaton
+module E = March_ctxesc.Escape
+
+(* --diff mode: render each behaviour-changing hole BOTH ways -- as ~H used to
+   (HTML entity-encode everything) and as it does now (contextual) -- against a
+   probe value, and show the surrounding literal context. Answers the question
+   the escaper counts cannot: does the OUTPUT change in a way that breaks the
+   page? *)
+let diff_mode = ref false
+
+(* Probes chosen to be REALISTIC for the position, not adversarial: the point is
+   to find legitimate values the new escapers would mangle. The attack cases are
+   already covered by test_ctx_escape.c. *)
+let probes_for (e : C.escaper) =
+  match e with
+  | C.EscUrlComponent ->
+    [ "bastion"; "march_doc"; "0.2.3"; "readme"; "before"; "a b"; "x/y" ]
+  | C.EscUrlWhole ->
+    [ "/packages/bastion"; "/admin/users"; "https://example.com/a?b=c"; "#frag";
+      "/x?a=b&c=d"; "back`tick" ]
+  | C.EscCssValue ->
+    [ "#22d3ee"; "transparent"; "var(--text-muted)"; "inline-block"; "none" ]
+  | C.EscCssDecl ->
+    [ "border:1px solid rgba(34,211,238,0.35);background:transparent";
+      "display:flex;gap:8px" ]
+  (* The backtick matters: EscAttr escapes it (old IE attribute-delimiter
+     quirk) and the old EscHtml did not, so it is the one byte whose attribute
+     rendering changes for an entirely benign value. *)
+  | C.EscAttr -> [ "hello"; "a b"; "quote\"here"; "back`tick"; "a&b" ]
+  | C.EscJsString -> [ "hello"; "a\"b" ]
+  | _ -> [ "plain" ]
+
+let mangled : (string * int * string * string * string * string) list ref = ref []
+
 
 type finding =
   | Ok_hole of C.escaper
@@ -65,8 +98,21 @@ let scan_sigil tbl file line content =
           | Ok (esc, _, c') ->
             ctx := c';
             bump escaper_counts (C.escaper_name esc);
-            if esc <> C.EscHtml then
+            if esc <> C.EscHtml then begin
               changed := (file, line, C.escaper_name esc) :: !changed;
+              (* Old behaviour was EscHtml for EVERY hole, whatever the
+                 context. Compare against that. *)
+              if !diff_mode then
+                List.iter
+                  (fun probe ->
+                     let old_out = E.apply C.EscHtml probe in
+                     let new_out = E.apply esc probe in
+                     if old_out <> new_out then
+                       mangled :=
+                         (file, line, C.escaper_name esc, probe, old_out, new_out)
+                         :: !mangled)
+                  (probes_for esc)
+            end;
             ignore (Ok_hole esc)
           | Error d ->
             problems := (file, line, Rejected d) :: !problems)
@@ -158,13 +204,20 @@ let () =
     prerr_endline "usage: scan_templates.exe <table.tbl> <dir> [<dir> ...]";
     exit 2
   end;
+  let args = Array.to_list Sys.argv in
+  let args = List.filter (fun a -> if a = "--diff" then (diff_mode := true; false) else true) args in
+  let args = Array.of_list args in
+  if Array.length args < 3 then begin
+    prerr_endline "usage: scan_templates.exe [--diff] <table.tbl> <dir> [<dir> ...]";
+    exit 2
+  end;
   let tbl =
-    match P.parse_file Sys.argv.(1) with
+    match P.parse_file args.(1) with
     | Ok t -> A.compile t
     | Error e -> prerr_endline e; exit 2
   in
-  for i = 2 to Array.length Sys.argv - 1 do
-    walk Sys.argv.(i) (scan_file tbl)
+  for i = 2 to Array.length args - 1 do
+    walk args.(i) (scan_file tbl)
   done;
   Printf.printf "templates: %d   holes: %d\n\n" !n_templates !n_holes;
   print_endline "escaper selected per hole:";
@@ -173,6 +226,17 @@ let () =
   Printf.printf "\nBEHAVIOUR CHANGES (compile fine, output differs): %d\n"
     (List.length chg);
   List.iter (fun (f, l, e) -> Printf.printf "  %-14s %s:%d\n" e f l) chg;
+  (if !diff_mode then begin
+     let m = List.rev !mangled in
+     Printf.printf
+       "\nRENDERED DIFFS (realistic probe values whose output changes): %d\n"
+       (List.length m);
+     List.iter
+       (fun (f, l, e, probe, o, n) ->
+          Printf.printf "  %s:%d  [%s]\n    probe: %s\n    was:   %s\n    now:   %s\n"
+            (Filename.basename f) l e probe o n)
+       m
+   end);
   let probs = List.rev !problems in
   Printf.printf "\nWOULD-BREAK: %d\n" (List.length probs);
   List.iter

--- a/specs/progress/2026-08-06-ctxesc-corpus-validation.md
+++ b/specs/progress/2026-08-06-ctxesc-corpus-validation.md
@@ -1,0 +1,95 @@
+# Task 8 — corpus validation of `~H` contextual escaping
+
+**Date:** 2026-08-06
+**Corpora:** `bastion/lib`, `forgepm/lib` — 121 templates, 253 interpolations
+
+Task 8 of `specs/plans/2026-08-05-contextual-autoescaping.md`. Two claims from
+Tasks 3–5 rested on reading rather than rendering; this settles both with
+evidence.
+
+## Method
+
+The plan assumed forgepm could be built against the compiler. It cannot — 68
+pre-existing errors from bastion version drift, unrelated to this work. But
+building it was never the goal; *rendering before and after* was.
+
+`lib/ctxesc/scan_templates.ml --diff` does that directly. It already walks every
+`~H` template through the automaton and knows each hole's escaper, so it renders
+each hole **both ways** — as `~H` used to (HTML entity-encode everything,
+regardless of context) and as it does now — against probe values chosen to be
+**realistic for the position**, not adversarial. Attack cases are already covered
+by `test/test_ctx_escape.c`; the question here is the opposite one: does the new
+behaviour mangle anything legitimate?
+
+## Result
+
+40 of 253 holes get a different escaper. **Zero produce different rendered output
+for values these applications can actually produce**, with one wire-format
+exception.
+
+### CSS — zero diffs
+
+`var(--text-muted)`, `transparent`, `#22d3ee`, `inline-block`, and the full
+declaration list `border:1px solid rgba(34,211,238,0.35);background:transparent`
+all render identically before and after.
+
+This is the claim that most needed checking: Task 3's original CSS escaper broke
+two of these, and `2333523e` fixed it. Confirmed fixed by rendering, not by
+reading the diff.
+
+### URL component — zero diffs in practice
+
+All 14 holes are path segments, and every value is validated by forgepm itself:
+
+| hole | value | rule | RFC 3986 |
+|---|---|---|---|
+| `/packages/${pkg.name}` ×4 | package name | `^[a-z0-9][a-z0-9-]*[a-z0-9]$` | all unreserved |
+| `/users/${author}` | username | `^[a-z0-9][a-z0-9_-]*[a-z0-9]$` | all unreserved |
+| `/orgs/${o.handle}` ×2 | org handle | lowercase, digits, `-`, `_` | all unreserved |
+| `?tab=${name}` | tab name | source literal | unreserved |
+| `?after=${last.id}` | integer id | digits | unreserved |
+| `${path}?${param_name}=` | source literal | — | unreserved |
+
+Percent-encoding is a **no-op** on every one. The scanner does report diffs for
+`a b` → `a%20b` and `x/y` → `x%2Fy`, which is the escaper working as designed —
+but no validated value can contain a space or a slash.
+
+**One near-miss worth recording.** Versions allow `+`
+(`^[0-9]+\.[0-9]+\.[0-9]+[-+0-9A-Za-z.]*$`), which *would* encode:
+`1.2.3+build` → `1.2.3%2Bbuild`. No version reaches a URL context in forgepm —
+they appear in element content (`<span>${pkg.version}</span>`), which is
+unchanged. If a future route interpolates a version into an `href`, that is the
+case to check.
+
+### Whole URL — zero diffs
+
+`/packages/bastion`, `/admin/users`, `#frag`, `https://example.com/a?b=c`,
+`/x?a=b&c=d` all render identically. The scheme allowlist does not disturb
+legitimate URLs; it only changes output for a URL that would have been an
+injection.
+
+### Attribute — one wire-format difference
+
+The backtick: `back` + backtick + `tick` → `back&#96;tick`. Deliberate — old IE
+accepted a backtick as an attribute delimiter, so a value containing one could
+break out of a double-quoted attribute. It entity-decodes to the same character
+in a browser, so there is **no visible change**, only a different byte sequence
+on the wire.
+
+Worth knowing for anyone diffing raw HTTP responses across this change.
+
+## What this does and does not establish
+
+**Does:** for these two codebases, contextual escaping changes which escaper runs
+without changing what a user sees — except where it is neutralising an
+injection.
+
+**Does not:** prove the escapers are right in general. It proves they do not
+regress *this* corpus. A codebase that interpolates a value containing `/`, a
+space, or `+` into a URL component, or a CSS function outside the allowlist,
+would see real changes. The `--diff` mode is the tool to check that before
+adopting.
+
+The CSS function allowlist remains the judgement call flagged in #202: a function
+not on it degrades to strict escaping — visibly broken styling, at runtime only.
+Nothing in either corpus hits it.


### PR DESCRIPTION
Adds `--diff` to the template scanner and uses it to settle the two claims from #202 that rested on **reading** the templates rather than **rendering** them.

## Method

The plan assumed forgepm could be built against the compiler. It can't — 68 pre-existing errors from bastion version drift, unrelated to this work. But building it was never the goal; *rendering before and after* was.

`scan_templates.exe --diff` does that directly. It already walks every `~H` template through the automaton and knows each hole's escaper, so it renders each hole **both ways** — as `~H` used to (entity-encode everything regardless of context) and as it does now — against probes chosen to be **realistic for the position**, not adversarial. Attack cases are covered by `test_ctx_escape.c`; the question here is the opposite one: does the new behaviour mangle anything legitimate?

## Result

**40 of 253 holes get a different escaper. Zero produce different rendered output** for values these applications can actually produce, with one wire-format exception.

### CSS — zero diffs

`var(--text-muted)`, `transparent`, `#22d3ee`, `inline-block`, and the full declaration list `border:1px solid rgba(34,211,238,0.35);background:transparent` all render identically.

This is the claim that most needed checking: Task 3's original CSS escaper broke two of these and `2333523e` fixed it. Now confirmed by rendering rather than by reading the diff.

### URL component — zero diffs in practice

All 14 holes are path segments, and every value is validated by forgepm itself:

| hole | value | rule |
|---|---|---|
| `/packages/${pkg.name}` ×4 | package name | `^[a-z0-9][a-z0-9-]*[a-z0-9]$` |
| `/users/${author}` | username | `^[a-z0-9][a-z0-9_-]*[a-z0-9]$` |
| `/orgs/${o.handle}` ×2 | org handle | lowercase, digits, `-`, `_` |
| `?tab=${name}` | tab name | source literal |
| `?after=${last.id}` | integer id | digits |

Every one is entirely RFC 3986 unreserved, so percent-encoding is a **no-op**. The scanner does flag `a b` → `a%20b` and `x/y` → `x%2Fy`, which is the escaper working as designed — but no validated value can contain a space or slash.

**Near-miss recorded**: versions allow `+` (`^[0-9]+\.[0-9]+\.[0-9]+[-+0-9A-Za-z.]*$`), which *would* encode to `%2B`. No version reaches a URL context in forgepm — they sit in element content (`<span>${pkg.version}</span>`), which is unchanged. That's the case to check if a future route puts a version in an `href`.

### Whole URL — zero diffs

`/packages/bastion`, `/admin/users`, `#frag`, `https://example.com/a?b=c`, `/x?a=b&c=d` all identical. The scheme allowlist doesn't disturb legitimate URLs; it only changes output for one that would have been an injection.

### Attribute — one wire-format difference

A backtick becomes `&#96;`. Deliberate — old IE accepted a backtick as an attribute delimiter, so a value containing one could break out of a double-quoted attribute. It entity-decodes to the same character in a browser, so there's **no visible change**, only a different byte sequence on the wire.

Worth knowing for anyone diffing raw HTTP responses across this change. I'd missed it in my first probe set and added it specifically because `EscAttr` escapes the backtick and the old `EscHtml` didn't.

## What this does and does not establish

**Does:** for these two codebases, contextual escaping changes which escaper runs without changing what a user sees — except where it's neutralising an injection.

**Does not:** prove the escapers right in general. It proves they don't regress *this* corpus. A codebase interpolating a value containing `/`, a space, or `+` into a URL component, or a CSS function outside the allowlist, would see real changes. `--diff` is the tool to check that before adopting.

The CSS function allowlist remains the judgement call flagged in #202 — a function not on it degrades to strict escaping, visibly broken styling at runtime only. Nothing in either corpus hits it.
