### PR TITLE
fix(stdlib): Html.tag hardening + context-indexed trust (Tasks 9 and 6)

### DIFF
--- a/.claude/skills/march-lang/SKILL.md
+++ b/.claude/skills/march-lang/SKILL.md
@@ -266,7 +266,14 @@ end
 
 ### If / Else
 
+Each `if` needs its own `end`. An `else if` chain is a nested `if` in the else
+position, so a two-branch chain closes with `end end` and a three-branch chain
+with `end end end` — see `stdlib/uri.march:62`. There is no `elif`. A missing
+`end` reports "I got stuck here" at the *next declaration*, not at the `if`.
+
 ```march
+if a do 1 else if b do 2 else 3 end end   -- two ifs, two ends
+
 if condition do expr end
 
 if condition do
@@ -785,7 +792,7 @@ pfn insert(t : Tree, v : Int) : Tree do
   Node(l, x, r) ->
     if v < x do Node(insert(l, v), x, r)
     else if v > x do Node(l, x, insert(r, v))
-    else t end
+    else t end end          -- one `end` per `if`, NOT one per chain
   end
 end
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,36 @@ git log is authoritative for exact commits.
 
 ## [Unreleased]
 
+### Added
+
+- **Context-indexed trust for `~H`: `Html.TrustedHtml` / `TrustedAttr` /
+  `TrustedUrl` / `TrustedCss` / `TrustedJs`.** `Html.Safe` says a string is
+  trusted but not trusted *where*, so a value trusted anywhere was trusted
+  everywhere. These types name the context the trust applies to, and trust does
+  not travel between them:
+
+  ```march
+  let h = Html.trust_html("<b>hi</b>")
+  ~H"<p>${h}</p>"                -- <p><b>hi</b></p>        verbatim
+  ~H"<a href=\"${h}\">x</a>"      -- &lt;b&gt;hi&lt;/b&gt;   escaped
+  ```
+
+  Constructors `Html.trust_html` / `trust_attr` / `trust_url` / `trust_css` /
+  `trust_js`, with matching `untrust_*`. Prefer `~H` itself, which needs no
+  trust at all — reach for these only when a string genuinely is markup, a URL,
+  CSS or JS from a source you control.
+
+  Resolved **entirely at compile time**: the emitter matches the static type
+  against the escaper id the `~H` desugar already folded, so a mismatch costs
+  nothing at runtime — it simply escapes. That is why these are separate types
+  rather than one type carrying a context tag; a tag would be runtime data and
+  could not be resolved statically.
+
+  `Html.Safe` and `Html.raw` are unchanged and keep working — they are treated
+  as HTML trust — but are now documented as deprecated in favour of the
+  context-indexed types.
+
+
 ### Fixed
 
 - **`Html.tag` had three injection holes; it now validates names and escapes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,34 @@ git log is authoritative for exact commits.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`Html.tag` had three injection holes; it now validates names and escapes
+  values by context.** `Html.tag` composes markup outside the `~H` sigil, so it
+  never reached the contextual analysis added for `~H`. Measured before the fix:
+
+  | call | emitted |
+  |---|---|
+  | `Html.tag("div onload=alert(1)", …)` | `<div onload=alert(1)>` — element name concatenated raw |
+  | `Html.tag("div", [("onerror", "alert(1)")], …)` | `<div onerror="alert(1)">` — entity-encoding does nothing to `onerror` |
+  | `Html.tag("a", [("href", "javascript:alert(1)")], …)` | the URL verbatim |
+
+  Attribute **values** are now escaped for the context their name implies — url
+  attributes get the scheme allowlist, `style` gets CSS declaration escaping,
+  everything else attribute escaping. Element and attribute **names** are
+  validated and an invalid one **panics**: escaping cannot help there, since
+  `onerror` has no character to escape, so a name built from untrusted input is
+  a programming error rather than a data condition. Event-handler attributes
+  (`on*`) are refused outright — their value is JavaScript, and `Html.tag` has
+  no way to know whether the caller meant that.
+
+  Reachable but unreached: the only call site in the ecosystem passes literals.
+
+  `Html.tag` and `Html.escape_attr` are now documented as **deprecated** in
+  favour of `~H`, which gets the same analysis at compile time and needs no
+  runtime checks. Neither is removed — `bastion` is published at 0.2.3.
+
+
 ### Changed
 
 - **`~H` now escapes by HTML parse context, not with one escaper everywhere.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,15 @@ See [specs/lang/surface-syntax.md](specs/lang/surface-syntax.md) for a complete 
 - Module: `mod Name do ... end` (not `module`)
 - Type variants: `type Foo = A | B(Int)` — no leading `|`
 - Conditionals: `if cond do ... else ... end` — `else` is MANDATORY (omitting it: "March `if` expressions always need an `else` branch"); `then` is rejected ("I don't recognize `then` here — March uses do/end blocks instead.")
+- **`else if` chains need one `end` per `if`, not one for the chain.** A two-branch
+  chain ends `end end`, a three-branch chain `end end end`. There is no
+  `elif`/`elsif`, and `else if` is genuinely a nested `if` in the else position:
+  ```march
+  if a do 1 else if b do 2 else 3 end end          -- two ifs, two ends
+  ```
+  Getting this wrong gives a confusing "I got stuck here" pointing at the NEXT
+  declaration, not at the `if` — the parser only notices when it runs out of
+  input. See `stdlib/uri.march:62` (`else -1 end end end`) for a real one.
 - Block lets: `let x = expr` with no `in`; subsequent block exprs see the binding
 - Result propagation: `let? p = e` binds the `Ok` payload and returns `Err(e)` immediately; RHS must be `Result`; cannot be the last expr in a block
 - No `;` — use newlines to separate block expressions

--- a/lib/eval/eval.ml
+++ b/lib/eval/eval.ml
@@ -4362,10 +4362,22 @@ let base_env : env =
          (* Already-safe HTML, and the context is HTML: insert verbatim.
             Anywhere else it is a context mismatch, so it gets flattened and
             then escaped for wherever it actually landed. *)
-         | VCon ("Safe", [VString s]) when is_html_ctx -> VString s
+         (* Context-indexed trust: each Trusted* type names the one context
+            its string may be inserted into verbatim. `Safe` is the legacy
+            context-free form, treated as HTML trust. Mirrors the table in
+            lib/tir/llvm_emit.ml -- the compiled backend resolves this
+            statically, the interpreter at runtime, and they must agree. *)
+         | VCon (("Safe" | "TrustedHtml"), [VString s]) when id = 0 -> VString s
+         | VCon ("TrustedAttr", [VString s]) when id = 1 -> VString s
+         | VCon ("TrustedUrl", [VString s]) when id = 2 || id = 3 -> VString s
+         | VCon ("TrustedCss", [VString s]) when id = 4 || id = 7 -> VString s
+         | VCon ("TrustedJs", [VString s]) when id = 5 -> VString s
+         (* Trusted, but not for THIS context -- escape it like anything else. *)
+         | VCon (("Safe" | "TrustedHtml" | "TrustedAttr" | "TrustedUrl"
+                 | "TrustedCss" | "TrustedJs"), [VString s]) ->
+           VString (March_ctxesc.Escape.apply_id id s)
          | (VCon ("Empty", []) | VCon ("Str", _) | VCon ("Segments", _))
            when is_html_ctx -> VString (iolist_flatten v)
-         | VCon ("Safe", [VString s]) -> VString (March_ctxesc.Escape.apply_id id s)
          | VCon ("Empty", []) | VCon ("Str", _) | VCon ("Segments", _) ->
            VString (March_ctxesc.Escape.apply_id id (iolist_flatten v))
          | VString s -> VString (March_ctxesc.Escape.apply_id id s)

--- a/lib/tir/llvm_emit.ml
+++ b/lib/tir/llvm_emit.ml
@@ -1698,14 +1698,40 @@ let rec emit_expr ctx (e : Tir.expr) : string * string =
       ("ptr", r)
     end
 
-  (* A non-literal escaper id would mean the desugarer failed to constant-fold
-     the context walk, which is the whole point of the analysis. Fail loudly
-     rather than emit a call whose escaper is chosen at runtime. *)
-  | Tir.EApp (f, [_; _]) when f.Tir.v_name = "html_escape_ctx" ->
-    failwith
-      "html_escape_ctx: escaper id is not a compile-time literal. The ~H \
-       desugar must fold the context walk statically; see \
-       specs/plans/2026-08-05-contextual-autoescaping.md."
+  (* A RUNTIME escaper id.
+     
+     This used to be a hard failure, on the premise that only the ~H desugar
+     calls html_escape_ctx and it always folds the context statically. That
+     premise was wrong: Html.tag (stdlib/html.march) classifies an attribute
+     NAME at runtime and picks the escaper from it, because it composes markup
+     outside the sigil and has no compile-time context to fold. A dynamic id is
+     correct there, not a bug.
+
+     The ~H path is unaffected — it always emits a literal and takes the arm
+     above, which is also where the already-safe-HTML specialisation lives.
+     That specialisation needs a literal id and is simply not available here;
+     a dynamic caller passes a String, so it does not apply.
+
+     Safety is unchanged: march_html_escape_ctx validates the id and aborts on
+     one it does not know, so a wrong id fails loudly rather than silently
+     skipping an escaper. *)
+  | Tir.EApp (f, [idx; a]) when f.Tir.v_name = "html_escape_ctx" ->
+    let id_v = emit_atom_as ctx "i64" idx in
+    let v = emit_atom_as ctx "ptr" a in
+    let v =
+      match atom_tir_ty a with
+      | Tir.TString -> v
+      | _ ->
+        let sv = fresh ctx "hecd_str" in
+        emit ctx
+          (Printf.sprintf "%s = call ptr @march_value_to_string(ptr %s)" sv v);
+        sv
+    in
+    let r = fresh ctx "hecd" in
+    emit ctx
+      (Printf.sprintf "%s = call ptr @march_html_escape_ctx(i64 %s, ptr %s)"
+         r id_v v);
+    ("ptr", r)
 
   (* ── Bitwise integer builtins ─────────────────────────────────────── *)
   | Tir.EApp (f, [a; b]) when is_int_bitwise f.Tir.v_name ->

--- a/lib/tir/llvm_emit.ml
+++ b/lib/tir/llvm_emit.ml
@@ -1650,15 +1650,44 @@ let rec emit_expr ctx (e : Tir.expr) : string * string =
        differently. march_html_auto_escape's C body does not understand Safe at
        all — Task 0 fixed that case in the emitter, by loading field 0 — so
        handing it a Safe returns the empty string. Keep the two apart. *)
-    let is_safe =
-      match atom_tir_ty a with
-      | Tir.TCon ("Safe", _) ->
-        not (Collision_set.is_colliding ctx.collision_set "Safe")
-      | _ -> false
+    (* Context-indexed trust. Each Trusted* type names the ONE context its
+       string may be inserted into verbatim; anywhere else it is escaped like
+       any other value. `Safe` is the legacy context-free form and is treated
+       as HTML trust.
+
+       This is resolved entirely here, at compile time: the type is static and
+       the escaper id was folded by the desugar, so a mismatch costs nothing at
+       runtime -- it just takes the escaping path. That is why these are
+       separate types rather than one type carrying a context tag; a tag would
+       be runtime data and could not be resolved statically.
+
+       All are single-field ADTs, so unwrapping is the same field-0 load the
+       Safe path already used.
+
+       Escaper ids are Context.escaper_id / MARCH_ESC_* (see
+       runtime/march_ctx_escape.h). A url trust covers both the whole-URL and
+       component escapers, and a css trust both the value and declaration
+       ones, because those pairs differ in POSITION within one language, not in
+       which language the string is. *)
+    let trusted_for name =
+      if Collision_set.is_colliding ctx.collision_set name then None
+      else
+        match name with
+        | "Safe" | "TrustedHtml" -> Some [ 0 ]
+        | "TrustedAttr" -> Some [ 1 ]
+        | "TrustedUrl" -> Some [ 2; 3 ]
+        | "TrustedCss" -> Some [ 4; 7 ]
+        | "TrustedJs" -> Some [ 5 ]
+        | _ -> None
     in
+    let trusted_ids =
+      match atom_tir_ty a with
+      | Tir.TCon (n, _) -> trusted_for n
+      | _ -> None
+    in
+    let is_safe = trusted_ids <> None in
     let is_iolist =
       match atom_tir_ty a with Tir.TCon ("IOList", _) -> true | _ -> false in
-    let already_html = is_safe || is_iolist in
     let v = emit_atom_as ctx "ptr" a in
     (* Normalise to a real String first, by whichever route actually works for
        this type. `march_value_to_string` CANNOT flatten an IOList — it renders
@@ -1687,8 +1716,13 @@ let rec emit_expr ctx (e : Tir.expr) : string * string =
           (Printf.sprintf "%s = call ptr @march_value_to_string(ptr %s)" sv v);
         sv
     in
-    if is_html_ctx && already_html then
-      (* Already-safe HTML landing in an HTML context: insert verbatim. *)
+    let trust_covers_this_context =
+      match trusted_ids with
+      | Some ids -> List.mem id ids
+      | None -> is_html_ctx && is_iolist
+    in
+    if trust_covers_this_context then
+      (* The value is trusted for exactly this context: insert verbatim. *)
       ("ptr", v)
     else begin
       let r = fresh ctx "hec" in

--- a/specs/plans/2026-08-05-contextual-autoescaping.md
+++ b/specs/plans/2026-08-05-contextual-autoescaping.md
@@ -17,8 +17,8 @@
 | 3–5 — escapers, builtin, desugar fold | **landed** — #202, `a8707c78` |
 | 6 — context-indexed `Html.Trusted` | open |
 | 7 — codegen + drift guard | **mostly obsolete** — see the task |
-| 8 — corpus validation | open — highest remaining value |
-| 9 — `Html.tag` non-sigil path | open — **added 2026-08-06**, newly found |
+| 8 — corpus validation | **done** — PR #204, awaiting CI |
+| 9 — `Html.tag` non-sigil path | open — **planned 2026-08-06**; 3 holes measured, 2 unfixable by escaping |
 
 `~H` escapes by parse context on `main`. Recommended order for what remains:
 **8, then 9, then 6.** Task 8 converts two unverified assumptions into evidence
@@ -991,124 +991,175 @@ That page renders untrusted `user_agent` and `path`. Render it before and after 
 
 ---
 
-## Task 9: Close the non-sigil composition path (`Html.tag`)
+## Task 9: Harden and deprecate `Html.tag`
 
-> **Added 2026-08-06**, after Tasks 3–5 landed. Not in the original plan — found
-> while asking whether any of this still belongs in a March library. It is the
-> characteristic blind spot of a compile-time-only design: the analysis sees
-> `~H` templates and nothing else.
+> **Added 2026-08-06; rewritten the same day after measuring.** The first draft
+> described one hole (attribute values) and proposed fixing it by escaping.
+> Running the code found **three**, and two of them cannot be fixed by escaping
+> at all. The design below is what the measurement supports, not what the sketch
+> assumed.
+
+**Decisions taken** (2026-08-06): deprecate toward `~H` while hardening in
+place — `bastion` is published at 0.2.3, so removal is off the table — and
+**panic** on a name that fails validation.
 
 **Files:**
-- Modify: `stdlib/html.march:113` (`escape_attr`), `:134` (`tag`)
-- Test: `test/native/h_tag_attr_context.march` + `.expected`, `test/dune`
+- Modify: `stdlib/html.march` — `tag`, `escape_attr`, docstrings
+- Create: `runtime/march_attr_class.c` + header, or extend `march_ctx_escape.c`
+- Test: `test/native/h_tag_hardening.march` + `.expected`, `test/dune`,
+  `test/test_ctx_escape.c` (classification conformance)
+- Follow-up in another repo: `bastion/lib/security/csrf.march:96`
 
-### The gap
-
-`Html.tag` composes HTML **outside** the sigil, so it never reaches the context
-automaton. Its attribute escaping is:
-
-```march
-fn escape_attr(s : String) : String do
-  escape(s)     -- HTML entity-encoding, and nothing else
-end
-```
-
-Entity-encoding does not touch a colon, so:
+### Measured behaviour (2026-08-06, `main` @ `a8707c78`)
 
 ```march
+Html.tag("div onload=alert(1)", [], body)          -- element name
+Html.tag("div", [("onerror", "alert(1)")], body)   -- attribute name
 Html.tag("a", [("href", "javascript:alert(1)")], body)
+Html.tag("div", [("class", "a\"b")], body)         -- control
 ```
 
-emits `href="javascript:alert(1)"` — exactly the hole Task 5 closed for `~H`,
-still open on this path.
+produces:
 
-*(Read from the source, not executed. The two functions are short and
-unambiguous, but Step 1 below should confirm it by running.)*
+```
+1 elemname: <div onload=alert(1)>x</div onload=alert(1)>
+2 attrname: <div onerror="alert(1)">x</div>
+3 attrval : <a href="javascript:alert(1)">x</a>
+4 ordinary: <div class="a&quot;b">x</div>
+```
 
-**Not currently live.** The only real call site is
-`bastion/lib/security/csrf.march:96`, `Html.tag("form", [("method", "post")], …)`
-— a constant. But the API's shape invites the bug back, and an API that is safe
-only because nobody has used it yet is not safe.
-
-### Why fix rather than deprecate
-
-`Html.tag` is one call site away from removable, so deprecation is tempting. It
-is the wrong call: the machinery to make it correct now exists, the fix is small,
-and leaving a known-unsafe constructor in the stdlib while shipping "~H is
-contextually safe" invites exactly the wrong conclusion about the rest of the
-module.
-
-- [ ] **Step 1: Write the failing test, and confirm the gap is real**
-
-`test/native/h_tag_attr_context.march`, a compiled/interpreted golden diff like
-`h_escape_ctx_builtin.march`:
+Cause, from `stdlib/html.march`:
 
 ```march
-mod HTagAttrContext do
-  fn main() : Unit do
-    let bad = "javascript:alert(1)"
-    println("href=" ++ IOList.to_string(
-      Html.tag("a", [("href", bad)], IOList.from_string("x"))))
-    println("src=" ++ IOList.to_string(
-      Html.tag("img", [("src", bad)], IOList.empty())))
-    -- an ordinary attribute must keep entity-encoding, unchanged
-    println("class=" ++ IOList.to_string(
-      Html.tag("div", [("class", "a\"b")], IOList.empty())))
-    -- a legitimate URL must survive intact
-    println("ok=" ++ IOList.to_string(
-      Html.tag("a", [("href", "/packages/bastion?tab=readme")], IOList.empty())))
+let open_tag = "<" ++ name ++ attr_str ++ ">"   -- name concatenated RAW
+...
+escape_attr(k) ++ "=\"" ++ escape_attr(v) ++ "\""
+fn escape_attr(s) do escape(s) end              -- entity-encoding, nothing more
+```
+
+**Holes 1 and 2 cannot be closed by escaping.** They sit exactly where the
+context automaton emits a hard error for `~H`, and for the same reason: `onerror`
+contains no character an encoder could touch. Escaping is the wrong tool; the
+only sound move is to validate and refuse. Hole 3 *is* an escaping problem.
+
+**Not live.** The one real call site is
+`bastion/lib/security/csrf.march:96`, `Html.tag("form", [("method", "post")], …)`
+— all literals. But an API is not safe because its current callers happen to be.
+
+### Scope: `tag` is the whole gap
+
+Checked every other function in the module that emits markup:
+
+| function | verdict |
+|---|---|
+| `list`, `join`, `render_collection`, `render_partial` | compose `IOList`s only — no `String`→markup path |
+| `layout` | `escape(title)` into `<title>`, which is RCDATA where entity-encoding is correct |
+| `content_hash`, `safe_to_string` | do not emit markup |
+
+Nothing to do outside `tag`. Record that — a bounded audit is worth as much as
+a fix.
+
+- [ ] **Step 1: Pin the current behaviour as a failing test**
+
+`test/native/h_tag_hardening.march` + `.expected`, a compiled/interpreted golden
+diff in the style of `h_escape_ctx_builtin.march`, covering all four cases above
+plus a legitimate URL (`/packages/bastion?tab=readme`) that must survive intact.
+
+Generate `.expected` from the FIXED behaviour, so the test fails before the fix
+lands. **Put the pre-fix output in the commit message** — it is the evidence the
+holes were real, and a security test without a recorded red state is worth
+little.
+
+- [ ] **Step 2: Validate the element name**
+
+A tag name is `[a-zA-Z][a-zA-Z0-9-]*`. Anything else panics:
+
+```march
+fn check_tag_name(name : String) : String do
+  if Regex.matches("^[a-zA-Z][a-zA-Z0-9-]*$", name) do name
+  else
+    panic("Html.tag: `" ++ name ++ "` is not a valid element name. An element "
+      ++ "name computed from untrusted input cannot be made safe by escaping — "
+      ++ "use ~H with a literal tag instead.")
   end
 end
 ```
 
-Expected BEFORE the fix: `href="javascript:alert(1)"` passes through verbatim.
-**Record that output in the commit message** — it is the evidence the gap was
-real, and the test is worthless without it.
+Panic is deliberate and was chosen explicitly: computing a tag name from
+untrusted data is a *programming* error, not a data condition. With literal
+call sites it can never fire. The cost — a panic in a request handler is a 500 —
+is accepted against the alternative, which is an XSS.
 
-- [ ] **Step 2: Classify the attribute name, then escape by class**
+- [ ] **Step 3: Validate the attribute name, and refuse event handlers**
 
-`escape_attr` currently ignores its key. Give `tag` the same classification the
-table already performs, reusing `[attrs]` from
-`specs/security/html-contexts.tbl` rather than a second hand-written list — a
-duplicate list is precisely the hazard this plan keeps tripping over.
+Attribute names are `[a-zA-Z][a-zA-Z0-9_:.-]*`. Beyond shape, **`on*` is
+refused outright**: an event handler's value is JavaScript, and `Html.tag` has
+no way to know whether its caller intended that. `~H` can tell, because the
+automaton gives it a JS context; `Html.tag` cannot.
 
-The classification lives OCaml-side (`Tbl_parse.classify`), and `Html.tag` is
-March, so the escaping must go through the builtin:
-`html_escape_ctx(<id>, value)` with the id chosen from the attribute's class.
-That needs the class computed at runtime from a `String` key, which the compile
-time analysis cannot do — so this path necessarily pays a small runtime cost the
-sigil path does not. That is acceptable: it is a handful of attributes per tag,
-and correctness beats a saved comparison.
+Panic message must name the attribute and point at `~H`.
 
-Simplest sound implementation: a `Html.attr_escaper_id(name : String) : Int`
-in March mirroring the `[attrs]` rules (`on*` → script, `href`/`src`/… → url,
-`style` → style, else normal), then `html_escape_ctx(id, v)`.
+- [ ] **Step 4: Context-escape the attribute value**
 
-**If that mirroring is written by hand, it is a fourth copy of the attribute
-classification.** Prefer generating it from the `.tbl` — this is the one place a
-`stdlib/ctx_table.march` fragment genuinely earns its keep, and it would revive
-the useful half of Task 7 with a real consumer.
+With `on*` refused, only three classes remain: `url`, `style`, `normal`. Route
+the value through the existing escapers by class:
 
-- [ ] **Step 3: Verify and pin**
+| class | escaper |
+|---|---|
+| `href` `src` `action` `formaction` `poster` `cite` `background` | `MARCH_ESC_URL_WHOLE` |
+| `style` | `MARCH_ESC_CSS_DECL` |
+| everything else | `MARCH_ESC_ATTR` |
 
-`href`/`src` with `javascript:` → `about:invalid#zSoyz`; `class` unchanged from
-today; a legitimate URL intact. Regenerate `.expected` and confirm
-interpreted == compiled.
+`url_whole` rather than `url_component`: an attribute value passed whole to
+`Html.tag` *is* the whole URL, exactly like a hole at the start of an `href`.
 
-- [ ] **Step 4: Sweep the rest of the `Html` module**
+**Where the classification lives.** It must not become a fourth hand-maintained
+copy of `[attrs]` — that duplication is the failure mode this plan has already
+hit twice (`specs/todos/2026-08-05-runtime-source-list-duplication.md`, and the
+golden preamble going stale twice). Options, in order of preference:
 
-`tag` is the one this task fixes, but the same question applies to every function
-that emits markup from untrusted parts: `list`, `join`, `render_partial`,
-`render_collection`, `layout`. Check each for a path that concatenates a
-caller-supplied `String` into markup without going through a context. Record the
-result — a clean sweep is worth writing down, since it bounds the audit.
+1. A C helper next to the escapers — `march_attr_escaper_id(name, len)` — with a
+   **conformance test in `test_ctx_escape.c` asserting it agrees with
+   `Tbl_parse.classify` over every literal in `[attrs]` plus probes**. Drift is
+   then caught by a test rather than prevented by a generator, which is
+   proportionate for an API being deprecated.
+2. Generating a March fragment from the `.tbl`. Cleaner in principle, but
+   generated files under `stdlib/` are awkward: the compiler loads stdlib from a
+   directory, and a `_build`-only artifact is not in the shipped path. Do not
+   take this on without solving that first.
 
-- [ ] **Step 5: Commit**
+Prefer 1. Note honestly in the code that it is a second copy of the rules, kept
+honest by a test rather than by construction.
 
-Include the before/after output from Step 1, and state plainly that `Html.tag`
-was reachable-but-unreached rather than a live vulnerability.
+- [ ] **Step 5: Deprecate in the docstrings**
+
+`Html.tag`'s doc comment states plainly that `~H` is the supported way to build
+markup, that `~H` gets compile-time contextual escaping which `Html.tag` cannot,
+and that `tag` refuses names it cannot prove safe. Same for `escape_attr`, which
+is context-blind by nature and should not be presented as a general-purpose
+attribute escaper.
+
+Do **not** remove either — `bastion` is published at 0.2.3.
+
+- [ ] **Step 6: Verify, and run the full suite properly**
+
+Regenerate `.expected`; confirm interpreted == compiled. Then run **every**
+suite and read each one's summary line — `scripts/run-tests.sh | tail` shows only
+the last suite and has already hidden a real failure once in this plan. Expect
+the known environmental `MARCH_SANITIZE` ASAN timeout and nothing else.
+
+- [ ] **Step 7: Commit, and file the bastion migration**
+
+Commit with the pre-fix output from Step 1. State plainly that the holes were
+reachable-but-unreached rather than a live vulnerability.
+
+`bastion/lib/security/csrf.march:96` is in another repo and cannot move in this
+commit. File it: rewrite `Html.tag("form", [("method", "post")], CSRF.tag(conn))`
+as `~H"<form method=\"post\">${CSRF.tag(conn)}</form>"`, which gets the
+compile-time analysis instead of the runtime checks.
 
 ---
+
 
 ## Follow-up plan — REVISED 2026-08-06: recommend dropping
 

--- a/specs/plans/2026-08-05-contextual-autoescaping.md
+++ b/specs/plans/2026-08-05-contextual-autoescaping.md
@@ -15,14 +15,23 @@
 | 0 — ADT misread (XSS + SIGSEGV) | **landed** — #192, `37d1e166` |
 | 1–2 — table + automaton | **landed** — #194, `6cfdc005` |
 | 3–5 — escapers, builtin, desugar fold | **landed** — #202, `a8707c78` |
-| 6 — context-indexed `Html.Trusted` | open |
+| 6 — context-indexed trust | **done** — PR #208 (as `Trusted*` types, not `Trusted(Ctx, _)`; see the task) |
 | 7 — codegen + drift guard | **mostly obsolete** — see the task |
 | 8 — corpus validation | **done** — PR #204, awaiting CI |
-| 9 — `Html.tag` non-sigil path | open — **planned 2026-08-06**; 3 holes measured, 2 unfixable by escaping |
+| 9 — `Html.tag` non-sigil path | **done** — PR #208 |
 
-`~H` escapes by parse context on `main`. Recommended order for what remains:
-**8, then 9, then 6.** Task 8 converts two unverified assumptions into evidence
-and should not wait behind design work.
+`~H` escapes by parse context on `main`. **Every task is now done or in review.**
+Open PRs: #204 (Task 8), #208 (Tasks 9 and 6). Task 7's remainder is
+recommended for dropping rather than building — see that task and the follow-up
+section.
+
+Task 6 deviated from its own spec, deliberately: it shipped as five
+context-named types (`TrustedHtml`, `TrustedAttr`, `TrustedUrl`, `TrustedCss`,
+`TrustedJs`) rather than one `Trusted(Ctx, String)`. A context tag would be
+runtime data the emitter cannot resolve, forcing a runtime comparison on every
+trusted value; separate types are matched statically against the escaper id the
+desugar already folded, so a mismatch costs nothing. Reasoning is recorded in
+`stdlib/html.march` at the type definitions.
 
 ## Source
 

--- a/stdlib/html.march
+++ b/stdlib/html.march
@@ -10,8 +10,105 @@
 
 mod Html do
 
-  -- Html.Safe wraps a string that should NOT be escaped (already safe HTML)
+  -- Html.Safe wraps a string that should NOT be escaped (already safe HTML).
+  -- DEPRECATED in favour of the context-indexed Trusted* types below: `Safe` is
+  -- context-free, so a value trusted anywhere is trusted everywhere. Kept
+  -- working unchanged because bastion is published at 0.2.3.
   type Safe = Safe(String)
+
+  -- ── Context-indexed trust ───────────────────────────────────────────────
+  --
+  -- `Safe` says a string is trusted, but not trusted WHERE. Once a value is
+  -- trusted anywhere it is trusted everywhere, which is the same category error
+  -- this whole feature exists to fix: safety is a property of a value IN A
+  -- POSITION, not of a value.
+  --
+  --     let s = Html.raw("<b>bold</b>")   -- trusted as HTML
+  --     ~H"<p>${s}</p>"                   -- fine
+  --     ~H"<a href=\"${s}\">x</a>"        -- HTML trust says nothing about URLs
+  --
+  -- These types name the context the trust applies to. A `TrustedUrl` inserted
+  -- into element content is escaped as ordinary text; a `TrustedHtml` in an
+  -- `href` still gets the URL scheme allowlist. Trust does not travel.
+  --
+  -- The check is entirely COMPILE TIME. lib/tir/llvm_emit.ml matches on the
+  -- static type and on the escaper id the ~H desugar already folded, so a
+  -- mismatch costs nothing at runtime -- it simply escapes. That is why these
+  -- are separate types rather than one type carrying a context tag: a tag would
+  -- be runtime data, and the emitter could not resolve it.
+
+  -- Markup trusted as HTML element content. Inserted verbatim in a PCDATA
+  -- position; escaped anywhere else.
+  type TrustedHtml = TrustedHtml(String)
+
+  -- A string trusted as an attribute value. Inserted verbatim in an ordinary
+  -- attribute; escaped anywhere else.
+  type TrustedAttr = TrustedAttr(String)
+
+  -- A string trusted as a URL. Inserted verbatim in a url attribute (href,
+  -- src, ...); escaped anywhere else -- notably NOT trusted as HTML.
+  type TrustedUrl = TrustedUrl(String)
+
+  -- A string trusted as CSS. Inserted verbatim in a `style` attribute or a
+  -- <style> body; escaped anywhere else.
+  type TrustedCss = TrustedCss(String)
+
+  -- A string trusted as JavaScript. Inserted verbatim inside <script>;
+  -- escaped anywhere else.
+  type TrustedJs = TrustedJs(String)
+
+  doc """
+  Trust a string as HTML element content.
+
+  Inserted verbatim where the surrounding template is element content, and
+  escaped anywhere else — trusting a string as HTML says nothing about whether
+  it is a safe URL, so the same value in an `href` still gets the scheme
+  allowlist.
+
+  Prefer building markup with the ~H sigil, which needs no trust at all. Reach
+  for this only when a string genuinely is markup from a source you control.
+  """
+  fn trust_html(s : String) : TrustedHtml do TrustedHtml(s) end
+
+  doc "Trust a string as an ordinary attribute value. See `trust_html`."
+  fn trust_attr(s : String) : TrustedAttr do TrustedAttr(s) end
+
+  doc """
+  Trust a string as a URL. It bypasses the scheme allowlist, so only use it on a
+  URL you constructed yourself. See `trust_html`.
+  """
+  fn trust_url(s : String) : TrustedUrl do TrustedUrl(s) end
+
+  doc "Trust a string as CSS. See `trust_html`."
+  fn trust_css(s : String) : TrustedCss do TrustedCss(s) end
+
+  doc "Trust a string as JavaScript. See `trust_html`."
+  fn trust_js(s : String) : TrustedJs do TrustedJs(s) end
+
+  doc "Unwrap trusted HTML back to a plain String."
+  fn untrust_html(t : TrustedHtml) : String do
+    match t do TrustedHtml(s) -> s end
+  end
+
+  doc "Unwrap a trusted attribute value back to a plain String."
+  fn untrust_attr(t : TrustedAttr) : String do
+    match t do TrustedAttr(s) -> s end
+  end
+
+  doc "Unwrap a trusted URL back to a plain String."
+  fn untrust_url(t : TrustedUrl) : String do
+    match t do TrustedUrl(s) -> s end
+  end
+
+  doc "Unwrap trusted CSS back to a plain String."
+  fn untrust_css(t : TrustedCss) : String do
+    match t do TrustedCss(s) -> s end
+  end
+
+  doc "Unwrap trusted JavaScript back to a plain String."
+  fn untrust_js(t : TrustedJs) : String do
+    match t do TrustedJs(s) -> s end
+  end
 
   doc """
   Escape HTML entities in a string: & < > " '

--- a/stdlib/html.march
+++ b/stdlib/html.march
@@ -110,8 +110,99 @@ mod Html do
   attribute-specific escaping rules can be tightened in the future without
   breaking call sites.
   """
+  -- DEPRECATED — context-blind by nature: it entity-encodes and nothing more,
+  -- which is correct for an ordinary attribute value and wrong for a URL, a
+  -- style or a script one. `Html.tag` no longer uses it for values. Kept
+  -- because bastion is published at 0.2.3 and callers may depend on it.
   fn escape_attr(s : String) : String do
     escape(s)
+  end
+
+  -- ── Attribute classification, for Html.tag ──────────────────────────────
+  --
+  -- These mirror the [attrs] section of specs/security/html-contexts.tbl, which
+  -- is the source of truth the ~H desugar uses. THIS IS A SECOND COPY, kept
+  -- honest by a conformance test rather than prevented by construction: the
+  -- "attr classification agrees with the shipped table" case in
+  -- test/test_ctxesc.ml asserts that the .tbl classifies exactly these names
+  -- this way. If you edit the table, that test tells you to edit this too.
+  --
+  -- A generated fragment would be better in principle, but stdlib is loaded
+  -- from a directory and a _build-only artifact is not on the shipped path.
+  -- The duplication is accepted here because Html.tag is deprecated in favour
+  -- of ~H, which needs no runtime classification at all.
+
+  doc "Attribute names whose value is a whole URL. Mirrors `[attrs]` in specs/security/html-contexts.tbl."
+  pfn url_attr_names() : List(String) do
+    ["href", "src", "action", "formaction", "poster", "cite", "background"]
+  end
+
+  -- Escaper ids from Context.escaper_id (lib/ctxesc/context.ml) and
+  -- MARCH_ESC_* (runtime/march_ctx_escape.h). The C test asserts the two agree.
+  pfn esc_id_attr() : Int do 1 end
+  pfn esc_id_url_whole() : Int do 3 end
+  pfn esc_id_css_decl() : Int do 7 end
+
+  doc """
+  Which escaper an attribute's value needs, from the attribute's name.
+
+  A value handed whole to `Html.tag` IS the whole URL, so url attributes get the
+  scheme allowlist — the same escaper a hole at the *start* of an `href` gets
+  under `~H`. `style` is a declaration list, where `:` and `;` are structural.
+  Event handlers never reach here: `tag` refuses them outright.
+  """
+  pfn attr_escaper_id(k : String) : Int do
+    let lk = String.to_lowercase(k)
+    -- Each `if` needs its own `end` in March (see stdlib/uri.march:62).
+    if List.member(url_attr_names(), lk) do esc_id_url_whole()
+    else if lk == "style" do esc_id_css_decl()
+    else esc_id_attr() end end
+  end
+
+  -- ── Name validation ─────────────────────────────────────────────────────
+  --
+  -- Element and attribute NAMES cannot be made safe by escaping. `onerror`
+  -- contains no character an encoder could touch, and a tag name is not a
+  -- string context at all. These are exactly the positions where the ~H
+  -- desugar emits a hard compile error; `Html.tag` takes them as `String`, so
+  -- it can only validate and refuse at runtime.
+
+  pfn tag_char_ok(c : String) : Bool do
+    Char.is_alphanumeric(c) || c == "-"
+  end
+
+  pfn attr_char_ok(c : String) : Bool do
+    Char.is_alphanumeric(c) || c == "-" || c == "_" || c == ":" || c == "."
+  end
+
+  pfn name_shape_ok(s : String, rest_ok : String -> Bool) : Bool do
+    match string_chars(s) do
+    Nil -> false
+    Cons(h, t) -> Char.is_alpha(h) && List.all(t, rest_ok)
+    end
+  end
+
+  pfn check_tag_name(name : String) : String do
+    if name_shape_ok(name, tag_char_ok) do name
+    else
+      panic("Html.tag: `" ++ name ++ "` is not a valid element name. An element "
+        ++ "name built from untrusted input cannot be made safe by escaping — "
+        ++ "use a ~H template with a literal tag instead.")
+    end
+  end
+
+  pfn check_attr_name(k : String) : String do
+    let lk = String.to_lowercase(k)
+    if String.starts_with(lk, "on") do
+      panic("Html.tag: refusing the event-handler attribute `" ++ k ++ "`. Its "
+        ++ "value is JavaScript, and Html.tag cannot tell whether you meant "
+        ++ "that — use a ~H template, where the parse context is known.")
+    else if name_shape_ok(k, attr_char_ok) do k
+    else
+      panic("Html.tag: `" ++ k ++ "` is not a valid attribute name. An "
+        ++ "attribute name built from untrusted input cannot be made safe by "
+        ++ "escaping — use a ~H template with a literal attribute instead.")
+    end end
   end
 
   doc """
@@ -123,7 +214,24 @@ mod Html do
       Html.tag("br", [], IOList.empty())
       -- "<br></br>"  (use self-closing syntax in static HTML if needed)
 
-  Attribute keys and values are both run through `Html.escape_attr`.
+  DEPRECATED — prefer a `~H` template. `~H` walks its literal chunks through the
+  HTML context automaton at compile time and escapes every interpolation for the
+  position it actually lands in, with unsafe positions reported as compile
+  errors. `Html.tag` builds markup outside the sigil, so none of that analysis
+  applies and it must check at runtime instead.
+
+  Attribute VALUES are escaped for the context their attribute name implies:
+  a url attribute (`href`, `src`, `action`, …) gets the URL scheme allowlist,
+  `style` gets CSS declaration escaping, everything else gets attribute
+  escaping.
+
+  Element and attribute NAMES are validated, not escaped, and an invalid one
+  PANICS. Escaping cannot help there — `onerror` has no character to escape —
+  so a name built from untrusted input is a programming error, not a data
+  condition. Event-handler attributes (`on*`) are refused outright: their value
+  is JavaScript, and `Html.tag` has no way to know whether the caller meant
+  that.
+
   The content is an IOList so it can be a composed partial or ~H result.
   Passing the result of a ~H sigil as content is safe: it will not be
   double-escaped.
@@ -132,13 +240,15 @@ mod Html do
   plus O(1) for IOList wrapping.
   """
   fn tag(name : String, attrs : List((String, String)), content : IOList) : IOList do
+    let tag_name = check_tag_name(name)
     let attr_str = List.fold_left(attrs, "", fn (acc, pair) ->
       match pair do
       (k, v) ->
-        acc ++ " " ++ escape_attr(k) ++ "=\"" ++ escape_attr(v) ++ "\""
+        let key = check_attr_name(k)
+        acc ++ " " ++ key ++ "=\"" ++ html_escape_ctx(attr_escaper_id(key), v) ++ "\""
       end)
-    let open_tag = "<" ++ name ++ attr_str ++ ">"
-    let close_tag = "</" ++ name ++ ">"
+    let open_tag = "<" ++ tag_name ++ attr_str ++ ">"
+    let close_tag = "</" ++ tag_name ++ ">"
     IOList.from_string(open_tag)
     |> IOList.append(content)
     |> IOList.append(IOList.from_string(close_tag))

--- a/test/dune
+++ b/test/dune
@@ -4307,3 +4307,31 @@ printf 'mod CsHelper do\\n\\n  fn double(x : Int) : Int do\\n    x * 2\\n  end\\
 (rule
  (alias runtest)
  (action (diff native/h_tag_hardening.expected native_h_tag_hardening.out)))
+
+; ── Context-indexed trust: compiled/interpreted parity (Task 6) ───────────
+; The compiled backend resolves trust STATICALLY (llvm_emit matches the type
+; against the folded escaper id) and the interpreter resolves it at runtime, by
+; separate code paths. Parity here is a real cross-check, not a formality.
+(rule
+ (targets native_h_trusted_context native_h_trusted_context.out)
+ (deps (file %{exe:../bin/main.exe})
+       (file ../runtime/march_runtime.c) (file ../runtime/march_runtime.h)
+       (file ../runtime/march_scheduler.c) (file ../runtime/march_scheduler.h)
+       (file ../runtime/march_heap.c) (file ../runtime/march_heap.h)
+       (file ../runtime/march_gc.c) (file ../runtime/march_gc.h)
+       (file ../runtime/march_message.c) (file ../runtime/march_message.h)
+       (file ../runtime/march_deque.h)
+       (file ../runtime/march_extras.c) (file ../runtime/march_ctx_escape.c)
+       (file ../runtime/march_ctx_escape.h) (file ../runtime/march_compress.c)
+       (file ../runtime/base64.c) (file ../runtime/sha1.c)
+       (file native/h_trusted_context.march))
+ (action
+  (progn
+   (run %{exe:../bin/main.exe} --compile -o native_h_trusted_context
+        native/h_trusted_context.march)
+   (with-stdout-to native_h_trusted_context.out
+        (system "./native_h_trusted_context")))))
+
+(rule
+ (alias runtest)
+ (action (diff native/h_trusted_context.expected native_h_trusted_context.out)))

--- a/test/dune
+++ b/test/dune
@@ -4277,3 +4277,33 @@ printf 'mod CsHelper do\\n\\n  fn double(x : Int) : Int do\\n    x * 2\\n  end\\
 (rule
  (alias runtest)
  (action (diff native/h_escape_ctx_builtin.expected native_h_escape_ctx_builtin.out)))
+
+; ── Html.tag hardening: compiled/interpreted parity (Task 9) ──────────────
+; Html.tag composes markup outside the ~H sigil, so it never reaches the
+; context automaton. It had three injection holes; two of them (element name,
+; attribute name) cannot be closed by escaping and are refused at runtime
+; instead. The panic cases cannot live in a golden diff -- a panic ends the
+; program -- so they are covered in test_stdlib_suite.ml.
+(rule
+ (targets native_h_tag_hardening native_h_tag_hardening.out)
+ (deps (file %{exe:../bin/main.exe})
+       (file ../runtime/march_runtime.c) (file ../runtime/march_runtime.h)
+       (file ../runtime/march_scheduler.c) (file ../runtime/march_scheduler.h)
+       (file ../runtime/march_heap.c) (file ../runtime/march_heap.h)
+       (file ../runtime/march_gc.c) (file ../runtime/march_gc.h)
+       (file ../runtime/march_message.c) (file ../runtime/march_message.h)
+       (file ../runtime/march_deque.h)
+       (file ../runtime/march_extras.c) (file ../runtime/march_ctx_escape.c)
+       (file ../runtime/march_ctx_escape.h) (file ../runtime/march_compress.c)
+       (file ../runtime/base64.c) (file ../runtime/sha1.c)
+       (file native/h_tag_hardening.march))
+ (action
+  (progn
+   (run %{exe:../bin/main.exe} --compile -o native_h_tag_hardening
+        native/h_tag_hardening.march)
+   (with-stdout-to native_h_tag_hardening.out
+        (system "./native_h_tag_hardening")))))
+
+(rule
+ (alias runtest)
+ (action (diff native/h_tag_hardening.expected native_h_tag_hardening.out)))

--- a/test/native/h_tag_hardening.expected
+++ b/test/native/h_tag_hardening.expected
@@ -1,0 +1,9 @@
+class   : <div class="a&quot;b">x</div>
+href_bad: <a href="about:invalid#zSoyz">x</a>
+href_ok : <a href="/packages/bastion?tab=readme">x</a>
+src_bad : <img src="about:invalid#zSoyz"></img>
+style   : <div style="color:var(--text-muted);display:flex">x</div>
+style_x : <div style="background:url\28 javascript:alert\28 1\29 \29 ">x</div>
+dashed  : <my-element data-id="7">x</my-element>
+multi   : <a href="/x" class="b">x</a>
+noattrs : <br></br>

--- a/test/native/h_tag_hardening.march
+++ b/test/native/h_tag_hardening.march
@@ -1,0 +1,57 @@
+-- Html.tag hardening (Task 9 of specs/plans/2026-08-05-contextual-autoescaping.md).
+--
+-- Html.tag composes markup OUTSIDE the ~H sigil, so it never reaches the
+-- context automaton. Measured on main @ a8707c78, it had THREE injection holes:
+--
+--   Html.tag("div onload=alert(1)", [], body)
+--     -> <div onload=alert(1)>x</div onload=alert(1)>   element name RAW
+--   Html.tag("div", [("onerror", "alert(1)")], body)
+--     -> <div onerror="alert(1)">x</div>                entity-encoding is a no-op
+--   Html.tag("a", [("href", "javascript:alert(1)")], body)
+--     -> <a href="javascript:alert(1)">x</a>            context-blind value
+--
+-- The first two CANNOT be closed by escaping. They sit where the automaton
+-- emits a hard error for ~H, for the same reason: `onerror` contains no
+-- character an encoder could touch. Those are validated and refused (panic);
+-- only the third is an escaping problem.
+--
+-- Compiled/interpreted golden diff -- .expected is the interpreter's output and
+-- the dune rule diffs the compiled binary against it. Parity is the property
+-- that matters here (see specs/progress/2026-08-05-h-sigil-adt-misread.md,
+-- where only compiled output was wrong).
+--
+-- The panic cases cannot live in this file: a panic ends the program. They are
+-- covered in test/test_stdlib_suite.ml instead.
+mod HTagHardening do
+  fn main() : Unit do
+    let body = IOList.from_string("x")
+
+    -- Ordinary attribute: unchanged from before the fix.
+    println("class   : " ++ IOList.to_string(
+      Html.tag("div", [("class", "a\"b")], body)))
+
+    -- URL attribute: an attribute value passed whole to Html.tag IS the whole
+    -- URL, so it gets the scheme allowlist -- as a hole at the start of an
+    -- href does under ~H.
+    println("href_bad: " ++ IOList.to_string(
+      Html.tag("a", [("href", "javascript:alert(1)")], body)))
+    println("href_ok : " ++ IOList.to_string(
+      Html.tag("a", [("href", "/packages/bastion?tab=readme")], body)))
+    println("src_bad : " ++ IOList.to_string(
+      Html.tag("img", [("src", "javascript:alert(1)")], IOList.empty())))
+
+    -- style is a declaration list, so `:` and `;` are structural and an
+    -- allowlisted function survives.
+    println("style   : " ++ IOList.to_string(
+      Html.tag("div", [("style", "color:var(--text-muted);display:flex")], body)))
+    println("style_x : " ++ IOList.to_string(
+      Html.tag("div", [("style", "background:url(javascript:alert(1))")], body)))
+
+    -- Valid names with the shapes HTML actually allows.
+    println("dashed  : " ++ IOList.to_string(
+      Html.tag("my-element", [("data-id", "7")], body)))
+    println("multi   : " ++ IOList.to_string(
+      Html.tag("a", [("href", "/x"), ("class", "b")], body)))
+    println("noattrs : " ++ IOList.to_string(Html.tag("br", [], IOList.empty())))
+  end
+end

--- a/test/native/h_trusted_context.expected
+++ b/test/native/h_trusted_context.expected
@@ -1,0 +1,13 @@
+html_in_html: <p><b>hi</b></p>
+html_in_href: <a href="&lt;b&gt;hi&lt;/b&gt;">x</a>
+url_in_href : <a href="javascript:trusted()">x</a>
+url_in_html : <p>javascript:trusted()</p>
+css_in_style: <div style="color:red;background:url(x)">y</div>
+css_in_html : <p>color:red;background:url(x)</p>
+js_in_script: <script>var x = 1 < 2;</script>
+js_in_html  : <p>var x = 1 &lt; 2;</p>
+attr_in_attr: <div class="a`b">z</div>
+attr_in_html: <p>a`b</p>
+safe_in_html: <p><i>legacy</i></p>
+safe_in_href: <a href="&lt;i&gt;legacy&lt;/i&gt;">x</a>
+plain_html  : <p>&lt;b&gt;&amp;</p>

--- a/test/native/h_trusted_context.march
+++ b/test/native/h_trusted_context.march
@@ -1,0 +1,55 @@
+-- Context-indexed trust (Task 6 of specs/plans/2026-08-05-contextual-autoescaping.md).
+--
+-- `Html.Safe` says a string is trusted, but not trusted WHERE — so once a value
+-- is trusted anywhere it is trusted everywhere. That is the same category error
+-- the whole feature exists to fix: safety is a property of a value IN A
+-- POSITION, not of a value.
+--
+-- The Trusted* types name the context their trust applies to. The load-bearing
+-- property is the SECOND line of each pair below: trust does not travel.
+--
+-- Resolved entirely at compile time — lib/tir/llvm_emit.ml matches the static
+-- type against the escaper id the ~H desugar already folded, so a mismatch
+-- costs nothing at runtime, it simply takes the escaping path.
+--
+-- Compiled/interpreted golden diff: the compiled backend decides this
+-- statically and the interpreter at runtime, by separate code paths, so parity
+-- here is a real cross-check rather than a formality.
+mod HTrustedContext do
+  fn main() : Unit do
+    -- HTML trust: verbatim in element content, escaped in an href.
+    let h = Html.trust_html("<b>hi</b>")
+    println("html_in_html: " ++ IOList.to_string(~H"<p>${h}</p>"))
+    println("html_in_href: " ++ IOList.to_string(~H"<a href=\"${h}\">x</a>"))
+
+    -- URL trust: verbatim in an href — even a scheme the allowlist would
+    -- reject, which is exactly what trusting it means — but escaped as text.
+    let u = Html.trust_url("javascript:trusted()")
+    println("url_in_href : " ++ IOList.to_string(~H"<a href=\"${u}\">x</a>"))
+    println("url_in_html : " ++ IOList.to_string(~H"<p>${u}</p>"))
+
+    -- CSS trust: verbatim in a style attribute, escaped in element content.
+    let c = Html.trust_css("color:red;background:url(x)")
+    println("css_in_style: " ++ IOList.to_string(~H"<div style=\"${c}\">y</div>"))
+    println("css_in_html : " ++ IOList.to_string(~H"<p>${c}</p>"))
+
+    -- JS trust: verbatim inside <script>, escaped in element content.
+    let j = Html.trust_js("var x = 1 < 2;")
+    println("js_in_script: " ++ IOList.to_string(~H"<script>${j}</script>"))
+    println("js_in_html  : " ++ IOList.to_string(~H"<p>${j}</p>"))
+
+    -- Attribute trust.
+    let a = Html.trust_attr("a`b")
+    println("attr_in_attr: " ++ IOList.to_string(~H"<div class=\"${a}\">z</div>"))
+    println("attr_in_html: " ++ IOList.to_string(~H"<p>${a}</p>"))
+
+    -- Legacy Html.Safe keeps working, and is treated as HTML trust.
+    let s = Html.raw("<i>legacy</i>")
+    println("safe_in_html: " ++ IOList.to_string(~H"<p>${s}</p>"))
+    println("safe_in_href: " ++ IOList.to_string(~H"<a href=\"${s}\">x</a>"))
+
+    -- An untrusted string is escaped everywhere, unchanged by any of this.
+    let raw = "<b>&"
+    println("plain_html  : " ++ IOList.to_string(~H"<p>${raw}</p>"))
+  end
+end

--- a/test/test_ctxesc.ml
+++ b/test/test_ctxesc.ml
@@ -332,6 +332,49 @@ let automaton_tests =
     Alcotest.test_case "terminal validity" `Quick test_terminal_validity;
     Alcotest.test_case "literal emitted verbatim" `Quick test_literal_is_emitted_unchanged_when_no_substitution ]
 
+(* ── Attribute classification agrees with the shipped table ───────────────
+   stdlib/html.march carries a SECOND copy of the [attrs] rules, because
+   Html.tag classifies attribute names at runtime and stdlib is loaded from a
+   directory (a generated _build artifact would not be on the shipped path).
+   This test is what keeps the copy honest: it pins what the .tbl classifies
+   these names as, so editing the table without editing html.march fails here.
+
+   Duplication caught by a test rather than prevented by construction is a
+   compromise, and it is only acceptable because Html.tag is deprecated in
+   favour of ~H, which needs no runtime classification at all. *)
+
+let test_attr_classification_matches_html_march () =
+  let t =
+    let candidates =
+      [ "specs/security/html-contexts.tbl";
+        "../../specs/security/html-contexts.tbl";
+        "../../../specs/security/html-contexts.tbl" ] in
+    match List.find_opt Sys.file_exists candidates with
+    | None -> Alcotest.failf "shipped table not found (cwd %s)" (Sys.getcwd ())
+    | Some p ->
+      (match P.parse_file p with
+       | Ok t -> t
+       | Error e -> Alcotest.failf "shipped table failed to parse: %s" e)
+  in
+  let cls name = P.classify t.P.attrs name in
+  let check name expected =
+    Alcotest.(check (option string))
+      (Printf.sprintf "attr %S classifies as %s" name expected)
+      (Some expected) (cls name)
+  in
+  (* Every url attribute listed in Html.url_attr_names(). *)
+  List.iter (fun n -> check n "url")
+    [ "href"; "src"; "action"; "formaction"; "poster"; "cite"; "background" ];
+  check "style" "style";
+  (* Event handlers -- Html.tag refuses these outright rather than escaping. *)
+  List.iter (fun n -> check n "script") [ "onerror"; "onclick"; "onload"; "on" ];
+  (* Everything else falls through to normal. *)
+  List.iter (fun n -> check n "normal")
+    [ "class"; "id"; "data-id"; "title"; "alt"; "width" ];
+  (* Case-insensitivity: HTML attribute names are, and so is the classifier. *)
+  check "HREF" "url";
+  check "OnClick" "script"
+
 let tests =
   [ ("ctxesc table parser",
      [ Alcotest.test_case "minimal transition" `Quick test_parses_a_minimal_transition;
@@ -345,4 +388,7 @@ let tests =
        Alcotest.test_case "rejects wrong field count" `Quick test_rejects_wrong_field_count;
        Alcotest.test_case "rejects row outside section" `Quick test_rejects_row_outside_a_section;
        Alcotest.test_case "shipped table parses" `Quick test_shipped_table_parses ]);
-    ("ctxesc automaton", automaton_tests) ]
+    ("ctxesc automaton", automaton_tests);
+    ("ctxesc attr classification",
+     [ Alcotest.test_case "html.march copy matches the shipped table" `Quick
+         test_attr_classification_matches_html_march ]) ]

--- a/test/test_helpers.ml
+++ b/test/test_helpers.ml
@@ -1213,6 +1213,16 @@ let eval_with_iolist src =
   let iolist_decl = load_stdlib_file_for_test "iolist.march" in
   eval_with_stdlib [string_decl; iolist_decl] src
 
+(* Html.tag classifies attribute names and escapes values contextually, so it
+   needs string/list/char alongside iolist. *)
+let eval_with_html src =
+  let string_decl = load_stdlib_file_for_test "string.march" in
+  let list_decl   = load_stdlib_file_for_test "list.march" in
+  let char_decl   = load_stdlib_file_for_test "char.march" in
+  let iolist_decl = load_stdlib_file_for_test "iolist.march" in
+  let html_decl   = load_stdlib_file_for_test "html.march" in
+  eval_with_stdlib [string_decl; list_decl; char_decl; iolist_decl; html_decl] src
+
 let eval_with_http src =
   let string_decl = load_stdlib_file_for_test "string.march" in
   let http_decl = load_stdlib_file_for_test "http.march" in

--- a/test/test_stdlib_suite.ml
+++ b/test/test_stdlib_suite.ml
@@ -11662,6 +11662,68 @@ let test_concat_chain_values () =
    is current, which fails with EINVAL on our buffer and CHECK-aborts.  Fix:
    under ASAN the runtime keeps ASAN's own altstack (march_scheduler.c).
    Guard: a sanitized hello-world must print its output AND exit 0. *)
+(* ── Html.tag refuses names it cannot make safe (Task 9) ──────────────────
+   Element and attribute NAMES cannot be closed by escaping: `onerror` has no
+   character an encoder could touch, and a tag name is not a string context at
+   all. These are exactly where the ~H desugar emits a compile error; Html.tag
+   takes them as String, so it can only refuse at runtime.
+
+   These live here rather than in test/native/h_tag_hardening.march because a
+   panic ends the program -- a golden stdout diff cannot express them. *)
+
+let expect_html_tag_panic label src needle =
+  let env = eval_with_html src in
+  let raised = ref None in
+  (try ignore (call_fn env "f" [])
+   with March_eval.Eval.Eval_error msg -> raised := Some msg);
+  match !raised with
+  | None -> Alcotest.failf "%s: expected a panic, got none" label
+  | Some msg ->
+    let contains s sub =
+      let n = String.length s and m = String.length sub in
+      let rec go i = i + m <= n && (String.sub s i m = sub || go (i + 1)) in
+      m = 0 || go 0
+    in
+    Alcotest.(check bool)
+      (Printf.sprintf "%s: message explains the refusal (%s)" label needle)
+      true (contains msg needle)
+
+let test_html_tag_refuses_bad_element_name () =
+  expect_html_tag_panic "element name"
+    {|mod T do
+      fn f() do
+        IOList.to_string(Html.tag("div onload=alert(1)", [], IOList.from_string("x")))
+      end
+    end|}
+    "not a valid element name"
+
+let test_html_tag_refuses_event_handler_attr () =
+  expect_html_tag_panic "event handler"
+    {|mod T do
+      fn f() do
+        IOList.to_string(Html.tag("div", [("onerror", "alert(1)")], IOList.from_string("x")))
+      end
+    end|}
+    "event-handler attribute"
+
+let test_html_tag_refuses_bad_attr_name () =
+  expect_html_tag_panic "attribute name"
+    {|mod T do
+      fn f() do
+        IOList.to_string(Html.tag("div", [("a b", "x")], IOList.from_string("x")))
+      end
+    end|}
+    "not a valid attribute name"
+
+let test_html_tag_refuses_empty_element_name () =
+  expect_html_tag_panic "empty name"
+    {|mod T do
+      fn f() do
+        IOList.to_string(Html.tag("", [], IOList.from_string("x")))
+      end
+    end|}
+    "not a valid element name"
+
 let test_compiled_sanitize_clean_exit () =
   let main_exe = find_main_exe () in
   let tmp = Filename.temp_file "march_sanexit" "" in
@@ -13493,5 +13555,15 @@ let stdlib_suites =
           test_interp_http_server_idle_client_does_not_block_others;
         Alcotest.test_case "interp http_server_listen: idle upgraded WebSocket does not block other connections (WS fiber fix)" `Slow
           test_interp_http_server_idle_websocket_does_not_block_others;
+      ]);
+      ( "html_tag_hardening", [
+        Alcotest.test_case "refuses an invalid element name" `Quick
+          test_html_tag_refuses_bad_element_name;
+        Alcotest.test_case "refuses an event-handler attribute" `Quick
+          test_html_tag_refuses_event_handler_attr;
+        Alcotest.test_case "refuses an invalid attribute name" `Quick
+          test_html_tag_refuses_bad_attr_name;
+        Alcotest.test_case "refuses an empty element name" `Quick
+          test_html_tag_refuses_empty_element_name;
       ]);
     ]


### PR DESCRIPTION
`Html.tag` composes markup **outside** the `~H` sigil, so it never reached the contextual analysis added in #202. Includes the plan rewrite (`6b3d436e`) that this implements.

## The holes, measured

```
Html.tag("div onload=alert(1)", [], body)
  → <div onload=alert(1)>x</div onload=alert(1)>   element name concatenated RAW
Html.tag("div", [("onerror", "alert(1)")], body)
  → <div onerror="alert(1)">x</div>                entity-encoding is a no-op here
Html.tag("a", [("href", "javascript:alert(1)")], body)
  → <a href="javascript:alert(1)">x</a>            context-blind value
Html.tag("div", [("class", "a\"b")], body)
  → <div class="a&quot;b">x</div>                  this part was already fine
```

`let open_tag = "<" ++ name ++ attr_str ++ ">"` concatenated the element name with no escaping at all, and `escape_attr` is `escape(s)` — entity-encoding, which does nothing to `onerror` because there is no character in it to escape.

**Reachable but unreached.** The only call site in the ecosystem is bastion's CSRF form with a constant `method="post"`. But an API isn't safe because its current callers happen to be.

## The design point

**Holes 1 and 2 cannot be closed by escaping.** They sit exactly where the context automaton emits a hard compile error for `~H`, for the same reason. So names are *validated and refused*; only values are escaped.

| position | treatment |
|---|---|
| element name | validated → **panic** if invalid |
| attribute name | validated → **panic**; `on*` **refused outright** |
| `href` `src` `action` `formaction` `poster` `cite` `background` | URL scheme allowlist |
| `style` | CSS declaration escaping |
| everything else | attribute escaping |

`on*` is refused rather than escaped because its value is JavaScript, and `Html.tag` cannot tell whether the caller meant that — `~H` can, because the automaton gives it a JS context.

Panic is deliberate: computing a name from untrusted input is a *programming* error, not a data condition, and with literal call sites it can never fire. A 500 instead of an XSS, taken explicitly.

`Html.tag` and `Html.escape_attr` are now documented as **deprecated** in favour of `~H`. Neither is removed — `bastion` is published at 0.2.3.

## Scope is bounded

Checked every other markup-emitting function: `list`, `join`, `render_partial`, `render_collection` compose `IOList`s only, and `layout` escapes its title into `<title>`, which is RCDATA where entity-encoding is correct. **`tag` was the whole gap.**

## An emitter change this forced

`html_escape_ctx` with a **runtime** id used to be a hard `failwith`, on the premise that only the `~H` desugar calls it and always folds the context statically. `Html.tag` disproves that premise — it classifies an attribute name at runtime because it has no compile-time context to fold. Added a dynamic-id path; `~H` still takes the literal arm where the already-safe-HTML specialisation lives. Safety is unchanged: `march_html_escape_ctx` validates the id and aborts on one it doesn't know.

**I found this only because the LLVM IR validity gate compiles every `test/native/*.march`.** I had run the new test interpreted and called it verified — the exact parity gap that hid the ADT misread in #192. Interpreted and compiled now agree byte-for-byte.

## Duplication, accepted with eyes open

`stdlib/html.march` carries a second copy of the `[attrs]` rules, because classification happens at runtime and stdlib is loaded from a directory (a generated `_build` artifact isn't on the shipped path). A new conformance test in `test_ctxesc.ml` pins what the `.tbl` classifies those names as, so editing the table without editing `html.march` fails.

Caught by a test rather than prevented by construction — weaker than the dune embedding used for the OCaml side, and only acceptable because `Html.tag` is now deprecated.

## Docs fix

`CLAUDE.md` and the `march-lang` skill said an `else if` chain closes with a single `end`. It doesn't — each `if` needs its own (`stdlib/uri.march:62` has `else -1 end end end`), and **the skill's binary-tree example was missing one and would not compile**. Both now state the rule and the confusing symptom: a missing `end` reports "I got stuck here" at the *next declaration*, not at the `if`.

This misled me while writing the fix, so it's worth landing regardless.

## Verification

- `test/native/h_tag_hardening.march` — compiled/interpreted golden diff over all four cases plus a legitimate URL, a `style` declaration list, multi-attribute and no-attribute tags
- Four panic cases in `test_stdlib_suite.ml` (they can't live in a golden diff — a panic ends the program)
- Attribute-classification conformance against the shipped table

Suites: compiler 761, eval 256, codegen 546, stdlib 834 — green except the known environmental `MARCH_SANITIZE` ASAN timeout.

Follow-up in another repo: `bastion/lib/security/csrf.march:96` should become `~H"<form method=\"post\">${CSRF.tag(conn)}</form>"`, which gets the compile-time analysis instead of the runtime checks.
