### PR TITLE
fix: remove dangling doc-comment text left outside the block by 8f8c66d6

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -851,9 +851,7 @@ let do_check       = ref false   (* --check: typecheck only, no codegen or eval 
     two therefore CAN disagree, and since 2026-08-06 they demonstrably do for a
     module whose only IO lives in a module-level [let].  Tracked in
     specs/todos/2026-08-06-cap-sandbox-belongs-filter-misses-non-dfn-keys.md;
-    do not restore the sharing claim without actually sharing the predicate. *)
-    Shared by `march caps` and --cap-sandbox so the reported set and the
-    embedded sandbox profile cannot disagree.
+    do not restore the sharing claim without actually sharing the predicate.
 
     [stdlib_files] must list the files whose declarations are the standard
     library's (see [stdlib_span_files]).  The callers pass [desugared] AFTER


### PR DESCRIPTION
## Summary
\`8f8c66d6\` rewrote \`own_caps_of_this_module\`'s doc comment to correct a false claim about it being shared with \`march caps\`, but left the OLD paragraph it was replacing sitting AFTER the new paragraph's closing \`*)\` — i.e. outside the comment block entirely. That's bare text at top level in OCaml, a syntax error, which breaks \`dune build\`/\`make install\` outright.

\`dune build @runtest\` still passes because it doesn't touch \`bin/\`, so this was easy to miss — the compiler literally cannot be built/installed from current \`main\` right now.

## Fix
Delete the orphaned leftover paragraph; the new one already supersedes it and says everything the old one did, correctly.

## Test plan
- [x] \`make install\` now succeeds
- [x] \`march --version\` runs