### PR TITLE
fix(build): main does not compile — docstring closed twice by a merge

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -851,9 +851,7 @@ let do_check       = ref false   (* --check: typecheck only, no codegen or eval 
     two therefore CAN disagree, and since 2026-08-06 they demonstrably do for a
     module whose only IO lives in a module-level [let].  Tracked in
     specs/todos/2026-08-06-cap-sandbox-belongs-filter-misses-non-dfn-keys.md;
-    do not restore the sharing claim without actually sharing the predicate. *)
-    Shared by `march caps` and --cap-sandbox so the reported set and the
-    embedded sandbox profile cannot disagree.
+    do not restore the sharing claim without actually sharing the predicate.
 
     [stdlib_files] must list the files whose declarations are the standard
     library's (see [stdlib_span_files]).  The callers pass [desugared] AFTER


### PR DESCRIPTION
`main` does not compile:

```
File "bin/main.ml", line 855, characters 27-30:
855 |     Shared by `march caps` and --cap-sandbox so the reported set and the
                                 ^^^
Error: Syntax error
```

## What happened

Two PRs edited the same docstring above `own_caps_of_this_module`, and the merge stacked both edits instead of reconciling them.

- **#209** rewrote the docstring — the old text claimed the capability set was *"Shared by `march caps` and --cap-sandbox so the reported set and the embedded sandbox profile cannot disagree"*, which is false (they use different filters and demonstrably disagree). The rewrite replaced that sentence and closed the comment with `*)`.
- **#206** appended a new `[stdlib_files]` paragraph to the same docstring, ending with its own `*)`.

The merged result is: #209's corrected text, a `*)`, then the sentence #209 had **deleted**, then #206's paragraph, then a second `*)`. Everything between the two delimiters is outside the comment and parses as OCaml.

Neither PR is at fault on its own — CI passed on #209 against a `main` that did not yet contain #206, and the collision only existed once both were on the same commit.

## The fix

Remove the premature `*)` and the resurrected false sentence, so the single comment runs to the real terminator. Both PRs' intended content survives: #209's correction about the two filters disagreeing, and #206's `[stdlib_files]` explanation.

Three lines deleted, one added. No behaviour change — it is entirely inside a comment.

## Verification

- `dune build --root .` — clean (the comment was the only merge artifact; nothing else on `main` was broken).
- Spot-checked the shipped safety properties of both PRs against this build, since `main` had been unbuildable and therefore unverified:
  - `cap no_panic`: a guarded `List.tail` compiles clean; unguarded errors; an undecidable call errors (fail-closed); `Array.pop` is banned; and `--refine-suggest-all` / `--refine-suggest-json` do not change any of those verdicts.
  - Capability propagation: importing for a pure function costs nothing; importing for an impure one still requires the capability; a capability reached through a module-level `let` is attributed; a function passed as a *value* counts as an edge.
  - False-positive direction: a parameter shadowing a sibling function does not inherit its capabilities, and an interface default body is not credited to a same-named plain `fn`.

All hold.
