### PR TITLE
fix(desugar): refuse interpolation into parsed sigils (~xml, ~toml, ~yaml)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,34 @@ git log is authoritative for exact commits.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`~xml`, `~toml` and `~yaml` allowed an interpolated value to change the
+  parsed structure; interpolation into them is now a compile error.** These
+  sigils hand their handler a single already-concatenated string which the
+  handler then *parses*, so a hole was spliced into the source text before
+  parsing. Measured before the fix:
+
+  ```march
+  let evil = "</name><admin>true</admin><name>"
+  ~xml"<user><name>${evil}</name></user>"
+  -- <user><name/><admin>true</admin><name/></user>   3 children, not 1
+  ```
+
+  `~toml"name = \"${v}\""` and `~yaml"name: ${v}"` likewise injected entire new
+  keys.
+
+  `~H` is unaffected and keeps its interpolation: it must emit *text*, so it
+  escapes per parse context. These sigils produce a *structure*, where the sound
+  fix is supplying values as data rather than as source text — the
+  parameterisation analogue — not a second family of escapers. YAML in
+  particular cannot be made safe by escaping in any way worth trusting.
+
+  Sigils without interpolation are unchanged. Nothing is known to break: across
+  the compiler, bastion, forgepm, conduit, depot and march_doc there are six
+  uses of these sigils, all in the compiler's own tests, and none with a hole.
+
+
 ### Added
 
 - **Context-indexed trust for `~H`: `Html.TrustedHtml` / `TrustedAttr` /

--- a/lib/desugar/desugar.ml
+++ b/lib/desugar/desugar.ml
@@ -879,7 +879,49 @@ let rec desugar_expr (e : expr) : expr =
          Html.escape, and build a multi-segment IOList directly. *)
       html_interp_to_iolist content' sp
     else begin
-      (* Other sigils: ~R"..." → Sigil.r(content), ~xml"..." → Sigil.xml(content), etc. *)
+      (* Other sigils: ~R"..." → Sigil.r(content), ~xml"..." → Sigil.xml(content), etc.
+      
+         These hand the handler a single ALREADY-CONCATENATED string, which it
+         then PARSES. So an interpolated value is spliced into the source text
+         before parsing and can change the parsed STRUCTURE, not just a value
+         in it. Demonstrated on every shipped handler:
+
+           ~xml"<user><name>${v}</name></user>"
+             v = "</name><admin>true</admin><name>"
+             -> <user><name/><admin>true</admin><name/></user>   3 children
+
+           ~toml"name = \"${v}\""   -> injects a whole new key
+           ~yaml"name: ${v}"        -> injects a whole new key
+
+         ~H solves its version of this by escaping per parse context, but ~H
+         must emit TEXT and has no alternative. These sigils produce a parsed
+         STRUCTURE, so the sound fix is to supply values as data rather than as
+         source text — the parameterisation analogue — not a second family of
+         escapers. YAML in particular cannot be made safe by escaping in any way
+         worth trusting.
+
+         Until a handler offers that, interpolation here is refused. It is used
+         nowhere: across the compiler, bastion, forgepm, conduit, depot and
+         march_doc there are six uses of these sigils, all in this repo's own
+         tests, and NONE with interpolation. *)
+      let parts = decompose_concat content' in
+      let has_hole =
+        List.exists
+          (function
+            | EApp (EVar { txt = "to_string"; _ }, _, _) -> true
+            | _ -> false)
+          parts
+      in
+      if has_hole then
+        desugar_expr_error ~sp
+          ~hint:("Build the value programmatically instead — e.g. parse a "
+                 ^ "literal document and set fields on it — so the "
+                 ^ "interpolated value is data rather than source text.")
+          (Printf.sprintf
+             "Cannot interpolate into a ~%s sigil. Its content is parsed, so an \
+              interpolated value would be spliced into the source text and could \
+              change the parsed structure rather than appear as a value in it."
+             name);
       let fn_name = "Sigil." ^ String.lowercase_ascii name in
       EApp (EVar { txt = fn_name; span = sp }, [content'], sp)
     end

--- a/test/test_compiler.ml
+++ b/test/test_compiler.ml
@@ -11519,8 +11519,88 @@ let test_or_pattern_binding_type_mismatch_rejected () =
   Alcotest.(check bool) "same binder at differing types: rejected" true
     (has_errors ctx)
 
+(* ── Parsed sigils refuse interpolation ───────────────────────────────────
+   ~xml / ~toml / ~yaml hand their handler a single already-concatenated string
+   which the handler then PARSES, so an interpolated value is spliced into the
+   source text before parsing and can change the parsed STRUCTURE. Measured
+   before this was refused:
+
+     ~xml"<user><name>${v}</name></user>" with v = "</name><admin>true</admin><name>"
+       -> <user><name/><admin>true</admin><name/></user>     3 children, not 1
+     ~toml"name = \"${v}\""  -> injected a whole new key
+     ~yaml"name: ${v}"      -> injected a whole new key
+
+   ~H is different: it must emit TEXT, so it escapes per parse context. These
+   produce a STRUCTURE, where the sound fix is supplying values as data rather
+   than as source text. Until a handler offers that, the hole is refused. *)
+
+(* The refusal is raised in the DESUGAR pass, so drive it the way the
+   satisfy/derive desugar-error tests do. *)
+let sigil_interp_errors src =
+  let errors = March_errors.Errors.create () in
+  ignore (March_desugar.Desugar.desugar_module ~errors (parse_module src));
+  List.filter_map
+    (fun (d : March_errors.Errors.diagnostic) ->
+       if d.March_errors.Errors.severity = March_errors.Errors.Error
+       then Some d.March_errors.Errors.message else None)
+    errors.March_errors.Errors.diagnostics
+
+let sigil_contains_sub s sub =
+  let n = String.length s and m = String.length sub in
+  let rec go i = i + m <= n && (String.sub s i m = sub || go (i + 1)) in
+  m = 0 || go 0
+
+let test_xml_sigil_refuses_interpolation () =
+  let msgs =
+    sigil_interp_errors
+      {|mod T do fn f(v : String) do ~xml"<a>${v}</a>" end end|} in
+  Alcotest.(check bool) "an error is reported" true (msgs <> []);
+  Alcotest.(check bool) "it names the sigil" true
+    (List.exists (fun m -> sigil_contains_sub m "~xml sigil") msgs)
+
+let test_toml_sigil_refuses_interpolation () =
+  let msgs =
+    sigil_interp_errors
+      {|mod T do fn f(v : String) do ~toml"k = ${v}" end end|} in
+  Alcotest.(check bool) "it names the sigil" true
+    (List.exists (fun m -> sigil_contains_sub m "~toml sigil") msgs)
+
+let test_yaml_sigil_refuses_interpolation () =
+  let msgs =
+    sigil_interp_errors
+      {|mod T do fn f(v : String) do ~yaml"k: ${v}" end end|} in
+  Alcotest.(check bool) "it names the sigil" true
+    (List.exists (fun m -> sigil_contains_sub m "~yaml sigil") msgs)
+
+let test_parsed_sigils_without_holes_still_work () =
+  let msgs = sigil_interp_errors {|mod T do fn f() do ~xml"<a>b</a>" end end|} in
+  Alcotest.(check bool) "no error for a literal document" true (msgs = [])
+
+let test_h_sigil_still_allows_interpolation () =
+  (* ~H must keep working -- it escapes per context rather than refusing. *)
+  let msgs =
+    sigil_interp_errors
+      {|mod T do fn f(v : String) do ~H"<p>${v}</p>" end end|} in
+  Alcotest.(check bool) "~H is unaffected" true
+    (not (List.exists (fun m -> sigil_contains_sub m "Cannot interpolate into a ~") msgs))
+
+let sigil_interp_suite =
+  ( "parsed_sigil_interpolation", [
+      Alcotest.test_case "~xml refuses a hole" `Quick
+        test_xml_sigil_refuses_interpolation;
+      Alcotest.test_case "~toml refuses a hole" `Quick
+        test_toml_sigil_refuses_interpolation;
+      Alcotest.test_case "~yaml refuses a hole" `Quick
+        test_yaml_sigil_refuses_interpolation;
+      Alcotest.test_case "a literal document is still fine" `Quick
+        test_parsed_sigils_without_holes_still_work;
+      Alcotest.test_case "~H is unaffected" `Quick
+        test_h_sigil_still_allows_interpolation;
+    ] )
+
 let compiler_suites =
   [
+      sigil_interp_suite;
       ("cap_strip", Test_cap_strip.tests);
       ("cap_symbols", Test_cap_symbols.tests);
       ("cap_markers", Test_cap_markers.tests);


### PR DESCRIPTION
Same class of bug as the `~H` holes closed in #202, in three sigils that ship today.

## The bug

`~xml`, `~toml` and `~yaml` hand their handler a single **already-concatenated string**, which the handler then **parses**. So an interpolated value is spliced into the source text *before* parsing, and can change the parsed **structure** rather than appear as a value in it.

Measured on `main` @ `29f460f6`:

```march
let evil = "</name><admin>true</admin><name>"
~xml"<user><name>${evil}</name></user>"
-- <user><name/><admin>true</admin><name/></user>    3 children, not 1
```

An `<admin>true</admin>` element injected into the parsed document. `~toml"name = \"${v}\""` and `~yaml"name: ${v}"` likewise injected entire new keys.

## Refused rather than escaped — the asymmetry is the point

This deliberately does **not** mirror `~H`:

- **`~H` must emit *text*.** There's no structural alternative to templating HTML, so escaping per parse context is the right tool and worth the machinery it took.
- **These produce a parsed *structure*.** The sound fix is supplying values as **data** rather than as source text — the parameterisation analogue — which eliminates the class instead of escaping around it. YAML in particular is indentation-sensitive with many scalar forms and cannot be made safe by escaping in any way worth trusting.

Writing three escapers would have been symmetric and wrong.

The error names the sigil and the hint points at the alternative, so the parameterisation route stays open as future work rather than being closed off:

```
error: Cannot interpolate into a ~xml sigil. Its content is parsed, so an
interpolated value would be spliced into the source text and could change the
parsed structure rather than appear as a value in it.
hint: Build the value programmatically instead — e.g. parse a literal document
and set fields on it — so the interpolated value is data rather than source text.
```

## Safe to refuse — checked, not assumed

Across the compiler, bastion, forgepm, conduit, depot and march_doc there are **six uses of these sigils, all in this repo's own tests, and none with interpolation**.

Had anyone been using it, refusing would have been the wrong call and the parameterisation work would have been required up front. Sigils without interpolation are unchanged.

## Tests

Five cases, including two negative controls that matter as much as the positives:

- `~xml` / `~toml` / `~yaml` each refuse a hole, and the message names the sigil
- a literal `~xml` document still works
- **`~H` is explicitly asserted unaffected** — a careless broadening of this check would silently disable HTML templating, which is the regression I'd most want a guard against

Suites: compiler 770, eval 256, codegen 546, stdlib 833 — all green, no failures at all.

## Scope note

This closes the *reachable* injection. It does not implement parameterised interpolation for these formats; that remains available as future work if someone wants holes in them, and the diagnostic points that way.
