### PR TITLE
fix(desugar): CSRF double-injection, plus severity labelling and the subsidiary-automata gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,28 @@ git log is authoritative for exact commits.
 
 ### Fixed
 
+- **`~H` no longer emits two CSRF tokens when a form already interpolates one.**
+  The desugar injects a hidden `_csrf_token` input after a mutating `<form>`
+  whenever a `conn` binding is in scope. If the author also wrote
+  `${CSRF.tag(conn)}`, both were emitted — silently, because `CSRF.tag` returns
+  `IOList` and passes through unescaped. With `CSRF.tag_string`, which returns
+  `String`, the contextual escaper treated it as untrusted text and rendered a
+  visible chunk of escaped markup onto the page.
+
+  Injection is now skipped for a form that already contains an explicit token,
+  and a **warning** points out that the explicit call is redundant.
+
+  Detection is scoped **per form**, not per template: a template with two forms
+  where only one carries an explicit token keeps injection on the other. A
+  template-wide check would have turned a cosmetic duplicate into an
+  unprotected form.
+
+- **Desugar diagnostics are labelled by their actual severity.** Both printers
+  in `bin/main.ml` hardcoded `error:`, which was harmless only while the desugar
+  emitted nothing but errors. The warning above is the first exception, and a
+  warning printed as `error:` misleads people and any tooling that greps the
+  output. The exit decision is unchanged — it still keys off `has_errors`.
+
 - **`~xml`, `~toml` and `~yaml` allowed an interpolated value to change the
   parsed structure; interpolation into them is now a compile error.** These
   sigils hand their handler a single already-concatenated string which the

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2,6 +2,17 @@
 
 (* Decode URL-safe base64 (with or without padding) to bytes.
  * Returns Some bytes_string on success, None on invalid input. *)
+(* Label a desugar diagnostic by its ACTUAL severity. Both desugar printers
+   hardcoded "error:", which was harmless only while desugar emitted nothing but
+   errors. It now also emits a warning (the redundant-CSRF-token one), and a
+   warning printed as "error:" misleads people and any tooling that greps the
+   output. The exit decision is unchanged -- it still keys off has_errors. *)
+let severity_word (sev : March_errors.Errors.severity) : string =
+  match sev with
+  | March_errors.Errors.Error -> "error"
+  | March_errors.Errors.Warning -> "warning"
+  | March_errors.Errors.Hint -> "hint"
+
 let b64_decode_pubkey b64 =
   let tbl = Array.make 256 (-1) in
   let chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=" in
@@ -1380,9 +1391,9 @@ let run_test_cmd args =
     let desugared = March_desugar.Desugar.desugar_module ~errors:desugar_errors module_ast in
     if March_errors.Errors.has_errors desugar_errors then begin
       List.iter (fun (d : March_errors.Errors.diagnostic) ->
-          Printf.eprintf "%s:%d:%d: error: %s\n"
+          Printf.eprintf "%s:%d:%d: %s: %s\n"
             d.span.March_ast.Ast.file d.span.March_ast.Ast.start_line
-            d.span.March_ast.Ast.start_col d.message
+            d.span.March_ast.Ast.start_col (severity_word d.severity) d.message
         ) (March_errors.Errors.sorted desugar_errors);
       exit 1
     end;
@@ -1971,9 +1982,9 @@ let compile filename =
   let desugar_errors = March_errors.Errors.create () in
   let desugared = March_desugar.Desugar.desugar_module ~errors:desugar_errors module_ast in
   List.iter (fun (d : March_errors.Errors.diagnostic) ->
-      Printf.eprintf "%s:%d:%d: error: %s\n"
+      Printf.eprintf "%s:%d:%d: %s: %s\n"
         d.span.March_ast.Ast.file d.span.March_ast.Ast.start_line
-        d.span.March_ast.Ast.start_col d.message
+        d.span.March_ast.Ast.start_col (severity_word d.severity) d.message
     ) (March_errors.Errors.sorted desugar_errors);
   let has_desugar_errors = March_errors.Errors.has_errors desugar_errors in
   stamp "desugar";

--- a/lib/desugar/desugar.ml
+++ b/lib/desugar/desugar.ml
@@ -428,38 +428,6 @@ let csrf_form_close_pos (s : string) : int option =
   in
   scan 0
 
-(** Inject CSRF hidden-input string expressions into a ~H parts list.
-
-    For each [ELit (LitString s, _)] that contains a [<form method="post/...">]
-    opening tag, split the literal at the closing [>] and insert an
-    [EApp(CSRF.tag_string, [EVar "conn"])] call between the two halves.
-
-    The injected call returns [String] (not IOList), so it is valid as an
-    element in the [List(String)] passed to [IOList.from_strings].
-
-    Only called when [csrf_conn_in_scope] holds — the caller guarantees a
-    [conn] variable is lexically in scope (the standard Bastion convention
-    for request-handler functions that use ~H templates). *)
-let inject_csrf_tokens (parts : expr list) (sp : span) : expr list =
-  let v s = EVar { txt = s; span = sp } in
-  let csrf_call = EApp (v "CSRF.tag_string", [v "conn"], sp) in
-  let rec go = function
-    | [] -> []
-    | ELit (LitString s, lsp) :: rest ->
-      (match csrf_form_close_pos s with
-       | None -> ELit (LitString s, lsp) :: go rest
-       | Some close_pos ->
-         let before = String.sub s 0 close_pos in
-         let after  = String.sub s close_pos (String.length s - close_pos) in
-         (* Recurse on the remainder to handle multiple forms in one literal *)
-         ELit (LitString before, lsp)
-         :: csrf_call
-         :: go (ELit (LitString after, lsp) :: rest))
-    | part :: rest ->
-      part :: go rest
-  in
-  go parts
-
 (** Diagnostic sink for expression-level desugar errors.
 
     [desugar_expr] is public API called without an error context by the
@@ -485,6 +453,118 @@ let desugar_expr_error ~(sp : span) ?hint msg : unit =
                 pos_bol  = 0;
                 pos_cnum = sp.start_col } in
     raise (March_errors.Errors.ParseError (msg, hint, pos))
+
+(* Same sink, Warning severity. Unlike the error path this does NOT raise when
+   no context is installed: a warning that aborts the REPL would be worse than
+   the thing it warns about. *)
+let desugar_expr_warning ~(sp : span) ?hint msg : unit =
+  match !expr_err_ctx with
+  | Some ctx ->
+    Err.report ctx
+      { severity = Err.Warning; span = sp; message = msg; labels = [];
+        notes = (match hint with Some h -> [h] | None -> []);
+        code = Some "redundant_csrf_token"; fix = None }
+  | None -> ()
+
+(** Inject CSRF hidden-input string expressions into a ~H parts list.
+
+    For each [ELit (LitString s, _)] that contains a [<form method="post/...">]
+    opening tag, split the literal at the closing [>] and insert an
+    [EApp(CSRF.tag_string, [EVar "conn"])] call between the two halves.
+
+    The injected call returns [String] (not IOList), so it is valid as an
+    element in the [List(String)] passed to [IOList.from_strings].
+
+    Only called when [csrf_conn_in_scope] holds — the caller guarantees a
+    [conn] variable is lexically in scope (the standard Bastion convention
+    for request-handler functions that use ~H templates). *)
+(* Is this part an explicit CSRF token interpolation -- `${CSRF.tag(conn)}` or
+   `${CSRF.tag_string(conn)}`? At this point in the pipeline a hole is still
+   `to_string(inner)`; the contextual escaper is applied later.
+
+   Matched EXACTLY (or as a dotted suffix of a module path), never as a loose
+   substring. The asymmetry matters: a false negative leaves a duplicate token,
+   which is ugly. A FALSE POSITIVE suppresses injection and leaves the form
+   unprotected. So this errs towards not matching. *)
+let is_explicit_csrf_token (e : expr) : bool =
+  let is_token_name n =
+    n = "CSRF.tag" || n = "CSRF.tag_string"
+    || (let suffix s = String.length n > String.length s
+                       && String.sub n (String.length n - String.length s)
+                            (String.length s) = s in
+        suffix ".CSRF.tag" || suffix ".CSRF.tag_string")
+  in
+  match e with
+  | EApp (EVar { txt = "to_string"; _ }, [inner], _) ->
+    (match inner with
+     | EApp (EVar { txt; _ }, _, _) -> is_token_name txt
+     | _ -> false)
+  | EApp (EVar { txt; _ }, _, _) -> is_token_name txt
+  | _ -> false
+
+(* Does an explicit token appear inside THIS form -- after its opening tag and
+   before the form ends?
+
+   Scoped PER FORM on purpose. A template-wide check would be actively harmful:
+   a template with two forms, only one carrying an explicit token, would lose
+   injection on BOTH, turning a cosmetic duplicate into an unprotected form.
+   Scanning stops at `</form` or at the next `<form`, so each form is judged on
+   its own contents. *)
+let explicit_token_in_this_form (after : string) (rest : expr list) : bool =
+  let lower s = String.lowercase_ascii s in
+  let ends_scope s =
+    let l = lower s in
+    let contains sub =
+      let n = String.length l and m = String.length sub in
+      let rec go i = i + m <= n && (String.sub l i m = sub || go (i + 1)) in
+      m = 0 || go 0
+    in
+    contains "</form" || contains "<form"
+  in
+  if ends_scope after then false
+  else
+    let rec scan = function
+      | [] -> false
+      | ELit (LitString s, _) :: tl -> if ends_scope s then false else scan tl
+      | p :: tl -> if is_explicit_csrf_token p then true else scan tl
+    in
+    scan rest
+
+let inject_csrf_tokens (parts : expr list) (sp : span) : expr list =
+  let v s = EVar { txt = s; span = sp } in
+  let csrf_call = EApp (v "CSRF.tag_string", [v "conn"], sp) in
+  let rec go = function
+    | [] -> []
+    | ELit (LitString s, lsp) :: rest ->
+      (match csrf_form_close_pos s with
+       | None -> ELit (LitString s, lsp) :: go rest
+       | Some close_pos ->
+         let before = String.sub s 0 close_pos in
+         let after  = String.sub s close_pos (String.length s - close_pos) in
+         if explicit_token_in_this_form after rest then begin
+           (* The author wrote their own token in this form. Injecting as well
+              would emit TWO hidden inputs -- silently, when the explicit call
+              returns IOList. Skip, and say so: the explicit call is now
+              redundant, and silence would leave the author believing it is
+              load-bearing. *)
+           desugar_expr_warning ~sp
+             ~hint:("Remove the explicit token — ~H injects one automatically \
+                     for a mutating <form> whenever `conn` is in scope.")
+             "This <form> already interpolates a CSRF token, so ~H did not \
+              inject one. Emitting both would put two hidden _csrf_token \
+              inputs in the form.";
+           ELit (LitString before, lsp)
+           :: go (ELit (LitString after, lsp) :: rest)
+         end else
+           (* Recurse on the remainder to handle multiple forms in one literal *)
+           ELit (LitString before, lsp)
+           :: csrf_call
+           :: go (ELit (LitString after, lsp) :: rest))
+    | part :: rest ->
+      part :: go rest
+  in
+  go parts
+
 
 
 (** Build an IOList directly from the parts of an ~H sigil interpolation.

--- a/lib/desugar/desugar.ml
+++ b/lib/desugar/desugar.ml
@@ -308,8 +308,31 @@ let process_island_tags (parts : expr list) (sp : span) : expr list =
    (function/lambda parameter, `let`/`let?` binding earlier in the block, or
    a match-branch pattern). Templates without `conn` render verbatim and
    never see an unbound-`conn` error; templates following the Bastion
-   convention keep automatic CSRF protection. An explicit
-   `${CSRF.tag_string(conn)}` interpolation still works either way. *)
+   convention keep automatic CSRF protection.
+
+   DO NOT ALSO INTERPOLATE A TOKEN YOURSELF. An earlier version of this comment
+   claimed an explicit `${CSRF.tag_string(conn)}` "still works either way". It
+   does not — injection is unconditional once `conn` is in scope, so an explicit
+   token is emitted IN ADDITION to the injected one. Measured:
+
+     ~H"<form method=\"post\"></form>"
+       -> <form method="post"><input _csrf ...></form>          correct
+
+     ~H"<form method=\"post\">${CSRF.tag(conn)}</form>"
+       -> <form ...><input _csrf ...><input _csrf ...></form>   DUPLICATE
+
+     ~H"<form method=\"post\">${CSRF.tag_string(conn)}</form>"
+       -> <form ...><input _csrf ...>&lt;input name=&quot;...   ESCAPED GARBAGE
+
+   The `tag_string` case is the worse-looking one — it returns `String`, so the
+   contextual escaper treats it as untrusted text and renders a visible chunk of
+   escaped markup on the page. The `tag` case returns `IOList`, which passes
+   through unescaped and duplicates SILENTLY, which is the more dangerous of the
+   two.
+
+   Inside a ~H template with `conn` in scope, write the bare form tag and let
+   the injection do it. Explicit token helpers are for markup built OUTSIDE ~H
+   (see bastion's Form.render, which concatenates strings and is correct). *)
 
 (** Is a `conn` binding lexically in scope at the expression currently being
     desugared?  Maintained imperatively (like [expr_err_ctx]) because

--- a/specs/todos/2026-08-06-ctxesc-no-subsidiary-automata.md
+++ b/specs/todos/2026-08-06-ctxesc-no-subsidiary-automata.md
@@ -1,0 +1,79 @@
+# `~H` has no subsidiary automata — nested languages are handled coarsely
+
+**Filed:** 2026-08-06
+**Priority:** P3 — a correctness/usability defect, not a known vulnerability
+
+The contextual escaping in `specs/plans/2026-08-05-contextual-autoescaping.md`
+matches the paper (Samuel et al., arXiv:2605.16561v1) on transition tables, the
+context tuple, substitutions, terminal validity and diagnostics. It **diverges
+on one element**: subsidiary automata.
+
+## What the paper does
+
+> "Subsidiary automata handle processing of nested content languages. Upon
+> encountering `<a href=`, the HTML automaton spins up a URL parsing automaton
+> and mediates its input via an HTML attribute codec."
+
+The codec "decodes content as seen by the HTML automaton and re-encodes any
+modifications made by the URL automaton", and the subsidiary relationship is
+tracked alongside the context value.
+
+## What we do instead
+
+The nested language is flattened into the `attr` field of the 4-tuple
+(`url` / `urlmid` / `style` / `stylevalue` / `script`), and the escaper does that
+language's work in one shot. There is no separate automaton object and no codec.
+
+Two positions instead of a real automaton: `url` → `urlmid` on the first literal
+character, and `style` → `stylevalue` on a `:`. A real URL automaton would track
+scheme / authority / path / query / fragment; a real CSS one would track far
+more than declaration-vs-value.
+
+## The cost, measured
+
+The codec's absence turns out **not** to be exploitable, because the attribute
+escaper escapes `&` after the URL check, so an entity cannot be decoded a second
+time:
+
+```
+href="${'javascript&#58;alert(1)'}"  ->  href="javascript&amp;#58;alert(1)"
+```
+
+The coarseness does bite for a URL nested inside CSS:
+
+```
+style="background:url(${'/img/logo.png'})"
+  -> url(\2F img\2F logo.png)          slashes escaped, legitimate URL BROKEN
+
+<style>a{background:url(${'javascript:alert(1)'})}</style>
+  -> url(javascript:alert\28 1\29 )    colon SURVIVES; only the parens escaped
+```
+
+The first is a plain usability defect: a legitimate relative URL in `url()` is
+mangled.
+
+The second is not exploitable as it stands — the escaped parens leave the JS
+malformed, and current browsers do not execute `javascript:` in a CSS `url()` —
+but the colon surviving is a smell, and it is there only because a `<style>`
+body is treated as declaration position throughout, when inside `url(...)` it is
+really a URL position.
+
+**Not currently reachable.** Nothing in bastion or forgepm interpolates inside a
+CSS `url()` — checked.
+
+## Fix
+
+Give `url(` a context of its own. Minimally: add `cssurl` to the `attr` field
+with transitions `style|stylevalue --url(--> cssurl` and `cssurl --)--> back`,
+and select the URL escaper there. That is a table change plus one escaper
+mapping, and it uses machinery that already exists.
+
+The full paper design — a real subsidiary automaton with a codec — is a larger
+change and is only worth it if a nested language appears whose *position* matters
+in ways the flat model cannot express. The `url(` case does not need it.
+
+## Do not "fix" this by widening the CSS allowlist
+
+Adding `/` to the CSS-safe character set would repair the broken-URL symptom and
+reintroduce a hole: `/` is how a CSS comment (`/*`) starts. The escaper's
+allowlist is deliberate — see `specs/security/README.md`.

--- a/test/test_compiler.ml
+++ b/test/test_compiler.ml
@@ -12199,9 +12199,95 @@ let sigil_interp_suite =
         test_h_sigil_still_allows_interpolation;
     ] )
 
+(* ── ~H CSRF auto-injection vs an explicit token ──────────────────────────
+   The desugar injects a hidden CSRF input after a mutating <form> whenever a
+   `conn` binding is in scope. If the author ALSO interpolates a token, both
+   were emitted -- silently when the explicit call returns IOList, and as
+   visibly escaped markup when it returns String.
+
+   Detection is scoped PER FORM, and the two-form case below is why: a
+   template-wide check would drop injection for EVERY form as soon as one had
+   an explicit token, turning a cosmetic duplicate into an UNPROTECTED form. *)
+
+let csrf_src body =
+  Printf.sprintf
+    {|mod T do
+      mod CSRF do
+        fn tag_string(conn) : String do "[TOK]" end
+        fn tag(conn) : IOList do IOList.from_string("[TOK]") end
+      end
+      fn render(conn) do IOList.to_string(%s) end
+    end|} body
+
+let csrf_tokens_in body =
+  let env = eval_with_html (csrf_src body) in
+  let out = match call_fn env "render" [March_eval.Eval.VString "c"] with
+    | March_eval.Eval.VString s -> s
+    | _ -> Alcotest.fail "render did not return a String" in
+  (* count occurrences of the token marker *)
+  let n = String.length out and m = String.length "[TOK]" in
+  let rec count i acc =
+    if i + m > n then acc
+    else count (i + 1) (if String.sub out i m = "[TOK]" then acc + 1 else acc)
+  in
+  (out, count 0 0)
+
+let test_csrf_auto_injects_one () =
+  let (_, n) = csrf_tokens_in {|~H"<form method=\"post\">a</form>"|} in
+  Alcotest.(check int) "auto-injection emits exactly one token" 1 n
+
+let test_csrf_explicit_iolist_not_duplicated () =
+  let (_, n) = csrf_tokens_in {|~H"<form method=\"post\">${CSRF.tag(conn)}</form>"|} in
+  Alcotest.(check int) "explicit IOList token is not duplicated" 1 n
+
+let test_csrf_explicit_string_not_duplicated () =
+  let (out, n) =
+    csrf_tokens_in {|~H"<form method=\"post\">${CSRF.tag_string(conn)}</form>"|} in
+  Alcotest.(check int) "explicit String token is not duplicated" 1 n;
+  (* the String form used to render visibly escaped markup onto the page *)
+  Alcotest.(check bool) "no escaped markup leaks into the output" false
+    (let n' = String.length out in
+     let rec has i = i + 4 <= n' && (String.sub out i 4 = "&lt;" || has (i + 1)) in
+     has 0)
+
+let test_csrf_two_forms_only_one_explicit () =
+  (* THE case: form 1 has an explicit token, form 2 has none. Form 2 must STILL
+     be injected -- otherwise this "fix" would create an unprotected form. *)
+  let (_, n) =
+    csrf_tokens_in
+      {|~H"<form method=\"post\">${CSRF.tag(conn)}</form><form method=\"post\">b</form>"|} in
+  Alcotest.(check int) "one token per form, both forms covered" 2 n
+
+let test_csrf_two_forms_explicit_second () =
+  let (_, n) =
+    csrf_tokens_in
+      {|~H"<form method=\"post\">a</form><form method=\"post\">${CSRF.tag(conn)}</form>"|} in
+  Alcotest.(check int) "order does not matter" 2 n
+
+let test_csrf_get_form_never_injected () =
+  let (_, n) = csrf_tokens_in {|~H"<form method=\"get\">a</form>"|} in
+  Alcotest.(check int) "a GET form is never injected" 0 n
+
+let csrf_suite =
+  ( "h_csrf_explicit_token", [
+      Alcotest.test_case "auto-injection emits one" `Quick
+        test_csrf_auto_injects_one;
+      Alcotest.test_case "explicit IOList token not duplicated" `Quick
+        test_csrf_explicit_iolist_not_duplicated;
+      Alcotest.test_case "explicit String token not duplicated, no escaped leak" `Quick
+        test_csrf_explicit_string_not_duplicated;
+      Alcotest.test_case "two forms, one explicit: both still covered" `Quick
+        test_csrf_two_forms_only_one_explicit;
+      Alcotest.test_case "two forms, explicit second: both still covered" `Quick
+        test_csrf_two_forms_explicit_second;
+      Alcotest.test_case "GET form never injected" `Quick
+        test_csrf_get_form_never_injected;
+    ] )
+
 let compiler_suites =
   [
       sigil_interp_suite;
+      csrf_suite;
       ("cap_strip", Test_cap_strip.tests);
       ("cap_symbols", Test_cap_symbols.tests);
       ("cap_markers", Test_cap_markers.tests);


### PR DESCRIPTION
Three related findings from verifying the `~H` work against the paper and against bastion.

## 1. `~H` emitted two CSRF tokens when a form already had one

The desugar injects a hidden `_csrf_token` input after a mutating `<form>` whenever a `conn` binding is in scope. If the author also interpolated a token, both were emitted. Measured before the fix:

```
~H"<form method=\"post\"></form>"                          -> one token, correct
~H"<form method=\"post\">${CSRF.tag(conn)}</form>"         -> TWO tokens, silently
~H"<form method=\"post\">${CSRF.tag_string(conn)}</form>"  -> one token + visible ESCAPED MARKUP
```

`CSRF.tag` returns `IOList` and passes through unescaped, so it duplicates **silently** — the more dangerous of the two. `CSRF.tag_string` returns `String`, so the contextual escaper treats it as untrusted text and renders a visible chunk of escaped markup onto the page.

Injection is now skipped for a form that already contains an explicit token, with a **warning** saying the explicit call is redundant — silence would leave the author believing it's load-bearing.

### Scoped per form, and that's the whole design risk

A template-wide check would drop injection for **every** form as soon as one carried an explicit token — turning a cosmetic duplicate into an **unprotected form**. Scanning stops at `</form` or the next `<form`, so each form is judged on its own contents:

```
<form method="post">${CSRF.tag(conn)}</form><form method="post">b</form>
  ->  <form ...>[TOK]</form><form ...>[TOK]b</form>     both covered
```

Both orderings are pinned by tests, along with a GET form (never injected).

Detection errs toward **not** matching — exact names or dotted module suffixes, never a loose substring. The asymmetry is deliberate: a false negative leaves a duplicate token, which is ugly; a false **positive** suppresses injection and leaves a form unprotected.

## 2. A driver bug this exposed

My warning printed as `error:`. Both desugar diagnostic printers in `bin/main.ml` hardcoded that label — harmless only while the desugar emitted nothing but errors. This warning is the first exception, and a warning printed as `error:` misleads people and any tooling that greps the output.

Now labelled by actual severity. **The exit decision is unchanged** — it still keys off `has_errors`, so nothing new fails a build.

## 3. The comment that caused this, and a filed gap

`desugar.ml`'s own comment claimed an explicit `${CSRF.tag_string(conn)}` "still works either way". It didn't. Corrected with the measured outputs, and it now points at where explicit helpers *do* belong: markup built outside `~H`, like bastion's `Form.render`, which concatenates strings and is correct today.

Also files `specs/todos/2026-08-06-ctxesc-no-subsidiary-automata.md`. Verifying the implementation against the paper (arXiv:2605.16561v1) found it conforms on transition tables, the context tuple, epsilon-transitions-with-substitutions, `isValidTerminalContext` and diagnostics — including the paper's own worked examples, which pass — but **diverges on subsidiary automata**: nested languages are flattened into the `attr` field rather than getting their own automaton and codec.

The codec's absence turns out not to be exploitable (the attribute escaper escapes `&` after the URL check, so no second decode round). The coarseness does bite for a URL inside CSS — a legitimate `url(/img/logo.png)` gets its slashes escaped and breaks, and in a `<style>` body `url(javascript:…)` keeps its colon. Not currently reachable: nothing in bastion or forgepm interpolates inside a CSS `url()`.

## Note on bastion

The migration that prompted this — `bastion/lib/security/csrf.march:96` — **is not a call site**. It's a prose example inside a docstring, not compiled and not a doctest. There are no remaining real `Html.tag` call sites in bastion. I had reported it as outstanding work; that was wrong.

Worth knowing: the rewrite I'd proposed for it would itself have introduced the duplicate-token bug fixed here.

Suites: compiler 792, eval 256, codegen 546, stdlib 833 — all green, no failures.
