### PR TITLE
fix(ctxesc): CSS url() context, and rewrite the ~H docs

### DIFF
--- a/docs/cookbook/html.md
+++ b/docs/cookbook/html.md
@@ -7,7 +7,7 @@ scrollmd: true
 
 # HTML
 
-March's `~H` sigil generates safe HTML. String interpolations inside `~H` are auto-escaped — user input can't inject markup. `Html.raw` opts out for trusted content you've already sanitized.
+March's `~H` sigil generates HTML with **contextual auto-escaping**: every `${...}` is escaped for the exact place it lands — element content, an attribute, a URL, CSS, or JavaScript — worked out at compile time. You never pick an escaper. The `Html.trust_*` functions opt out for content you produced yourself. See [Sigils & Templating]({{ site.baseurl }}/docs/sigils/) for the full picture.
 
 ---
 
@@ -34,16 +34,43 @@ end
 
 ---
 
-## Trusted HTML
+## Escaping follows the position
 
-`Html.raw` marks a string as already safe — `~H` won't escape it:
+The same value is treated differently depending on where you put it:
 
 ```march
-let icon = Html.raw("<svg>...</svg>")
+let u = "javascript:alert(1)"
+~H"<a href=\"${u}\">x</a>"        -- <a href="about:invalid#zSoyz">x</a>
+
+let q = "a b&c"
+~H"<a href=\"/s?q=${q}\">x</a>"   -- <a href="/s?q=a%20b%26c">x</a>
+
+let col = "var(--accent)"
+~H"<div style=\"color:${col}\">"  -- <div style="color:var(--accent)">
+```
+
+A URL that fails the scheme allowlist becomes `about:invalid#zSoyz`. Positions no
+escaping can make safe — an attribute name, an element name, inside a comment — are
+compile errors.
+
+## Trusted HTML
+
+`Html.trust_html` marks a string as real markup, so `~H` inserts it verbatim:
+
+```march
+let icon = Html.trust_html("<svg>...</svg>")
 let html = ~H"<button>${icon} Click me</button>"
 ```
 
-Use `Html.raw` only for content you've verified or generated yourself, never for user input.
+**Trust names a context and does not travel out of it.** The same value in an `href` is
+still escaped, because trusting something as HTML says nothing about it being a safe
+URL. Use `Html.trust_url`, `trust_css`, `trust_js` or `trust_attr` when the target is
+one of those.
+
+Use these only for content you verified or generated yourself, never for user input.
+
+> `Html.raw` still works and behaves as HTML trust, but it is deprecated: being
+> context-free, it cannot say *where* the content is trusted. Prefer `Html.trust_html`.
 
 ---
 
@@ -55,7 +82,7 @@ fn layout(title : String, body : IOList) : IOList do
   <!DOCTYPE html>
   <html>
     <head><title>${title}</title></head>
-    <body>${Html.raw(IOList.to_string(body))}</body>
+    <body>${body}</body>
   </html>
   """
 end

--- a/docs/sigils.md
+++ b/docs/sigils.md
@@ -10,9 +10,10 @@ permalink: /docs/sigils/
 Some kinds of text aren't really "just a string" — a chunk of TOML, an HTML template, an
 XML document. March's **sigils** let you write that text as a literal, right in your
 source, and have the compiler hand it to a parser or template builder instead of
-treating it as a plain `String`. The most-used one, `~H`, builds safe, auto-escaping
-HTML templates — the rest of this page starts with the general mechanism, then goes deep
-on `~H` specifically.
+treating it as a plain `String`. The most-used one, `~H`, builds HTML with
+**contextual auto-escaping** — every interpolation is escaped for the exact place it
+lands, worked out at compile time. The rest of this page starts with the general
+mechanism, then goes deep on `~H`.
 
 ---
 
@@ -48,6 +49,22 @@ runtime). If you need to handle a malformed document gracefully, parse a runtime
 with the ordinary `Toml.parse`/`Xml.parse`/`Yaml.parse` functions instead, which return
 a `Result` rather than panicking.
 
+**They do not accept interpolation.** `~toml`, `~xml` and `~yaml` hand their content to
+a parser, so a `${...}` hole would be spliced into the source text *before* parsing and
+could change the parsed structure rather than appear as a value in it — an interpolated
+`</name><admin>true</admin><name>` would add a whole element. That is a compile error:
+
+```march
+~xml"<user><name>${v}</name></user>"
+-- error: Cannot interpolate into a ~xml sigil. Its content is parsed, so an
+-- interpolated value would be spliced into the source text and could change
+-- the parsed structure rather than appear as a value in it.
+```
+
+Build the value programmatically instead — parse a literal document and set fields on
+it — so the value arrives as *data* rather than as source text. `~H` is the exception,
+and the next section explains why it can afford to be.
+
 ```march
 let config = ~toml"""
 port = 8080
@@ -72,12 +89,63 @@ let html = ~H"<p>Hello, ${name}!</p>"
 -- renders: <p>Hello, &lt;script&gt;alert(1)&lt;/script&gt;!</p>
 ```
 
-**Interpolation is `${expr}`, and it's auto-escaped.** Any value you interpolate is run
-through `Html.escape` before it lands in the output — the string above is safe to render
-even though it contains `<script>`, because `~H` escaped it for you. This is the
-headline reason to use `~H` instead of building HTML with plain string concatenation:
-you'd have to remember to escape every interpolated value yourself, and forgetting even
-once is exactly how HTML injection bugs happen.
+**Interpolation is `${expr}`, and you never choose how it is escaped.** The compiler
+works out where in the HTML each hole lands and applies the escaping that position
+needs. That is the headline reason to use `~H` over string concatenation: with
+concatenation you have to remember to escape every value *and* pick the right escaping
+for its position, and getting either wrong is how injection bugs happen.
+
+### What happens where
+
+The same `${name}` is treated differently depending on where you put it:
+
+| Where the hole is | What `~H` does |
+|---|---|
+| element content — `<p>${x}</p>` | HTML entity-encoding |
+| an attribute value — `<div class="${x}">` | entity-encoding, plus a backtick |
+| the start of a URL attribute — `<a href="${x}">` | **URL scheme allowlist** |
+| later in a URL — `<a href="/s?q=${x}">` | percent-encoding |
+| a `style` attribute — `<div style="color:${x}">` | CSS escaping, allowlisted functions |
+| a CSS `url()` — `style="background:url(${x})"` | URL rules that also survive CSS |
+| inside `<script>` — `<script>var n="${x}"</script>` | JavaScript string escaping |
+
+Worked through:
+
+```march
+let u = "javascript:alert(1)"
+~H"<a href=\"${u}\">x</a>"        -- <a href="about:invalid#zSoyz">x</a>
+
+let q = "a b&c"
+~H"<a href=\"/s?q=${q}\">x</a>"   -- <a href="/s?q=a%20b%26c">x</a>
+
+let col = "var(--accent)"
+~H"<div style=\"color:${col}\">"  -- <div style="color:var(--accent)">
+```
+
+A URL that fails the scheme allowlist becomes `about:invalid#zSoyz` — inert, and
+visible in the page source so the problem is obvious rather than silent. `http`,
+`https`, `mailto`, `tel`, `ftp` and any relative reference are allowed.
+
+**Unquoted attributes are quoted for you.** `<div class=${x}>` emits
+`<div class="...">`, so a value containing a space cannot start a new attribute.
+
+### What will not compile
+
+Some positions cannot be made safe by escaping at all — an attacker-chosen attribute
+name like `onerror` contains no character an encoder could touch. Those are compile
+errors rather than silently-wrong output:
+
+```march
+~H"<div ${attr}=1>x</div>"   -- error: Cannot interpolate where an attribute name
+                             --        is expected...
+~H"<${tag}>x</${tag}>"       -- error: Cannot interpolate an element name...
+~H"<!-- ${x} -->"            -- error: Cannot interpolate inside an HTML comment...
+~H"<div class=\"${x}"         -- error: This ~H template does not end in a
+                             --        well-formed state...
+```
+
+The last one catches a template that stops mid-tag or mid-attribute: whatever you
+concatenate after it would be spliced into that position.
 
 Multi-line templates use triple quotes, exactly like triple-quoted strings elsewhere in
 March:
@@ -93,18 +161,53 @@ fn render_card(title : String, body : String) : IOList do
 end
 ```
 
-### Trusted content: `Html.raw`
+### Trusted content, and why trust does not travel
 
-Sometimes you *want* to interpolate real markup — an icon's `<svg>`, or HTML you already
-sanitized elsewhere. `Html.raw` marks a string as pre-trusted, so `~H` skips escaping it:
+Sometimes you *want* to interpolate real markup — an icon's `<svg>`, or HTML you
+produced yourself. The `Html.trust_*` functions say so, and each names the context the
+trust applies to:
 
 ```march
-let icon = Html.raw("<svg>...</svg>")
-let html = ~H"<button>${icon} Click me</button>"
+let icon = Html.trust_html("<svg>...</svg>")
+~H"<button>${icon} Click me</button>"     -- <button><svg>...</svg> Click me</button>
 ```
 
-Only reach for `Html.raw` on content you generated or verified yourself — never on user
-input, since that's exactly the escaping `~H` exists to give you automatically.
+**The context matters, and this is the part worth internalising.** Trusting a string as
+HTML says nothing about whether it is a safe URL, so the same value in an `href` is
+still escaped:
+
+```march
+let h = Html.trust_html("<em>ok</em>")
+~H"<p>${h}</p>"                  -- <p><em>ok</em></p>          verbatim
+~H"<a href=\"${h}\">x</a>"        -- href="&lt;em&gt;ok&lt;/em&gt;"  escaped
+```
+
+Trust does not travel between contexts. Use the one that matches where the value is
+going:
+
+| Function | Trusted in |
+|---|---|
+| `Html.trust_html` | element content |
+| `Html.trust_attr` | an ordinary attribute value |
+| `Html.trust_url` | a URL attribute — **bypasses the scheme allowlist** |
+| `Html.trust_css` | a `style` attribute or `<style>` body |
+| `Html.trust_js` | inside `<script>` |
+
+Each has a matching `Html.untrust_*` to get the plain `String` back.
+
+Only reach for these on content you generated or verified yourself — never on user
+input, since that is exactly the escaping `~H` exists to give you automatically. Most
+templates need none of them.
+
+> **`Html.raw` is deprecated.** It still works and is treated as HTML trust, so
+> `Html.raw` in element content behaves as it always did. But it is context-free — it
+> cannot say *where* the content is trusted — so `Html.raw("javascript:...")` in an
+> `href` is escaped to `about:invalid#zSoyz` rather than inserted. Prefer
+> `Html.trust_html`, which says what it means.
+
+> **`Html.tag` is deprecated too.** It builds markup outside the sigil, so it never gets
+> this analysis and has to validate at runtime instead — it refuses element and
+> attribute names it cannot prove safe, and rejects `on*` handlers outright. Use `~H`.
 
 ### Composing templates
 
@@ -145,6 +248,18 @@ rendering a form outside of a request-handling context (no `conn` in scope), the
 isn't injected and you won't get a compile error about it — so if you rely on this
 protection, make sure the form-rendering function actually has `conn` available, rather
 than assuming every `~H` form is automatically protected.
+
+**Do not add your own token as well.** Injection is automatic, so writing
+`${CSRF.tag(conn)}` inside the form used to emit two hidden inputs. `~H` now notices an
+explicit token and skips its own injection, warning that yours is redundant — but the
+clean form is simply to leave it out:
+
+```march
+~H"<form method=\"post\">...</form>"    -- token injected for you
+```
+
+Explicit token helpers are for markup built *outside* `~H`, by string concatenation,
+where nothing is injected.
 
 ---
 

--- a/lib/ctxesc/automaton.ml
+++ b/lib/ctxesc/automaton.ml
@@ -150,7 +150,9 @@ let escaper_for (c : C.t) =
   | C.Rcdata ->
     (match c.C.element with
      | C.ElScript -> C.EscJsString
-     | C.ElStyle -> C.EscCssDecl
+     | C.ElStyle ->
+       (* a url() inside a <style> body is a URL, not a CSS value *)
+       if c.C.attr = C.AtCssUrl then C.EscCssUrl else C.EscCssDecl
      | _ -> C.EscHtml)
   | C.Attrvalue ->
     (match c.C.attr with
@@ -158,6 +160,7 @@ let escaper_for (c : C.t) =
      | C.AtUrlMid -> C.EscUrlComponent
      | C.AtStyle -> C.EscCssDecl
      | C.AtStyleValue -> C.EscCssValue
+     | C.AtCssUrl -> C.EscCssUrl
      | C.AtScript -> C.EscJsString
      | C.AtNormal -> C.EscAttr)
   | _ -> C.EscAttr  (* unreachable: every other state rejects holes *)

--- a/lib/ctxesc/context.ml
+++ b/lib/ctxesc/context.ml
@@ -38,6 +38,13 @@ type attr =
       (** a `style` attribute at a VALUE position — after a `:`. A hole here is
           a single value (`#fff`, `var(--x)`), so `:` and `;` are NOT allowed:
           either would let the value start a new declaration. *)
+  | AtCssUrl
+      (** inside a CSS `url(...)`, whether in a `style` attribute or a `<style>`
+          body. A hole here is a URL, not a CSS value: escaping it as CSS
+          mangles the slashes and breaks the reference, while escaping it as a
+          plain URL would not stop it closing the `url(`. This is the one place
+          the paper's subsidiary automata genuinely earn their keep — see
+          [EscCssUrl]. *)
   | AtScript
 
 type delim =
@@ -62,7 +69,8 @@ let all_states =
     Beforeattrvalue; Attrvalue; Comment ]
 
 let all_elements = [ ElNormal; ElScript; ElStyle; ElTextarea; ElTitle ]
-let all_attrs = [ AtNormal; AtUrl; AtUrlMid; AtStyle; AtStyleValue; AtScript ]
+let all_attrs =
+  [ AtNormal; AtUrl; AtUrlMid; AtStyle; AtStyleValue; AtCssUrl; AtScript ]
 let all_delims = [ DlNone; DlSingle; DlDouble; DlUnquoted; DlDoubleSubst ]
 
 let state_name = function
@@ -89,6 +97,7 @@ let attr_name = function
   | AtUrlMid -> "urlmid"
   | AtStyle -> "style"
   | AtStyleValue -> "stylevalue"
+  | AtCssUrl -> "cssurl"
   | AtScript -> "script"
 
 let delim_name = function
@@ -119,6 +128,7 @@ let describe c =
   | Attrvalue, AtUrlMid, _ -> "inside a URL attribute value"
   | Attrvalue, AtStyle, _ -> "at a declaration position in a style attribute"
   | Attrvalue, AtStyleValue, _ -> "at a value position in a style attribute"
+  | Attrvalue, AtCssUrl, _ -> "inside a CSS url() in a style attribute"
   | Attrvalue, AtScript, _ -> "in an event-handler attribute value"
   | Attrvalue, _, DlUnquoted -> "in an unquoted attribute value"
   | Attrvalue, _, _ -> "in an attribute value"
@@ -144,6 +154,14 @@ type escaper =
           carry `color:red;background:blue`. Appended rather than inserted so
           the existing ids stay stable -- they are shared verbatim with the C
           runtime's MARCH_ESC_* defines. *)
+  | EscCssUrl
+      (** a URL inside a CSS `url(...)`. Must be safe in the INTERSECTION of
+          three languages at once: a URL (so the scheme allowlist applies), a
+          CSS url-token (so it must not close the paren or the quoting), and —
+          when the CSS is in a `style` attribute — an HTML attribute value.
+          Neither the CSS nor the URL escaper alone is right: CSS escaping
+          mangles the slashes, and URL escaping leaves `)` free to close the
+          construct. *)
 
 let escaper_id = function
   | EscHtml -> 0
@@ -154,6 +172,7 @@ let escaper_id = function
   | EscJsString -> 5
   | EscNone -> 6
   | EscCssDecl -> 7
+  | EscCssUrl -> 8
 
 let escaper_name = function
   | EscHtml -> "html"
@@ -164,3 +183,4 @@ let escaper_name = function
   | EscJsString -> "js_string"
   | EscNone -> "none"
   | EscCssDecl -> "css_decl"
+  | EscCssUrl -> "css_url"

--- a/lib/ctxesc/escape.ml
+++ b/lib/ctxesc/escape.ml
@@ -184,6 +184,37 @@ let css ~decl s =
     Buffer.contents b
   end
 
+(* CSS url(...) — safe in the intersection of URL, CSS url-token and (when the
+   CSS is in a style attribute) HTML attribute value. Mirrors esc_css_url in
+   runtime/march_ctx_escape.c.
+
+   Neither existing escaper works: the CSS one mangles slashes, so a good
+   url(/img/logo.png) broke; the URL one leaves `)` free to close the construct.
+   Percent-encoding is right because the URL layer decodes it AFTER CSS and HTML
+   have parsed, so the escape survives meaning what it said. *)
+let css_url_safe c =
+  is_unreserved c
+  || (match c with
+      | '/' | ':' | '?' | '#' | '@' | '[' | ']'
+      | '!' | '$' | '&' | '*' | '+' | ',' | ';' | '=' | '%' -> true
+      (* NOT safe, each for a reason: parens close or nest the url-token;
+         quote and apostrophe close the CSS string or the HTML attribute;
+         angle brackets are defensive; backslash starts a CSS escape; and
+         space or control bytes terminate a url-token. *)
+      | _ -> false)
+
+let css_url s =
+  if not (url_scheme_is_allowed s) then "about:invalid#zSoyz"
+  else begin
+    let b = Buffer.create (String.length s) in
+    String.iter
+      (fun c ->
+         if css_url_safe c then Buffer.add_char b c
+         else (Buffer.add_char b '%'; buf_add_hex2 b c))
+      s;
+    Buffer.contents b
+  end
+
 let apply (e : C.escaper) s =
   match e with
   | C.EscHtml -> html_like ~attr:false s
@@ -192,13 +223,15 @@ let apply (e : C.escaper) s =
   | C.EscUrlWhole -> url_whole s
   | C.EscCssValue -> css ~decl:false s
   | C.EscCssDecl -> css ~decl:true s
+  | C.EscCssUrl -> css_url s
   | C.EscJsString -> js_string s
   | C.EscNone -> s
 
 let apply_id id s =
   match List.find_opt (fun e -> C.escaper_id e = id)
           [ C.EscHtml; C.EscAttr; C.EscUrlComponent; C.EscUrlWhole;
-            C.EscCssValue; C.EscJsString; C.EscNone; C.EscCssDecl ] with
+            C.EscCssValue; C.EscJsString; C.EscNone; C.EscCssDecl;
+            C.EscCssUrl ] with
   | Some e -> apply e s
   | None ->
     invalid_arg

--- a/runtime/march_ctx_escape.c
+++ b/runtime/march_ctx_escape.c
@@ -263,6 +263,54 @@ static void esc_css(sink *s, const char *src, size_t len, int decl) {
     }
 }
 
+/* CSS url(...) -- the one place three languages nest at once.
+ *
+ * A hole here must be safe as ALL of:
+ *   a URL          -> the scheme allowlist applies; javascript:/data: are out
+ *   a CSS url-token-> it must not close the paren or the quoting
+ *   an HTML attr   -> when the CSS lives in style="...", it must not close that
+ *
+ * Neither existing escaper is right. esc_css mangles the slashes, so a
+ * perfectly good url(/img/logo.png) came out as url(\2F img\2F logo.png) and
+ * broke. esc_url_whole leaves `)` alone, so a value could close the url() and
+ * start writing CSS.
+ *
+ * So: run the same scheme allowlist, then percent-encode only the characters
+ * that are structural in CSS or HTML, and let the rest of the URL through
+ * intact. Percent-encoding is the right tool because the URL layer decodes it
+ * AFTER CSS and HTML have finished parsing, so the escape survives to mean what
+ * it said. */
+static int css_url_safe(unsigned char c) {
+    if (is_unreserved(c)) return 1;
+    /* URL structure that must survive verbatim or the reference breaks */
+    switch (c) {
+    case '/': case ':': case '?': case '#': case '@': case '[': case ']':
+    case '!': case '$': case '&': case '*': case '+': case ',': case ';':
+    case '=': case '%':
+        return 1;
+    default:
+        return 0;
+    }
+    /* Deliberately NOT safe, and each for a specific reason:
+         ( )   would close or nest the url()
+         " '   would close the CSS string, or the HTML attribute
+         < >   defensive: keeps the value inert if it ever lands in markup
+         \     starts a CSS escape
+         space and control bytes terminate a CSS url-token */
+}
+
+static void esc_css_url(sink *s, const char *src, size_t len) {
+    if (!url_scheme_is_allowed(src, len)) {
+        put_str(s, MARCH_URL_UNSAFE_REPLACEMENT);
+        return;
+    }
+    for (size_t i = 0; i < len; i++) {
+        unsigned char c = (unsigned char)src[i];
+        if (css_url_safe(c)) put1(s, (char)c);
+        else { put1(s, '%'); put_hex2(s, c); }
+    }
+}
+
 size_t march_ctx_escape(int escaper_id, const char *src, size_t len, char *out) {
     sink s = { out, 0 };
     switch (escaper_id) {
@@ -272,6 +320,7 @@ size_t march_ctx_escape(int escaper_id, const char *src, size_t len, char *out) 
     case MARCH_ESC_URL_WHOLE:     esc_url_whole(&s, src, len); break;
     case MARCH_ESC_CSS_VALUE:     esc_css(&s, src, len, 0); break;
     case MARCH_ESC_CSS_DECL:      esc_css(&s, src, len, 1); break;
+    case MARCH_ESC_CSS_URL:       esc_css_url(&s, src, len); break;
     case MARCH_ESC_JS_STRING:     esc_js_string(&s, src, len); break;
     case MARCH_ESC_NONE:          put(&s, src, len); break;
     default:

--- a/runtime/march_ctx_escape.h
+++ b/runtime/march_ctx_escape.h
@@ -31,7 +31,8 @@
 #define MARCH_ESC_JS_STRING     5
 #define MARCH_ESC_NONE          6
 #define MARCH_ESC_CSS_DECL      7
-#define MARCH_ESC__COUNT        8
+#define MARCH_ESC_CSS_URL       8
+#define MARCH_ESC__COUNT        9
 
 /* What a URL that failed the scheme allowlist is replaced with. Chosen to be
  * inert in every context: it navigates nowhere and executes nothing. */

--- a/specs/security/README.md
+++ b/specs/security/README.md
@@ -47,7 +47,7 @@ Four fields, exactly as the paper describes:
 |---|---|
 | `state` | `pcdata` `rcdata` `tagname` `closetagname` `beforeattrname` `afterattrname` `beforeattrvalue` `attrvalue` `comment` |
 | `element` | `normal` `script` `style` `textarea` `title` |
-| `attr` | `normal` `url` `urlmid` `style` `stylevalue` `script` |
+| `attr` | `normal` `url` `urlmid` `style` `stylevalue` `cssurl` `script` |
 | `delim` | `none` `single` `double` `unquoted` `doublesubst` |
 
 `element` tracks which element's content we are inside, because `<script>` and
@@ -145,6 +145,7 @@ row — one less thing to get out of sync:
 | `attrvalue` with `attr = urlmid` | percent-encode |
 | `attrvalue` with `attr = style`, or `rcdata` in `style` | CSS **declaration** escape |
 | `attrvalue` with `attr = stylevalue` | CSS **value** escape |
+| `attr = cssurl`, or `rcdata` in `style` inside `url(` | CSS **url** escape |
 | `attrvalue` with `attr = script`, or `rcdata` in `script` | JS string escape |
 
 ## Escaper implementations
@@ -168,6 +169,22 @@ might first appear:
   (`style="${'color: red'}"`) will not work: the colon is escaped. This is
   intended. CSS has too many routes to a URL or an expression for a denylist to
   be credible, and a hole should be a *value*, not a declaration.
+
+`cssurl` is the one place three languages nest at once. A hole inside
+`url(...)` must be safe as a URL (so the scheme allowlist applies), as a CSS
+url-token (so it must not close the paren or the quoting), and — when the CSS
+sits in a `style` attribute — as an HTML attribute value. Neither the CSS nor
+the URL escaper alone works: CSS escaping mangles the slashes and breaks a
+perfectly good `url(/img/logo.png)`, while URL escaping leaves `)` free to close
+the construct and start writing CSS. The `css_url` escaper runs the scheme
+allowlist and then percent-encodes only what is structural in CSS or HTML —
+percent-encoding being the right tool because the URL layer decodes it *after*
+CSS and HTML have parsed.
+
+This is the nearest thing here to the paper's subsidiary automata. It is still a
+flat context rather than a nested automaton with codecs; see
+`specs/todos/2026-08-06-ctxesc-no-subsidiary-automata.md` for what that would
+buy and why it was not needed for this case.
 
 **The `MARCH_ESC_*` ids in `march_ctx_escape.h` must match `Context.escaper_id`
 in `lib/ctxesc/context.ml`.** That pairing is the one cross-language contract

--- a/specs/security/html-contexts.tbl
+++ b/specs/security/html-contexts.tbl
@@ -111,6 +111,17 @@ attrvalue,*,*,unquoted    | cls+:[ \t\r\n] |  | beforeattrname,=,normal,none |
 attrvalue,*,url,*         | interp         |  | =,=,=,=                  |
 attrvalue,*,url,*         | any            |  | =,=,urlmid,=             |
 
+# -- CSS url() gets its own context --
+# A hole inside url(...) is a URL, not a CSS value. Escaping it as CSS mangles
+# the slashes and breaks the reference; escaping it as a plain URL would leave
+# `)` free to close the construct. `ilit` because `URL(` is valid CSS.
+# These MUST precede the generic style/stylevalue rows below.
+attrvalue,*,style,*       | ilit:"url("    |  | =,=,cssurl,=             |
+attrvalue,*,stylevalue,*  | ilit:"url("    |  | =,=,cssurl,=             |
+attrvalue,*,cssurl,*      | lit:")"        |  | =,=,stylevalue,=         |
+attrvalue,*,cssurl,*      | interp         |  | =,=,=,=                  |
+attrvalue,*,cssurl,*      | any            |  | =,=,=,=                  |
+
 # -- CSS position tracking --
 # A style attribute alternates between DECLARATION and VALUE positions, and the
 # two need different escapers: a declaration list may contain `:` and `;`, a
@@ -130,6 +141,12 @@ attrvalue,*,*,*           | any            |  | =,=,=,=                  |
 # ── RCDATA / RAW TEXT (script, style, textarea, title bodies) ────────────
 # Exit only on the MATCHING close tag, case-insensitively -- `</b>` inside a
 # script string must not be mistaken for the end of the script.
+# A url() inside a <style> body needs the same context as one in a style
+# attribute -- the language nesting is identical, only the outer wrapper differs.
+rcdata,style,*,*      | ilit:"url("       |  | =,=,cssurl,=            |
+rcdata,style,cssurl,* | lit:")"           |  | =,=,normal,=            |
+rcdata,style,cssurl,* | interp            |  | =,=,=,=                 |
+
 rcdata,script,*,*     | ilit:"</script"   |  | closetagname,normal,=,= |
 rcdata,style,*,*      | ilit:"</style"    |  | closetagname,normal,=,= |
 rcdata,textarea,*,*   | ilit:"</textarea" |  | closetagname,normal,=,= |

--- a/test/dune
+++ b/test/dune
@@ -4358,3 +4358,31 @@ printf 'mod CsHelper do\\n\\n  fn double(x : Int) : Int do\\n    x * 2\\n  end\\
 (rule
  (alias runtest)
  (action (diff native/h_trusted_context.expected native_h_trusted_context.out)))
+
+; ── CSS url() context: compiled/interpreted parity ───────────────────────
+; A hole inside url() must be safe as a URL, as a CSS url-token, AND as an HTML
+; attribute value. Closes the subsidiary-automata gap recorded in
+; specs/todos/2026-08-06-ctxesc-no-subsidiary-automata.md.
+(rule
+ (targets native_h_css_url_context native_h_css_url_context.out)
+ (deps (file %{exe:../bin/main.exe})
+       (file ../runtime/march_runtime.c) (file ../runtime/march_runtime.h)
+       (file ../runtime/march_scheduler.c) (file ../runtime/march_scheduler.h)
+       (file ../runtime/march_heap.c) (file ../runtime/march_heap.h)
+       (file ../runtime/march_gc.c) (file ../runtime/march_gc.h)
+       (file ../runtime/march_message.c) (file ../runtime/march_message.h)
+       (file ../runtime/march_deque.h)
+       (file ../runtime/march_extras.c) (file ../runtime/march_ctx_escape.c)
+       (file ../runtime/march_ctx_escape.h) (file ../runtime/march_compress.c)
+       (file ../runtime/base64.c) (file ../runtime/sha1.c)
+       (file native/h_css_url_context.march))
+ (action
+  (progn
+   (run %{exe:../bin/main.exe} --compile -o native_h_css_url_context
+        native/h_css_url_context.march)
+   (with-stdout-to native_h_css_url_context.out
+        (system "./native_h_css_url_context")))))
+
+(rule
+ (alias runtest)
+ (action (diff native/h_css_url_context.expected native_h_css_url_context.out)))

--- a/test/native/h_css_url_context.expected
+++ b/test/native/h_css_url_context.expected
@@ -1,0 +1,10 @@
+rel-attr : <div style="background:url(/img/logo.png)">x</div>
+abs-query: <div style="background:url(https://cdn.example/a/b.png?v=2&x=1)">x</div>
+rel-body : <style>a{background:url(/img/logo.png)}</style>
+js-attr  : <div style="background:url(about:invalid#zSoyz)">x</div>
+js-body  : <style>a{background:url(about:invalid#zSoyz)}</style>
+breakout : <div style="background:url(%29%20;background:red;a:url%28)">x</div>
+attr-out : <div style="background:url(%22%20onload=%22alert%281%29)">x</div>
+style-out: <style>a{background:url(x%3C/style%3E%3Cscript%3Ealert%281%29%3C/script%3E)}</style>
+plain-css: <div style="color:var(--text-muted)">x</div>
+upper    : <div style="background:URL(about:invalid#zSoyz)">x</div>

--- a/test/native/h_css_url_context.march
+++ b/test/native/h_css_url_context.march
@@ -1,0 +1,47 @@
+-- A CSS url(...) gets its own parse context (Task: close the subsidiary-automata
+-- gap recorded in specs/todos/2026-08-06-ctxesc-no-subsidiary-automata.md).
+--
+-- A hole inside url() must be safe in the INTERSECTION of three languages: a
+-- URL (the scheme allowlist applies), a CSS url-token (it must not close the
+-- paren), and -- when the CSS is in a style attribute -- an HTML attribute
+-- value. Neither existing escaper worked:
+--
+--   esc_css   mangled the slashes, so url(/img/logo.png) came out as
+--             url(\2F img\2F logo.png) and the image never loaded
+--   esc_url_*  left `)` alone, so a value could close the url() and write CSS
+--
+-- Percent-encoding is the right tool because the URL layer decodes it AFTER
+-- CSS and HTML have finished parsing, so the escape survives meaning what it
+-- said.
+--
+-- Compiled/interpreted golden diff.
+mod CssUrl do
+  fn main() : Unit do
+    -- legitimate URLs must survive intact
+    let a = "/img/logo.png"
+    println("rel-attr : " ++ IOList.to_string(~H"<div style=\"background:url(${a})\">x</div>"))
+    let b = "https://cdn.example/a/b.png?v=2&x=1"
+    println("abs-query: " ++ IOList.to_string(~H"<div style=\"background:url(${b})\">x</div>"))
+    let c = "/img/logo.png"
+    println("rel-body : " ++ IOList.to_string(~H"<style>a{background:url(${c})}</style>"))
+    -- hostile schemes rejected
+    let d = "javascript:alert(1)"
+    println("js-attr  : " ++ IOList.to_string(~H"<div style=\"background:url(${d})\">x</div>"))
+    println("js-body  : " ++ IOList.to_string(~H"<style>a{background:url(${d})}</style>"))
+    -- must not CLOSE the url() and write new CSS
+    let e = ") ;background:red;a:url("
+    println("breakout : " ++ IOList.to_string(~H"<div style=\"background:url(${e})\">x</div>"))
+    -- must not close the HTML attribute
+    let f = "\" onload=\"alert(1)"
+    println("attr-out : " ++ IOList.to_string(~H"<div style=\"background:url(${f})\">x</div>"))
+    -- must not close a <style> element
+    let g = "x</style><script>alert(1)</script>"
+    println("style-out: " ++ IOList.to_string(~H"<style>a{background:url(${g})}</style>"))
+    -- a plain CSS value is unaffected by the new context
+    let h = "var(--text-muted)"
+    println("plain-css: " ++ IOList.to_string(~H"<div style=\"color:${h}\">x</div>"))
+    -- uppercase URL( must enter the same context
+    let i = "javascript:alert(1)"
+    println("upper    : " ++ IOList.to_string(~H"<div style=\"background:URL(${i})\">x</div>"))
+  end
+end

--- a/test/test_ctx_escape.c
+++ b/test/test_ctx_escape.c
@@ -65,6 +65,7 @@ int main(void) {
         { MARCH_ESC_JS_STRING,     "js_string" },
         { MARCH_ESC_NONE,          "none" },
         { MARCH_ESC_CSS_DECL,      "css_decl" },
+        { MARCH_ESC_CSS_URL,       "css_url" },
     };
     for (int i = 0; i < MARCH_ESC__COUNT; i++) {
         checks++;
@@ -200,6 +201,29 @@ int main(void) {
     expect_absent(MARCH_ESC_CSS_VALUE, "a\"b", "\"", "css escapes a quote");
     expect_absent(MARCH_ESC_CSS_VALUE, "a/*x*/b", "/", "css escapes a comment");
     expect_absent(MARCH_ESC_CSS_DECL, "@import url(x)", "@", "css escapes @import");
+
+    /* ── CSS url() ───────────────────────────────────────────────────────
+       Safe in the intersection of URL, CSS url-token and HTML attribute. The
+       first case is the regression: esc_css mangled the slashes and broke a
+       perfectly good relative URL. */
+    expect(MARCH_ESC_CSS_URL, "/img/logo.png", "/img/logo.png",
+           "css url keeps a relative path intact");
+    expect(MARCH_ESC_CSS_URL, "https://cdn.example/a.png?v=2&x=1",
+           "https://cdn.example/a.png?v=2&x=1",
+           "css url keeps a query string intact");
+    expect(MARCH_ESC_CSS_URL, "javascript:alert(1)", MARCH_URL_UNSAFE_REPLACEMENT,
+           "css url rejects javascript:");
+    expect(MARCH_ESC_CSS_URL, "  JaVaScRiPt:alert(1)", MARCH_URL_UNSAFE_REPLACEMENT,
+           "css url rejects an obfuscated javascript:");
+    /* must not close the url(), the CSS string, the HTML attribute, or a
+       <style> element */
+    expect_absent(MARCH_ESC_CSS_URL, "a)b", ")", "css url escapes a close paren");
+    expect_absent(MARCH_ESC_CSS_URL, "a(b", "(", "css url escapes an open paren");
+    expect_absent(MARCH_ESC_CSS_URL, "a\"b", "\"", "css url escapes a quote");
+    expect_absent(MARCH_ESC_CSS_URL, "a'b", "'", "css url escapes an apostrophe");
+    expect_absent(MARCH_ESC_CSS_URL, "a</style>b", "<", "css url escapes a tag open");
+    expect_absent(MARCH_ESC_CSS_URL, "a\\b", "\\", "css url escapes a backslash");
+    expect_absent(MARCH_ESC_CSS_URL, "a b", " ", "css url escapes a space");
 
     /* ── None ────────────────────────────────────────────────────────────── */
     expect(MARCH_ESC_NONE, "<b>&", "<b>&", "none passes through verbatim");


### PR DESCRIPTION
Two commits: the last reachable gap between our implementation and the paper, plus the doc rewrite that gap's fix made necessary.

## 1. CSS `url()` gets its own parse context

Found by checking the implementation against the paper (arXiv:2605.16561v1), which mediates nested languages through subsidiary automata and codecs. We flatten that into the context tuple — and the flattening had a reachable cost:

```
url(/img/logo.png)        was  url(\2F img\2F logo.png)      BROKEN
                          now  url(/img/logo.png)             intact

url(javascript:alert(1))  was  url(javascript:alert\28 1\29 )  colon SURVIVED
                          now  url(about:invalid#zSoyz)        rejected
```

The first is a plain defect: a legitimate relative URL was mangled and the image never loaded.

### Why a new escaper rather than reusing one

A hole inside `url(...)` must be safe in the **intersection of three languages** at once — a URL (so the scheme allowlist applies), a CSS url-token (so it must not close the paren or the quoting), and, when the CSS sits in a `style` attribute, an HTML attribute value. Neither existing escaper spans that:

- `esc_css` mangles the slashes → breaks every legitimate URL
- `esc_url_whole` leaves `)` alone → the value can close the `url(` and start writing CSS

So `cssurl` becomes its own `attr` context (entered on `ilit:"url("`, left on `")"`, in both a `style` attribute and a `<style>` body — the nesting is identical, only the outer wrapper differs), with an escaper that runs the scheme allowlist then percent-encodes only what is structural in CSS or HTML.

**Percent-encoding is the right tool specifically because the URL layer decodes it *after* CSS and HTML have parsed**, so the escape survives meaning what it said — which CSS `\XX ` escaping does not.

Verified across every breakout route:

| attack | result |
|---|---|
| close the `url()` — `") ;background:red"` | `%29` |
| close the HTML attribute — `"\" onload=…"` | `%22` |
| close the `<style>` element — `"x</style><script>"` | `%3C` `%3E` |
| `javascript:` and obfuscated `JaVaScRiPt:` | `about:invalid#zSoyz` |

Legitimate URLs survive whole, **including query strings with `&`** — which the plain url-component escaper would have wrecked. `URL(` uppercase enters the same context. Interpreted == compiled.

**Still a flat context, not a nested automaton with codecs.** `specs/security/README.md` says so, and `specs/todos/2026-08-06-ctxesc-no-subsidiary-automata.md` stays open for what a real subsidiary automaton would buy — which is nothing this case needed.

## 2. The `~H` docs were stale, and one part was actively misleading

`docs/sigils.md` described pre-#202 behaviour. Its `Html.raw` section **taught a pattern that now behaves differently**: someone following it would put `Html.raw` in a URL attribute and get `about:invalid#zSoyz` rather than verbatim insertion, with nothing on the page to suggest anything had changed.

**Naming.** Called *contextual auto-escaping* throughout — the established term (Go's `html/template`, Closure Templates, and the paper). The differentiator goes in the tagline rather than the name: escaping is decided at **compile time**, and unsafe positions are **compile errors**. I avoided "safe templates" and "injection-proof"; both overclaim, and the guarantee has known edges.

**Framing.** Leads with what the developer *doesn't* do — no choosing escapers, no `Html.escape`, no reasoning about position. The automaton and transition tables stay out of user docs; `specs/security/README.md` is their home.

`docs/sigils.md` now has:
- **What happens where** — a position → escaping table, with worked output for the three that surprise people
- **What will not compile** — the four hard errors, quoting the compiler's real messages
- **Trusted content, and why trust does not travel** — replaces the `Html.raw` section, leading with the counterintuitive part: trusting a string as HTML says nothing about it being a safe URL
- `Html.raw` and `Html.tag` marked deprecated with what changed for each
- `~xml`/`~toml`/`~yaml` documented as refusing interpolation

`docs/cookbook/html.md` had a third problem beyond the same `Html.raw` issue: its layout example did `${Html.raw(IOList.to_string(body))}`, a round-trip through `String` and back. An `IOList` composes directly, so `${body}` suffices — the old form taught a habit that only *looks* necessary and spreads by copy-paste.

**Every example in both files was run before publishing**, including the cookbook's full user-list page end to end with `<` injected into a user's email, to confirm escaping still fires through `Html.list` and nested partials. The outputs shown are real; the error text is copied from the compiler, not paraphrased.

## Verification

73 C escaper checks. `test/native/h_css_url_context.march` is a compiled/interpreted golden diff covering legitimate URLs, hostile schemes, and all four breakout routes.

Suites: compiler 791, eval 256, codegen 546, stdlib 833 — all green. doc-lint passes.
