### PR TITLE
caps: the ceiling's "indirect calls" false positive was two tables disagreeing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ git log is authoritative for exact commits.
 
 ### Fixed
 
+- **`--cap-strict` no longer rejects correct programs that call `task_spawn`,
+  `unix_time_ms`, `uuid_v7`, or the `Signal` builtins.** These are lowered
+  through a trampoline rather than a named C symbol, and the capability
+  ceiling looked them up by C symbol only — so `IO.Spawn`, `IO.Clock` and
+  `IO.Signal` uses could not be charged to the calling module even when it
+  declared them. The reported reason ("reached only through indirect calls")
+  was itself wrong; the calls were direct. Attribution now consults the same
+  March-name table the typechecker uses.
+
 - **Actor messages can no longer carry a `NativeIntArr`/`NativeFloatArr` (the types
   backing the `NativeArray` stdlib module)** — the same "must be owned by a single
   actor" restriction `RingBuf` already had.

--- a/lib/tir/cap_attrib.ml
+++ b/lib/tir/cap_attrib.ml
@@ -4,14 +4,38 @@
 
 module SSet = Set.Make (String)
 
-(* March builtin name → capability, via the same name→C-symbol table codegen
-   uses.  Resolved through [c_symbol_of_march_name], NOT [mangle_extern]:
-   the latter records into the marker accumulator, and an analysis that
-   walks unreachable-at-emit code would mark capabilities the binary never
-   references. *)
+(* March builtin name → capability.
+
+   Consults [Typecheck.builtin_cap_table] (keyed by MARCH NAME) FIRST, then
+   falls back to [Cap_symbols] (keyed by C SYMBOL) via
+   [c_symbol_of_march_name] — NOT [mangle_extern]: the latter records into the
+   marker accumulator, and an analysis that walks unreachable-at-emit code
+   would mark capabilities the binary never references.
+
+   The March-name lookup was added 2026-08-07 because the C-symbol route alone
+   silently missed TEN capability-bearing builtins — every one of IO.Clock's,
+   IO.Signal's and IO.Spawn's. [c_symbol_of_march_name] returns its argument
+   UNCHANGED for a builtin with no [c_name] (a trampoline-lowered one like
+   [task_spawn]), and the bare March name is not a key in [Cap_symbols], so the
+   lookup quietly yielded [None] and attribution learned nothing.
+
+   The symptom did not look like a table mismatch. `--cap-strict` reported
+   "`IO.Spawn` is used but cannot be attributed to any module — it is reached
+   only through indirect calls" on programs that call [task_spawn] directly and
+   declare `needs IO.Spawn`; [Unattributed] simply had no better explanation to
+   offer. Four of a 24-program sample failed that way, all parallel code, none
+   fixable by declaring anything.
+
+   The C-symbol fallback is still required: [Cap_symbols] also keys synthesized
+   post-lowering symbols ([march_task_spawn_thunk]) that never appear as a
+   March name. Both tables are live; [test_cap_attrib_agreement] asserts they
+   agree for every capability-bearing builtin so a third one cannot drift in. *)
 let cap_of_call (name : string) : string option =
-  March_caps.Cap_symbols.cap_of_symbol
-    (Llvm_builtins.c_symbol_of_march_name name)
+  match List.assoc_opt name March_typecheck.Typecheck.builtin_cap_table with
+  | Some cap -> Some cap
+  | None ->
+    March_caps.Cap_symbols.cap_of_symbol
+      (Llvm_builtins.c_symbol_of_march_name name)
 
 (* A builtin can also appear as a VALUE rather than a call — [apply1(file_read,
    p)] passes it as an atom, and only later does defun synthesize the apply

--- a/lib/tir/cap_attrib.mli
+++ b/lib/tir/cap_attrib.mli
@@ -55,3 +55,11 @@ val attribute :
     row — the flat marker still reports the capability, it just carries no
     owner. Consumers must therefore treat "flat caps minus attributed caps"
     as unattributed rather than as absent. *)
+
+val cap_of_call : string -> string option
+(** [cap_of_call march_name] is the capability a call to [march_name] implies,
+    as [attribute] resolves it.  Exposed so [test_cap_attrib_agreement] can
+    assert this answers identically to [Typecheck.builtin_cap_table] for every
+    capability-bearing builtin — the two tables are keyed differently (March
+    name vs C symbol) and silently disagreed for the trampoline-lowered spawn
+    builtins, which made `--cap-strict` call them unattributable. *)

--- a/specs/progress/2026-08-07-cap-attrib-table-agreement.md
+++ b/specs/progress/2026-08-07-cap-attrib-table-agreement.md
@@ -1,0 +1,108 @@
+# The ceiling's "indirect calls" false positive was two tables disagreeing
+
+Landed 2026-08-07.
+
+## The symptom, and why it misled
+
+`--cap-strict` rejected correct programs:
+
+```
+$ march --compile --cap-strict -o /tmp/x bench/par_fib.march
+-- CAPABILITY CEILING --
+`IO.Spawn` is used but cannot be attributed to any module — it is reached only
+through indirect calls, whose callee is not statically known
+```
+
+`bench/par_fib.march` calls `task_spawn` **directly in its own body** (lines
+37–38) and declares `needs IO.Spawn` **on line 24**. Nothing about it is
+indirect, and no amount of declaring fixes it — the author already declared it.
+
+Measured before the fix: **4 of a 24-program sample** failed this way, all of
+them parallel code. That made defaulting `--cap-strict` impossible, because the
+diagnostic told users to do something that could not work.
+
+## The cause: two capability tables, keyed differently
+
+March has two, both load-bearing:
+
+| table | key | drives |
+|---|---|---|
+| `Typecheck.builtin_cap_table` | March name (`task_spawn`) | source-level checks — Check 1b, and the severity flip |
+| `Cap_symbols` | C symbol (`march_task_spawn_thunk`) | `Cap_attrib.attribute`, which the ceiling reads |
+
+`Cap_attrib.cap_of_call` bridged them with
+`Cap_symbols.cap_of_symbol (c_symbol_of_march_name name)`. That function returns
+its argument **unchanged** when a builtin has no `c_name` — a trampoline-lowered
+one like `task_spawn` — and the bare March name is not a key in `Cap_symbols`.
+So the lookup returned `None`, attribution recorded nothing, and the capability
+arrived in the ceiling's flat set with no owner.
+
+`Cap_ceiling.Unattributed` then reported it with the only explanation it had.
+
+## The fix
+
+`cap_of_call` consults `builtin_cap_table` (March name) first and falls back to
+`Cap_symbols` (C symbol). The fallback is still required: `Cap_symbols` also
+keys synthesized post-lowering symbols (`march_task_spawn_thunk`) that never
+appear as a March name.
+
+No table was duplicated — `march_tir` already depends on `march_typecheck`, so
+attribution now reads the *same* table typecheck does.
+
+## The test is the deliverable
+
+`test/test_cap_attrib_agreement.ml` asserts that every capability-bearing
+builtin in `builtin_cap_table` resolves to the *same* capability through
+attribution's path.
+
+**It found more than I did.** My source grep for `c_name = None` predicted 3
+affected builtins; the test found **10** — every one of `IO.Clock`'s,
+`IO.Signal`'s and `IO.Spawn`'s:
+
+```
+unix_time_ms, uuid_v7            IO.Clock
+signal_watch, signal_unwatch,
+  signal_raise_self              IO.Signal
+task_spawn, task_spawn_link,
+  task_spawn_steal,
+  task_spawn_with_cancel,
+  get_work_pool                  IO.Spawn
+```
+
+Three whole capability families were invisible to the ceiling. A grep-based
+estimate would have shipped a fix for a third of the problem and left the rest
+to be rediscovered.
+
+## Result
+
+`examples/` + `bench/`, all 72 programs, `--compile --cap-strict`:
+
+| | before | after |
+|---|---|---|
+| unattributed (false positives) | ~17% of sample | **1 of 72** |
+| undeclared (genuine violations) | — | 12 |
+
+The 12 undeclared are the ceiling working as intended — stdlib-mediated uses the
+module really has not declared. They are the migration that a future
+`--cap-strict`-by-default change has to do, and they are actionable: the
+diagnostic names the module and the capability.
+
+## What is left, and it is a different bug
+
+The single remaining false positive is `examples/capabilities.march`, and it is
+**not** the indirect-call gap despite the message saying so: a capability that
+appears only in a SIGNATURE (`fn demo_narrowing(cap : Cap(IO))`) is counted as
+used by the typecheck side and can never be attributed by the emitted-code side.
+Filed as
+`specs/todos/2026-08-07-ceiling-counts-signature-only-capabilities-as-used.md`,
+with a note not to "fix" it by treating declared-anywhere as attributed, which
+would defeat the fail-closed rule.
+
+That todo also records the meta-lesson: `Cap_ceiling.describe` has one
+`Unattributed` constructor that always blames indirect calls, so it
+misdescribed its own cause for the entire `task_spawn` investigation and would
+do so again. Carrying a reason on the constructor is cheap.
+
+## Verification
+
+corpus 277/277, compiler 799, eval 256, stdlib 833, codegen 546.

--- a/specs/todos/2026-08-07-ceiling-counts-signature-only-capabilities-as-used.md
+++ b/specs/todos/2026-08-07-ceiling-counts-signature-only-capabilities-as-used.md
@@ -1,0 +1,52 @@
+# The ceiling counts a signature-only capability as an unattributable use
+
+Found 2026-08-07 while fixing indirect-call attribution
+(`specs/progress/2026-08-07-cap-attrib-table-agreement.md`). It is the last
+remaining `--cap-strict` false positive in `examples/` + `bench/` — 1 of 72.
+
+- [ ] **A capability that appears only in a SIGNATURE is reported as
+  "cannot be attributed to any module".** Reproducer is in the tree:
+
+  ```
+  $ march --compile --cap-strict -o /tmp/x examples/capabilities.march
+  -- CAPABILITY CEILING --
+  `IO` is used but cannot be attributed to any module — it is reached only
+  through indirect calls, whose callee is not statically known
+  ```
+
+  The module declares `needs IO` and the only thing naming the root is a
+  parameter type — `fn demo_narrowing(cap : Cap(IO)) : Unit` at
+  `examples/capabilities.march:60`, which exists to demonstrate narrowing.
+
+  **Mechanism, and note it is NOT the indirect-call gap the message names.**
+  `--cap-strict` compares two sets:
+
+  - `flat_caps` — the union of attribution's caps and
+    `own_caps_of_this_module` (`bin/main.ml`), the latter derived from
+    typecheck's per-function closures, which record SIGNATURE capabilities;
+  - `attribution` — `Cap_attrib.attribute` over emitted TIR, which produces a
+    row only for a capability reached by an emitted CALL.
+
+  A signature type is not emitted code, so attribution can never produce a row
+  for it, while `own_caps_of_this_module` always contributes one to
+  `flat_caps`. `Cap_ceiling.check` computes "flat minus attributed" and reports
+  the difference as `Unattributed`, whose `describe` blames indirect calls
+  because that was the only cause it was written for.
+
+  **Do not fix by treating "declared by some module" as attributed** — that
+  would mask a genuine unattributed use whenever any module in the program
+  declares the same capability, which is the case the fail-closed rule in
+  `cap_ceiling.mli` exists for.
+
+  The likely right answer is that the unattributed check should compare
+  against BODY-derived uses only, since its stated purpose is "a capability
+  nobody can be held responsible for" and a capability sitting in a type is
+  not routed anywhere. That needs `own_caps_of_this_module` to distinguish
+  signature-derived from body-derived caps, which it currently does not.
+
+  Whatever lands should also fix `Cap_ceiling.describe`: a single
+  `Unattributed` constructor that always blames indirect calls produced a
+  diagnostic that misdescribed its own cause for the whole of the
+  `task_spawn` bug, and would do so again here. Carrying a reason on the
+  constructor is cheap and would have shortened both investigations
+  considerably.

--- a/test/dune
+++ b/test/dune
@@ -11,7 +11,7 @@
 (library
  (name march_test_compiler)
  (wrapped false)
- (modules test_compiler test_cap_strip test_cap_symbols test_cap_markers test_cap_package test_cap_scope test_cap_ceiling test_cap_unforgeable test_ctxesc)
+ (modules test_compiler test_cap_strip test_cap_symbols test_cap_markers test_cap_package test_cap_scope test_cap_ceiling test_cap_unforgeable test_cap_attrib_agreement test_ctxesc)
  (libraries march_test_helpers march_lexer march_parser march_ast march_desugar march_typecheck march_refinecheck march_errors march_effects march_eval march_tir march_repl march_debug march_scheduler march_cas march_caps march_ctxesc march_modules march_resolver march_forge march_lint alcotest str unix threads.posix))
 
 (library

--- a/test/test_cap_attrib_agreement.ml
+++ b/test/test_cap_attrib_agreement.ml
@@ -1,0 +1,88 @@
+(* The two capability tables must agree.
+
+   March has two, keyed differently, and both are load-bearing:
+
+   - [Typecheck.builtin_cap_table] maps a MARCH NAME to a capability. It drives
+     the source-level checks (Check 1b, and the severity flip that made an
+     undeclared direct builtin call an error).
+   - [Cap_symbols] maps a C SYMBOL to a capability. It drives
+     [Cap_attrib.attribute], which charges emitted TIR to an owning module and
+     is what `--cap-strict`'s ceiling reads.
+
+   They are bridged by [Llvm_builtins.c_symbol_of_march_name], which returns the
+   name UNCHANGED when a builtin has no [c_name] — a trampoline-lowered builtin
+   like [task_spawn]. The bare name is not in [Cap_symbols], so attribution
+   silently learned nothing about it while typecheck knew its capability
+   exactly.
+
+   The failure that produced this test is worth stating, because it did not look
+   like a table mismatch. `--cap-strict` reported:
+
+     `IO.Spawn` is used but cannot be attributed to any module — it is reached
+     only through indirect calls, whose callee is not statically known
+
+   on `bench/par_fib.march`, which calls [task_spawn] DIRECTLY in its own body
+   and declares `needs IO.Spawn` on line 24. Nothing was indirect; the ceiling
+   said so because [Unattributed] had no other explanation to offer. Four of a
+   24-program sample failed this way, all of them parallel code, and none of
+   them could be fixed by declaring anything — the author had already declared
+   it.
+
+   So this test asserts the bridge, not the fix: every capability-bearing
+   builtin typecheck knows must resolve to the SAME capability through the path
+   attribution uses. A new builtin that lands in one table and not the other
+   fails here rather than in a user's `--cap-strict` build with a diagnostic
+   that misdescribes its own cause. *)
+
+let cap_via_attribution (march_name : string) : string option =
+  (* Exactly the lookup [Cap_attrib.cap_of_call] performs. *)
+  March_tir.Cap_attrib.cap_of_call march_name
+
+let test_every_capability_builtin_is_attributable () =
+  let missing =
+    List.filter_map
+      (fun (march_name, expected_cap) ->
+         match cap_via_attribution march_name with
+         | Some c when c = expected_cap -> None
+         | Some c ->
+           Some (Printf.sprintf
+                   "%s: typecheck says %s, attribution says %s"
+                   march_name expected_cap c)
+         | None ->
+           Some (Printf.sprintf
+                   "%s: typecheck says %s, attribution resolves NOTHING"
+                   march_name expected_cap))
+      March_typecheck.Typecheck.builtin_cap_table
+  in
+  if missing <> [] then
+    Alcotest.failf
+      "%d capability-bearing builtin(s) are invisible to attribution, so \
+       `--cap-strict` reports them as unattributable even when the module \
+       declares them:\n  %s"
+      (List.length missing)
+      (String.concat "\n  " missing)
+
+(* The specific builtins that were broken, pinned by name.  The bulk assertion
+   above would catch a regression, but naming these keeps the original failure
+   legible: all three are trampoline-lowered (c_name = None), which is the
+   property that made them fall through. *)
+let test_trampoline_lowered_spawn_builtins_resolve () =
+  List.iter
+    (fun name ->
+       match cap_via_attribution name with
+       | Some "IO.Spawn" -> ()
+       | Some c -> Alcotest.failf "%s resolved to %s, expected IO.Spawn" name c
+       | None ->
+         Alcotest.failf
+           "%s resolves to no capability — it is trampoline-lowered \
+            (c_name = None), so c_symbol_of_march_name returns the bare name \
+            and Cap_symbols does not know it"
+           name)
+    [ "task_spawn"; "task_spawn_steal"; "get_work_pool" ]
+
+let tests =
+  [ Alcotest.test_case "every capability builtin is attributable" `Quick
+      test_every_capability_builtin_is_attributable;
+    Alcotest.test_case "trampoline-lowered spawn builtins resolve" `Quick
+      test_trampoline_lowered_spawn_builtins_resolve;
+  ]

--- a/test/test_compiler.ml
+++ b/test/test_compiler.ml
@@ -12407,6 +12407,7 @@ let compiler_suites =
       ("cap_scope", Test_cap_scope.tests);
       ("cap_ceiling", Test_cap_ceiling.tests);
       ("cap_unforgeable", Test_cap_unforgeable.tests);
+      ("cap_attrib_agreement", Test_cap_attrib_agreement.tests);
       ( "match_diagnostics",
         [
           Alcotest.test_case "or-pattern binding accepted" `Quick


### PR DESCRIPTION
## The symptom, and why it misled

`--cap-strict` rejected correct programs:

```
$ march --compile --cap-strict -o /tmp/x bench/par_fib.march
-- CAPABILITY CEILING --
`IO.Spawn` is used but cannot be attributed to any module — it is reached only
through indirect calls, whose callee is not statically known
```

`bench/par_fib.march` calls `task_spawn` **directly in its own body** (lines 37–38) and declares `needs IO.Spawn` **on line 24**. Nothing was indirect, and no amount of declaring fixed it — the author had already declared it. **4 of a 24-program sample** failed this way, all parallel code, which made defaulting `--cap-strict` impossible: the diagnostic told users to do something that could not work.

## Cause: two capability tables, keyed differently

| table | key | drives |
|---|---|---|
| `Typecheck.builtin_cap_table` | March name (`task_spawn`) | source checks — Check 1b, the severity flip |
| `Cap_symbols` | C symbol (`march_task_spawn_thunk`) | `Cap_attrib.attribute`, which the ceiling reads |

`Cap_attrib.cap_of_call` bridged them via `Cap_symbols.cap_of_symbol (c_symbol_of_march_name name)`. That returns its argument **unchanged** for a builtin with no `c_name` — a trampoline-lowered one like `task_spawn` — and the bare March name is not a key in `Cap_symbols`. Lookup yielded `None`, attribution recorded nothing, and the capability reached the ceiling with no owner. `Cap_ceiling.Unattributed` then reported it with the only explanation it had.

## Fix

`cap_of_call` consults `builtin_cap_table` first, falling back to `Cap_symbols`. The fallback is still required — `Cap_symbols` also keys synthesized post-lowering symbols that never appear as a March name. No table was duplicated: `march_tir` already depends on `march_typecheck`, so attribution now reads the *same* table typecheck does.

## The test is the deliverable, and it found more than I did

My grep for `c_name = None` predicted 3 affected builtins. `test/test_cap_attrib_agreement.ml` found **10** — every one of `IO.Clock`'s, `IO.Signal`'s and `IO.Spawn`'s: `unix_time_ms`, `uuid_v7`, `signal_watch`, `signal_unwatch`, `signal_raise_self`, `task_spawn`, `task_spawn_link`, `task_spawn_steal`, `task_spawn_with_cancel`, `get_work_pool`. Three whole capability families were invisible to the ceiling; a grep-based fix would have shipped a third of the problem.

## Result

`examples/` + `bench/`, all 72 programs under `--compile --cap-strict`:

| | before | after |
|---|---|---|
| unattributed (false positives) | ~17% of sample | **1 of 72** |
| undeclared (genuine violations) | — | 12 |

The 12 undeclared are the ceiling working as intended on stdlib-mediated uses; they are the migration a future `--cap-strict`-by-default change has to do, and the diagnostic names the module and the capability.

## What's left, and it's a different bug

The last false positive is `examples/capabilities.march`, and despite the identical message it is **not** the indirect-call gap: a capability appearing only in a SIGNATURE (`fn demo_narrowing(cap : Cap(IO))`) is counted as used by the typecheck side and can never be attributed by the emitted-code side. Filed as `specs/todos/2026-08-07-ceiling-counts-signature-only-capabilities-as-used.md`, with a warning not to "fix" it by treating declared-anywhere as attributed — that defeats `cap_ceiling.mli`'s fail-closed rule — plus the meta-lesson that one `Unattributed` constructor which always blames indirect calls misdescribed its own cause throughout this investigation.

## Review focus

`lib/tir/cap_attrib.ml` — confirm the `Cap_symbols` fallback is retained, not replaced. Dropping it would break attribution for synthesized symbols like `march_task_spawn_thunk`, which the agreement test does *not* cover (it only walks March names).

## Verification

corpus 277/277, compiler 799, eval 256, stdlib 833, codegen 546, `check-docs.sh` pass.