### PR TITLE
test(node): re-quarantine node_discovery (torn-output race flakes Linux CI)

### DIFF
--- a/specs/todos/2026-07-24-quarantined-tests-coverage-that-is-currently-dark-inventory-2026.md
+++ b/specs/todos/2026-07-24-quarantined-tests-coverage-that-is-currently-dark-inventory-2026.md
@@ -2,19 +2,22 @@
 
 
 **Read this before assuming a green CI run means the corresponding behavior works.**
-As of 2026-08-08, only **one** test remains pulled out of `dune runtest` onto its own
-alias: `test/signal_term_suppress_quarantined`. The struck rows below were revived —
-`forge/test/build_check` (made hermetic), and the three real-TCP node tests
-(`node_call_loopback`, `node_discovery`, `rpc_auto_enroll`, now binding ephemeral ports).
-The one remaining is quarantined on a **genuinely unresolved concurrency race, not a test
-bug** — the behavior it pins is unverified on every commit, and a regression there would
-not turn CI red. Quarantining was a containment decision (it flaked CI), explicitly not a
-fix.
+As of 2026-08-08, **two** tests remain pulled out of `dune runtest` onto their own
+aliases: `test/signal_term_suppress_quarantined` and `test/node_discovery_quarantined`.
+The struck rows below were revived — `forge/test/build_check` (made hermetic) and two of
+the three real-TCP node tests (`node_call_loopback`, `rpc_auto_enroll`, now binding
+ephemeral ports). `node_discovery` was revived then RE-QUARANTINED the same day: the
+ephemeral-port fix resolved its port collision, but it also prints from two green threads
+concurrently and hits the same torn-output race as signal_term_suppress on Linux CI.
+Both remaining are quarantined on a **genuinely unresolved concurrency race, not a test
+bug** — the behavior each pins is unverified on every commit, and a regression there would
+not turn CI red. Quarantining was a containment decision (they flaked CI), explicitly not
+a fix.
 
 | Alias | Pinned behavior now unverified | Blocked on |
 |---|---|---|
 | ~~`test/node_call_loopback_quarantined`~~ | ~~multi-node RPC over real TCP loopback~~ | **RESOLVED 2026-08-08** — took option (b): the tests now bind an OS-assigned ephemeral port (`tcp_listen(0)` + the new `tcp_local_port` builtin, read back in-process) instead of a fixed 29850/29851/29760, so shared-host collisions cannot happen. Soaked 10/10 clean each (0 hangs) under host load ~10. Back on `runtest`. |
-| ~~`test/node_discovery_quarantined`~~ | ~~SWIM node discovery / membership~~ | **RESOLVED 2026-08-08** — same ephemeral-port fix. Back on `runtest`. |
+| `test/node_discovery_quarantined` | SWIM node discovery / membership | **RE-QUARANTINED 2026-08-08** — the ephemeral-port fix resolved the port collision, but node-a and node-b println CONCURRENTLY and ~1-in-2 ubuntu CI runs tears two lines together with a lost newline (`...peer=node-anode-a: handshake...` + a stray blank line), which the sort-before-diff golden cannot absorb. Same pre-write allocator/GC torn-output race as `signal_term_suppress` (a writev-retry fix was measured ineffective and reverted). Un-quarantine once that race is fixed. |
 | ~~`test/rpc_auto_enroll_quarantined`~~ | ~~RPC auto-enrollment handshake~~ | **RESOLVED 2026-08-08** — same ephemeral-port fix. The macOS `result:15` vs `fail:call_error` mismatch was the fixed-port collision (a concurrent listener answering the connect), gone with ephemeral ports. Back on `runtest`. |
 | `test/signal_term_suppress_quarantined` | a watched `SIGTERM` must NOT kill the process | `Signal.watch` deferred-dispatch race (entry below) |
 | ~~`forge/test/build_check_quarantined`~~ | ~~`forge build` end-to-end check~~ | **RESOLVED 2026-08-08** — made hermetic (tests the just-built compiler via `MARCH_TEST_BIN`) and the constructor-resolution bug fixed; back on `runtest`. See `specs/progress/2026-08-08-forge-check-build-suite-un-quarantined.md`. |

--- a/test/dune
+++ b/test/dune
@@ -3576,11 +3576,24 @@ printf 'mod CsHelper do\\n\\n  fn double(x : Int) : Int do\\n    x * 2\\n  end\\
   (with-stdout-to native_node_discovery.sorted.out
    (system "LC_ALL=C sort native_node_discovery.out"))))
 
-; REVIVED 2026-08-08 alongside node_call_loopback (same fix: ephemeral port via
-; tcp_listen(0) + tcp_local_port; the scheduler deadlock it was preemptively
-; quarantined against is fixed). Soaked 10/10 clean (0 hangs) under host load ~10.
+; RE-QUARANTINED 2026-08-08: un-quarantined earlier the same day (ephemeral-port
+; fix), which correctly resolved the fixed-port collision — but exposed a
+; DIFFERENT, pre-existing flake on Linux CI. Unlike node_call_loopback/
+; rpc_auto_enroll (whose client prints from a single green thread), this test has
+; node-a AND node-b println their status lines CONCURRENTLY, and roughly 1-in-2
+; ubuntu runs tears two lines together with a lost newline, e.g.
+; `node-b: handshake ok, peer=node-anode-a: handshake ok, peer=node-b` plus a
+; stray blank line — which the sort-before-diff golden cannot absorb (it tolerates
+; REORDERING, not torn lines). This is the SAME torn-output race as
+; signal_term_suppress (below): the ci-infra investigation determined it is NOT
+; I/O-level write interleaving (march_println already does one atomic writev, and
+; a writev-retry fix measured no benefit and was reverted) but a pre-write
+; allocator/GC race between concurrent green threads on >1 scheduler thread.
+; Un-quarantine only once that scheduler race is fixed. The ephemeral-port and
+; deadlock fixes still stand and keep node_call_loopback/rpc_auto_enroll green.
+; Runnable manually via `dune build @test/node_discovery_quarantined`.
 (rule
- (alias runtest)
+ (alias node_discovery_quarantined)
  (action (diff native/node_discovery.expected native_node_discovery.sorted.out)))
 
 ; ── Compiler-emitted enroll/stub: auto-registration of __rpc_stub functions ──


### PR DESCRIPTION
Fixes a flake introduced on `main` by #223.

## Symptom

`test (ubuntu-24.04)` fails ~1-in-2 on the `native_node_discovery` golden with
**torn output** — two concurrent status lines glued with a lost newline plus a
stray blank line:

```
-node-a: handshake ok, peer=node-b
+
-node-b: handshake ok, peer=node-a
+node-b: handshake ok, peer=node-anode-a: handshake ok, peer=node-b
```

The sort-before-diff golden tolerates line REORDERING (the two nodes race), but
not torn lines.

## Why

#223 un-quarantined the three real-TCP node tests after a **local macOS soak**
(10/10). That fix — ephemeral ports via `tcp_listen(0)` + `tcp_local_port` — was
correct and resolved the fixed-port collision. But `node_discovery` is the only
one of the three that prints from **two green threads concurrently** (node-a and
node-b each `println` their status), and on Linux CI that hits the same
**torn-output race as `signal_term_suppress`**: the ci-infra investigation
already determined `march_println` does one atomic `writev`, a writev-retry fix
measured no benefit and was reverted, and the corruption happens **before** the
write syscall (a pre-write allocator/GC race between concurrent green threads on
>1 scheduler thread) — not I/O interleaving. macOS local runs didn't expose it.

## Change

Re-quarantine only `node_discovery` (its own `node_discovery_quarantined` alias),
restoring CI reliability. `node_call_loopback` and `rpc_auto_enroll` print from a
single thread, are not exposed to this race, and stay on `runtest` — the
ephemeral-port and deadlock fixes still stand. Un-quarantine once the underlying
scheduler race is fixed; `node_discovery` is now a *better* repro of it than
`signal_term_suppress` (~50% on ubuntu CI vs 2-5%). Inventory todo updated.