### PR TITLE
Fix try_finally link failure + fd-streaming Option niche mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,23 @@ git log is authoritative for exact commits.
 
 ### Fixed
 
+- **`try_finally` now has a native implementation, so compiled programs using
+  fd-streaming file I/O link and run.** It was a typecheck+interpreter builtin
+  only; any natively compiled program that reached it — `File.with_lines`,
+  `File.with_chunks`, `Logger`'s context stack, or a direct call — failed at
+  link time with `Undefined symbols: "_try_finally"` (first seen via
+  `examples/read_file.march`). The native version preserves the interpreter's
+  contract: cleanup runs even when the action panics (the panic is re-raised
+  after cleanup; a panic inside cleanup itself is swallowed).
+
+- **`file_read_line` / `file_read_chunk` no longer misread every compiled
+  result.** The C runtime returned `Ok`/`Err` Result cells while the March
+  type is `Option(String)` (niche-encoded: `None` is NULL, `Some`'s payload is
+  the value itself), so a compiled read-to-EOF loop never saw EOF
+  (`File.with_lines` spun forever) and any use of the "line" crashed. Both now
+  return the string directly or NULL, matching the interpreter. This was
+  unreachable before the `try_finally` fix above — nothing fd-based could link.
+
 - **A bare constructor pattern on a value of a known type is no longer reported
   as ambiguous against a same-named stdlib constructor.** Matching `Defs.make(n)`
   (of type `Defs.Thing`) with a bare `Bar(_)` arm errored with "Constructor `Bar`

--- a/lib/tir/llvm_builtins.ml
+++ b/lib/tir/llvm_builtins.ml
@@ -91,6 +91,17 @@ let builtins : builtin list = [
     in_is_builtin = true; declare_sig = Some "declare ptr  @march_panic_ext(ptr %s)" };
   { march_name = "todo_"; c_name = Some "march_todo_ext"; ret_ty = Some (Tir.TPtr Tir.TUnit);
     in_is_builtin = true; declare_sig = Some "declare ptr  @march_todo_ext(ptr %s)" };
+  (* Structured cleanup: try_finally(action, cleanup) runs action(), then
+     cleanup() (even if action panicked), then re-raises action's panic.
+     Returns the action's value at the polymorphic type `a` DIRECTLY, so
+     ret_ty is the erased TVar "_" (the record_put precedent): the call site
+     reads a uniform ptr and the consumer conditionally untags. A concrete
+     scalar here (e.g. TInt at an Int-instantiated call site) would read the
+     runtime's uniform tagged value raw — 42 back as (42<<1)|1 = 85. Without
+     this row the name fell through to the unknown-extern fallback and
+     linked against a nonexistent bare `try_finally` symbol. *)
+  { march_name = "try_finally"; c_name = Some "march_try_finally"; ret_ty = Some (Tir.TVar "_");
+    in_is_builtin = false; declare_sig = Some "declare ptr  @march_try_finally(ptr %action, ptr %cleanup)" };
   { march_name = "println"; c_name = Some "march_println"; ret_ty = Some Tir.TUnit;
     in_is_builtin = true; declare_sig = Some "declare void @march_println(ptr %s)" };
   { march_name = "print_stderr"; c_name = Some "march_print_stderr"; ret_ty = Some Tir.TUnit;
@@ -954,6 +965,7 @@ let core_items : preamble_item list = [    (* always emitted, all targets *)
   PDeclare "march_panic";
   PDeclare "march_panic_ext";
   PDeclare "march_todo_ext";
+  PDeclare "march_try_finally";
   PDeclare "march_test_init";
   PDeclare "march_test_run";
   PDeclare "march_test_setup_all";

--- a/runtime/march_runtime.c
+++ b/runtime/march_runtime.c
@@ -1469,6 +1469,92 @@ void *__try_call_val(void *thunk) {
     return result;
 }
 
+/* ── march_try_finally ───────────────────────────────────────────────────── */
+/*
+ * try_finally : (Bool -> a) -> (Bool -> b) -> a
+ *
+ * Runs action(), then cleanup(), and returns action's result.  If action
+ * panics, cleanup STILL runs, and the panic is then re-raised (so it
+ * reaches whatever handler is outermost — test harness, supervised actor,
+ * or the default print-and-exit).  A panic raised by cleanup itself is
+ * swallowed, matching the interpreter builtin (lib/eval/eval.ml's
+ * "try_finally": `try ignore (cleanup ()) with _ -> ()`).
+ *
+ * This is the primitive behind stdlib resource wrappers (File.with_lines /
+ * File.with_chunks close their fd here; Logger pops its context stack), so
+ * the panic path is the whole point: without it a panicking callback leaks
+ * the resource.
+ *
+ * Panic capture reuses the test-harness longjmp channel exactly like
+ * __try_call / __try_call_val above (save/restore of march_test_jmp_buf +
+ * march_test_fail_buf + march_test_in_test supports nesting); see their
+ * header comments for the closure layout and for why there is NO
+ * march_decrc of either closure here (a capturing closure's apply function
+ * releases its own $clo reference as its first action, on both the
+ * normal-return and the longjmp path).
+ *
+ * The March return type is the type variable `a`, so like __try_call_val
+ * the action's result is returned in the *uniform* representation, verbatim
+ * (heap pointers raw, immediates low-bit-tagged) — the compiled call site
+ * declares `ptr @march_try_finally` and the consumer coerces.  Ownership of
+ * the result transfers straight through (Perceus return convention).
+ * cleanup's result is discarded WITHOUT a decrc: for a Unit-returning
+ * cleanup (the overwhelmingly common case) the apply's return slot is not
+ * a meaningful uniform value, so blindly decrc'ing it could corrupt a
+ * stranger's heap object.  A heap-returning cleanup therefore leaks one
+ * reference — same accepted trade-off as __try_call's panic path.
+ */
+void *march_try_finally(void *action, void *cleanup) {
+    typedef int64_t (*apply_fn_t)(void *, int64_t);
+    apply_fn_t apply_action  = *(apply_fn_t *)((char *)action + 16);
+    apply_fn_t apply_cleanup = *(apply_fn_t *)((char *)cleanup + 16);
+
+    jmp_buf saved_jmp;
+    char    saved_fail[sizeof(march_test_fail_buf)];
+    int     saved_in_test = march_test_in_test;
+    memcpy(&saved_jmp, &march_test_jmp_buf, sizeof(jmp_buf));
+    memcpy(saved_fail, march_test_fail_buf, sizeof(march_test_fail_buf));
+
+    march_test_fail_buf[0] = '\0';
+    march_test_in_test     = 1;
+
+    int64_t result   = 0;
+    int     panicked = 0;
+
+    if (setjmp(march_test_jmp_buf) == 0) {
+        result = apply_action(action, 1);   /* 1 = dummy Bool argument */
+    } else {
+        panicked = 1;
+    }
+
+    /* Capture action's panic message before cleanup can clobber the buffer. */
+    void *err_str = NULL;
+    if (panicked) {
+        const char *msg = march_test_fail_buf[0]
+            ? march_test_fail_buf : "panic";
+        err_str = march_string_lit(msg, (int64_t)strlen(msg));
+    }
+
+    /* Run cleanup under its own guard: its panic must neither mask action's
+       panic nor escape a successful action. */
+    march_test_fail_buf[0] = '\0';
+    if (setjmp(march_test_jmp_buf) == 0) {
+        (void)apply_cleanup(cleanup, 1);
+    }
+    /* else: cleanup panicked — swallowed. */
+
+    /* Restore the outer panic handler BEFORE re-raising, so the re-raise
+       lands in the caller's handler, not back in our own (stale) setjmp. */
+    memcpy(&march_test_jmp_buf, &saved_jmp, sizeof(jmp_buf));
+    memcpy(march_test_fail_buf, saved_fail, sizeof(march_test_fail_buf));
+    march_test_in_test = saved_in_test;
+
+    if (panicked) {
+        march_panic(err_str);   /* does not return */
+    }
+    return (void *)result;
+}
+
 /* ── Actor runtime — green thread based ──────────────────────────────────── */
 /*
  * Design overview
@@ -3703,31 +3789,43 @@ void *march_file_close(void *handle_ptr) {
     return mk_ok_unit();
 }
 
+/* file_read_line / file_read_chunk : Int -> Option(String).
+ *
+ * Option(String) is NICHE-encoded in compiled March (Some's payload is the
+ * value itself, None is raw NULL — see the csv_next_row note in
+ * lib/typecheck/typecheck.ml for the same convention), so these MUST return
+ * the march_string directly or NULL.  They historically returned mk_ok /
+ * mk_err Result cells like the rest of the file family — under the niche
+ * read, every return (including the EOF Err) looked like Some(<Result
+ * cell>), so a compiled read-to-EOF loop never terminated and any use of
+ * the "line" crashed on the misread cell.  Unreachable until try_finally
+ * gained a native implementation (nothing fd-based would link), which is
+ * why it survived: the interpreter (lib/eval/eval.ml) always had the
+ * Some/None contract these now match.  Non-EOF read errors fold into None
+ * (end of stream), mirroring the interpreter's End_of_file handling — the
+ * Option type has no error channel. */
 void *march_file_read_line(void *handle_ptr) {
     FILE *f = (FILE *)(uintptr_t)MARCH_FIELD(handle_ptr, 0);
-    if (!f) return mk_err_cstr("file not open");
+    if (!f) return NULL;                                   /* None */
     char buf[4096];
-    if (!fgets(buf, sizeof(buf), f)) {
-        if (feof(f)) return mk_err_cstr("eof");
-        return mk_err_errno();
-    }
+    if (!fgets(buf, sizeof(buf), f)) return NULL;          /* None: EOF/error */
     size_t len = strlen(buf);
     /* Strip trailing newline */
     if (len > 0 && buf[len-1] == '\n') { buf[--len] = '\0'; }
     if (len > 0 && buf[len-1] == '\r') { buf[--len] = '\0'; }
-    return mk_ok(march_string_lit(buf, (int64_t)len));
+    return march_string_lit(buf, (int64_t)len);            /* Some(line) */
 }
 
 void *march_file_read_chunk(void *handle_ptr, int64_t size) {
     FILE *f = (FILE *)(uintptr_t)MARCH_FIELD(handle_ptr, 0);
-    if (!f || size <= 0) return mk_err_cstr("file not open");
+    if (!f || size <= 0) return NULL;                      /* None */
     char *buf = (char *)malloc((size_t)size);
-    if (!buf) return mk_err_cstr("out of memory");
+    if (!buf) return NULL;                                 /* None */
     size_t n = fread(buf, 1, (size_t)size, f);
+    if (n == 0) { free(buf); return NULL; }                /* None: EOF/error */
     void *s = march_string_lit(buf, (int64_t)n);
     free(buf);
-    if (n == 0 && feof(f)) return mk_err_cstr("eof");
-    return mk_ok(s);
+    return s;                                              /* Some(chunk) */
 }
 
 /* ── Directory builtins ─────────────────────────────────────────────── */

--- a/runtime/march_runtime_wasm.c
+++ b/runtime/march_runtime_wasm.c
@@ -553,6 +553,22 @@ void march_panic(void *s) {
     __builtin_trap();
 }
 
+/* Structured cleanup — see march_try_finally in march_runtime.c for the
+ * full contract.  WASM has no longjmp-based panic channel (march_panic
+ * traps the instance above), so there is nothing to catch: on the panic
+ * path the whole instance is already gone before cleanup could run.  This
+ * covers the non-panicking path so programs using File/Logger-style
+ * wrappers still compile and run. Closure apply fn lives at offset 16
+ * (same layout as native; see __try_call's header comment there). */
+void *march_try_finally(void *action, void *cleanup) {
+    typedef int64_t (*apply_fn_t)(void *, int64_t);
+    apply_fn_t apply_action  = *(apply_fn_t *)((char *)action + 16);
+    apply_fn_t apply_cleanup = *(apply_fn_t *)((char *)cleanup + 16);
+    int64_t result = apply_action(action, 1);   /* 1 = dummy Bool argument */
+    (void)apply_cleanup(cleanup, 1);
+    return (void *)result;
+}
+
 /* ── Scheduler stubs ────────────────────────────────────────────────── */
 
 int64_t march_tls_reductions = 0;

--- a/specs/progress/2026-08-08-try-finally-native-builtin-and-fd-streaming-option-contract.md
+++ b/specs/progress/2026-08-08-try-finally-native-builtin-and-fd-streaming-option-contract.md
@@ -1,0 +1,66 @@
+# try_finally native builtin + fd-streaming Option contract (2 stacked compiled-only bugs)
+
+**Date:** 2026-08-08
+**Symptom:** `examples/read_file.march` failed native compilation at link time:
+`Undefined symbols for architecture arm64: "_try_finally"`. After fixing that,
+the same example *hung* (100% CPU) in the `File.with_lines` section — a second,
+previously masked bug.
+
+## Bug 1 — try_finally had no native implementation
+
+`try_finally(action, cleanup)` was a typecheck + interpreter builtin only
+(`lib/typecheck/typecheck.ml`, `lib/eval/eval.ml`). It had no
+`lib/tir/llvm_builtins.ml` row, so compiled call sites fell into the
+unknown-extern fallback in `llvm_emit.ml`, which emitted
+`declare ptr @try_finally(...)` against a C symbol that never existed. Its
+siblings `__try_call` / `__try_call_val` only link because their C functions
+are literally named after the March builtin (identity mangle).
+
+**Fix:**
+- `lib/tir/llvm_builtins.ml`: row mapping `try_finally` → `march_try_finally`
+  with `ret_ty = TVar "_"` (the `record_put` precedent — the action's result
+  is returned at the polymorphic type `a` *directly*, so call sites must read
+  a uniform ptr and conditionally untag; a concrete scalar ret would read
+  42 back as `(42<<1)|1 = 85`). `PDeclare` in `core_items`.
+- `runtime/march_runtime.c`: `march_try_finally` next to `__try_call_val`,
+  same jmp-buf save/restore panic capture. Contract: run action; run cleanup
+  even if action panicked (cleanup's own panic is swallowed, matching the
+  interpreter); re-raise action's panic after restoring the outer handler.
+  No decrc of either closure (capturing closures' apply fns self-drop $clo —
+  see the `__try_call` header comment).
+- `runtime/march_runtime_wasm.c`: non-catching version (wasm panic traps the
+  instance; there is no longjmp channel and nothing to clean up after).
+
+## Bug 2 — file_read_line / file_read_chunk returned Result cells at type Option(String)
+
+Only reachable once bug 1 let fd-streaming programs link. `Option(String)` is
+**niche**-encoded compiled (Some's payload is the value itself, None is raw
+NULL), but `march_file_read_line` / `march_file_read_chunk` returned
+`mk_ok(string)` / `mk_err("eof")` Result cells like the rest of the file
+family. Under the niche read every return — including the EOF Err — looked
+like `Some(<Result cell>)`: a read-to-EOF fold never terminated
+(`File.with_lines` hang) and using the misread "line" crashed (SIGBUS on a
+straight-line read). The interpreter always had its own correct Some/None
+implementation, which is why stdlib tests (interpreted) never saw it.
+
+**Fix:** both functions now return the `march_string` directly on success and
+NULL on EOF/error (non-EOF read errors fold into None — the Option type has
+no error channel, matching the interpreter's `End_of_file` handling).
+
+## Tests
+
+`test/test_codegen.ml` (`try_call_capture_ownership_codegen` group):
+- `try_finally: value untag + cleanup order` — Int result (the 42-vs-85
+  untag witness), heap result, action/cleanup ordering, compiled vs interpreted.
+- `try_finally: cleanup runs when the action panics` — nonzero exit, cleanup
+  marker present, original panic message propagated.
+- `File.with_lines streaming: fd Option niche contract` — end-to-end
+  with_lines + Seq.take/to_list, compiled vs interpreted, with a 30s timeout
+  so a contract regression fails instead of hanging the suite.
+
+## Left open
+
+`march_file_open`'s Err payload is a bare String, but the March-level type is
+`Result(Int, FileError)` (and the llvm_builtins row says `Result(Int, String)`)
+— the compiled Err path misreads the payload as a FileError ADT. Not on the
+happy path; filed as a follow-up.

--- a/test/test_codegen.ml
+++ b/test/test_codegen.ml
@@ -9991,6 +9991,158 @@ let test_try_call_panic_with_capture_no_double_free_compiled () =
         true (Test_helpers.contains "boom" run_out)
     done
 
+(* try_finally — the third member of the try-call family, and the one the
+   stdlib leans on for resource cleanup (File.with_lines / File.with_chunks /
+   Logger's context stack). Unlike __try_call/__try_call_val it was a
+   typecheck+interpreter builtin ONLY: no llvm_builtins row, so compiled
+   call sites fell into the unknown-extern fallback and emitted
+   `declare ptr @try_finally(...)` against a C symbol that never existed —
+   any program whose compiled code reached try_finally failed at LINK time
+   ("Undefined symbols: _try_finally", first seen via
+   examples/read_file.march's File.with_lines call).
+
+   try_finally returns the action's value at the polymorphic type `a`
+   DIRECTLY (not wrapped in a Result field like its siblings), so its
+   llvm_builtins row uses ret_ty = TVar "_" (the record_put precedent): the
+   call site reads a uniform ptr and the consumer coerces. The Int case
+   below is the adversarial witness for exactly that — if the runtime
+   returned a raw untagged value, or the call site skipped the conditional
+   untag, 42 would come back as 85 ((42<<1)|1) compiled-only. *)
+let test_try_finally_value_and_order_compiled () =
+  let (project_root, main_exe, src, tmp) = write_march_source ~name:"march_tryfin"
+    "mod TryFin do\n\
+    \  needs IO.Console\n\
+    \  fn main() : Unit do\n\
+    \    let k = 40\n\
+    \    let n = try_finally(\n\
+    \      fn _ ->\n\
+    \        let _ = println(\"action\")\n\
+    \        k + 2,\n\
+    \      fn _ -> println(\"cleanup\"))\n\
+    \    println(int_to_string(n))\n\
+    \    let s = try_finally(fn _ -> \"he\" ++ \"ap\", fn _ -> ())\n\
+    \    println(s)\n\
+    \  end\n\
+     end\n"
+  in
+  let expected = "action\ncleanup\n42\nheap" in
+  let interp_out = read_cmd_output (Printf.sprintf
+    "cd %s && %s %s 2>&1"
+    (Filename.quote project_root)
+    (Filename.quote main_exe) (Filename.quote src)) in
+  Alcotest.(check string) "interpreted try_finally value + cleanup order"
+    expected interp_out;
+  let bin = Filename.concat tmp "tryfinbin" in
+  match compile_march_or_skip ~cmd_prefix:(Printf.sprintf "cd %s && " (Filename.quote project_root))
+          ~main_exe ~bin ~src () with
+  | None -> ()  (* legitimate, counted skip: no clang on PATH *)
+  | Some bin ->
+    let run_out = read_cmd_output (Printf.sprintf "%s 2>&1" (Filename.quote bin)) in
+    Alcotest.(check string) "compiled matches interpreted" expected run_out
+
+(* The semantic contract that justifies try_finally's existence: cleanup runs
+   even when the action panics, and the panic still propagates afterwards
+   (nonzero exit). Combined stdout+stderr capture can interleave the two
+   streams arbitrarily around process exit, so assert presence of both
+   markers rather than their relative order — cleanup-before-repanic is
+   enforced by construction inside march_try_finally. *)
+let test_try_finally_cleanup_runs_on_panic_compiled () =
+  let (project_root, main_exe, src, tmp) = write_march_source ~name:"march_tryfinpanic"
+    "mod TryFinPanic do\n\
+    \  needs IO.Console\n\
+    \  fn main() : Unit do\n\
+    \    let label = \"kaboom\"\n\
+    \    let _ = try_finally(\n\
+    \      fn _ ->\n\
+    \        let _ = panic(label)\n\
+    \        0,\n\
+    \      fn _ -> println(\"cleanup-ran\"))\n\
+    \    println(\"unreachable\")\n\
+    \  end\n\
+     end\n"
+  in
+  let bin = Filename.concat tmp "tryfinpanicbin" in
+  match compile_march_or_skip ~cmd_prefix:(Printf.sprintf "cd %s && " (Filename.quote project_root))
+          ~main_exe ~bin ~src () with
+  | None -> ()  (* legitimate, counted skip: no clang on PATH *)
+  | Some bin ->
+    let out_file = Filename.concat tmp "tryfinpanic.out" in
+    let rc = Sys.command (Printf.sprintf "%s > %s 2>&1"
+                            (Filename.quote bin) (Filename.quote out_file)) in
+    let run_out = read_cmd_output (Printf.sprintf "cat %s" (Filename.quote out_file)) in
+    Alcotest.(check bool) "panicking action still exits nonzero" true (rc <> 0);
+    Alcotest.(check bool) "cleanup ran before the panic propagated" true
+      (Test_helpers.contains "cleanup-ran" run_out);
+    Alcotest.(check bool) "the original panic message propagated" true
+      (Test_helpers.contains "kaboom" run_out);
+    Alcotest.(check bool) "code after try_finally did not run" false
+      (Test_helpers.contains "unreachable" run_out)
+
+(* The fd-streaming builtins' C→March return contract — the SECOND bug the
+   try_finally link failure was masking. file_read_line/file_read_chunk are
+   typed Option(String), which is NICHE-encoded compiled (Some's payload is
+   the value itself, None is raw NULL), but the C runtime returned mk_ok /
+   mk_err RESULT cells: every return — including the EOF Err — read as
+   Some(<Result cell>), so a read-to-EOF fold never terminated (the
+   File.with_lines hang) and using the misread "line" crashed (SIGBUS in a
+   straight-line read). Unreachable before try_finally linked: every
+   fd-streaming stdlib path goes through it, and the interpreter (where
+   stdlib tests run) has its own correct Some/None implementation. This
+   drives File.with_lines end-to-end, compiled vs interpreted. *)
+let test_file_with_lines_streaming_compiled () =
+  (* The input file lives in its own temp path, embedded into the source
+     verbatim, so the test is hermetic and CWD-independent. *)
+  let input_path = Filename.temp_file "march_withlines_input" ".txt" in
+  let oc = open_out input_path in
+  output_string oc "alpha\nbeta\ngamma\ndelta\nepsilon\n";
+  close_out oc;
+  let (project_root, main_exe, src, tmp) = write_march_source ~name:"march_withlines"
+    (Printf.sprintf
+    "mod WithLines do\n\
+    \  needs IO.Console\n\
+    \  fn main() : Unit do\n\
+    \    let path = \"%s\"\n\
+    \    match File.with_lines(path, fn(lines) -> Seq.to_list(Seq.take(lines, 3))) do\n\
+    \    Err(e) -> println(\"Error: \" ++ to_string(e))\n\
+    \    Ok(first3) -> do\n\
+    \      println(int_to_string(List.length(first3)))\n\
+    \      println(List.fold_left(first3, \"\", fn(acc, line) -> acc ++ line ++ \"|\"))\n\
+    \    end\n\
+    \    end\n\
+    \    match File.with_lines(path, fn(lines) -> Seq.to_list(lines)) do\n\
+    \    Err(e) -> println(\"Error: \" ++ to_string(e))\n\
+    \    Ok(all) -> println(int_to_string(List.length(all)))\n\
+    \    end\n\
+    \  end\n\
+     end\n" input_path)
+  in
+  let expected = "3\nalpha|beta|gamma|\n5" in
+  let interp_out = read_cmd_output (Printf.sprintf
+    "cd %s && %s %s 2>&1"
+    (Filename.quote project_root)
+    (Filename.quote main_exe) (Filename.quote src)) in
+  Alcotest.(check string) "interpreted File.with_lines streaming"
+    expected interp_out;
+  let bin = Filename.concat tmp "withlinesbin" in
+  match compile_march_or_skip ~cmd_prefix:(Printf.sprintf "cd %s && " (Filename.quote project_root))
+          ~main_exe ~bin ~src () with
+  | None -> ()  (* legitimate, counted skip: no clang on PATH *)
+  | Some bin ->
+    (* Bounded run: the pre-fix failure mode was an infinite read loop, so a
+       plain Sys.command here would hang the whole suite. *)
+    let out_file = Filename.concat tmp "withlines.out" in
+    (match Test_helpers.run_with_timeout ~timeout_secs:30.0 ~stdout_file:out_file
+             [| bin |] with
+     | `Timeout ->
+       Alcotest.fail
+         "compiled File.with_lines hung (>30s): fd-streaming EOF was never \
+          seen — the file_read_line niche-Option contract is broken again"
+     | `Exited 0 ->
+       let run_out = read_cmd_output (Printf.sprintf "cat %s" (Filename.quote out_file)) in
+       Alcotest.(check string) "compiled matches interpreted" expected run_out
+     | `Exited rc ->
+       Alcotest.failf "compiled File.with_lines exited with rc=%d" rc)
+
 (* NativeArray.map_int/map_float et al. and TypedArray.map/fold — a THIRD
    family of call sites sharing the same double-consumption bug as
    __try_call above, but shaped differently: instead of one call plus an
@@ -11811,6 +11963,7 @@ declare void @march_print(ptr %s)
 declare void @march_panic(ptr %s)
 declare ptr  @march_panic_ext(ptr %s)
 declare ptr  @march_todo_ext(ptr %s)
+declare ptr  @march_try_finally(ptr %action, ptr %cleanup)
 declare void @march_test_init(i32 %argc, ptr %argv)
 declare void @march_test_run(ptr %fn, ptr %name, ptr %setup_or_null)
 declare void @march_test_setup_all(ptr %fn)
@@ -13826,6 +13979,12 @@ let codegen_suites =
             test_try_call_val_single_capture_no_double_free_compiled;
           Alcotest.test_case "single-capture __try_call thunk panics: no double-free (15x)" `Quick
             test_try_call_panic_with_capture_no_double_free_compiled;
+          Alcotest.test_case "try_finally: value untag + cleanup order (compiled vs interpreted)" `Quick
+            test_try_finally_value_and_order_compiled;
+          Alcotest.test_case "try_finally: cleanup runs when the action panics (compiled)" `Quick
+            test_try_finally_cleanup_runs_on_panic_compiled;
+          Alcotest.test_case "File.with_lines streaming: fd Option niche contract (compiled)" `Quick
+            test_file_with_lines_streaming_compiled;
           Alcotest.test_case "NativeArray.map_int: reused capturing closure not freed mid-map (20x)" `Quick
             test_native_array_map_reused_capturing_closure_compiled;
           Alcotest.test_case "NativeArray.set_int: aliased (rc>1) array is copy-on-write, not mutated" `Quick


### PR DESCRIPTION
## Summary

Two stacked compiled-only bugs found while investigating why
`examples/read_file.march` failed native compilation.

- **`try_finally` had no native implementation.** It was a
  typecheck+interpreter builtin only, so any compiled program reaching it
  (`File.with_lines`, `File.with_chunks`, `Logger`'s context stack, or a
  direct call) failed at link time with `Undefined symbols: "_try_finally"`.
  Added `march_try_finally` to `runtime/march_runtime.c` (preserves the
  interpreter's contract: cleanup runs even if the action panics, panic is
  re-raised after cleanup, a panic inside cleanup is swallowed) plus a
  non-catching wasm stub, and the `lib/tir/llvm_builtins.ml` wiring.

- **`file_read_line`/`file_read_chunk` misread every compiled result.**
  Unmasked once `try_finally` could link. Their March type is
  `Option(String)`, which compiles to a *niche* encoding (`None` = NULL,
  `Some`'s payload = the value itself), but the C runtime returned
  `Ok`/`Err` Result cells — every return, including the EOF `Err`, read as
  `Some(<Result cell>)`. A compiled read-to-EOF loop never terminated
  (`File.with_lines` hung at 100% CPU) and using the misread "line" crashed.
  Both now return the string directly or `NULL`, matching the interpreter.

Left open (spun off separately, not bundled here): `file_open`'s compiled
`Err` path returns a bare string where the type is `Result(Int, FileError)`
— same family of bug, not on this example's happy path.

## Test plan

- [x] New compiled-vs-interpreted tests in `test/test_codegen.ml`: value
      untag correctness, cleanup-runs-on-panic, end-to-end
      `File.with_lines` streaming (with a 30s hang-guard so a regression
      fails instead of hanging the suite)
- [x] Preamble golden test updated for the new `march_try_finally` declare
- [x] `examples/read_file.march` compiles, links, and runs natively;
      output matches the interpreter
- [x] Full `run_codegen` suite (561 tests), `run_stdlib` suite (833 tests,
      including Slow), `run_compiler`, `run_eval`, TIR snapshots, all green
- [x] `scripts/check-docs.sh` passes