### PR TITLE
caps: the unused-needs warning must not contradict the ceiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,21 @@ git log is authoritative for exact commits.
 
 ### Fixed
 
+- **The unused-capability warning no longer contradicts the capability
+  ceiling.** A module reaching a capability only through a stdlib wrapper
+  (`Parallel.pmap` → `IO.Spawn`) was told by the ceiling to add the `needs`
+  line and then by the unused-`needs` warning to remove that same line — with
+  an autofix that re-broke the build. The warning now consults the transitive
+  capability closure (the same analysis import checking uses), so a
+  stdlib-mediated use counts as a use. A `needs` that nothing requires still
+  warns.
+
+- **The "cannot be attributed" ceiling error no longer asserts a cause it
+  cannot know.** It claimed the capability was "reached only through indirect
+  calls" — wrong in every diagnosed case to date. It now states what is known,
+  and says to report the diagnostic if adding the `needs` line does not
+  resolve it, since that indicates an attribution gap in the compiler.
+
 - **A module with no entry point is no longer charged capability violations
   for the entire standard library.** A file with no `fn main` (a library, or a
   test-only file) drew up to 17 ceiling violations naming stdlib modules

--- a/lib/caps/cap_ceiling.ml
+++ b/lib/caps/cap_ceiling.ml
@@ -45,8 +45,23 @@ let describe = function
   | Undeclared { cap; owner } ->
     Printf.sprintf
       "module `%s` uses `%s` but does not declare `needs %s`" owner cap cap
+  (* Do NOT name a single cause here.  This message used to end "— it is
+     reached only through indirect calls, whose callee is not statically
+     known", asserting the one cause the check could imagine.  Every
+     unattributable capability actually diagnosed in 2026-08 had a DIFFERENT
+     cause — a builtin-name-table mismatch (fixed, #221), DCE fail-open
+     charging main-less modules for the stdlib (fixed, #225), a signature-only
+     capability (fixed, #225), and a nested-module actor handler's synthesized
+     bare name (open, specs/todos/2026-08-08-actor-handler-attribution-…) —
+     and each investigation began by disbelieving this message.  The check
+     knows only that emitted code reaches the capability and attribution
+     found no owner; say that, and point at what the user can actually do. *)
   | Unattributed { cap } ->
     Printf.sprintf
-      "`%s` is used but cannot be attributed to any module — it is reached \
-       only through indirect calls, whose callee is not statically known"
+      "`%s` is used by emitted code but cannot be attributed to any module, \
+       so no `needs` declaration can vouch for it. This fails closed. Likely \
+       causes: the capability is reached only through an indirect call whose \
+       callee is not statically known, or attribution has a gap for this \
+       route — if adding the `needs` line does not resolve it, the route is \
+       the compiler's gap, not your program's; please report it"
       cap

--- a/lib/typecheck/typecheck.ml
+++ b/lib/typecheck/typecheck.ml
@@ -9123,6 +9123,36 @@ let check_module_needs (env : env) (mod_name : Ast.name)
           MPText " to the module body." ])
   ) extern_cap_uses;
   (* Check 2: every needs declaration must be used *)
+  (* The capabilities this module's OWN functions reach TRANSITIVELY —
+     including through a stdlib wrapper, which none of the source-level lists
+     below can see (the stdlib deliberately declares no `needs`, so
+     [env.module_caps] never carries its uses either).  Without this, the
+     ceiling and Check 2 contradicted each other on the same line: a
+     stdlib-mediated `pmap` REQUIRES `needs IO.Spawn` at the ceiling, and
+     Check 2 then said "no function requires Cap(IO.Spawn) — help: remove",
+     whose autofix re-breaks the build.  First hit minutes after the ceiling
+     became the default (golden g43); filed as
+     specs/todos/2026-08-08-unused-cap-warning-contradicts-ceiling.md.
+
+     Same closure table Check 4 uses for imports, and it is [lazy] for the
+     same reason: only a module that both declares a `needs` and fails every
+     cheaper test below pays for the fixpoint.  Keyed by this module's
+     DECLARED function names ([cap_qname], skipping stdlib-span decls) — not
+     by key shape: at the entry module the prefix is empty, so prelude
+     functions are keyed bare exactly like the user's own, and selecting by
+     shape would fold the prelude's IO.Console into every module (the same
+     trap [own_caps_of_this_module] documents). *)
+  let own_transitive_caps : string list Lazy.t = lazy (
+    let tbl = Lazy.force trans_closures in
+    List.concat_map (fun (d : Ast.decl) ->
+        match d with
+        | Ast.DFn (fd, sp) when not (span_is_stdlib sp) ->
+          (match Hashtbl.find_opt tbl (cap_qname fd.Ast.fn_name.txt) with
+           | Some caps -> caps | None -> [])
+        | _ -> [])
+      decls
+    |> List.sort_uniq String.compare)
+  in
   List.iter (fun need ->
     let need_sp =
       let rec find_span = function
@@ -9138,7 +9168,9 @@ let check_module_needs (env : env) (mod_name : Ast.name)
               || List.exists (fun (cap_path, _) -> cap_subsumes need cap_path) extern_cap_uses
               || List.exists (fun (_, req_caps) ->
                    List.exists (fun req_cap -> cap_subsumes need req_cap) req_caps
-                 ) env.module_caps in
+                 ) env.module_caps
+              || List.exists (fun cap_path -> cap_subsumes need cap_path)
+                   (Lazy.force own_transitive_caps) in
     if not used then
       Err.warning_with_fix env.errors ~span:need_sp
         ~fix:(Err.FDelete {

--- a/specs/progress/2026-08-08-unused-cap-warning-contradicts-ceiling.md
+++ b/specs/progress/2026-08-08-unused-cap-warning-contradicts-ceiling.md
@@ -48,3 +48,31 @@ consistent everywhere.
 `march specs/lang/golden/g43_parallel_determinism.march` (interpret) prints
 the warning on stderr; `march --compile` on the same file with the line
 REMOVED fails the ceiling. Both cannot be right.
+
+---
+
+## RESOLVED 2026-08-08 — a third direction, better than either proposed
+
+Neither option above was taken. Typecheck already computes the per-function
+TRANSITIVE capability closure (`fn_transitive_capability_closures_tbl`, the
+table Check 4 uses for imports) — and that closure sees straight through a
+stdlib wrapper to the builtin. Check 2 now consults it: a `needs` reached by
+any function THIS module declares (DFn, stdlib-span decls excluded, keyed by
+`cap_qname` — never by key SHAPE, since at the entry module prelude functions
+are keyed bare exactly like the user's own) is used, so the warning and its
+`remove` autofix simply do not fire on a stdlib-mediated use. Consistent
+across interpret and compile, because it is all inside typecheck — the
+option-1 asymmetry never arises.
+
+Pinned by `cap_propagation` tests "stdlib-mediated needs is not unused"
+(RED first: warning fired on `needs IO.Clock` used only via `DateTime.now()`)
+and "unrelated needs warns with stdlib loaded" (the closure consult must not
+degenerate into never-warn). Witness: `march g43_parallel_determinism.march`
+now runs with zero warnings.
+
+Same commit: `Cap_ceiling.describe`'s `Unattributed` arm no longer asserts
+"reached only through indirect calls" — the one cause it could imagine, and
+wrong for every unattributable capability actually diagnosed in 2026-08 (all
+four had different causes; each investigation began by disbelieving the
+message). It now states what the check knows, lists indirect calls as one
+likely cause, and says to report it if adding `needs` does not resolve it.

--- a/test/test_compiler.ml
+++ b/test/test_compiler.ml
@@ -9582,6 +9582,73 @@ let test_cap_propagation_still_warns_unrelated () =
   Alcotest.(check bool) "unrelated needs IO.Console still warns when unused" true
     (has_warning_with ctx "unused capability")
 
+(* A `needs` satisfied only through a STDLIB call must not warn as unused.
+   Found 2026-08-08, minutes after the ceiling became the default, on the first
+   file it forced a migration of (golden g43): the ceiling — emitted-code
+   attribution — demands `needs IO.Spawn` for a stdlib-mediated `pmap`, and the
+   source-level Check 2 then said "no function requires Cap(IO.Spawn) —
+   help: remove the unused capability declaration", whose autofix re-breaks the
+   build.  The two checks gave contradictory instructions for the same line.
+
+   The sibling-module suppression above ([env.module_caps]) never covers this:
+   the stdlib deliberately declares no `needs` (doing so weakens attribution —
+   see the severity-flip progress doc), so a stdlib module never contributes an
+   entry.  The fix consults the per-function TRANSITIVE capability closure —
+   the same table Check 4 already uses for imports — which sees straight
+   through the stdlib wrapper to the builtin.
+
+   The stdlib file must be span-registered exactly as bin/main.ml does, or the
+   body-scan error fires on the stdlib's own builtin calls
+   (see [assert_stdlib_file_typechecks_cleanly]). *)
+let with_stdlib_registered name k =
+  let saved = !March_typecheck.Typecheck.stdlib_source_files in
+  let candidates = [
+    Filename.concat "stdlib" name;
+    Filename.concat "../../../stdlib" name;
+    Filename.concat "../../stdlib" name;
+  ] in
+  March_typecheck.Typecheck.stdlib_source_files := candidates @ saved;
+  Fun.protect ~finally:(fun () ->
+    March_typecheck.Typecheck.stdlib_source_files := saved) k
+
+let test_stdlib_mediated_needs_is_not_unused () =
+  with_stdlib_registered "datetime.march" (fun () ->
+    let dt = load_stdlib_file_for_test "datetime.march" in
+    let m = March_ast.Ast.{
+      mod_name = { txt = "Main"; span = dummy_span };
+      mod_decls = dt :: (parse_and_desugar {|mod Main do
+        needs IO.Clock
+        fn stamp() : Int do
+          DateTime.now()
+        end
+      end|}).March_ast.Ast.mod_decls;
+    } in
+    let (errors, _type_map, _env) = March_typecheck.Typecheck.check_module_core m in
+    Alcotest.(check bool)
+      "needs IO.Clock reached only via DateTime.now must not warn unused" false
+      (has_warning_with errors "unused capability"))
+
+(* The suppression must stay selective: with the same stdlib loaded, a `needs`
+   that nothing — direct, signature, sibling, or stdlib-mediated — requires
+   still warns.  Without this, "consult the closure" could degenerate into
+   "never warn" and pass the test above by checking nothing. *)
+let test_unrelated_needs_still_warns_with_stdlib_loaded () =
+  with_stdlib_registered "datetime.march" (fun () ->
+    let dt = load_stdlib_file_for_test "datetime.march" in
+    let m = March_ast.Ast.{
+      mod_name = { txt = "Main"; span = dummy_span };
+      mod_decls = dt :: (parse_and_desugar {|mod Main do
+        needs IO.NetListen
+        fn stamp() : Int do
+          DateTime.now()
+        end
+      end|}).March_ast.Ast.mod_decls;
+    } in
+    let (errors, _type_map, _env) = March_typecheck.Typecheck.check_module_core m in
+    Alcotest.(check bool)
+      "needs IO.NetListen with no use of any kind still warns" true
+      (has_warning_with errors "unused capability"))
+
 (* ── cap_infer: standalone refinecheck capability-inference hints ────────── *)
 
 (* Helper: run typecheck then the standalone cap_infer pass.
@@ -13167,6 +13234,8 @@ let compiler_suites =
       ( "cap_propagation", [
           Alcotest.test_case "needs from import suppresses unused-cap warn" `Quick test_cap_propagation_no_unused_warn;
           Alcotest.test_case "unrelated needs still warns"                  `Quick test_cap_propagation_still_warns_unrelated;
+          Alcotest.test_case "stdlib-mediated needs is not unused"          `Quick test_stdlib_mediated_needs_is_not_unused;
+          Alcotest.test_case "unrelated needs warns with stdlib loaded"     `Quick test_unrelated_needs_still_warns_with_stdlib_loaded;
         ] );
       ( "cap_infer", [
           Alcotest.test_case "cap hint shows chain from main"               `Quick test_cap_chain_from_main;


### PR DESCRIPTION
Stacked on #225 (base: `claude/cap-strict-default`) — both fixes are consequences of the ceiling becoming the default, and the witness file (g43) only exhibits the contradiction under that default. Retarget to `main` after #225 merges.

## Fix 1: the contradiction

The first file #225 forced a migration of hit it immediately: the ceiling demands `needs IO.Spawn` for a stdlib-mediated `pmap`, then the source-level unused-capability warning says *remove that same line* — with an autofix that re-breaks the build. Every stdlib-mediated capability use produces the pair, so this was the first experience of migrating any file.

The [filed todo](specs/progress/2026-08-08-unused-cap-warning-contradicts-ceiling.md) proposed two fixes (post-attribution suppression in bin/main.ml, or honest rewording + dropping the autofix). Neither was taken — a third was better: typecheck already computes the per-function **transitive capability closure** (the table Check 4 uses for import costs), which sees straight through a stdlib wrapper to the builtin. Check 2 now consults it, so the warning is simply *correct* rather than reworded, and interpret/compile agree because it's all inside typecheck.

Two traps stepped around, both with prior incidents in this codebase:
- Closure keys come from this module's **declared DFn names** (stdlib spans excluded), never from key *shape* — at the entry module the prelude's functions are keyed bare exactly like the user's own, and shape-selection folds the prelude's `IO.Console` into every module (the `own_caps_of_this_module` trap, re-hit live during #225).
- A counter-test guards against over-suppression: "unrelated needs warns with stdlib loaded". Without it, "consult the closure" could degenerate into never-warn and the fix's own test would pass by checking nothing.

TDD: RED first (`needs IO.Clock` used only via `DateTime.now()` warned), then GREEN. Witness: `march specs/lang/golden/g43_parallel_determinism.march` now runs with zero warnings.

## Fix 2: the message that misled four investigations

`Cap_ceiling.describe`'s `Unattributed` arm asserted the capability is "reached only through indirect calls" — the one cause the check could imagine, and **wrong in all four unattributable cases diagnosed since 2026-08-07** (name-table mismatch #221, DCE fail-open #225, signature-only #225, nested-actor-handler naming — still open). Each investigation began by disbelieving the message. It now states what the check actually knows, lists indirect calls as one likely cause, and asks for a report when adding `needs` doesn't resolve it — that being the signal the gap is the compiler's, not the program's. No test pinned the old wording; the load-bearing "cannot be attributed" phrase is kept.

## Verification

compiler 806 (2 new), eval 256, stdlib-quick 786, `check-docs.sh` + pagefind check pass.