### PR TITLE
test: fix missing needs IO.FileRead regression from #228

### DIFF
--- a/test/test_codegen.ml
+++ b/test/test_codegen.ml
@@ -10100,6 +10100,7 @@ let test_file_with_lines_streaming_compiled () =
     (Printf.sprintf
     "mod WithLines do\n\
     \  needs IO.Console\n\
+    \  needs IO.FileRead\n\
     \  fn main() : Unit do\n\
     \    let path = \"%s\"\n\
     \    match File.with_lines(path, fn(lines) -> Seq.to_list(Seq.take(lines, 3))) do\n\


### PR DESCRIPTION
## Summary

`main` currently fails `File.with_lines streaming: fd Option niche contract (compiled)` in `test/test_codegen.ml`: the embedded `WithLines` test source calls `File.with_lines` but only declares `needs IO.Console`, not `needs IO.FileRead`.

This is a regression that landed via #228 (my own PR): I discovered and fixed this locally against a merged snapshot of #225 (capability ceiling on by default) + #229, but PR #228 got merged before I could push that last fix commit — the diagnosis and full trace is in the PR conversation on #228. The failure is confirmed reproducible on a clean checkout of current `main`, and this one-line addition fixes it (verified: the specific test passes cleanly, full `scripts/run-tests.sh` suite green aside from one confirmed-unrelated flake — `Signal.watch: capturing handler survives repeated delivery`, a signal-delivery-timing test that passed 3/3 in isolated reruns).

## Test plan

- [x] `File.with_lines streaming: fd Option niche contract (compiled)` passes (was failing on `main`).
- [x] `scripts/run-tests.sh` full suite: 2456 tests, 0 failures (one unrelated flaky signal-timing test reran clean 3/3 in isolation).
- [x] `scripts/check-docs.sh`: passes.