### PR TITLE
test: split the read bound from the promptness bar in the idle-connection HTTP regressions

### DIFF
--- a/test/test_stdlib_suite.ml
+++ b/test/test_stdlib_suite.ml
@@ -12373,12 +12373,18 @@ let test_interp_http_server_idle_client_does_not_block_others () =
       let request = "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n" in
       ignore (Unix.write_substring client_sock request 0 (String.length request));
       (* Bound the read with select() so a hang shows up as a fast,
-         deterministic test failure instead of blocking the suite. *)
-      let deadline = 2.0 in
+         deterministic test failure instead of blocking the suite. As in the
+         WebSocket sibling below, the read bound and the promptness threshold
+         are separate constants: [read_deadline] decides when we stop waiting,
+         [prompt_limit] is the regression bar, and the bar is loose because
+         the pre-fix bug yields no response at all — tightening it only buys
+         false failures on a loaded machine. *)
+      let read_deadline = 6.0 in
+      let prompt_limit  = 3.0 in
       let buf = Buffer.create 256 in
       let rec read_until_closed_or_deadline () =
         let elapsed = Unix.gettimeofday () -. start_time in
-        let remaining = deadline -. elapsed in
+        let remaining = read_deadline -. elapsed in
         if remaining <= 0.0 then ()
         else
           match Unix.select [client_sock] [] [] remaining with
@@ -12406,9 +12412,10 @@ let test_interp_http_server_idle_client_does_not_block_others () =
       Alcotest.(check bool)
         (Printf.sprintf
            "second client served promptly (%.3fs) despite idle first client \
-            — must be well under the %.1fs deadline, not just barely under it"
-           elapsed deadline)
-        true (elapsed < 1.0))
+            — must be under the %.1fs promptness limit (itself well inside \
+            the %.1fs read deadline)"
+           elapsed prompt_limit read_deadline)
+        true (elapsed < prompt_limit))
   end
 
 (* Regression (sibling of the idle-HTTP-client test above, one layer deeper):
@@ -12554,11 +12561,24 @@ let test_interp_http_server_idle_websocket_does_not_block_others () =
       Unix.connect client_sock connect_addr;
       let request = "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n" in
       ignore (Unix.write_substring client_sock request 0 (String.length request));
-      let deadline = 2.0 in
+      (* Two deliberately different numbers, and they are not interchangeable:
+         [read_deadline] only bounds how long we wait before giving up (so a
+         pre-fix hang fails fast instead of blocking the suite), while
+         [prompt_limit] is the actual regression threshold. [prompt_limit]
+         must stay strictly below [read_deadline] or the check degenerates
+         into the "got a response at all" assertion above.
+
+         The bar is loose on purpose. A served request is milliseconds on an
+         idle box; the pre-fix bug produces no response at all, so anything
+         well under [read_deadline] discriminates. A tight bar buys no extra
+         detection and does cost false failures — this fired once at 1.284s
+         purely because other builds were running on the same machine. *)
+      let read_deadline = 6.0 in
+      let prompt_limit  = 3.0 in
       let buf = Buffer.create 256 in
       let rec read_until_closed_or_deadline () =
         let elapsed = Unix.gettimeofday () -. start_time in
-        let remaining = deadline -. elapsed in
+        let remaining = read_deadline -. elapsed in
         if remaining <= 0.0 then ()
         else
           match Unix.select [client_sock] [] [] remaining with
@@ -12628,9 +12648,10 @@ let test_interp_http_server_idle_websocket_does_not_block_others () =
       Alcotest.(check bool)
         (Printf.sprintf
            "HTTP client served promptly (%.3fs) despite an open idle WebSocket \
-            — must be well under the %.1fs deadline"
-           elapsed deadline)
-        true (elapsed < 1.0);
+            — must be under the %.1fs promptness limit (itself well inside \
+            the %.1fs read deadline)"
+           elapsed prompt_limit read_deadline)
+        true (elapsed < prompt_limit);
       Alcotest.(check bool)
         "the parked WebSocket still echoes after the HTTP request \
          (fiber resumed, not dropped)"


### PR DESCRIPTION
## Problem

Adversarial-regressions #51 and #52 (`test_interp_http_server_idle_client_does_not_block_others`, `test_interp_http_server_idle_websocket_does_not_block_others`) each built a failure message that interpolated `deadline` (2.0) while the predicate was the hard-coded `elapsed < 1.0`:

```ocaml
Alcotest.(check bool)
  (Printf.sprintf
     "HTTP client served promptly (%.3fs) despite an open idle WebSocket \
      — must be well under the %.1fs deadline"
     elapsed deadline)
  true (elapsed < 1.0);
```

A failure therefore reported `1.284s ... must be well under the 2.0s deadline`, which reads as a contradiction and makes a marginal timing flake look like a real regression.

## Why neither one-line fix is right

The two numbers are genuinely different things, not a naming slip:

- `deadline` (2.0) bounds the `select()` read — how long we wait before giving up.
- `1.0` is the regression threshold.

Changing the predicate to `elapsed < deadline` would have made the check **vacuous**: the read loop already stops at `deadline`, so `elapsed < 2.0` is nearly implied by the preceding `String.length response > 0` assertion.

So instead both concepts get their own name — `read_deadline` and `prompt_limit` — and both the predicate and the message reference them. The message now names exactly the number the predicate tests, plus the read bound it sits inside.

The sibling test's original wording ("must be well under the %.1fs deadline, **not just barely under it**") is what confirms this was the intent all along; #52 dropped that clause when it was copied, which is what turned it into a contradiction.

## Threshold

Raised to `prompt_limit = 3.0`, `read_deadline = 6.0`. The pre-fix bug produces *no response at all*, so a loose bar discriminates exactly as well as a tight one — tightening buys zero extra detection and costs false failures. #52 was observed failing at 1.284s purely because other builds were running concurrently, passing on a re-run. The read bound had to move up too, or a 3.0s bar would sit at the point where the read loop gives up. A real regression still fails fast (6s, not a hang).

## Scope

Both tests changed. Only #52 had the contradictory message, but #51 has the identical 1.0s bar and identical load exposure — fixing only #52 would leave the same flake firing from the test directly above it.

What either test verifies is unchanged: same handshake, same idle-connection-then-GET shape, same 200-OK and post-request WS-echo assertions.

No CHANGELOG entry — test-only, no observable behavior change.

## Verification

`scripts/run-tests.sh stdlib` → exit 0, 834 tests, "All suites passed", including adversarial-regressions #51 and #52.

Not verified empirically: that the check is still non-vacuous by measuring actual `elapsed`. Alcotest doesn't print the message on success and forcing a failure costs a ~240s run. The indirect evidence is that the old 1.0s bar passed consistently on an idle box, so normal serve time is well under it.
