### PR TITLE
fix(typecheck): Pass 3 matched call sites against a pre-desugar namespace

### DIFF
--- a/lib/typecheck/typecheck.ml
+++ b/lib/typecheck/typecheck.ml
@@ -12138,11 +12138,18 @@ let scrutinee_is_param_or_smaller (params : StringSet.t) (smaller : StringSet.t)
     for its extent, so a call to a shadowing local is not misattributed to the
     same-named recursive function. *)
 let rec check_tail_position
+    ?(display = fun (n : string) -> n)
     (errors : Err.ctx)
     (recursive_names : StringSet.t)
     (fn_name : string)
     (fn_params : StringSet.t)
     (body : Ast.expr) : unit =
+  (* [recursive_names] is in the post-desugar CALL-SITE namespace, which inside
+     a nested `mod` carries a qualifying prefix the author never typed
+     (`Inner.boom` for a source that says `boom`).  [display] maps a matched
+     call-site name back to the bare name, so the diagnostic quotes the program
+     rather than the desugarer's rewrite.  Defaults to the identity for the
+     inner-`fn` recursion below, whose names are local and never qualified. *)
   (* [smaller] accumulates variables known to be structurally smaller than a
      function parameter (introduced by pattern-matching on a parameter). *)
   let rec chk in_tail (names : StringSet.t) (smaller : StringSet.t) ctx expr =
@@ -12162,7 +12169,7 @@ let rec check_tail_position
                "Function `%s`: recursive call to `%s` is not in tail position \
                 (%s).\n\
                 Hint: Consider using an accumulator parameter."
-               fn_name fn.txt ctx)
+               fn_name (display fn.txt) ctx)
         else begin
           (* Structural recursion: warn but allow — distinguish arithmetic
              reductions (n-1, n-2) from pattern-bound sub-components. *)
@@ -12312,8 +12319,57 @@ let rec check_tail_position
   chk true recursive_names StringSet.empty "" body
 
 (** Run tail-call enforcement for all [DFn] declarations in [decls]
-    (at a single scope level).  Recurses into [DMod] sub-modules. *)
-let rec enforce_tail_calls_in_decls (errors : Err.ctx) (decls : Ast.decl list) : unit =
+    (at a single scope level).  Recurses into [DMod] sub-modules.
+
+    [mod_path] is the accumulated dotted path of the enclosing [DMod]s, with a
+    trailing dot ("" at the top level, then "Inner.", then "Outer.Inner.").
+    [file_mod] is the name of the module this file declares.
+
+    ── Why a PATH is needed at all ──────────────────────────────────────────
+
+    This pass runs AFTER desugaring, and desugaring rewrites call sites into a
+    different namespace than the one declarations live in.
+    [Desugar.qualify_module_refs] rewrites bare intra-module CALL SITES inside
+    every nested [DMod] to [Prefix.name] ([EVar "boom"] -> [EVar "Inner.boom"]),
+    and deliberately leaves the DECLARATION name alone.  Building [fn_names]
+    from the bare [def.fn_name.txt] therefore searched a post-desugar body for a
+    pre-desugar name: [collect_direct_fn_calls] matched nothing, [is_recursive]
+    came out false, and the function was never checked.  Everything this pass
+    rejects at the top level was silently accepted one [mod] deeper, at any
+    depth — and the [DMod] recursion below, which looks like it covers nested
+    modules, ran and found nothing.
+
+    The top level of the ENTRY file hid this: [qualify_module_refs] seeds
+    [entry_prefix = ""] and only rewrites inside [DMod] NODES, and the parser
+    splits a file's sole top-level [mod] into [mod_name]/[mod_decls] — so a
+    top-level [DFn] is never qualified and never mismatched.
+
+    ── Why TWO candidate prefixes ───────────────────────────────────────────
+
+    A name declared here can be referenced under either of two conventions, and
+    which one applies is a property of the FILE, not of this declaration list:
+
+    - [mod_path] — the entry file's convention.  [desugar_module] passes
+      [~entry_prefix:""] when [is_entry], so the accumulation starts empty.
+    - [file_mod ^ "." ^ mod_path] — the non-entry convention.  A dependency
+      file is desugared with [~entry_prefix:(mod_name ^ ".")], so a nested
+      module inside stdlib's [Helper] qualifies to ["Helper.Inner."], not
+      ["Inner."].
+
+    Typecheck is not told which one it is looking at, so it accepts both.  This
+    costs nothing in precision: a file is one or the other, so the inapplicable
+    candidate simply never occurs in any body.
+
+    At the TOP level ([mod_path = ""]) the second candidate is [file_mod ^ "."],
+    which additionally catches a hand-written SELF-QUALIFIED call in a non-entry
+    module ([Helper.boom] inside [mod Helper]) — [strip_entry_self_qual]
+    normalises that away only for the entry file, so in a dependency it survives
+    to here and was a second, nesting-free instance of the same blind spot.
+    Recognising it cannot misfire: inside [mod Helper], [Helper.boom] is
+    unambiguously this module's [boom]. *)
+let rec enforce_tail_calls_in_decls
+    ?(mod_path = "") ~(file_mod : string)
+    (errors : Err.ctx) (decls : Ast.decl list) : unit =
   (* Names declared in an [extern] block at this level.  An extern has no
      body, so it can never recurse; a bare call to one must not be resolved
      against a same-named ordinary function (the entry module's decls include
@@ -12328,22 +12384,49 @@ let rec enforce_tail_calls_in_decls (errors : Err.ctx) (decls : Ast.decl list) :
       | _ -> acc
     ) StringSet.empty decls
   in
-  (* Collect function names at this level *)
-  let fn_names =
+  (* Collect function names at this level, BARE — the namespace declarations
+     and diagnostics live in, and the one the call graph is keyed by. *)
+  let bare_fn_names =
     List.fold_left (fun acc d ->
       match d with
       | Ast.DFn (def, _) -> StringSet.add def.fn_name.txt acc
       | _ -> acc
     ) StringSet.empty decls
   in
-  let fn_names = StringSet.diff fn_names extern_names in
+  (* Extern names are subtracted BARE, before qualification: an extern is never
+     qualified at a call site either ([qualify_level] passes [~externs:false]),
+     so the two sets are comparable only here. *)
+  let bare_fn_names = StringSet.diff bare_fn_names extern_names in
+  (* The two conventions a name declared here can be referenced under — see
+     this function's doc comment. *)
+  let prefixes = [ mod_path; file_mod ^ "." ^ mod_path ] in
+  (* [call_names] is the CALL-SITE namespace (what [collect_direct_fn_calls]
+     and [check_tail_position] match [EVar]s against); [to_bare] maps back, so
+     the graph, the SCCs and the diagnostics all stay in the bare namespace. *)
+  let to_bare = Hashtbl.create 16 in
+  let call_names =
+    StringSet.fold (fun bare acc ->
+      List.fold_left (fun acc p ->
+        let qualified = p ^ bare in
+        Hashtbl.replace to_bare qualified bare;
+        StringSet.add qualified acc
+      ) acc prefixes
+    ) bare_fn_names StringSet.empty
+  in
+  (* Callees of [body], as BARE local names. *)
+  let bare_calls_in body =
+    StringSet.fold (fun called acc ->
+      match Hashtbl.find_opt to_bare called with
+      | Some bare -> StringSet.add bare acc
+      | None -> acc
+    ) (collect_direct_fn_calls call_names body) StringSet.empty
+  in
   (* Build call graph *)
   let adj = List.filter_map (function
     | Ast.DFn (def, _) ->
       (match def.fn_clauses with
        | [clause] ->
-         Some (def.fn_name.txt,
-               collect_direct_fn_calls fn_names clause.Ast.fc_body)
+         Some (def.fn_name.txt, bare_calls_in clause.Ast.fc_body)
        | _ -> None)
     | _ -> None
   ) decls in
@@ -12367,7 +12450,14 @@ let rec enforce_tail_calls_in_decls (errors : Err.ctx) (decls : Ast.decl list) :
            StringSet.mem def.fn_name.txt direct
          in
          if is_recursive && not (List.mem "no_warn_recursion" def.fn_attrs) then begin
-           let rec_set = List.fold_right StringSet.add scc StringSet.empty in
+           (* [check_tail_position] matches [EVar]s, so the recursive-name set
+              has to be in the CALL-SITE namespace, not the bare one. *)
+           let rec_set =
+             List.fold_left (fun acc bare ->
+               List.fold_left (fun acc p -> StringSet.add (p ^ bare) acc)
+                 acc prefixes
+             ) StringSet.empty scc
+           in
            let fn_params =
              List.fold_left (fun acc p ->
                match p with
@@ -12376,11 +12466,15 @@ let rec enforce_tail_calls_in_decls (errors : Err.ctx) (decls : Ast.decl list) :
                | Ast.FPPat pat -> StringSet.union acc (collect_pattern_vars pat)
              ) StringSet.empty clause.Ast.fc_params
            in
-           check_tail_position errors rec_set def.fn_name.txt fn_params clause.Ast.fc_body
+           let display n =
+             match Hashtbl.find_opt to_bare n with Some b -> b | None -> n in
+           check_tail_position ~display errors rec_set def.fn_name.txt fn_params
+             clause.Ast.fc_body
          end
        | _ -> ())
-    | Ast.DMod (_, _, inner_decls, _) ->
-      enforce_tail_calls_in_decls errors inner_decls
+    | Ast.DMod (name, _, inner_decls, _) ->
+      enforce_tail_calls_in_decls
+        ~mod_path:(mod_path ^ name.txt ^ ".") ~file_mod errors inner_decls
     | _ -> ()
   ) decls
 
@@ -12943,7 +13037,7 @@ let check_module_core ?(errors = Err.create ()) ?seed_env (m : Ast.module_)
   (* Warn about any unused imports or aliases *)
   warn_unused_imports final_env;
   (* Pass 3: tail-call enforcement *)
-  enforce_tail_calls_in_decls errors m.Ast.mod_decls;
+  enforce_tail_calls_in_decls ~file_mod:m.Ast.mod_name.txt errors m.Ast.mod_decls;
   (errors, type_map, final_env)
 
 let check_module ?errors (m : Ast.module_) : Err.ctx * (Ast.span, ty) Hashtbl.t =
@@ -13184,7 +13278,7 @@ let check_module_with_env (env : env) (m : Ast.module_) : Err.ctx * (Ast.span, t
   let final_env = List.fold_left check_decl pre_env (reorder_decls m.Ast.mod_decls) in
   last_with_env_final := final_env;
   (* Pass 3: tail-call enforcement *)
-  enforce_tail_calls_in_decls errors m.Ast.mod_decls;
+  enforce_tail_calls_in_decls ~file_mod:m.Ast.mod_name.txt errors m.Ast.mod_decls;
   (errors, type_map)
 
 (** Like [check_module_with_env] but also returns the final typing env.

--- a/test/test_compiler.ml
+++ b/test/test_compiler.ml
@@ -11858,6 +11858,209 @@ let test_tce_real_mutual_recursion_still_errors () =
   Alcotest.(check bool) "genuine mutual recursion still reported"
     true (has_error_with ctx "not in tail position")
 
+(* ── Pass 3 inside a nested `mod` ────────────────────────────────────────────
+
+   `enforce_tail_calls_in_decls` recurses into `DMod`, so Pass 3 *runs* at every
+   nesting level — but it found nothing there, because it was comparing two
+   different namespaces.  `Desugar.qualify_module_refs` rewrites bare
+   intra-module CALL SITES inside every nested `DMod` to `Prefix.name`
+   (`EVar "boom"` -> `EVar "Inner.boom"`), and deliberately leaves the
+   DECLARATION name alone.  Pass 3 then built `fn_names` from the bare
+   `def.fn_name.txt`, so `collect_direct_fn_calls` searched a post-desugar body
+   for a pre-desugar name, matched nothing, and concluded the function was not
+   recursive at all.
+
+   The entry module was unaffected and hid this: `qualify_module_refs` seeds
+   `entry_prefix = ""` and only rewrites inside `DMod` NODES, and the parser
+   splits a file's sole top-level `mod` into `mod_name`/`mod_decls` — so the
+   entry level has no prefix to mismatch.
+
+   Everything Pass 3 rejects at top level was therefore silently accepted one
+   `mod` deeper. *)
+
+let test_tce_nested_mod_non_tail_recursion_errors () =
+  let ctx = typecheck {|mod T do
+    mod Inner do
+      fn boom(n : Int) : Int do
+        if n == 0 do 0 else boom(n + 1) + 1 end
+      end
+    end
+  end|} in
+  Alcotest.(check bool) "non-tail recursion inside a nested mod is reported"
+    true (has_error_with ctx "not in tail position")
+
+let test_tce_nested_mod_mutual_recursion_errors () =
+  let ctx = typecheck {|mod T do
+    mod Inner do
+      fn even(n : Int) : Int do
+        if n == 0 do 1 else 1 + odd(n) end
+      end
+      fn odd(n : Int) : Int do
+        if n == 0 do 0 else even(n) end
+      end
+    end
+  end|} in
+  Alcotest.(check bool) "mutual recursion inside a nested mod is reported"
+    true (has_error_with ctx "not in tail position")
+
+let test_tce_doubly_nested_mod_non_tail_recursion_errors () =
+  (* The prefix ACCUMULATES (`Outer.Inner.`), so a fix that only strips one
+     level would still miss this. *)
+  let ctx = typecheck {|mod T do
+    mod Outer do
+      mod Inner do
+        fn boom(n : Int) : Int do
+          if n == 0 do 0 else boom(n + 1) + 1 end
+        end
+      end
+    end
+  end|} in
+  Alcotest.(check bool) "non-tail recursion two mods deep is reported"
+    true (has_error_with ctx "not in tail position")
+
+(* Controls: the fix must not over-correct.  Each of these is a shape Pass 3
+   deliberately allows at top level, and must keep allowing one mod deeper. *)
+
+let test_tce_nested_mod_structural_recursion_no_error () =
+  let ctx = typecheck {|mod T do
+    mod Inner do
+      fn fact(n : Int) : Int do
+        if n <= 1 do 1 else fact(n - 1) * n end
+      end
+    end
+  end|} in
+  Alcotest.(check bool) "structural recursion inside a nested mod: no error"
+    false (has_error_with ctx "not in tail position")
+
+let test_tce_nested_mod_tail_recursion_no_error () =
+  let ctx = typecheck {|mod T do
+    mod Inner do
+      fn count(n : Int, acc : Int) : Int do
+        if n == 0 do acc else count(n - 1, acc + 1) end
+      end
+    end
+  end|} in
+  Alcotest.(check bool) "tail recursion inside a nested mod: no error"
+    false (has_error_with ctx "not in tail position")
+
+let test_tce_nested_mod_no_warn_recursion_opts_out () =
+  let ctx = typecheck {|mod T do
+    mod Inner do
+      @[no_warn_recursion]
+      fn boom(n : Int) : Int do
+        if n == 0 do 0 else boom(n + 1) + 1 end
+      end
+    end
+  end|} in
+  Alcotest.(check bool) "`no_warn_recursion` still opts out inside a nested mod"
+    false (has_error_with ctx "not in tail position")
+
+(* A DEPENDENCY file is desugared with [~is_entry:false], which changes two
+   things at once: [strip_entry_self_qual] does NOT run (so a hand-written
+   self-qualified call survives verbatim), and [qualify_module_refs] is seeded
+   with [~entry_prefix:(mod_name ^ ".")] (so a nested module qualifies to
+   "Helper.Inner.", not "Inner.").  Both were blind spots, and the second one
+   is why this pass accepts BOTH candidate prefixes at every level. *)
+let typecheck_non_entry src =
+  let m = March_desugar.Desugar.desugar_module ~is_entry:false (parse_module src) in
+  let (errors, _type_map) = March_typecheck.Typecheck.check_module m in
+  errors
+
+let test_tce_non_entry_self_qualified_call_errors () =
+  (* No nesting at all — `Helper.boom` inside `mod Helper` is this module's own
+     `boom`, but the call site carries a prefix the declaration does not. *)
+  let ctx = typecheck_non_entry {|mod Helper do
+    fn boom(n : Int) : Int do
+      if n == 0 do 0 else Helper.boom(n + 1) + 1 end
+    end
+  end|} in
+  Alcotest.(check bool) "self-qualified call in a dependency module is reported"
+    true (has_error_with ctx "not in tail position")
+
+let test_tce_non_entry_nested_mod_errors () =
+  (* Prefix here is "Helper.Inner.", so a fix that accumulated only the nested
+     names would still miss this. *)
+  let ctx = typecheck_non_entry {|mod Helper do
+    mod Inner do
+      fn boom(n : Int) : Int do
+        if n == 0 do 0 else boom(n + 1) + 1 end
+      end
+    end
+  end|} in
+  Alcotest.(check bool) "nested mod inside a dependency module is reported"
+    true (has_error_with ctx "not in tail position")
+
+let test_tce_non_entry_structural_recursion_no_error () =
+  let ctx = typecheck_non_entry {|mod Helper do
+    mod Inner do
+      fn fact(n : Int) : Int do
+        if n <= 1 do 1 else fact(n - 1) * n end
+      end
+    end
+  end|} in
+  Alcotest.(check bool) "structural recursion in a dependency module: no error"
+    false (has_error_with ctx "not in tail position")
+
+let test_tce_nested_mod_local_shadow_no_false_recursion () =
+  (* The shadowing discipline must survive the namespace change.  `Desugar`
+     already declines to qualify a call to a shadowed name (`make_qualifier`
+     tracks `bound`), so the call site stays bare `go` while the declaration
+     is `Inner.go` — the two must not be conflated back together. *)
+  let ctx = typecheck {|mod T do
+    mod Inner do
+      fn helper(n : Int) : Int do
+        fn go(k : Int, acc : Int) : Int do
+          if k == 0 do acc else go(k - 1, acc + 1) end
+        end
+        go(n, 0)
+      end
+      fn go(m : Int) : Int do
+        if helper(m) == 0 do 0 else 1 end
+      end
+    end
+  end|} in
+  Alcotest.(check bool) "local helper shadowing a nested-mod fn: no error"
+    false (has_error_with ctx "not in tail position")
+
+let test_tce_nested_mod_let_lambda_shadow_no_false_recursion () =
+  let ctx = typecheck {|mod T do
+    mod Inner do
+      fn helper(n : Int) : Int do
+        let go = fn k -> k + 1
+        go(n)
+      end
+      fn go(m : Int) : Int do
+        if helper(m) == 0 do 0 else 1 end
+      end
+    end
+  end|} in
+  Alcotest.(check bool) "let-bound lambda shadowing a nested-mod fn: no error"
+    false (has_error_with ctx "not in tail position")
+
+let test_tce_nested_mod_arm_bound_shadow_no_false_recursion () =
+  (* The sharpest of the three.  `f`/`g` really ARE mutually recursive here, so
+     the SCC is genuine and `f` really is checked — only the arm-bound `g` must
+     not be mistaken for the module's `g`.  At top level `check_tail_position`
+     retires the arm binder itself; inside a nested `mod` the recursive-name set
+     is qualified (`Inner.g`), so that retirement is a no-op and the property
+     rests entirely on `Desugar.make_qualifier` having declined to qualify the
+     shadowed call.  This test is what proves it does. *)
+  let ctx = typecheck {|mod T do
+    mod Inner do
+      fn f(n : Int) : Int do
+        match Some(fn x -> x + 1) do
+          Some(g) -> g(n) + 1
+          None -> g(n)
+        end
+      end
+      fn g(n : Int) : Int do
+        if n == 0 do 0 else f(n - 1) end
+      end
+    end
+  end|} in
+  Alcotest.(check bool) "arm-bound name shadowing a nested-mod SCC member: no error"
+    false (has_error_with ctx "not in tail position")
+
 (* ── collect_direct_names: the inner pattern walk must be exhaustive ─────── *)
 
 (* `collect_direct_names`' inner pattern walk feeds `strip_entry_self_qual`. Its
@@ -13567,6 +13770,18 @@ let compiler_suites =
           Alcotest.test_case "match-arm name shadowing an SCC member: no error"     `Quick test_tce_arm_bound_name_shadows_scc_member;
           Alcotest.test_case "genuine non-tail self-recursion: still errors"        `Quick test_tce_real_non_tail_recursion_still_errors;
           Alcotest.test_case "genuine mutual recursion: still errors"               `Quick test_tce_real_mutual_recursion_still_errors;
+          Alcotest.test_case "nested mod, non-tail self-recursion: errors"          `Quick test_tce_nested_mod_non_tail_recursion_errors;
+          Alcotest.test_case "nested mod, mutual recursion: errors"                 `Quick test_tce_nested_mod_mutual_recursion_errors;
+          Alcotest.test_case "doubly-nested mod, non-tail recursion: errors"        `Quick test_tce_doubly_nested_mod_non_tail_recursion_errors;
+          Alcotest.test_case "nested mod, structural recursion: no error"           `Quick test_tce_nested_mod_structural_recursion_no_error;
+          Alcotest.test_case "nested mod, tail recursion: no error"                 `Quick test_tce_nested_mod_tail_recursion_no_error;
+          Alcotest.test_case "nested mod, `no_warn_recursion`: no error"            `Quick test_tce_nested_mod_no_warn_recursion_opts_out;
+          Alcotest.test_case "nested mod, local shadow: no error"                   `Quick test_tce_nested_mod_local_shadow_no_false_recursion;
+          Alcotest.test_case "nested mod, let-lambda shadow: no error"              `Quick test_tce_nested_mod_let_lambda_shadow_no_false_recursion;
+          Alcotest.test_case "nested mod, arm-bound shadow in a real SCC: no error" `Quick test_tce_nested_mod_arm_bound_shadow_no_false_recursion;
+          Alcotest.test_case "dependency mod, self-qualified call: errors"          `Quick test_tce_non_entry_self_qualified_call_errors;
+          Alcotest.test_case "dependency mod, nested mod: errors"                   `Quick test_tce_non_entry_nested_mod_errors;
+          Alcotest.test_case "dependency mod, structural recursion: no error"       `Quick test_tce_non_entry_structural_recursion_no_error;
         ] );
   ]
 


### PR DESCRIPTION
Tail-call enforcement silently did nothing inside a nested `mod`, at any depth. Everything it rejects at the top level was accepted one `mod` deeper:

```march
mod M do
  mod Inner do
    fn boom(n : Int) : Int do
      if n == 0 do 0 else boom(n + 1) + 1 end   -- accepted; rejected at top level
    end
  end
end
```

## Root cause

`enforce_tail_calls_in_decls` recurses into `DMod`, so the pass **ran** at every level — it just never matched anything.

It runs after desugaring, and `Desugar.qualify_module_refs` rewrites bare intra-module **call sites** inside every nested `DMod` to `Prefix.name` (`EVar "boom"` → `EVar "Inner.boom"`), while deliberately leaving the **declaration** name bare. Building `fn_names` from `def.fn_name.txt` therefore searched a post-desugar body for a pre-desugar name: `collect_direct_fn_calls` matched nothing, `is_recursive` came out false, and the function was never checked.

The entry file's top level hid it. `qualify_module_refs` seeds `entry_prefix = ""` and only rewrites inside `DMod` *nodes*, and the parser splits a file's sole top-level `mod` into `mod_name`/`mod_decls` — so a top-level `DFn` is never qualified and never mismatched.

## Fix

Thread the module path, and match call sites under **both** conventions a name can be referenced by — which one applies is a property of the *file*, and typecheck is not told which it has:

- `mod_path` — the entry convention (`~entry_prefix:""`).
- `file_mod ^ "." ^ mod_path` — the non-entry convention. A dependency is desugared with `~entry_prefix:(mod_name ^ ".")`, so a nested module inside stdlib's `Helper` qualifies to `"Helper.Inner."`, not `"Inner."`.

Accepting both costs nothing in precision: a file is one or the other, so the inapplicable candidate never occurs in any body.

The graph, the SCCs and the diagnostics stay in the bare namespace via a `to_bare` map; only the `EVar`-matching sets are qualified. Without that last part the error read ``recursive call to `Inner.boom` `` for a source that says `boom`.

At the top level the second candidate is `file_mod ^ "."`, which catches a **second, nesting-free instance of the same blind spot**: a hand-written self-qualified call in a dependency module (`Helper.boom` inside `mod Helper`). `strip_entry_self_qual` normalises that away only for the entry file, so in a dependency it survived to here.

## Scope of the change

This un-hides a check that has been dormant, so the question is what it now catches.

- **Zero** new diagnostics across 360 of march's own files (`stdlib/`, `examples/`, `specs/lang/`).
- Five stdlib files (`duration`, `json`, `msgpack`, `toml`, `yaml`) do carry genuine non-tail recursion — but **identically before and after this commit**, verified by building both ways. Pre-existing, untouched here.
- Full `dune build @runtest` green (563 codegen tests + the rest, `RUNTEST_EXIT=0`).

## Tests

18 cases in `tail_call_enforcement`. Five assert the newly-caught rejects and **fail without the fix**: nested, mutual-inside-nested, doubly-nested (the prefix accumulates, so a one-level fix would still miss it), dependency self-qualified, dependency nested.

The rest are controls that must keep *not* firing: structural recursion, tail recursion, `@[no_warn_recursion]`, and all three shadowing shapes at nested level.

The shadowing controls carry more weight than usual here. With a qualified recursive-name set, `check_tail_position`'s own bare-name retirement becomes a no-op inside a nested `mod`, so correctness now rests on `Desugar.make_qualifier` having declined to qualify a shadowed call. `nested mod, arm-bound shadow in a real SCC` guards exactly that new coupling — mutation-tested: it goes red, and only it, if `make_qualifier` stops tracking match-arm binders.

## How this was found

While building an independent Lean model of Pass 3 (march-language/march-lean#22), a hand-built probe showed march accepting a nested-`mod` recursion it rejects at top level. Reading `enforce_tail_calls_in_decls` would not have found it — the `DMod` arm is right there and looks load-bearing.