### PR TITLE
tir(trmc): destination-passing transform + reuse-with-hole (2.7x on list producers)

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1258,6 +1258,12 @@ let hr_cas_tag () = match !hot_reload_prefix with Some p -> ["hr:" ^ p] | None -
 let codegen_cas_tags () =
   "rtcflags2"
   :: (if Sys.getenv_opt "MARCH_SANITIZE" <> None then ["sanitize"] else [])
+  (* MARCH_TRMC rewrites eligible functions into destination-passing style, so
+     it changes the emitted binary.  Without this tag a cached non-TRMC
+     artifact silently satisfies a TRMC build and vice versa — which is exactly
+     how the first TRMC benchmark run reported a 0.06s "TRMC off" number that
+     was really the TRMC binary served from the cache. *)
+  @ (if Sys.getenv_opt "MARCH_TRMC" <> None then ["trmc"] else [])
   @ (if (try Sys.getenv "MARCH_HTTP_EVLOOP" = "1" with Not_found -> false)
      then ["evloop"] else [])
   @ (if !fast_math then ["fast-math"] else [])
@@ -2522,6 +2528,10 @@ let compile filename =
        longer syntactically visible.  See
        specs/todos/2026-08-07-trmc-tail-recursion-modulo-cons.md. *)
     March_tir.Trmc.report tir;
+    (* Phase 3 (WIP, gated on MARCH_TRMC=1): destination-passing rewrite of
+       TRMC-eligible functions.  Off by default — this is a measurement
+       vehicle until the RC integration (phase 4) is done. *)
+    let tir = March_tir.Trmc.transform_module tir in
     (* Phase 5: collect actor state schemas for .schemas.json emission.
        Picks up TDRecord entries named *_State — the state record emitted
        by lower_actor for every actor definition. Only collected when both
@@ -3793,7 +3803,9 @@ let compile filename =
             | EReuse (a, _, args) ->
               scan_atom caller a;
               List.iter (scan_atom caller) args
-            | EAllocHole (_, args, _) -> List.iter (scan_atom caller) args
+            | EAllocHole (tok, _, args, _) ->
+              Option.iter (scan_atom caller) tok;
+              List.iter (scan_atom caller) args
             | ESetField (o, _, v) -> scan_atom caller o; scan_atom caller v
           and scan_atom _caller _a = ()
           in

--- a/lib/cas/pipeline.ml
+++ b/lib/cas/pipeline.ml
@@ -75,8 +75,10 @@ let rec add_tycons_of_expr acc (e : expr) : string list =
   | EReuse (a, ty, args) ->
     List.fold_left add_tycons_of_atom (add_tycons_of_ty (add_tycons_of_atom acc a) ty) args
   | EFree a | EIncRC a | EDecRC a | EAtomicIncRC a | EAtomicDecRC a -> add_tycons_of_atom acc a
-  | EAllocHole (ty, args, _) ->
-    List.fold_left add_tycons_of_atom (add_tycons_of_ty acc ty) args
+  | EAllocHole (tok, ty, args, _) ->
+    List.fold_left add_tycons_of_atom
+      (Option.fold ~none:(add_tycons_of_ty acc ty)
+         ~some:(add_tycons_of_atom (add_tycons_of_ty acc ty)) tok) args
   | ESetField (o, _, v) -> add_tycons_of_atom (add_tycons_of_atom acc o) v
   | ESeq (e1, e2)      -> add_tycons_of_expr (add_tycons_of_expr acc e1) e2
 

--- a/lib/cas/scc.ml
+++ b/lib/cas/scc.ml
@@ -51,7 +51,9 @@ let rec refs_in_expr (known : string list) (e : expr) : string list =
   | EAtomicIncRC a | EAtomicDecRC a -> refs_in_atom known a
   | EReuse (a, _, args)       ->
     refs_in_atom known a @ List.concat_map (refs_in_atom known) args
-  | EAllocHole (_, args, _)   -> List.concat_map (refs_in_atom known) args
+  | EAllocHole (tok, _, args, _) ->
+    (match tok with Some a -> refs_in_atom known a | None -> [])
+    @ List.concat_map (refs_in_atom known) args
   | ESetField (o, _, v)       -> refs_in_atom known o @ refs_in_atom known v
   | ESeq (e1, e2)             -> refs_in_expr known e1 @ refs_in_expr known e2
 

--- a/lib/cas/serialize.ml
+++ b/lib/cas/serialize.ml
@@ -302,10 +302,17 @@ let rec write_expr buf (next : int ref) (scope : (string * int) list) (e : expr)
   (* TRMC.  The hole INDEX is part of the fingerprint: two otherwise identical
      allocations that leave different fields unwritten are different programs,
      so omitting it would let the CAS serve one for the other. *)
-  | EAllocHole (ty, args, hole) ->
+  | EAllocHole (tok, ty, args, hole) ->
     buf_u8 buf 0x53;
     write_ty buf ty;
     buf_u32_le buf hole;
+    (* The reuse token is part of the fingerprint: the same hole allocation
+       with and without a token compiles to different code (in-place reuse vs
+       a fresh cell), so omitting it would let the CAS serve one for the
+       other. *)
+    (match tok with
+     | None -> buf_u8 buf 0x00
+     | Some a -> buf_u8 buf 0x01; write_atom buf scope a);
     buf_u32_le buf (List.length args);
     List.iter (write_atom buf scope) args
   | ESetField (o, i, v) ->

--- a/lib/dump/dump.ml
+++ b/lib/dump/dump.ml
@@ -401,7 +401,7 @@ let rec count_tir_nodes (e : March_tir.Tir.expr) =
   | EField _ | EUpdate _          -> 1
   | EIncRC _ | EDecRC _ | EAtomicIncRC _ | EAtomicDecRC _ | EFree _ -> 1
   | EReuse (_, _, args)           -> 1 + List.length args
-  | EAllocHole (_, args, _)       -> 1 + List.length args
+  | EAllocHole (_, _, args, _)    -> 1 + List.length args
   | ESetField _                   -> 1
 
 (** Check whether a function body calls itself (direct recursion check). *)

--- a/lib/tir/borrow.ml
+++ b/lib/tir/borrow.ml
@@ -500,7 +500,7 @@ let rec owned_in (name : string) (bm : borrow_map) (e : Tir.expr) : bool =
      EAlloc — an owning use.  ESetField likewise moves the stored value into
      the object; the TARGET is only mutated, which is not an owning use of
      the target itself. *)
-  | Tir.EAllocHole (_, args, _) ->
+  | Tir.EAllocHole (_, _, args, _) ->
     List.exists (fun a -> atom_is name a) args
   | Tir.ESetField (_, _, v) -> atom_is name v
 

--- a/lib/tir/cap_attrib.ml
+++ b/lib/tir/cap_attrib.ml
@@ -92,7 +92,7 @@ let rec walk (caps, callees) (e : Tir.expr) =
   | Tir.EAlloc (_, atoms) | Tir.EStackAlloc (_, atoms) ->
     (add_atoms caps atoms, callees)
   | Tir.EReuse (a, _, atoms) -> (add_atoms caps (a :: atoms), callees)
-  | Tir.EAllocHole (_, atoms, _) -> (add_atoms caps atoms, callees)
+  | Tir.EAllocHole (_, _, atoms, _) -> (add_atoms caps atoms, callees)
   | Tir.ESetField (o, _, v) -> (add_atoms caps [ o; v ], callees)
   (* RC ops and EFree only ever carry an already-bound local, never a
      top-level function name, but scanning them costs nothing and keeps this

--- a/lib/tir/cprop.ml
+++ b/lib/tir/cprop.ml
@@ -291,8 +291,10 @@ let rec cprop_expr ~changed (env : env) (avar : avar_env) (fenv : field_env)
   | Tir.EStackAlloc (ty, args) ->
     Tir.EStackAlloc (ty, subst_atoms ~changed env avar args)
 
-  | Tir.EAllocHole (ty, args, hole) ->
-    Tir.EAllocHole (ty, subst_atoms ~changed env avar args, hole)
+    (* The reuse token, like EReuse's, is NOT substituted: it names the exact
+     cell whose storage is taken over. *)
+  | Tir.EAllocHole (tok, ty, args, hole) ->
+    Tir.EAllocHole (tok, ty, subst_atoms ~changed env avar args, hole)
 
   (* The stored VALUE may be substituted like any other operand.  The target
      object may NOT: ESetField mutates it in place, so replacing it with an

--- a/lib/tir/dce.ml
+++ b/lib/tir/dce.ml
@@ -44,8 +44,9 @@ let rec free_vars : Tir.expr -> StringSet.t = function
   | Tir.EAtomicIncRC a | Tir.EAtomicDecRC a -> free_atom a
   | Tir.EReuse (a, _, args)  ->
     List.fold_left (fun s v -> StringSet.union s (free_atom v)) (free_atom a) args
-  | Tir.EAllocHole (_, args, _) ->
-    List.fold_left (fun s v -> StringSet.union s (free_atom v)) StringSet.empty args
+  | Tir.EAllocHole (tok, _, args, _) ->
+    List.fold_left (fun s v -> StringSet.union s (free_atom v))
+      (match tok with Some a -> free_atom a | None -> StringSet.empty) args
   | Tir.ESetField (o, _, v)  -> StringSet.union (free_atom o) (free_atom v)
   | Tir.ESeq (e1, e2)        -> StringSet.union (free_vars e1) (free_vars e2)
 

--- a/lib/tir/defun.ml
+++ b/lib/tir/defun.ml
@@ -267,8 +267,10 @@ let free_vars_of_expr (top_level : StringSet.t) (body : Tir.expr) (params : Tir.
     | Tir.EUpdate (a, fields) ->
       fv_atom a bound;
       List.iter (fun (_, a) -> fv_atom a bound) fields
-    | Tir.EAlloc (_, args) | Tir.EStackAlloc (_, args)
-    | Tir.EAllocHole (_, args, _) ->
+    | Tir.EAlloc (_, args) | Tir.EStackAlloc (_, args) ->
+      List.iter (fun a -> fv_atom a bound) args
+    | Tir.EAllocHole (tok, _, args, _) ->
+      Option.iter (fun a -> fv_atom a bound) tok;
       List.iter (fun a -> fv_atom a bound) args
     | Tir.ESetField (o, _, v) -> fv_atom o bound; fv_atom v bound
     | Tir.EFree a -> fv_atom a bound

--- a/lib/tir/escape.ml
+++ b/lib/tir/escape.ml
@@ -58,7 +58,10 @@ let rec all_atom_vars (e : Tir.expr) : StringSet.t =
   | Tir.EAtomicIncRC a | Tir.EAtomicDecRC a -> vars_of_atom a
   | Tir.EReuse (a, _, args) ->
     StringSet.union (vars_of_atom a) (vars_of_atoms args)
-  | Tir.EAllocHole (_, args, _) -> vars_of_atoms args
+  | Tir.EAllocHole (tok, _, args, _) ->
+    StringSet.union
+      (match tok with Some a -> vars_of_atom a | None -> StringSet.empty)
+      (vars_of_atoms args)
   | Tir.ESetField (o, _, v) ->
     StringSet.union (vars_of_atom o) (vars_of_atom v)
 
@@ -229,7 +232,7 @@ let rec escaping_vars (e : Tir.expr) (candidates : StringSet.t) : StringSet.t =
      a heap cell, and ESetField stores into one whose lifetime this analysis
      cannot see.  A stack-promoted value written through either would dangle
      once the frame returns, so nothing here may be stack-allocated. *)
-  | Tir.EAllocHole (_, args, _) -> candidate_atoms args
+  | Tir.EAllocHole (_, _, args, _) -> candidate_atoms args
   | Tir.ESetField (o, _, v) ->
     StringSet.union (candidate_atoms [o]) (candidate_atoms [v])
 

--- a/lib/tir/fusion.ml
+++ b/lib/tir/fusion.ml
@@ -130,8 +130,9 @@ let rec use_count (n : string) : Tir.expr -> int = function
     uca n a + List.fold_left (fun s (_, a) -> s + uca n a) 0 fs
   | Tir.EReuse (a, _, atoms) ->
     uca n a + List.fold_left (fun s a -> s + uca n a) 0 atoms
-  | Tir.EAllocHole (_, atoms, _) ->
-    List.fold_left (fun s a -> s + uca n a) 0 atoms
+  | Tir.EAllocHole (tok, _, atoms, _) ->
+    (match tok with Some a -> uca n a | None -> 0)
+    + List.fold_left (fun s a -> s + uca n a) 0 atoms
   | Tir.ESetField (o, _, v)  -> uca n o + uca n v
   | Tir.ESeq (e1, e2)        -> use_count n e1 + use_count n e2
 

--- a/lib/tir/inline.ml
+++ b/lib/tir/inline.ml
@@ -208,7 +208,8 @@ let rec add_expr_names names = function
     add_atom_name names atom
   | Tir.EReuse (reuse, _, args) ->
     add_atom_names (add_atom_name names reuse) args
-  | Tir.EAllocHole (_, args, _) -> add_atom_names names args
+  | Tir.EAllocHole (tok, _, args, _) ->
+    add_atom_names (match tok with Some a -> add_atom_name names a | None -> names) args
   | Tir.ESetField (o, _, v) -> add_atom_name (add_atom_name names o) v
   | Tir.ESeq (first, second) ->
     add_expr_names (add_expr_names names first) second
@@ -317,8 +318,9 @@ let alpha_rename (params : Tir.var list) (body : Tir.expr)
     | Tir.EReuse (a, ty, args) ->
       Tir.EReuse
         (subst_atom env a, ty, List.map (subst_atom env) args)
-    | Tir.EAllocHole (ty, args, hole) ->
-      Tir.EAllocHole (ty, List.map (subst_atom env) args, hole)
+    | Tir.EAllocHole (tok, ty, args, hole) ->
+      Tir.EAllocHole (Option.map (subst_atom env) tok, ty,
+                      List.map (subst_atom env) args, hole)
     | Tir.ESetField (o, i, v) ->
       Tir.ESetField (subst_atom env o, i, subst_atom env v)
     | Tir.ESeq (e1, e2)      ->

--- a/lib/tir/join_points.ml
+++ b/lib/tir/join_points.ml
@@ -118,8 +118,10 @@ let rec expr_mentions_any (names : string list) (e : Tir.expr) : bool =
   | Tir.EUpdate (a, fs) ->
     atom_mentions_any names a
     || List.exists (fun (_, av) -> atom_mentions_any names av) fs
-  | Tir.EAlloc (_, xs) | Tir.EStackAlloc (_, xs)
-  | Tir.EAllocHole (_, xs, _) -> atoms_mention_any names xs
+  | Tir.EAlloc (_, xs) | Tir.EStackAlloc (_, xs) -> atoms_mention_any names xs
+  | Tir.EAllocHole (tok, _, xs, _) ->
+    (match tok with Some a -> atom_mentions_any names a | None -> false)
+    || atoms_mention_any names xs
   | Tir.ESetField (o, _, v) ->
     atom_mentions_any names o || atom_mentions_any names v
   | Tir.ESeq (e1, e2) ->
@@ -189,7 +191,8 @@ let rec rename_expr (from_name : string) (to_name : string) (e : Tir.expr)
   | Tir.EAtomicDecRC a -> Tir.EAtomicDecRC (ra a)
   | Tir.EFree a -> Tir.EFree (ra a)
   | Tir.EReuse (a, t, xs) -> Tir.EReuse (ra a, t, List.map ra xs)
-  | Tir.EAllocHole (t, xs, hole) -> Tir.EAllocHole (t, List.map ra xs, hole)
+  | Tir.EAllocHole (tok, t, xs, hole) ->
+    Tir.EAllocHole (Option.map ra tok, t, List.map ra xs, hole)
   | Tir.ESetField (o, i, v) -> Tir.ESetField (ra o, i, ra v)
 
 (* ── Core transform ─────────────────────────────────────────────────────── *)

--- a/lib/tir/js_emit.ml
+++ b/lib/tir/js_emit.ml
@@ -730,7 +730,7 @@ and emit_val_impl ctx expr =
   (* EReuse(old, ty, args): Perceus reuses old's memory — in GC'd JS just alloc fresh *)
   | Tir.EReuse (_, ty, args) -> emit_tagged_alloc ctx ty args
 
-  | Tir.EAllocHole (ty, args, hole) -> emit_tagged_alloc_hole ctx ty args hole
+  | Tir.EAllocHole (_, ty, args, hole) -> emit_tagged_alloc_hole ctx ty args hole
 
   (* TRMC hole fill: an in-place property write, sequenced with [undefined] so
      the expression's value is unit rather than the assigned value. *)

--- a/lib/tir/llvm_emit.ml
+++ b/lib/tir/llvm_emit.ml
@@ -3492,7 +3492,7 @@ let rec emit_expr ctx (e : Tir.expr) : string * string =
      that reaches an unfilled hole is a no-op rather than a wild dereference.
      That is the property the whole TRMC scheme leans on for the window between
      allocation and fill. *)
-  | Tir.EAllocHole (Tir.TCon (ctor, _), args, hole) ->
+  | Tir.EAllocHole (tok, Tir.TCon (ctor, _), args, hole) ->
     (* Same repr guard as EStackAlloc: this arm builds a BOXED cell
        unconditionally, so a Newtype-/Niche-repr type would be constructed
        boxed and decoded erased.  TRMC must never select such a type. *)
@@ -3518,30 +3518,76 @@ let rec emit_expr ctx (e : Tir.expr) : string * string =
         "LLVM emit: EAllocHole of %s has hole index %d outside arity %d"
         ctor hole arity);
     let entry = ctor_entry ctx ctor arity in
-    let ptr = emit_heap_alloc ctx entry.ce_tag arity in
     (* [args] carries only the FILLED fields, in order, with the hole's slot
-       skipped — so walk the full field list and consume [args] around it. *)
-    let rest = ref args in
-    for i = 0 to arity - 1 do
-      if i <> hole then begin
-        match !rest with
-        | atom :: tl ->
-          rest := tl;
-          let field_ty = match List.nth_opt entry.ce_fields i with
-            | Some t -> llvm_ty t | None -> "ptr" in
-          let (v_ty, v_val) = emit_atom ctx atom in
-          emit_store_field ctx ptr i field_ty (coerce ctx v_ty v_val field_ty)
-        | [] ->
-          failwith (Printf.sprintf
-            "LLVM emit: EAllocHole of %s supplies %d filled field(s) for arity %d"
-            ctor (List.length args) arity)
-      end
-    done;
-    ("ptr", ptr)
+       skipped.  Pair each with its destination index and LLVM field type, and
+       evaluate the operands ONCE here — before any branch — so the reuse and
+       fresh paths below store already-materialised SSA values (same discipline
+       as EReuse; evaluating inside a branch would define values in one block
+       and use them in another). *)
+    let slot_vals =
+      let rest = ref args in
+      List.filter_map (fun i ->
+        if i = hole then None
+        else match !rest with
+          | atom :: tl ->
+            rest := tl;
+            let field_ty = match List.nth_opt entry.ce_fields i with
+              | Some t -> llvm_ty t | None -> "ptr" in
+            let (v_ty, v_val) = emit_atom ctx atom in
+            Some (i, field_ty, coerce ctx v_ty v_val field_ty)
+          | [] ->
+            failwith (Printf.sprintf
+              "LLVM emit: EAllocHole of %s supplies %d filled field(s) for arity %d"
+              ctor (List.length args) arity)
+      ) (List.init arity (fun i -> i))
+    in
+    let store_slots p =
+      List.iter (fun (i, field_ty, v) -> emit_store_field ctx p i field_ty v)
+        slot_vals
+    in
+    (match tok with
+     | None ->
+       let ptr = emit_heap_alloc ctx entry.ce_tag arity in
+       store_slots ptr;
+       ("ptr", ptr)
+     | Some reuse_atom ->
+       (* Same discipline as EReuse: take the cell over when it is unique at
+          runtime, otherwise release it and allocate fresh. *)
+       let (_, rv) = emit_atom ctx reuse_atom in
+       let rc = fresh ctx "rhrc" in
+       emit ctx (Printf.sprintf
+                   "%s = load atomic i64, ptr %s monotonic, align 8" rc rv);
+       let uniq = fresh ctx "rhuniq" in
+       emit ctx (Printf.sprintf "%s = icmp eq i64 %s, 1" uniq rc);
+       let reuse_lbl = fresh_block ctx "rhole_reuse" in
+       let fresh_lbl = fresh_block ctx "rhole_fresh" in
+       let merge_lbl = fresh_block ctx "rhole_merge" in
+       emit_term ctx (Printf.sprintf "br i1 %s, label %%%s, label %%%s"
+                        uniq reuse_lbl fresh_lbl);
+       emit_label ctx reuse_lbl;
+       emit_store_tag ctx rv entry.ce_tag;
+       store_slots rv;
+       (* A fresh cell comes from calloc and is already zero.  A REUSED cell is
+          not: its hole slot still holds the old child pointer, whose ownership
+          has already moved to the match's branch variables.  Leaving it there
+          would let any drop in the window before the fill walk into a child
+          someone else now owns — so clear it explicitly. *)
+       emit_store_field ctx rv hole "ptr" "null";
+       emit_term ctx (Printf.sprintf "br label %%%s" merge_lbl);
+       emit_label ctx fresh_lbl;
+       emit ctx (Printf.sprintf "call void @march_decrc(ptr %s)" rv);
+       let hp = emit_heap_alloc ctx entry.ce_tag arity in
+       store_slots hp;
+       emit_term ctx (Printf.sprintf "br label %%%s" merge_lbl);
+       emit_label ctx merge_lbl;
+       let result = fresh ctx "rhole_r" in
+       emit ctx (Printf.sprintf "%s = phi ptr [ %s, %%%s ], [ %s, %%%s ]"
+                   result rv reuse_lbl hp fresh_lbl);
+       ("ptr", result))
 
   (* TRMC only ever selects a data constructor, so a non-TCon hole allocation
      is a bug in the transformation rather than a shape to support. *)
-  | Tir.EAllocHole (ty, _, _) ->
+  | Tir.EAllocHole (_, ty, _, _) ->
     failwith (Printf.sprintf
       "LLVM emit: EAllocHole of non-constructor type %s — TRMC selects data \
        constructors only" (Tir.show_ty ty))

--- a/lib/tir/lower.ml
+++ b/lib/tir/lower.ml
@@ -1834,7 +1834,9 @@ let lower_module ?type_map ?(stdlib_context : Ast.decl list = []) ?(test_mode=fa
     | Tir.EAtomicIncRC a | Tir.EAtomicDecRC a -> atom_uses name a
     | Tir.EReuse (a, _, atoms) ->
       atom_uses name a || List.exists (atom_uses name) atoms
-    | Tir.EAllocHole (_, atoms, _) -> List.exists (atom_uses name) atoms
+    | Tir.EAllocHole (tok, _, atoms, _) ->
+      (match tok with Some a -> atom_uses name a | None -> false)
+      || List.exists (atom_uses name) atoms
     | Tir.ESetField (o, _, v) -> atom_uses name o || atom_uses name v
     | Tir.ESeq (e1, e2) -> fn_body_uses name e1 || fn_body_uses name e2
   and atom_uses name a =

--- a/lib/tir/lower_decls.ml
+++ b/lib/tir/lower_decls.ml
@@ -68,8 +68,9 @@ let rename_tir_vars (prefix : string) (names : string list) (fn : Tir.fn_def) : 
     | Tir.EAtomicIncRC a -> Tir.EAtomicIncRC (rename_atom bound a)
     | Tir.EAtomicDecRC a -> Tir.EAtomicDecRC (rename_atom bound a)
     | Tir.EReuse (a, ty, args) -> Tir.EReuse (rename_atom bound a, ty, List.map (rename_atom bound) args)
-    | Tir.EAllocHole (ty, args, hole) ->
-      Tir.EAllocHole (ty, List.map (rename_atom bound) args, hole)
+    | Tir.EAllocHole (tok, ty, args, hole) ->
+      Tir.EAllocHole (Option.map (rename_atom bound) tok, ty,
+                      List.map (rename_atom bound) args, hole)
     | Tir.ESetField (o, i, v) ->
       Tir.ESetField (rename_atom bound o, i, rename_atom bound v)
     | Tir.ESeq (e1, e2) -> Tir.ESeq (rename_expr bound e1, rename_expr bound e2)
@@ -173,8 +174,9 @@ let uniquify_fn (fn : Tir.fn_def) : Tir.fn_def =
     | Tir.EAtomicIncRC a -> Tir.EAtomicIncRC (rename_atom env a)
     | Tir.EAtomicDecRC a -> Tir.EAtomicDecRC (rename_atom env a)
     | Tir.EReuse (a, ty, args) -> Tir.EReuse (rename_atom env a, ty, List.map (rename_atom env) args)
-    | Tir.EAllocHole (ty, args, hole) ->
-      Tir.EAllocHole (ty, List.map (rename_atom env) args, hole)
+    | Tir.EAllocHole (tok, ty, args, hole) ->
+      Tir.EAllocHole (Option.map (rename_atom env) tok, ty,
+                      List.map (rename_atom env) args, hole)
     | Tir.ESetField (o, i, v) ->
       Tir.ESetField (rename_atom env o, i, rename_atom env v)
     | Tir.ESeq (e1, e2)  -> Tir.ESeq (go env e1, go env e2)

--- a/lib/tir/mono.ml
+++ b/lib/tir/mono.ml
@@ -121,8 +121,9 @@ let rec subst_expr (s : ty_subst) : Tir.expr -> Tir.expr = function
   | Tir.EAtomicDecRC a    -> Tir.EAtomicDecRC (subst_atom s a)
   | Tir.EReuse (a, ty, args) ->
     Tir.EReuse (subst_atom s a, subst_ty s ty, List.map (subst_atom s) args)
-  | Tir.EAllocHole (ty, args, hole) ->
-    Tir.EAllocHole (subst_ty s ty, List.map (subst_atom s) args, hole)
+  | Tir.EAllocHole (tok, ty, args, hole) ->
+    Tir.EAllocHole (Option.map (subst_atom s) tok, subst_ty s ty,
+                    List.map (subst_atom s) args, hole)
   | Tir.ESetField (o, i, v) ->
     Tir.ESetField (subst_atom s o, i, subst_atom s v)
   | Tir.ESeq (e1, e2)     -> Tir.ESeq (subst_expr s e1, subst_expr s e2)
@@ -349,7 +350,8 @@ let retype_known_vars (vars : Tir.var list) (body : Tir.expr) : Tir.expr =
     | Tir.EAtomicIncRC atom -> Tir.EAtomicIncRC (ra env atom)
     | Tir.EAtomicDecRC atom -> Tir.EAtomicDecRC (ra env atom)
     | Tir.EReuse (atom, ty, args) -> Tir.EReuse (ra env atom, ty, ral env args)
-    | Tir.EAllocHole (ty, args, hole) -> Tir.EAllocHole (ty, ral env args, hole)
+    | Tir.EAllocHole (tok, ty, args, hole) ->
+      Tir.EAllocHole (Option.map (ra env) tok, ty, ral env args, hole)
     | Tir.ESetField (o, i, v) -> Tir.ESetField (ra env o, i, ra env v)
     | Tir.ESeq (e1, e2) -> Tir.ESeq (go env e1, go env e2)
   in
@@ -1128,7 +1130,8 @@ let refine_field_types (body : Tir.expr) : Tir.expr =
     | Tir.EAtomicIncRC a       -> Tir.EAtomicIncRC (ra a)
     | Tir.EAtomicDecRC a       -> Tir.EAtomicDecRC (ra a)
     | Tir.EReuse (a, t, args)  -> Tir.EReuse (ra a, t, ral args)
-    | Tir.EAllocHole (t, args, hole) -> Tir.EAllocHole (t, ral args, hole)
+    | Tir.EAllocHole (tok, t, args, hole) ->
+      Tir.EAllocHole (Option.map ra tok, t, ral args, hole)
     | Tir.ESetField (o, i, v)  -> Tir.ESetField (ra o, i, ra v)
     | Tir.ESeq (e1, e2)        -> Tir.ESeq (go e1, go e2)
   in

--- a/lib/tir/native_map_inline.ml
+++ b/lib/tir/native_map_inline.ml
@@ -158,8 +158,9 @@ let rec count_uses (name : string) (e : Tir.expr) : int =
   | Tir.ERecord fields -> List.fold_left (fun acc (_, a) -> acc + ca a) 0 fields
   | Tir.EField (a, _) -> ca a
   | Tir.EUpdate (a, fields) -> ca a + List.fold_left (fun acc (_, a) -> acc + ca a) 0 fields
-  | Tir.EAlloc (_, args) | Tir.EStackAlloc (_, args)
-  | Tir.EAllocHole (_, args, _) -> cas args
+  | Tir.EAlloc (_, args) | Tir.EStackAlloc (_, args) -> cas args
+  | Tir.EAllocHole (tok, _, args, _) ->
+    (match tok with Some a -> ca a | None -> 0) + cas args
   | Tir.ESetField (o, _, v) -> ca o + ca v
   | Tir.EFree a -> ca a
   | Tir.EIncRC a | Tir.EAtomicIncRC a -> ca a

--- a/lib/tir/perceus.ml
+++ b/lib/tir/perceus.ml
@@ -181,6 +181,30 @@ type env = {
       (** Variables that appear as message arguments to [send()] in the
           current function.  Values in this set use atomic RC operations.
           Was [_actor_sent]. *)
+  moved_vars : StringSet.t;
+      (** Variables whose ownership has been MOVED into a heap object by an
+          [ESetField] anywhere in the current function (the TRMC hole-fill).
+
+          The store transfers the reference: the object's field now holds it,
+          and the object's own lifetime releases it.  The mover must therefore
+          never drop the value again — not at a dead binding, not at a branch
+          end, and in particular not as a post-call [EDecRC] when the value is
+          subsequently passed at a borrowed parameter position.
+
+          That last case is the one that bites.  In a TRMC loop the freshly
+          allocated cell is stored into the parent's hole and then handed to
+          the recursive call as its destination; borrow inference correctly
+          marks the destination parameter borrowed, so the caller-side
+          "borrowed arg at its last use" rule fires and emits a drop after the
+          call.  That drop releases a cell the parent now owns through its
+          field, AND it knocks the recursive call out of tail position so
+          [Llvm_tco] can no longer form a loop — which is the entire point of
+          the transformation.
+
+          Function-scoped and computed once by [collect_moved_vars]: a
+          conservative whole-body set is correct here because a value may be
+          moved on one path and dropped on another, and suppressing the drop
+          on every path is the safe direction (the object owns it either way). *)
   (* Subtree-scoped: updated on descent into ELet bindings / ECase branches. *)
   borrowed_field_vars : StringSet.t;
       (** Variables that were extracted from a borrowed record/tuple
@@ -238,6 +262,7 @@ let empty_env : env = {
   current_fn_name = "";
   closure_fvs = StringSet.empty;
   actor_sent = StringSet.empty;
+  moved_vars = StringSet.empty;
   borrowed_field_vars = StringSet.empty;
   var_ctx = StringMap.empty;
 }
@@ -301,6 +326,25 @@ let collect_closure_fvs (fn : Tir.fn_def) : StringSet.t =
     in
     scan fn.Tir.fn_body StringSet.empty
   | _ -> StringSet.empty
+
+(** Collect the variables moved into a heap object by an [ESetField].  See
+    [env.moved_vars] for why every such variable must be exempt from drops. *)
+let collect_moved_vars (fn : Tir.fn_def) : StringSet.t =
+  let acc = ref StringSet.empty in
+  let rec go e =
+    match e with
+    | Tir.ESetField (_, _, Tir.AVar v) -> acc := StringSet.add v.Tir.v_name !acc
+    | Tir.ESetField _ -> ()
+    | Tir.ELet (_, e1, e2) | Tir.ESeq (e1, e2) -> go e1; go e2
+    | Tir.ELetRec (fns, body) ->
+      List.iter (fun (fd : Tir.fn_def) -> go fd.Tir.fn_body) fns; go body
+    | Tir.ECase (_, branches, default) ->
+      List.iter (fun (br : Tir.branch) -> go br.Tir.br_body) branches;
+      Option.iter go default
+    | _ -> ()
+  in
+  go fn.Tir.fn_body;
+  !acc
 
 (* ── Actor-send analysis ─────────────────────────────────────────────────── *)
 
@@ -553,6 +597,7 @@ let rec insert_rc_expr (env : env) (e : Tir.expr) (live_after : live_set)
                   the caller from re-acquiring the double-free. *)
                && not (i = 0 && callee_is_apply)
                && not (StringSet.mem v.Tir.v_name env.closure_fvs)
+               && not (StringSet.mem v.Tir.v_name env.moved_vars)
                && not (StringSet.mem v.Tir.v_name env.borrowed_field_vars)
                && not (StringSet.mem v.Tir.v_name !seen) ->
           (* Borrowed field vars (extracted from a borrowed record parameter)
@@ -673,6 +718,7 @@ let rec insert_rc_expr (env : env) (e : Tir.expr) (live_after : live_set)
                && not (StringSet.mem v.Tir.v_name live_after)
                && Borrow.is_borrowed env.borrow_map fname i
                && not (StringSet.mem v.Tir.v_name env.closure_fvs)
+               && not (StringSet.mem v.Tir.v_name env.moved_vars)
                && not (StringSet.mem v.Tir.v_name env.borrowed_field_vars)
                && not (StringSet.mem v.Tir.v_name !seen) ->
           seen := StringSet.add v.Tir.v_name !seen;
@@ -892,6 +938,7 @@ let rec insert_rc_expr (env : env) (e : Tir.expr) (live_after : live_set)
     let e2'' =
       if not (StringSet.mem v.Tir.v_name live_into_e2)
          && not (StringSet.mem v.Tir.v_name env.closure_fvs)
+         && not (StringSet.mem v.Tir.v_name env.moved_vars)
          && not is_borrowed_field then
         (* Dead binding — insert cleanup at start of e2.
            Use atomic DecRC for actor-sent values (may be concurrently accessed).
@@ -1109,6 +1156,7 @@ let rec insert_rc_expr (env : env) (e : Tir.expr) (live_after : live_set)
         if needs_rc v.Tir.v_ty
            && not (StringSet.mem v.Tir.v_name live_before_br)
            && not (StringSet.mem v.Tir.v_name env.closure_fvs)
+           && not (StringSet.mem v.Tir.v_name env.moved_vars)
            && not (StringSet.mem v.Tir.v_name env.borrowed_field_vars) then
           Tir.ESeq (decrc_for env v (Tir.AVar v), body_acc)
         else
@@ -1174,6 +1222,7 @@ let rec insert_rc_expr (env : env) (e : Tir.expr) (live_after : live_set)
         |> (fun s -> StringSet.diff s bound)
         |> (fun s -> StringSet.diff s live_after)
         |> (fun s -> StringSet.diff s env.closure_fvs)
+        |> (fun s -> StringSet.diff s env.moved_vars)
         |> (fun s -> StringSet.diff s env.borrowed_field_vars)
         |> (fun s -> match scrutinee_name with
             | Some n -> StringSet.remove n s
@@ -1286,10 +1335,16 @@ let rec insert_rc_expr (env : env) (e : Tir.expr) (live_after : live_set)
   (* TRMC.  EAllocHole stores its operands into a fresh cell exactly as
      EAlloc does, so it takes the same ownership treatment: an operand still
      live afterwards needs an IncRC. *)
-  | Tir.EAllocHole (ty, atoms, hole) ->
+  | Tir.EAllocHole (tok, ty, atoms, hole) ->
     let inc_vars = find_inc_vars env atoms live_after in
-    let e' = wrap_incrcs env inc_vars (Tir.EAllocHole (ty, atoms, hole)) in
-    (e', StringSet.union live_after (vars_of_atoms atoms))
+    let e' = wrap_incrcs env inc_vars (Tir.EAllocHole (tok, ty, atoms, hole)) in
+    let lb =
+      live_after
+      |> StringSet.union
+           (match tok with Some a -> vars_of_atom a | None -> StringSet.empty)
+      |> StringSet.union (vars_of_atoms atoms)
+    in
+    (e', lb)
 
   (* ESetField MOVES [v] into [o]: the object takes over the reference, so no
      IncRC is emitted for [v] and no drop may be emitted for it afterwards.
@@ -1390,8 +1445,8 @@ let rename_borrowed_shadows (borrowed : StringSet.t) (body : Tir.expr) : Tir.exp
     | Tir.EAtomicDecRC a -> Tir.EAtomicDecRC (atom subst a)
     | Tir.EReuse (a, ty, args) ->
       Tir.EReuse (atom subst a, ty, List.map (atom subst) args)
-    | Tir.EAllocHole (ty, args, hole) ->
-      Tir.EAllocHole (ty, List.map (atom subst) args, hole)
+    | Tir.EAllocHole (tok, ty, args, hole) ->
+      Tir.EAllocHole (tok, ty, List.map (atom subst) args, hole)
     | Tir.ESetField (o, i, v) ->
       Tir.ESetField (atom subst o, i, atom subst v)
   in
@@ -1737,6 +1792,7 @@ let insert_rc ~(module_env : env) ?(repl = false) ?(borrowed = StringSet.empty)
       current_fn_name = fn'.Tir.fn_name;
       closure_fvs;
       actor_sent = collect_actor_sent_vars fn'.Tir.fn_body;
+      moved_vars = collect_moved_vars fn';
       borrowed_field_vars = StringSet.empty;
       var_ctx =
         List.fold_left (fun ctx v -> StringMap.add v.Tir.v_name v ctx)

--- a/lib/tir/perceus_fbip.ml
+++ b/lib/tir/perceus_fbip.ml
@@ -82,6 +82,21 @@ let rec try_fbip_sink (dec_v : Tir.var) (body : Tir.expr) : Tir.expr option =
       && same_arity dec_v.Tir.v_ty (List.length args)
       && not (args_alias_reuse dec_v args) ->
     Some (Tir.ELet (result, Tir.EReuse (Tir.AVar dec_v, ty, args), rest))
+  (* TRMC hole allocation in tail position — the same pairing as EAlloc, but
+     the cell keeps a hole.  This is what makes TRMC and reuse compose: without
+     it a TRMC'd loop allocates a fresh cell per iteration where the untransformed
+     version reused the scrutinee's, which measured 3.5x SLOWER than not
+     transforming at all.  [arity] counts the hole, so it is |filled| + 1. *)
+  | Tir.EAllocHole (None, ty, filled, hole)
+    when same_arity dec_v.Tir.v_ty (List.length filled + 1)
+      && not (args_alias_reuse dec_v filled) ->
+    Some (Tir.EAllocHole (Some (Tir.AVar dec_v), ty, filled, hole))
+  | Tir.ELet (result, Tir.EAllocHole (None, ty, filled, hole), rest)
+    when same_arity dec_v.Tir.v_ty (List.length filled + 1)
+      && not (args_alias_reuse dec_v filled) ->
+    Some (Tir.ELet (result,
+                    Tir.EAllocHole (Some (Tir.AVar dec_v), ty, filled, hole),
+                    rest))
   (* dec_v not used in rhs — safe to sink past this binding *)
   | Tir.ELet (v, rhs, inner)
     when not (Perceus_liveness.name_free_in dec_v.Tir.v_name rhs) ->
@@ -121,6 +136,14 @@ let rec fbip_expr (e : Tir.expr) : Tir.expr =
       && not (args_alias_reuse dec_v args) ->
     let rest' = fbip_expr rest in
     Tir.ELet (result, Tir.EReuse (Tir.AVar dec_v, ty, args), rest')
+  (* Same pairing for the ELet-bound hole allocation reached directly. *)
+  | Tir.ELet (_dead_v, Tir.EDecRC (Tir.AVar dec_v),
+              Tir.ELet (result, Tir.EAllocHole (None, ty, filled, hole), rest))
+    when same_arity dec_v.Tir.v_ty (List.length filled + 1)
+      && not (args_alias_reuse dec_v filled) ->
+    let rest' = fbip_expr rest in
+    Tir.ELet (result,
+              Tir.EAllocHole (Some (Tir.AVar dec_v), ty, filled, hole), rest')
   (* ESeq(EDecRC v, body): try to sink the decrc to be adjacent to an
      EAlloc of matching shape anywhere down the let-chain. *)
   | Tir.ESeq (Tir.EDecRC (Tir.AVar dec_v), body) ->

--- a/lib/tir/perceus_liveness.ml
+++ b/lib/tir/perceus_liveness.ml
@@ -108,9 +108,13 @@ let rec live_before (e : Tir.expr) (live_after : live_set) : live_set =
     live_after
     |> StringSet.union (vars_of_atom a)
     |> StringSet.union (vars_of_atoms atoms)
-  | Tir.EAlloc (_, atoms) | Tir.EStackAlloc (_, atoms)
-  | Tir.EAllocHole (_, atoms, _) ->
+  | Tir.EAlloc (_, atoms) | Tir.EStackAlloc (_, atoms) ->
     StringSet.union live_after (vars_of_atoms atoms)
+  | Tir.EAllocHole (tok, _, atoms, _) ->
+    live_after
+    |> StringSet.union
+         (match tok with Some a -> vars_of_atom a | None -> StringSet.empty)
+    |> StringSet.union (vars_of_atoms atoms)
   (* TRMC hole-fill: reads both the target object and the stored value. *)
   | Tir.ESetField (o, _, v) ->
     live_after
@@ -158,8 +162,9 @@ let rec name_free_in (name : string) (e : Tir.expr) : bool =
     || Option.fold ~none:false ~some:(name_free_in name) default
   | Tir.ESeq (e1, e2)                        -> name_free_in name e1 || name_free_in name e2
   | Tir.ETuple atoms | Tir.EAlloc (_, atoms)
-  | Tir.EStackAlloc (_, atoms)
-  | Tir.EAllocHole (_, atoms, _)             -> atoms_use atoms
+  | Tir.EStackAlloc (_, atoms)               -> atoms_use atoms
+  | Tir.EAllocHole (tok, _, atoms, _)        ->
+    (match tok with Some a -> atom_uses a | None -> false) || atoms_use atoms
   | Tir.ESetField (o, _, v)                  -> atom_uses o || atom_uses v
   | Tir.ERecord fields                       -> List.exists (fun (_, a) -> atom_uses a) fields
   | Tir.EField (a, _)                        -> atom_uses a

--- a/lib/tir/pp.ml
+++ b/lib/tir/pp.ml
@@ -79,14 +79,17 @@ let rec string_of_expr = function
     string_of_expr e1 ^ ";\n" ^ string_of_expr e2
   (* TRMC: the hole is printed as `_` at its field position so the arity and
      the hole's index are both readable straight off the dump. *)
-  | EAllocHole (ty, args, hole) ->
+  | EAllocHole (tok, ty, args, hole) ->
     let strs = List.map string_of_atom args in
     let rec insert i acc = function
       | rest when i = hole -> List.rev_append acc ("_" :: rest)
       | [] -> List.rev ("_" :: acc)
       | x :: rest -> insert (i + 1) (x :: acc) rest
     in
-    "alloc_hole " ^ string_of_ty ty ^ "(" ^ String.concat ", " (insert 0 [] strs) ^ ")"
+    (match tok with
+     | Some a -> "reuse_hole " ^ string_of_atom a ^ " as "
+     | None -> "alloc_hole ")
+    ^ string_of_ty ty ^ "(" ^ String.concat ", " (insert 0 [] strs) ^ ")"
   | ESetField (o, i, v) ->
     string_of_atom o ^ "." ^ string_of_int i ^ " <- " ^ string_of_atom v
 

--- a/lib/tir/single_use_inline.ml
+++ b/lib/tir/single_use_inline.ml
@@ -342,7 +342,8 @@ let run ~changed (module_ : Tir.tir_module) : Tir.tir_module =
     | Tir.EReuse (reuse, _, args) ->
       scan_atom ~caller ~bound NonDirect reuse;
       List.iter (scan_atom ~caller ~bound NonDirect) args
-    | Tir.EAllocHole (_, args, _) ->
+    | Tir.EAllocHole (tok, _, args, _) ->
+      Option.iter (scan_atom ~caller ~bound NonDirect) tok;
       List.iter (scan_atom ~caller ~bound NonDirect) args
     | Tir.ESetField (o, _, v) ->
       scan_atom ~caller ~bound NonDirect o;

--- a/lib/tir/tir.ml
+++ b/lib/tir/tir.ml
@@ -67,6 +67,15 @@ type expr =
      property is what makes it safe for a cell to be dropped (or deep-dropped)
      between allocation and hole-fill.
 
+     The optional first component is a REUSE TOKEN, set by [Perceus_fbip] when
+     a dropped cell of matching arity is available.  With a token the cell is
+     reused in place when it is unique at runtime (rc = 1), falling back to a
+     fresh allocation when shared — the same discipline as [EReuse].  Reuse
+     must CLEAR the hole slot explicitly: unlike a fresh [calloc]'d cell, a
+     reused cell's slot still holds the old child pointer, and leaving it
+     there would let a drop in the window before the fill walk into a child
+     whose ownership has already moved to the match's branch variables.
+
      [ESetField (obj, i, v)] writes [v] into field [i] of [obj] in place and
      evaluates to unit.  Ownership MOVES into the object: no incref is emitted
      for [v], and Perceus must not also drop it.
@@ -77,7 +86,7 @@ type expr =
      TRMC loop writes the same field of a freshly allocated cell.  That keeps
      raw interior pointers out of the IR entirely, so [Rc_types.needs_rc] and
      [Escape] need no new notion of an unowned pointer. *)
-  | EAllocHole of ty * atom list * int
+  | EAllocHole of atom option * ty * atom list * int
   | ESetField  of atom * int * atom
 
 (* A case branch: constructor tag + bound variables → body. *)
@@ -243,9 +252,10 @@ let rec show_expr = function
     Printf.sprintf "EReuse(%s,%s,[%s])" (show_atom a) (show_ty t)
       (String.concat "," (List.map show_atom args))
   | ESeq (e1, e2) -> Printf.sprintf "ESeq(%s,%s)" (show_expr e1) (show_expr e2)
-  | EAllocHole (t, args, hole) ->
-    Printf.sprintf "EAllocHole(%s,[%s],%d)" (show_ty t)
-      (String.concat "," (List.map show_atom args)) hole
+  | EAllocHole (tok, t, args, hole) ->
+    Printf.sprintf "EAllocHole(%s,%s,[%s],%d)"
+      (match tok with Some a -> show_atom a | None -> "-")
+      (show_ty t) (String.concat "," (List.map show_atom args)) hole
   | ESetField (o, i, v) ->
     Printf.sprintf "ESetField(%s,%d,%s)" (show_atom o) i (show_atom v)
 

--- a/lib/tir/trmc.ml
+++ b/lib/tir/trmc.ml
@@ -145,7 +145,9 @@ let rec calls_name (name : string) (e : Tir.expr) : bool =
   | Tir.EIncRC a | Tir.EDecRC a
   | Tir.EAtomicIncRC a | Tir.EAtomicDecRC a -> atom_is a
   | Tir.EReuse (a, _, atoms) -> atom_is a || List.exists atom_is atoms
-  | Tir.EAllocHole (_, atoms, _) -> List.exists atom_is atoms
+  | Tir.EAllocHole (tok, _, atoms, _) ->
+    (match tok with Some a -> atom_is a | None -> false)
+    || List.exists atom_is atoms
   | Tir.ESetField (o, _, v) -> atom_is o || atom_is v
 
 (** Collect the self-call sites of [self] in [e].
@@ -288,4 +290,143 @@ let report (m : Tir.tir_module) : unit =
       Printf.eprintf "\t%s=%d" k (Option.value ~default:0 (Hashtbl.find_opt counts k)))
       ["eligible"; "mixed"; "non-trmc"; "already-tail"];
     Printf.eprintf "\n%!"
+  end
+
+(* ── Phase 3: the destination-passing transformation ──────────────────────────
+
+   For an [Eligible] function with exactly one modulo-cons site, build a helper
+   whose recursive call is a genuine TAIL call, so [Llvm_tco] turns it into a
+   loop:
+
+     fn f(ps) = .. let t = f(as) in Ctor(.., t, ..) ..
+
+   becomes
+
+     fn f(ps)      = .. let c = allochole Ctor(.., _, ..) in f$dps(as, c); c ..
+     fn f$dps(ps, dst) = .. let c = allochole Ctor(.., _, ..) in
+                            dst.hole <- c;
+                            f$dps(as, c)              <- tail call
+                         .. and every OTHER tail expression E becomes
+                            let r = E in dst.hole <- r
+
+   [dst] is the parent CELL, not an interior pointer: the hole index is baked
+   into the helper, which is sound because every iteration of a single-
+   constructor loop writes the same field.  See the Phase 2 note in
+   specs/todos/2026-08-07-trmc-tail-recursion-modulo-cons.md.
+
+   GATED on MARCH_TRMC=1 — this is a work-in-progress measurement vehicle, not
+   yet a default pipeline stage. *)
+
+let trmc_ctr = ref 0
+
+let fresh_var (ty : Tir.ty) : Tir.var =
+  incr trmc_ctr;
+  { Tir.v_name = Printf.sprintf "$trmc%d" !trmc_ctr; v_ty = ty; v_lin = Tir.Unr }
+
+(** The continuation of a modulo-cons call, when it is a DIRECT [EAlloc].
+
+    v1 deliberately refuses intervening lets.  Those bindings are evaluated
+    after the recursive call in the original but would have to move BEFORE it
+    in destination-passing style, and while the eligibility check guarantees
+    they do not read the call's result, it does not guarantee they are pure —
+    so reordering them could move a side effect across the call. *)
+let modcons_alloc (v : string) (k : Tir.expr)
+    : (Tir.ty * Tir.atom list * int) option =
+  match k with
+  | Tir.EAlloc ((Tir.TCon _) as ty, atoms) ->
+    (match sole_atom_index v atoms with
+     | Some i ->
+       let filled = List.filteri (fun j _ -> j <> i) atoms in
+       Some (ty, filled, i)
+     | None -> None)
+  | _ -> None
+
+(** Rewrite the tail positions of a helper body so every result is WRITTEN into
+    [dst]'s hole instead of returned. *)
+let rec returnify ~(self : string) ~(dps : Tir.var) ~(dst : Tir.var)
+    ~(hole : int) ~(ret_ty : Tir.ty) (e : Tir.expr) : Tir.expr =
+  let store_tail tail =
+    let r = fresh_var ret_ty in
+    Tir.ELet (r, tail, Tir.ESetField (Tir.AVar dst, hole, Tir.AVar r))
+  in
+  let recur = returnify ~self ~dps ~dst ~hole ~ret_ty in
+  match e with
+  | Tir.ELet (bv, Tir.EApp (f, args), k)
+    when String.equal f.Tir.v_name self && not (calls_name self k) ->
+    (match modcons_alloc bv.Tir.v_name k with
+     | Some (alloc_ty, filled, i) ->
+       let c = fresh_var alloc_ty in
+       Tir.ELet (c, Tir.EAllocHole (None, alloc_ty, filled, i),
+         Tir.ESeq (Tir.ESetField (Tir.AVar dst, hole, Tir.AVar c),
+                   Tir.EApp (dps, args @ [Tir.AVar c])))
+     | None -> store_tail e)
+  | Tir.ELet (bv, rhs, k) -> Tir.ELet (bv, rhs, recur k)
+  | Tir.ESeq (e1, e2) -> Tir.ESeq (e1, recur e2)
+  | Tir.ECase (a, branches, default) ->
+    Tir.ECase (a,
+      List.map (fun br -> { br with Tir.br_body = recur br.Tir.br_body }) branches,
+      Option.map recur default)
+  | _ -> store_tail e
+
+(** Rewrite the ORIGINAL function: allocate the cell, hand it to the helper,
+    return it. *)
+let rec seed_entry ~(self : string) ~(dps : Tir.var) (e : Tir.expr) : Tir.expr =
+  let recur = seed_entry ~self ~dps in
+  match e with
+  | Tir.ELet (bv, Tir.EApp (f, args), k)
+    when String.equal f.Tir.v_name self && not (calls_name self k) ->
+    (match modcons_alloc bv.Tir.v_name k with
+     | Some (alloc_ty, filled, i) ->
+       let c = fresh_var alloc_ty in
+       Tir.ELet (c, Tir.EAllocHole (None, alloc_ty, filled, i),
+         Tir.ESeq (Tir.EApp (dps, args @ [Tir.AVar c]),
+                   Tir.EAtom (Tir.AVar c)))
+     | None -> e)
+  | Tir.ELet (bv, rhs, k) -> Tir.ELet (bv, rhs, recur k)
+  | Tir.ESeq (e1, e2) -> Tir.ESeq (e1, recur e2)
+  | Tir.ECase (a, branches, default) ->
+    Tir.ECase (a,
+      List.map (fun br -> { br with Tir.br_body = recur br.Tir.br_body }) branches,
+      Option.map recur default)
+  | _ -> e
+
+(** [Some (f', f_dps)] when [fn] is transformable. *)
+let transform_fn (fn : Tir.fn_def) : (Tir.fn_def * Tir.fn_def) option =
+  let r = report_of_fn fn.Tir.fn_name fn.Tir.fn_body in
+  match verdict_of r, r.r_modcons with
+  | Eligible, [ (_ctor, hole) ] ->
+    let dps_name = fn.Tir.fn_name ^ "$dps" in
+    let dst = { Tir.v_name = "$dst"; v_ty = fn.Tir.fn_ret_ty; v_lin = Tir.Unr } in
+    let dps_ty =
+      Tir.TFn (List.map (fun (p : Tir.var) -> p.Tir.v_ty)
+                 (fn.Tir.fn_params @ [dst]), Tir.TUnit)
+    in
+    let dps = { Tir.v_name = dps_name; v_ty = dps_ty; v_lin = Tir.Unr } in
+    let helper =
+      { Tir.fn_name = dps_name;
+        fn_params = fn.Tir.fn_params @ [dst];
+        fn_ret_ty = Tir.TUnit;
+        fn_body = returnify ~self:fn.Tir.fn_name ~dps ~dst ~hole
+                    ~ret_ty:fn.Tir.fn_ret_ty fn.Tir.fn_body;
+        fn_kind = Tir.FnNormal }
+    in
+    let entry =
+      { fn with Tir.fn_body = seed_entry ~self:fn.Tir.fn_name ~dps fn.Tir.fn_body }
+    in
+    Some (entry, helper)
+  | _ -> None
+
+(** Apply TRMC across a module.  Gated on MARCH_TRMC=1. *)
+let transform_module (m : Tir.tir_module) : Tir.tir_module =
+  if Sys.getenv_opt "MARCH_TRMC" = None then m
+  else begin
+    let out = List.concat_map (fun fn ->
+      match transform_fn fn with
+      | Some (entry, helper) ->
+        if Sys.getenv_opt "MARCH_TRMC_REPORT" <> None then
+          Printf.eprintf "TRMCXFORM\t%s -> %s\n%!" fn.Tir.fn_name helper.Tir.fn_name;
+        [entry; helper]
+      | None -> [fn]
+    ) m.Tir.tm_fns in
+    { m with Tir.tm_fns = out }
   end

--- a/specs/todos/2026-08-07-trmc-tail-recursion-modulo-cons.md
+++ b/specs/todos/2026-08-07-trmc-tail-recursion-modulo-cons.md
@@ -405,6 +405,85 @@ left alone. The likely shape is `EReuse` gaining a hole index, mirroring
 `EAllocHole` — a small amendment to the IR surface that will land after this
 one.
 
+## Phase 4 (2026-08-07) — TRMC is now FASTER than the accumulator style
+
+Both causes fixed. Same 20k/2000 workload, correct output throughout:
+
+| variant | time | vs today's stdlib | peak RSS |
+|---|---:|---:|---:|
+| natural, TRMC off | ~0.29s | 1.8x slower | 4.37 MB |
+| TRMC + 4B only | ~0.98s | 5.8x slower | 3.42 MB |
+| **TRMC + 4A + 4B** | **~0.06s** | **2.7x FASTER** | 3.41 MB |
+| accumulator + `reverse` (today) | ~0.16s | — | 3.41 MB |
+
+That beats the 1.5–2x estimate this file recorded before the work started.
+
+### 4B — the post-call drop (`moved_vars`)
+
+A new `Perceus.env.moved_vars`, populated per function by `collect_moved_vars`:
+every variable that appears as the VALUE of an `ESetField` is exempt from drops
+at all five sites where `closure_fvs` already suppresses them.
+
+The store transfers the reference into the object's field, so the mover must
+never drop it again. The case that bit was the caller-side "borrowed arg at its
+last use" rule: the freshly built cell is stored into the parent's hole and then
+handed to the recursive call as its destination, so a drop landed after the
+call. Removing it is not only an ownership fix — it restores the call to tail
+position, and `Llvm_tco` then forms a real loop. Verified in the emitted IR:
+`br label %tco_loop1` back-edge, zero self-calls in `nmap$dps`.
+
+**4B alone did not move the clock** (0.99s -> 0.98s). It fixes the stack and the
+ownership error; the time was all cause A.
+
+### 4A — reuse-with-hole (`EAllocHole` gains a reuse token)
+
+`EAllocHole of atom option * ty * atom list * int`. `Perceus_fbip.try_fbip_sink`
+now pairs a scrutinee drop with a hole allocation of matching arity exactly as
+it does with `EAlloc`, emitting `reuse_hole xs as List.Cons(h+1, _)`.
+
+Codegen mirrors `EReuse`: load the RC, and on `rc = 1` take the cell over in
+place, otherwise `march_decrc` and allocate fresh. The one thing it does that
+`EReuse` does not is **explicitly clear the hole slot on the reuse path**. A
+fresh cell comes from `calloc` and is already zero, but a reused cell's hole
+slot still holds the old child pointer whose ownership has already moved to the
+match's branch variables — leaving it would let any drop in the window before
+the fill walk into a child someone else now owns.
+
+This is the paper's "TRMC interacts well with reuse analysis" claim made real,
+and it is the whole win: it is the difference between 0.98s and 0.06s.
+
+### Correctness evidence
+
+- Full suite green with `MARCH_TRMC=1` — **2444 tests, zero failures**, with
+  the transformation active on all 19 eligible stdlib functions.
+- Full suite green with TRMC off.
+- **TIR snapshots unchanged** (33 tests). This is the decisive check that the
+  default path did not move: `moved_vars` is empty without an `ESetField` and
+  the new FBIP arm only matches `EAllocHole`, so the default pipeline is
+  provably inert — and the snapshots confirm the emitted IR shape is identical.
+
+### Measurement trap found (and fixed)
+
+`MARCH_TRMC` was not in `cas_flags`, so a cached artifact from one mode
+silently satisfied a build in the other. This produced a bogus "TRMC off"
+reading of 0.06s that was really the TRMC binary served from the cache — the
+numbers above were re-taken against a cold cache and confirmed. Fixed by adding
+a `trmc` tag to `codegen_cas_tags ()` (the shared helper, so both `cas_flags`
+sites get it). Any future flag that changes emitted code must do the same.
+
+### What is still NOT established
+
+- **One benchmark shape.** The 2.7x is a list-map workload. No claim is made
+  for tree-shaped or mixed workloads.
+- **No sanitizer evidence.** `MARCH_SANITIZE=1` still hangs on these programs
+  with TRMC *off*, so it proves nothing either way. The hole-clear on the reuse
+  path is reasoned, not stress-tested against a drop landing in the window.
+- **Still gated on `MARCH_TRMC=1`.** Not a default pipeline stage.
+- **The stdlib does not benefit yet.** `map`/`filter`/`filter_map` are still
+  accumulator-style and are classified `already-tail`, so TRMC does not touch
+  them. The 19 eligible functions (`insert_sorted`, `zip`, `ring_insert`,
+  `list_append`, …) do benefit, but the headline win needs Phase 6.
+
 ### Verdict on phases 2–5
 
 19 functions, all one constructor shape, plus one partial. That is a real but

--- a/test/test_trmc.ml
+++ b/test/test_trmc.ml
@@ -155,7 +155,7 @@ let trmc_hole_module () : Tir.tir_module =
   let c = v "c" list_int_ty and n = v "n" list_int_ty in
   let h = v "h" Tir.TInt and t = v "t" list_int_ty in
   let body =
-    Tir.ELet (c, Tir.EAllocHole (Tir.TCon ("List.Cons", []),
+    Tir.ELet (c, Tir.EAllocHole (None, Tir.TCon ("List.Cons", []),
                                  [Tir.ALit (March_ast.Ast.LitInt 42)], 1),
       Tir.ELet (n, Tir.EAlloc (Tir.TCon ("List.Nil", []), []),
         Tir.ESeq (Tir.ESetField (Tir.AVar c, 1, Tir.AVar n),


### PR DESCRIPTION
Phases 3 and 4 of [`specs/todos/2026-08-07-trmc-tail-recursion-modulo-cons.md`](specs/todos/2026-08-07-trmc-tail-recursion-modulo-cons.md), building on the analysis and IR nodes from #220.

**Gated on `MARCH_TRMC=1` and OFF by default** — the shipped pipeline is unchanged.

## Result

20k list × 2000 maps, correct output throughout:

| variant | time | vs today's stdlib | peak RSS |
|---|---:|---:|---:|
| **TRMC + 4A + 4B** | **0.06s** | **2.7x FASTER** | 3.42 MB |
| accumulator + `reverse` (what the stdlib does today) | 0.16s | — | 3.41 MB |
| natural style, no TRMC | 0.27s | 1.8x slower | 4.37 MB |
| TRMC + 4B only | 0.98s | 5.8x slower | 3.42 MB |

A first cut measured **3.5x slower** than not transforming at all. Two causes, both fixed here.

## Phase 3 — the transform

`Trmc.transform_module` builds `f$dps(params, dst)` from an `Eligible` function with one modulo-cons site, so the recursive call becomes a genuine tail call and `Llvm_tco` turns it into a loop. v1 refuses intervening lets between the call and the `EAlloc`, which removes the effect-reordering hazard entirely.

## 4B — the post-call drop (`moved_vars`)

New `Perceus.env.moved_vars`: every variable stored by an `ESetField` is exempt from drops at the five sites where `closure_fvs` already suppresses them. The store transfers the reference into the object's field, so the mover must not drop it again.

The case that bit was the caller-side "borrowed arg at its last use" rule firing on the cell just moved into the parent's hole. Removing it is not only an ownership fix — it restores the call to tail position, so `Llvm_tco` can form the loop. Verified in emitted IR: `br label %tco_loop1` back-edge, zero self-calls in `nmap$dps`.

**4B alone moved the clock by 1%** (0.99s → 0.98s). It fixes the stack and the ownership error; the time was all 4A.

## 4A — reuse-with-hole

`EAllocHole` gains a reuse token (`atom option`), and `Perceus_fbip` now pairs a scrutinee drop with a hole allocation exactly as it does with `EAlloc`, emitting `reuse_hole xs as List.Cons(h, _)`.

Codegen mirrors `EReuse` — take the cell over when unique at runtime, else `decrc` and allocate fresh — with one addition: **the reuse path clears the hole slot**. A fresh cell is `calloc`'d and already zero, but a reused cell's slot still holds the old child pointer whose ownership has moved to the match's branch variables; leaving it would let a drop in the window before the fill walk into a child someone else owns.

This is the paper's "TRMC interacts well with reuse analysis" claim made real. It does not come for free, and it is the entire win: 0.98s → 0.06s.

## Also fixed: a CAS cache-key bug

`MARCH_TRMC` was not in `cas_flags`, so a cached artifact from one mode silently satisfied a build in the other. This produced a bogus "TRMC off" reading of 0.06s that was really the TRMC binary served from cache. The numbers above were re-taken against a cold cache and confirmed. Fixed by adding a `trmc` tag to `codegen_cas_tags ()` (the shared helper, so both `cas_flags` sites get it), and verified: warm cache now yields 0.06s vs 0.27s for the same source in the two modes.

## Testing

- Full suite green **with `MARCH_TRMC=1`** — transformation active on all 19 eligible stdlib functions.
- Full suite green with it off (823 / 256 / 563 / 834).
- **TIR snapshots unchanged** (33 tests) — the decisive check that the default path is inert: `moved_vars` is empty without an `ESetField`, and the new FBIP arm only matches `EAllocHole`.
- `check-docs.sh` passes.

The 12 `CAPABILITY CEILING` failures under `dune build @all` in `demo/` are **pre-existing on main** — verified with a control build of clean `origin/main` in a throwaway worktree, which produces the same 12.

## What is NOT established

- **One benchmark shape** (list-map). No claim for tree-shaped or mixed workloads.
- **No sanitizer evidence.** `MARCH_SANITIZE=1` hangs on these programs with TRMC *off* too, so it is uninformative here. The hole-clear is reasoned, not stress-tested against a drop landing in the window.
- **The stdlib does not benefit yet.** `map`/`filter`/`filter_map` are accumulator-style and classify as `already-tail`, so TRMC never sees them. The 19 eligible functions (`insert_sorted`, `zip`, `ring_insert`, `list_append`, …) do benefit, but the headline win needs the phase 6 rewrite.
- Still gated; not a default pipeline stage. Enabling it by default should follow separate soak testing.
