### PR TITLE
fix(forge): audit/licenses/tree resolve git+registry deps under $HOME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -256,6 +256,17 @@ git log is authoritative for exact commits.
   the compiler, bastion, forgepm, conduit, depot and march_doc there are six
   uses of these sigils, all in the compiler's own tests, and none with a hole.
 
+- **`forge audit`, `forge licenses`, and `forge tree` now find git/registry
+  dependencies that `forge deps` actually installed.** All three reimplemented
+  their own dependency-directory lookup as `<project_root>/.march/cas/deps/<name>`,
+  but `forge deps` installs git and registry dependencies under
+  `$HOME/.march/cas/deps/<name>` — a global, cross-project location. A
+  just-installed git or registry dependency was therefore always reported as
+  "not installed" (`forge audit`), with blank version/license (`forge
+  licenses`), or as a childless leaf (`forge tree`). Path dependencies were
+  unaffected. Fixed by routing all three through the same `Project.dep_root_dir`
+  resolver `forge deps` already uses.
+
 
 ### Changed
 

--- a/forge/lib/cmd_audit.ml
+++ b/forge/lib/cmd_audit.ml
@@ -141,13 +141,14 @@ let scope_note ~inferred =
 (*  Dependency enumeration                                             *)
 (* ------------------------------------------------------------------ *)
 
-let cas_deps_dir root =
-  Filename.concat root (Filename.concat ".march" (Filename.concat "cas" "deps"))
-
-let dep_dir ~root ~base ~name ~dep =
-  match dep with
-  | Project.PathDep p -> if Filename.is_relative p then Filename.concat base p else p
-  | _ -> Filename.concat (cas_deps_dir root) name
+(* Git/registry deps are installed under [~/.march/cas/deps/<name>] (see
+   [Project.dep_root_dir]) — NOT under the project root. [base] is the
+   directory of the project that DECLARED [dep], needed to resolve a
+   relative PathDep. *)
+let dep_dir ~base ~name ~dep =
+  match Project.dep_root_dir ~project_root:base (name, dep) with
+  | Some d -> d
+  | None -> Filename.concat base name
 
 (** Every transitive dependency paired with the capabilities it declares.
     Mirrors [Cmd_licenses.collect]'s walk so the two agree on what counts as a
@@ -173,7 +174,7 @@ let collect ?(inferred = false) (proj : Project.project) : dep_caps list =
   let tbl : (string, dep_caps) Hashtbl.t = Hashtbl.create 32 in
   let rec visit ~base ~name ~dep =
     if not (Hashtbl.mem tbl name) then begin
-      let dir = dep_dir ~root ~base ~name ~dep in
+      let dir = dep_dir ~base ~name ~dep in
       let installed = Sys.file_exists dir && Sys.is_directory dir in
       Hashtbl.replace tbl name
         { dc_name = name;

--- a/forge/lib/cmd_licenses.ml
+++ b/forge/lib/cmd_licenses.ml
@@ -30,13 +30,14 @@ let format rows ~json =
 
 (* --- dependency enumeration (IO) --- *)
 
-let cas_deps_dir root =
-  Filename.concat root (Filename.concat ".march" (Filename.concat "cas" "deps"))
-
-let dep_dir ~root ~base ~name ~dep =
-  match dep with
-  | Project.PathDep p -> if Filename.is_relative p then Filename.concat base p else p
-  | _ -> Filename.concat (cas_deps_dir root) name
+(* Git/registry deps are installed under [~/.march/cas/deps/<name>] (see
+   [Project.dep_root_dir]) — NOT under the project root. [base] is the
+   directory of the project that DECLARED [dep], needed to resolve a
+   relative PathDep. *)
+let dep_dir ~base ~name ~dep =
+  match Project.dep_root_dir ~project_root:base (name, dep) with
+  | Some d -> d
+  | None -> Filename.concat base name
 
 (* Walk every (transitive) dependency, reading version + license from its
    forge.toml; deps that can't be read are listed with no metadata. *)
@@ -45,7 +46,7 @@ let collect proj =
   let tbl = Hashtbl.create 32 in
   let rec visit ~base ~name ~dep =
     if not (Hashtbl.mem tbl name) then begin
-      let dir = dep_dir ~root ~base ~name ~dep in
+      let dir = dep_dir ~base ~name ~dep in
       match Project.load_from_dir dir with
       | Ok p ->
         Hashtbl.replace tbl name (Some p.Project.version, p.Project.license);

--- a/forge/lib/cmd_tree.ml
+++ b/forge/lib/cmd_tree.ml
@@ -2,18 +2,18 @@
 
     forge.lock stores a flat list of resolved packages with no edges, so the
     graph is reconstructed by reading each installed dependency's own
-    forge.toml. Git/registry deps live under <root>/.march/cas/deps/<name>;
+    forge.toml. Git/registry deps live under ~/.march/cas/deps/<name>;
     path deps are relative to the forge.toml that declares them. Dependencies
     that aren't installed (or can't be read) show as leaves. *)
 
-let cas_deps_dir root =
-  Filename.concat root (Filename.concat ".march" (Filename.concat "cas" "deps"))
-
-let dep_dir ~root ~base ~name ~dep =
-  match dep with
-  | Project.PathDep p ->
-    if Filename.is_relative p then Filename.concat base p else p
-  | _ -> Filename.concat (cas_deps_dir root) name
+(* Git/registry deps are installed under [~/.march/cas/deps/<name>] (see
+   [Project.dep_root_dir]) — NOT under the project root. [base] is the
+   directory of the project that DECLARED [dep], needed to resolve a
+   relative PathDep. *)
+let dep_dir ~base ~name ~dep =
+  match Project.dep_root_dir ~project_root:base (name, dep) with
+  | Some d -> d
+  | None -> Filename.concat base name
 
 (* Walk the installed dependency dirs from [proj], building a name -> child
    names adjacency table. Returns (root_name, deps_of). *)
@@ -24,7 +24,7 @@ let build_adjacency proj =
     if not (Hashtbl.mem tbl name) then begin
       let dir = match dep_opt with
         | None     -> root
-        | Some dep -> dep_dir ~root ~base ~name ~dep
+        | Some dep -> dep_dir ~base ~name ~dep
       in
       let deps =
         match Project.load_from_dir dir with

--- a/forge/test/dune
+++ b/forge/test/dune
@@ -1,10 +1,10 @@
 (tests
  (names test_forge test_resolver test_solver test_cas_package test_patch
         test_api_surface test_properties test_regression test_cap_binary test_cap_inspect
-        test_cap_sandbox test_audit test_cap_package)
+        test_cap_sandbox test_audit test_cap_package test_dep_dir)
  (modules test_forge test_resolver test_solver test_cas_package test_patch
           test_api_surface test_properties test_regression test_cap_binary test_cap_inspect
-          test_cap_sandbox test_audit test_cap_package)
+          test_cap_sandbox test_audit test_cap_package test_dep_dir)
  (libraries march_forge march_search march_caps str alcotest unix qcheck-core qcheck-alcotest march_cas))
 
 ; test_build_check.ml's "forge check"/"forge build"/"forge test" cases shell

--- a/forge/test/test_dep_dir.ml
+++ b/forge/test/test_dep_dir.ml
@@ -1,0 +1,119 @@
+(** Regression test for `forge audit`/`forge licenses`/`forge tree`'s
+    dependency-directory resolution.
+
+    All three commands independently reimplemented a [dep_dir] helper that
+    computed git/registry dep locations under [<project_root>/.march/cas/deps]
+    — but the actual installer ([Cmd_deps]/[Project.dep_root_dir]) installs
+    them under [$HOME/.march/cas/deps] instead, a global cross-project
+    location. That mismatch meant a just-installed git/registry dep was
+    always reported "not installed" by these three commands.
+
+    Existing tests for these commands (test_forge.ml, test_audit.ml) only
+    exercise pure helpers or PathDep — which resolves relative to the
+    project and never touched the buggy branch — so they never caught this.
+    This test fakes HOME with a pre-populated fixture to exercise the
+    git/registry branch of each command's [dep_dir] directly. *)
+
+open March_forge
+
+let tmp_dir prefix =
+  let base = Filename.get_temp_dir_name () in
+  let rec attempt n =
+    let path = Filename.concat base (Printf.sprintf "%s-%d-%d" prefix (Unix.getpid ()) n) in
+    if Sys.file_exists path then attempt (n + 1)
+    else (Unix.mkdir path 0o755; path)
+  in
+  attempt 0
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Array.iter (fun n -> rm_rf (Filename.concat path n)) (Sys.readdir path);
+      Unix.rmdir path
+    end
+    else Sys.remove path
+
+let mkdir_p dir =
+  let rec go d =
+    if not (Sys.file_exists d) then begin
+      go (Filename.dirname d);
+      (try Unix.mkdir d 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ())
+    end
+  in
+  go dir
+
+(* Run [f home] with HOME overridden to a fresh temp dir, restoring the
+   previous value (or unsetting it) and cleaning up afterward. *)
+let with_fake_home f =
+  let home = tmp_dir "dep-dir-home" in
+  let prev = Sys.getenv_opt "HOME" in
+  Unix.putenv "HOME" home;
+  Fun.protect
+    ~finally:(fun () ->
+      (match prev with Some h -> Unix.putenv "HOME" h | None -> ());
+      rm_rf home)
+    (fun () -> f home)
+
+let git_dep = Project.GitTagDep { url = "https://example.com/widget.git"; tag = "v1.0" }
+let registry_dep = Project.RegistryDep { version = "~> 1.0" }
+
+let expected_cas_path home name =
+  Filename.concat home
+    (Filename.concat ".march" (Filename.concat "cas" (Filename.concat "deps" name)))
+
+let wrong_project_root_path proj_root name =
+  Filename.concat proj_root
+    (Filename.concat ".march" (Filename.concat "cas" (Filename.concat "deps" name)))
+
+(* For each command, a git/registry dep must resolve under $HOME (where
+   `forge deps` actually installs it) and NOT under <project_root>/.march
+   (the bug: that directory is never created by the installer). *)
+let check_resolves_under_home ~what dep_dir_fn =
+  with_fake_home (fun home ->
+      let name = "widget" in
+      mkdir_p (expected_cas_path home name);
+      let proj_root = tmp_dir "dep-dir-proj" in
+      let resolved = dep_dir_fn ~base:proj_root ~name ~dep:git_dep in
+      let wrong = wrong_project_root_path proj_root name in
+      rm_rf proj_root;
+      Alcotest.(check string) (what ^ ": resolves to the real $HOME install location")
+        (expected_cas_path home name) resolved;
+      Alcotest.(check bool) (what ^ ": does NOT resolve under the project root")
+        true (resolved <> wrong))
+
+let check_registry_dep_resolves_under_home ~what dep_dir_fn =
+  with_fake_home (fun home ->
+      let name = "gadget" in
+      mkdir_p (expected_cas_path home name);
+      let proj_root = tmp_dir "dep-dir-proj" in
+      let resolved = dep_dir_fn ~base:proj_root ~name ~dep:registry_dep in
+      rm_rf proj_root;
+      Alcotest.(check string) (what ^ ": registry dep resolves under $HOME too")
+        (expected_cas_path home name) resolved)
+
+let check_path_dep_unaffected ~what dep_dir_fn =
+  let proj_root = tmp_dir "dep-dir-proj" in
+  let vendor = Filename.concat proj_root "vendor/thing" in
+  mkdir_p vendor;
+  let dep = Project.PathDep "vendor/thing" in
+  let resolved = dep_dir_fn ~base:proj_root ~name:"thing" ~dep in
+  rm_rf proj_root;
+  Alcotest.(check string) (what ^ ": PathDep still relative to declaring root")
+    vendor resolved
+
+let cases ~what dep_dir_fn =
+  [ Alcotest.test_case (what ^ ": git dep under $HOME") `Quick
+      (fun () -> check_resolves_under_home ~what dep_dir_fn);
+    Alcotest.test_case (what ^ ": registry dep under $HOME") `Quick
+      (fun () -> check_registry_dep_resolves_under_home ~what dep_dir_fn);
+    Alcotest.test_case (what ^ ": PathDep unaffected") `Quick
+      (fun () -> check_path_dep_unaffected ~what dep_dir_fn) ]
+
+let () =
+  Alcotest.run "forge-dep-dir"
+    [ ( "Cmd_audit.dep_dir",
+        cases ~what:"audit" (fun ~base ~name ~dep -> Cmd_audit.dep_dir ~base ~name ~dep) );
+      ( "Cmd_licenses.dep_dir",
+        cases ~what:"licenses" (fun ~base ~name ~dep -> Cmd_licenses.dep_dir ~base ~name ~dep) );
+      ( "Cmd_tree.dep_dir",
+        cases ~what:"tree" (fun ~base ~name ~dep -> Cmd_tree.dep_dir ~base ~name ~dep) ) ]

--- a/specs/progress/2026-08-10-forge-audit-licenses-tree-dep-dir-home.md
+++ b/specs/progress/2026-08-10-forge-audit-licenses-tree-dep-dir-home.md
@@ -1,0 +1,25 @@
+# forge audit/licenses/tree: resolve git/registry deps under $HOME, not project root
+
+`forge/lib/cmd_audit.ml`, `forge/lib/cmd_licenses.ml`, and `forge/lib/cmd_tree.ml` each
+had their own `cas_deps_dir root` / `dep_dir` helper that computed a git/registry
+dependency's install location as `<project_root>/.march/cas/deps/<name>`.
+
+The actual installer (`forge/lib/cmd_deps.ml`'s `cas_deps_dir ()`, and
+`Project.dep_root_dir`) installs git and registry dependencies under
+`$HOME/.march/cas/deps/<name>` — a global, cross-project location — never under the
+project root. So `forge audit`, `forge licenses`, and `forge tree` could never find an
+actually-installed git/registry dependency's source tree: the computed directory never
+existed, `Sys.file_exists`/`Project.load_from_dir` failed, and the dependency was
+reported as "not installed" (audit), with empty version/license metadata (licenses), or
+as a childless leaf (tree) — even immediately after a successful `forge deps`. `PathDep`
+was unaffected since it resolves relative to the declaring project regardless.
+
+Fixed by replacing all three local reimplementations with `Project.dep_root_dir
+~project_root:base (name, dep)`, the same resolver the installer and `forge deps`'
+transitive-dependency BFS already use.
+
+Existing tests for these three commands (`test_forge.ml`'s `Cmd_licenses` cases,
+`test_audit.ml`) only exercised pure helpers or `PathDep`, which never touches the
+buggy branch — so none of them caught this. Added `forge/test/test_dep_dir.ml`, which
+fakes `$HOME` with a pre-populated `.march/cas/deps/<name>` fixture and exercises each
+command's `dep_dir` directly against `GitTagDep`, `RegistryDep`, and `PathDep`.


### PR DESCRIPTION
## Summary

- `forge audit`, `forge licenses`, and `forge tree` each reimplemented their own dependency-directory lookup as `<project_root>/.march/cas/deps/<name>`, but `forge deps` (via `Project.dep_root_dir`) actually installs git and registry dependencies under `$HOME/.march/cas/deps/<name>` — a global, cross-project location. So a just-installed git/registry dep was always reported as "not installed" by these three commands (blank version/license for `licenses`, a childless leaf for `tree`), even right after a successful `forge deps`.
- Fixed by routing all three through `Project.dep_root_dir`, the same resolver `forge deps`'s own transitive-dependency walk uses. Path deps were unaffected (they resolve relative to the declaring project) and are covered in the new test.
- Added `forge/test/test_dep_dir.ml`: existing tests for these commands (`test_forge.ml`, `test_audit.ml`) only exercised pure helpers or `PathDep`, which never touches the buggy branch. The new test fakes `$HOME` with a pre-populated `.march/cas/deps/<name>` fixture and exercises each command's `dep_dir` against `GitTagDep`, `RegistryDep`, and `PathDep` directly.

## Test plan

- [x] `dune build --root .` — full build succeeds
- [x] `dune build --root . @forge/test/runtest --force` — full forge test suite passes (including new `forge-dep-dir` suite, 9/9)
- [x] `scripts/check-docs.sh` — doc-lint passes