### PR TITLE
caps: trim the redundant capability-hint diagnostic at presentation time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,14 @@ git log is authoritative for exact commits.
   capability set (`march caps`, feeding `forge audit --inferred` and the
   `--cap-sandbox` profile) had the identical bug in the opposite direction —
   silently over-reporting a capability never used — also fixed.
+- **A missing-capability violation no longer prints two overlapping
+  diagnostics at the same source location.** Both the typechecker's own
+  `needs`-coverage check and the separate capability-inference pass anchor
+  at the exact call site and were repeating each other's "add `needs X`"
+  sentence almost verbatim. The hint now shows only what the error doesn't
+  already say — the call chain from `main` down to the offending call — and
+  is omitted entirely when there is no chain to show (a library with no
+  `main`, or a violation already inside `main`).
 
 - **A natively compiled program opening a nonexistent file no longer misreads
   the error value's representation.** `file_open`'s `Err` case is typed

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -13,6 +13,78 @@ let severity_word (sev : March_errors.Errors.severity) : string =
   | March_errors.Errors.Warning -> "warning"
   | March_errors.Errors.Hint -> "hint"
 
+(* [find_substring ~needle haystack] returns the index of the first
+   occurrence of [needle] in [haystack], or [None]. Small local helper so
+   [dedupe_cap_hints] below doesn't reach for a regex library over one fixed
+   marker string. *)
+let find_substring ~needle haystack =
+  let nl = String.length needle and hl = String.length haystack in
+  let rec go i =
+    if i + nl > hl then None
+    else if String.sub haystack i nl = needle then Some i
+    else go (i + 1)
+  in
+  if nl = 0 then Some 0 else go 0
+
+(* Presentation-only de-duplication of the capability diagnostics: the
+   typechecker's Check 1b (lib/typecheck/typecheck.ml, an Error) and
+   Cap_infer's call-site hint (lib/refinecheck/cap_infer.ml, a Hint) both
+   fire at the exact same span for the exact same missing capability once
+   Cap_infer's call-chain work landed — see
+   specs/progress/2026-08-10-capability-diagnostic-duplication.md. Their
+   "add `needs X`" clauses are now byte-for-byte redundant, but the hint's
+   trailing "reached from `main`: …" chain is genuinely new information the
+   error doesn't carry. So: when a Hint tagged `cap_needs:<cap>` shares its
+   span with an Error/Warning tagged with the same code, trim the hint down
+   to just the chain (dropping the now-redundant prefix); when there is no
+   chain to show, drop the hint entirely rather than print a sentence that
+   says nothing the error hasn't already said.
+
+   Both passes are tagged via the `code` field (not by re-parsing each
+   other's prose) specifically so this stays robust to independent wording
+   changes on either side; the chain suffix is split off via
+   [Cap_infer.chain_marker], the one constant Cap_infer exports for this
+   purpose, rather than by guessing at hint phrasing here.
+
+   This is deliberately scoped to THIS file: it changes only what the
+   combined single-file compiler pipeline renders. [Cap_infer.check_module]
+   itself is untouched and keeps emitting the hint's full text
+   unconditionally — its direct-call unit tests in test/test_compiler.ml
+   pin exactly that standalone contract for any caller (e.g. tooling that
+   runs Cap_infer without this file's Check 1b) that invokes it without
+   going through this pipeline. *)
+let dedupe_cap_hints (diags : March_errors.Errors.diagnostic list)
+    : March_errors.Errors.diagnostic list =
+  let module E = March_errors.Errors in
+  let cap_needs_code (d : E.diagnostic) =
+    match d.E.code with
+    | Some c when String.length c > 10 && String.sub c 0 10 = "cap_needs:" -> Some c
+    | _ -> None
+  in
+  let strong_codes =
+    List.filter_map (fun (d : E.diagnostic) ->
+        match d.E.severity, cap_needs_code d with
+        | (E.Error | E.Warning), Some code -> Some (d.E.span, code)
+        | _ -> None)
+      diags
+  in
+  List.filter_map
+    (fun (d : E.diagnostic) ->
+       match d.E.severity, cap_needs_code d with
+       | E.Hint, Some code when List.mem (d.E.span, code) strong_codes ->
+         let marker = March_refinecheck.Cap_infer.chain_marker in
+         (match find_substring ~needle:marker d.E.message with
+          | Some i ->
+            let chain_start = i + String.length marker in
+            let chain =
+              String.sub d.E.message chain_start
+                (String.length d.E.message - chain_start)
+            in
+            Some { d with E.message = "reached from `main`: " ^ chain }
+          | None -> None)
+       | _ -> Some d)
+    diags
+
 let b64_decode_pubkey b64 =
   let tbl = Array.make 256 (-1) in
   let chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=" in
@@ -2198,7 +2270,12 @@ let compile filename =
      "User" means any file loaded as user code: the entry file AND modules
      resolved from the source dir / MARCH_LIB_PATH.  Filtering by entry
      filename alone silently compiled ill-typed imported modules. *)
-  let diags = March_errors.Errors.sorted errors in
+  (* [dedupe_cap_hints]: trims/drops Cap_infer's call-site hint when Check 1b
+     already reported the identical missing capability at the identical
+     span — see its doc comment above. Applied here, once, so every
+     downstream consumer of [diags] (human-readable printing below,
+     --check-json, --emit-core-ast) sees the same de-duplicated set. *)
+  let diags = dedupe_cap_hints (March_errors.Errors.sorted errors) in
   let is_user_file (d : March_errors.Errors.diagnostic) =
     let f = d.span.March_ast.Ast.file in
     f = filename || f = "" || f = "<unknown>" || List.mem f user_files

--- a/lib/errors/errors.ml
+++ b/lib/errors/errors.ml
@@ -62,17 +62,17 @@ let warning ctx ~span message =
   report ctx
     { severity = Warning; span; message; labels = []; notes = []; code = None; fix = None }
 
-let hint ctx ~span message =
+let hint ctx ~span ?code message =
   report ctx
-    { severity = Hint; span; message; labels = []; notes = []; code = None; fix = None }
+    { severity = Hint; span; message; labels = []; notes = []; code; fix = None }
 
 let warning_with_code ctx ~span ~code message =
   report ctx
     { severity = Warning; span; message; labels = []; notes = []; code = Some code; fix = None }
 
-let error_with_fix ctx ~span ~fix message =
+let error_with_fix ctx ~span ?code ~fix message =
   report ctx
-    { severity = Error; span; message; labels = []; notes = []; code = None; fix = Some fix }
+    { severity = Error; span; message; labels = []; notes = []; code; fix = Some fix }
 
 let warning_with_fix ctx ~span ~fix message =
   report ctx

--- a/lib/refinecheck/cap_infer.ml
+++ b/lib/refinecheck/cap_infer.ml
@@ -328,6 +328,15 @@ let call_path (g : (string, string list) Hashtbl.t) ~(entry : string)
     !result
   end
 
+(** The fixed separator between a hint's "add `needs X`" prefix and its
+    call-chain suffix. Exposed (rather than left as an inline [Printf.sprintf]
+    literal) so a presentation-layer consumer can split a hint's message on
+    it — bin/main.ml uses this to show only the chain when the same missing
+    capability is already reported by the typechecker's Check 1b at the
+    identical span, instead of re-deriving the split by parsing prose it
+    doesn't own. *)
+let chain_marker = "\nreached from `main`: "
+
 (* ── Per-module check ────────────────────────────────────────────────────── *)
 
 (** Walk [decls] belonging to module [mod_name], emitting a hint for every
@@ -358,7 +367,7 @@ let rec check_decls ?(graph : (string, string list) Hashtbl.t option)
       (match call_path g ~entry:"main" ~target:enclosing with
        | None | Some [ _ ] -> ""
        | Some path ->
-         Printf.sprintf "\nreached from `main`: %s" (String.concat " → " path))
+         chain_marker ^ String.concat " → " path)
   in
   let emit_if_missing enclosing call_name call_span =
     match cap_of_call call_name with
@@ -368,7 +377,14 @@ let rec check_decls ?(graph : (string, string list) Hashtbl.t option)
       else if Hashtbl.mem hinted cap then ()
       else begin
         Hashtbl.replace hinted cap ();
-        Err.hint errctx ~span:call_span
+        (* [~code] tags this hint with the exact missing capability so a
+           presentation-layer consumer (bin/main.ml) can recognise when the
+           typechecker's Check 1b already reported the same fact at the same
+           span — without either pass depending on the other. This pass's
+           own contract (full text, unconditional) is untouched; see the
+           module header and
+           specs/progress/2026-08-10-capability-diagnostic-duplication.md. *)
+        Err.hint errctx ~span:call_span ~code:("cap_needs:" ^ cap)
           (Printf.sprintf
              "call to `%s` requires `needs %s` — add `needs %s` to module `%s`%s"
              call_name cap cap mod_name (chain_note enclosing))

--- a/lib/typecheck/typecheck.ml
+++ b/lib/typecheck/typecheck.ml
@@ -9157,7 +9157,12 @@ let check_module_needs (env : env) (mod_name : Ast.name)
       | None -> false
     in
     if not covered && not self_declared then
-      Err.error_with_fix env.errors ~span:sp
+      (* [~code] tags this diagnostic with the exact missing capability so
+         that a presentation-layer consumer (bin/main.ml) can recognise when
+         [Cap_infer]'s call-site hint at the SAME span is reporting the same
+         fact, without either pass having to know about the other — see
+         specs/progress/2026-08-10-capability-diagnostic-duplication.md. *)
+      Err.error_with_fix env.errors ~span:sp ~code:("cap_needs:" ^ cap_path)
         ~fix:(Err.FInsert {
           after_line = mod_name.March_ast.Ast.span.March_ast.Ast.start_line;
           text = "  needs " ^ cap_path })

--- a/specs/progress/2026-08-10-capability-diagnostic-duplication.md
+++ b/specs/progress/2026-08-10-capability-diagnostic-duplication.md
@@ -97,4 +97,60 @@ The plan also asks the capability error to *show where in the chain from `main`
 the capability should have been threaded*. That needs a call graph from the
 entry point to the offending call; `cap_infer` currently walks declarations
 per-module with no cross-function reachability. Larger than this cleanup and
-worth scoping separately.
+worth scoping separately. (Landed separately, before this resolution — see the
+2026-08-10 update below.)
+
+## Resolution, 2026-08-10 (Tier 3 of specs/2026-08-09-cap-loose-ends-plan.md)
+
+Went with **option 2, presentation-time suppression**, per the prior
+investigation's conclusion — not option 1 (moving Check 1b's span). Two
+reasons that decided it: (a) Check 1b's span is exactly the useful
+"go to error" cursor landing spot for an editor — the call site — and moving
+it to the module header would trade that for a worse UX than the duplication
+it fixes; (b) `cap_infer.ml` has exactly one production caller
+(`bin/main.ml`, both the eval and compile/check pipelines) besides its own
+direct-call unit tests in `test/test_compiler.ml`, so "presentation time"
+has one unambiguous place to live and no other consumer to accidentally
+affect.
+
+Implementation, all at rendering time in `bin/main.ml`, with neither
+`cap_infer.ml` nor `typecheck.ml`'s emission logic made conditional on the
+other (repeating the mistake documented above):
+
+- Both diagnostics now carry a `~code:"cap_needs:<cap>"` tag (Check 1b in
+  `lib/typecheck/typecheck.ml`, the hint in `lib/refinecheck/cap_infer.ml`)
+  so a downstream consumer can recognise "these two are about the same
+  missing capability" without parsing prose. `lib/errors/errors.ml` gained
+  an optional `?code` on `hint` and `error_with_fix` to carry it (existing
+  pattern — `warning_with_code`/`warning_with_code_and_fix` already did this
+  for `unused_binding`).
+- `cap_infer.ml` exports `chain_marker`, the literal separator between the
+  hint's "add `needs X`" prefix and its "reached from `main`: …" suffix, so
+  a presentation-layer caller can split the hint without hand-rolling a
+  parse of its exact wording.
+- `bin/main.ml` adds `dedupe_cap_hints`, applied once right after `diags` is
+  computed in the compile/check pipeline (covers the human-readable printer,
+  `--check-json`, and `--emit-core-ast` uniformly): when a Hint tagged
+  `cap_needs:<cap>` shares its span with an Error/Warning carrying the same
+  code, the hint is trimmed down to just `reached from \`main\`: …` (its only
+  non-redundant content); when there is no chain to show (a library with no
+  `main`, or the call site already lands inside `main`), the hint is dropped
+  entirely rather than printing a sentence that repeats the error verbatim.
+  The eval/test-runner pipeline already only prints Error-severity
+  diagnostics, so hints never rendered there regardless — no change needed.
+  `march caps` never calls `Cap_infer.check_module` at all, so it is
+  unaffected.
+- Took the "smaller, in scope" suggestion (trim rather than fully drop the
+  hint) instead of the todo's literal option 2 text ("drop the hint") because
+  full suppression would have thrown away the call-chain, which is exactly
+  the piece of information Check 1b's error does NOT carry.
+
+Verified: `scripts/run-tests.sh -q compiler` and the full suite green
+(`cap_infer`'s 12-test group in `test/test_compiler.ml`, which pins the
+pass's standalone unconditional-hint contract via `check_cap_infer`/
+`cap_hint_messages`, untouched); `specs/lang/types/check_types.sh` green;
+manual before/after on a real `--check`/`--check-json` run of a
+module-boundary capability violation (`main → issue → make_token`, missing
+`needs IO.Random`) confirms the ERROR is unchanged, the HINT collapses to
+`reached from \`main\`: main → issue → make_token`, and a library-only
+violation with no `main` drops the hint entirely and shows only the ERROR.


### PR DESCRIPTION
## Summary

Resolves `specs/todos/2026-08-03-capability-diagnostic-duplication.md`
(Tier 3 of `specs/2026-08-09-cap-loose-ends-plan.md`).

A missing capability produced two diagnostics anchored at the exact same
call-site span: the typechecker's Check 1b (an Error, with the mechanical
`needs` insertion fix) and `Cap_infer`'s call-site hint. Their "add
`needs X`" clauses had become byte-for-byte redundant; the hint's
"reached from `main`: ..." call-chain suffix was the only genuinely novel
part.

- Went with **presentation-time suppression** (not moving Check 1b's span)
  per the prior investigation's documented conclusion: Check 1b's span is
  the right "go to error" cursor landing spot (the call site), and
  `cap_infer.ml` has exactly one production caller (`bin/main.ml`) besides
  its own direct-call unit tests, so "presentation time" has one
  unambiguous home.
- Both diagnostics now carry a `~code:"cap_needs:<cap>"` tag (new optional
  `?code` on `Errors.hint`/`Errors.error_with_fix`, following the existing
  `warning_with_code` pattern) so they can be correlated without either
  pass parsing the other's prose.
- `bin/main.ml` adds `dedupe_cap_hints`: when a Hint tagged `cap_needs:X`
  shares its span with an Error/Warning carrying the same code, trim the
  hint to just its novel suffix (the call chain), or drop it entirely when
  there's no chain to show (a library with no `main`, or a violation
  already inside `main`).
- Neither `cap_infer.ml` nor `typecheck.ml`'s emission logic became
  conditional on the other — `cap_infer`'s standalone unit-test contract
  (unconditional hint) is untouched, as documented in the todo's "what was
  tried and reverted" section.

See `specs/progress/2026-08-10-capability-diagnostic-duplication.md` for
the full design writeup.

## Test plan

- [x] `./_build/default/test/run_compiler.exe -e -q` — 795 passed (incl.
      the `cap_infer` group, unconditional-hint contract intact)
- [x] `./_build/default/test/run_eval.exe -e -q` — 256 passed
- [x] `./_build/default/test/run_stdlib.exe -e -q` — 786 passed
- [x] `./_build/default/test/run_codegen.exe -e -q` — 562 passed
      (pre-rebase; the rebase delta, PR #242, is docs/specs-only —
      confirmed via `git show --stat` on the merge commit — so this result
      carries over unchanged)
- [x] `bash specs/lang/types/check_types.sh` — 280 passed, 0 failed
      (pre-rebase, same rationale)
- [x] Manual before/after `--check` and `--check-json` on a real
      module-boundary capability violation (`main → issue → make_token`,
      missing `needs IO.Random`): the ERROR is unchanged, the HINT
      collapses to `reached from \`main\`: main → issue → make_token`; a
      library-only violation with no `main` drops the hint entirely,
      showing only the ERROR. Re-verified on the rebased tree.
- [x] Full compiler suite (incl. Slow tests) — 844 passed
- [x] `git fetch origin && git rebase origin/main` — clean, no conflicts;
      `git merge-base --is-ancestor origin/main HEAD` confirmed