### PR TITLE
feat(bytes): array-backed Bytes — contiguous buffer instead of a cons list

### DIFF
--- a/lib/eval/eval.ml
+++ b/lib/eval/eval.ml
@@ -2939,26 +2939,28 @@ external caml_march_zstd_decode    : string -> string        = "caml_march_zstd_
 external caml_march_brotli_encode  : string -> int -> int -> string = "caml_march_brotli_encode"
 external caml_march_brotli_decode  : string -> string        = "caml_march_brotli_decode"
 
-(** Convert an OCaml raw string to a March Bytes(List(Int)) value. *)
+(** Convert an OCaml raw string to a March Bytes value.
+
+    [type Bytes = Bytes(String)] — the payload is the raw byte buffer itself,
+    so this is a wrap rather than the per-byte cons spine it used to build.
+    See specs/plans/2026-08-10-array-backed-bytes-design.md. *)
 let march_bytes_of_string (s : string) : value =
-  let n = String.length s in
-  let lst = ref (VCon ("Nil", [])) in
-  for i = n - 1 downto 0 do
-    lst := VCon ("Cons", [VInt (Char.code s.[i]); !lst])
-  done;
-  VCon ("Bytes", [!lst])
+  VCon ("Bytes", [VString s])
 
 (** Extract raw bytes from a March value (String or Bytes). *)
 let march_val_to_raw (v : value) : (string, string) result =
   match v with
   | VString s -> Ok s
+  | VCon ("Bytes", [VString s]) -> Ok s
+  (* Tolerate the legacy cons-spine payload: an FFI shim or a serialized value
+     produced before the representation change can still reach here. *)
   | VCon ("Bytes", [lst]) ->
     let buf = Buffer.create 16 in
     let rec go = function
       | VCon ("Nil", []) -> Ok ()
       | VCon ("Cons", [VInt b; rest]) ->
         Buffer.add_char buf (Char.chr (b land 0xFF)); go rest
-      | _ -> Error "Bytes: expected list of Int"
+      | _ -> Error "Bytes: expected String payload"
     in
     (match go lst with Ok () -> Ok (Buffer.contents buf) | Error e -> Error e)
   | _ -> Error (Printf.sprintf "expected String or Bytes, got %s" (value_to_string v))
@@ -5602,14 +5604,10 @@ let base_env : env =
           let sock = (Obj.magic fd : Unix.file_descr) in
           let buf = Bytes.create n in
           let rec loop off =
-            if off >= n then begin
-              (* Build March Bytes(List(Int)) value: Bytes(Cons(b0, Cons(b1, ... Nil))) *)
-              let lst = ref (VCon ("Nil", [])) in
-              for i = n - 1 downto 0 do
-                lst := VCon ("Cons", [VInt (Char.code (Bytes.get buf i)); !lst])
-              done;
-              VCon ("Ok", [VCon ("Bytes", [!lst])])
-            end else
+            if off >= n then
+              (* Bytes is Bytes(String): the received buffer IS the payload. *)
+              VCon ("Ok", [VCon ("Bytes", [VString (Bytes.to_string buf)])])
+            else
               (try
                  let got = Unix.recv sock buf off (n - off) [] in
                  if got = 0 then VCon ("Err", [VString "connection closed"])

--- a/runtime/march_compress.c
+++ b/runtime/march_compress.c
@@ -29,44 +29,34 @@
 
 /* ── Helpers (mirrors march_extras.c) ────────────────────────────────────── */
 
+/* Bytes is Bytes(String): a one-field boxed ADT cell whose field 0 (offset 16)
+ * is a march_string — one allocation, explicit length, contiguous payload.
+ *
+ * This is the hottest instance of the old representation's cost.  Building a
+ * Bytes from raw used to allocate one ~32-byte cons cell per byte, so
+ * march_gzip_decode of a 12 MB tar allocated ~12M cells (hundreds of MB) and
+ * a 3.1 MB tarball could not be processed at all; reading one back walked the
+ * whole spine twice.  Both are now a single memcpy.  See
+ * specs/plans/2026-08-10-array-backed-bytes-design.md. */
 static void *compress_bytes_from_raw(const uint8_t *data, size_t len) {
-    void *list = march_alloc(16); /* Nil */
-    for (ssize_t i = (ssize_t)len - 1; i >= 0; i--) {
-        void *node = march_alloc(16 + 8 + 8);
-        *(int32_t *)((char *)node + 8) = 1; /* tag = Cons */
-        /* Pre-tag the Int payload with (n<<1)|1 — uniform low-bit integer
-         * tagging for generic ctor slots (see make_int_cons, march_http.c). */
-        *(int64_t *)((char *)node + 16) = ((int64_t)data[i] << 1) | 1;
-        *(void **)((char *)node + 24) = list;
-        list = node;
-    }
+    void *s = march_string_lit((const char *)data, (int64_t)len);
     void *b = march_alloc(16 + 8);
     /* tag = 0 = Bytes ctor */
-    *(void **)((char *)b + 16) = list;
+    *(void **)((char *)b + 16) = s;
     return b;
 }
 
+/* Returns a malloc'd copy; caller frees.  The copy (rather than borrowing
+ * march_string::data) is kept because every caller below owns and frees the
+ * buffer, and zlib/zstd/brotli want a plain uint8_t* they may not alias the
+ * March heap for. */
 static uint8_t *compress_bytes_to_raw(void *bytes_val, size_t *out_len) {
-    void *list = *(void **)((char *)bytes_val + 16);
-    size_t n = 0;
-    void *p = list;
-    while (p) {
-        int32_t tag = *(int32_t *)((char *)p + 8);
-        if (tag == 0) break;
-        n++;
-        p = *(void **)((char *)p + 24);
-    }
+    march_string *ms = *(march_string **)((char *)bytes_val + 16);
+    size_t n = ms ? (size_t)ms->len : 0;
     uint8_t *buf = malloc(n > 0 ? n : 1);
     if (!buf) { *out_len = 0; return NULL; }
+    if (n > 0) memcpy(buf, ms->data, n);
     *out_len = n;
-    p = list; size_t i = 0;
-    while (p && i < n) {
-        int32_t tag = *(int32_t *)((char *)p + 8);
-        if (tag == 0) break;
-        /* Untag the Int payload: generic ctor slots store (n<<1)|1. */
-        buf[i++] = (uint8_t)((*(int64_t *)((char *)p + 16) >> 1) & 0xFF);
-        p = *(void **)((char *)p + 24);
-    }
     return buf;
 }
 

--- a/runtime/march_extras.c
+++ b/runtime/march_extras.c
@@ -222,59 +222,45 @@ static void b64_decode_init(void) {
 
 /* ── Bytes(List(Int)) helpers ─────────────────────────────────────────── */
 
-/* Create a Cons(int, tail) list node.  Transfers ownership of tail.
- * The Int payload is pre-tagged with (n<<1)|1: under the uniform low-bit
- * integer tagging scheme, compiled code emits `ashr #1` when extracting an
- * Int field from a generic constructor slot, so a raw value would be halved
- * on untag.  (Same convention as make_int_cons in march_http.c.) */
-static void *int_cons(int64_t n, void *tail) {
-    void *node = march_alloc(16 + 16);   /* hdr(16) + i64(8) + ptr(8) */
-    *(int32_t *)((char *)node + 8)  = 1; /* tag = 1 = Cons */
-    *(int64_t *)((char *)node + 16) = (n << 1) | 1;
-    *(void **)((char *)node + 24)   = tail;
-    return node;
-}
-
-/* Create a Bytes(list) wrapper.  Transfers ownership of list. */
-static void *bytes_wrap(void *list) {
+/* Create a Bytes(payload) wrapper.  Transfers ownership of payload.
+ * The wrapper cell layout is unchanged from the Bytes(List(Int)) era — a
+ * one-field boxed ADT cell with field 0 at offset 16 — only the payload's
+ * type changed, from a cons spine to a march_string.  Keeping the cell is
+ * deliberate: lib/tir/repr.ml, llvm_case.ml and drop.ml all encode
+ * assumptions about this shape.  See
+ * specs/plans/2026-08-10-array-backed-bytes-design.md. */
+static void *bytes_wrap(void *payload) {
     void *b = march_alloc(16 + 8);       /* hdr(16) + ptr(8) */
     /* tag stays 0 = Bytes ctor */
-    *(void **)((char *)b + 16) = list;
+    *(void **)((char *)b + 16) = payload;
     return b;
 }
 
-/* Build a Bytes(List(Int)) from raw bytes.  Returns owned reference. */
+/* Build a Bytes from raw bytes.  Returns owned reference.
+ *
+ * This used to allocate one ~32-byte cons cell PER BYTE, so a 12 MB
+ * march_gzip_decode allocated ~12M cells (hundreds of MB) before any March
+ * code ran.  march_string_lit is one allocation and one memcpy. */
 static void *bytes_from_raw(const uint8_t *data, size_t len) {
-    void *list = march_alloc(16); /* Nil: tag=0, rc=1 */
-    for (ssize_t i = (ssize_t)len - 1; i >= 0; i--)
-        list = int_cons((int64_t)data[i], list);
-    return bytes_wrap(list);
+    return bytes_wrap(march_string_lit((const char *)data, (int64_t)len));
 }
 
-/* Extract raw bytes from a Bytes(List(Int)) value. Returns malloc'd buffer,
- * sets *out_len. Caller must free. */
+/* Extract raw bytes from a Bytes value. Returns malloc'd buffer, sets
+ * *out_len. Caller must free.
+ *
+ * The payload is already contiguous, so this is a single memcpy where it used
+ * to be two full spine walks (one to count, one to copy).  The copy is kept
+ * rather than borrowing march_string::data directly because every caller here
+ * free()s the result and several mutate it in place; a borrowing variant is a
+ * separate, larger change to those call sites. */
 static uint8_t *bytes_to_raw(void *bytes_val, size_t *out_len) {
-    /* Bytes(list): field 0 at offset 16 is the list pointer */
-    void *list = *(void **)((char *)bytes_val + 16);
-    /* Count entries first */
-    size_t n = 0;
-    void *p = list;
-    while (p) {
-        int32_t tag = *(int32_t *)((char *)p + 8);
-        if (tag == 0) break; /* Nil */
-        n++;
-        p = *(void **)((char *)p + 24);
-    }
+    /* Bytes(payload): field 0 at offset 16 is the march_string. */
+    march_string *ms = *(march_string **)((char *)bytes_val + 16);
+    size_t n = ms ? (size_t)ms->len : 0;
     uint8_t *buf = malloc(n > 0 ? n : 1);
+    if (!buf) { *out_len = 0; return NULL; }
+    if (n > 0) memcpy(buf, ms->data, n);
     *out_len = n;
-    p = list; size_t i = 0;
-    while (p && i < n) {
-        int32_t tag = *(int32_t *)((char *)p + 8);
-        if (tag == 0) break;
-        /* Untag the Int payload: generic ctor slots store (n<<1)|1. */
-        buf[i++] = (uint8_t)((*(int64_t *)((char *)p + 16) >> 1) & 0xFF);
-        p = *(void **)((char *)p + 24);
-    }
     return buf;
 }
 

--- a/runtime/march_http.c
+++ b/runtime/march_http.c
@@ -118,31 +118,18 @@ static void *make_cons(void *head, void *tail) {
     return c;
 }
 
-/* Build a March List(Int) Cons node: tag=1, field0=int (raw i64), field1=tail.
- * Monomorphized List(Int) stores ints raw (no low-bit tag), matching the
- * layout produced by Bytes.from_list on the March side. */
-static void *make_int_cons(int64_t n, void *tail) {
-    void *c = march_alloc(16 + 16);
-    *(int32_t *)((char *)c + 8)  = 1;          /* tag = 1 (Cons) */
-    /* Pre-tag the Int payload with (n<<1)|1: under the uniform low-bit
-     * integer tagging scheme, the compiler emits `ashr #1` when extracting
-     * an Int field, so a raw value would be halved on untag. */
-    *(int64_t *)((char *)c + 16) = (n << 1) | 1;
-    *(void **)((char *)c + 24)   = tail;
-    return c;
-}
-
-/* Build a Bytes(List(Int)) wrapper value from raw bytes.  Matches the
- * March stdlib `type Bytes = Bytes(List(Int))` layout: a 24-byte wrapper
- * whose single field at offset 16 points to a List(Int) chain whose
- * Cons nodes carry raw i64 byte values. */
+/* Build a Bytes(String) wrapper value from raw bytes.  Matches the March
+ * stdlib `type Bytes = Bytes(String)` layout: a 24-byte wrapper whose single
+ * field at offset 16 points to a march_string {rc,tag,pad,len,data[]}.
+ *
+ * This replaced a per-byte cons-cell builder (~32 bytes of heap per byte of
+ * payload, plus a full spine walk on every Bytes.get).  See
+ * specs/plans/2026-08-10-array-backed-bytes-design.md. */
 static void *make_bytes_from_raw(const uint8_t *data, int64_t len) {
-    void *list = march_alloc(16); /* Nil: tag=0 */
-    for (int64_t i = len - 1; i >= 0; i--)
-        list = make_int_cons((int64_t)data[i], list);
+    void *s = march_string_lit((const char *)data, len);
     void *b = march_alloc(16 + 8);
     /* tag stays 0 = Bytes ctor */
-    *(void **)((char *)b + 16) = list;
+    *(void **)((char *)b + 16) = s;
     return b;
 }
 
@@ -492,7 +479,7 @@ void *march_tcp_recv_chunk(int64_t fd_arg, int64_t max_bytes) {
  * Reads exactly n bytes from the socket, blocking until all are received. */
 void *march_tcp_recv_exact(int64_t fd, int64_t n) {
     if (n <= 0) {
-        /* Ok(Bytes(Nil)) — empty Bytes, not empty String. */
+        /* Ok(Bytes("")) — an empty Bytes wrapper, not a bare empty String. */
         return make_ok(make_bytes_from_raw(NULL, 0));
     }
     uint8_t *buf = (uint8_t *)malloc((size_t)n);
@@ -512,9 +499,9 @@ void *march_tcp_recv_exact(int64_t fd, int64_t n) {
     }
     march_unblock_preempt(&saved);
     /* The March-side declaration is `tcp_recv_exact : Int -> Int -> Result(Bytes, String)`,
-     * where `type Bytes = Bytes(List(Int))`.  Return a proper Bytes wrapper
-     * (NOT a march_string) so that `match Ok(header) -> Bytes.get(header, 0)`
-     * reads the List(Int) chain at offset 16 rather than raw UTF-8 bytes. */
+     * where `type Bytes = Bytes(String)`.  Return the Bytes WRAPPER, not a bare
+     * march_string: `match Ok(header) -> Bytes.get(header, 0)` destructures the
+     * constructor first and reads the payload at offset 16. */
     void *b = make_bytes_from_raw(buf, n);
     free(buf);
     return make_ok(b);

--- a/share/march/bytes.march
+++ b/share/march/bytes.march
@@ -1,292 +1,268 @@
 -- Bytes module: raw byte manipulation.
 --
--- Bytes wraps a List(Int) of byte values in the range 0–255.
--- March strings are UTF-8 byte sequences; Bytes exposes the raw bytes.
--- All encoding functions (hex, base64) are implemented in pure March.
+-- Bytes wraps a String, which in the runtime is an array-backed buffer:
+-- `march_string` is {rc, tag, pad, len, data[]} — one allocation, an explicit
+-- length field, and a contiguous NUL-safe payload.  Nothing here treats a
+-- String as text: `string_byte_at`, `string_slice`, `string_chars` and
+-- `char_from_int` are all byte-indexed in both backends.
+--
+-- This replaced `Bytes(List(Int))`, which cost one ~32-byte cons cell per
+-- byte and made `length` O(n), `get` O(i) and `slice` O(start+len).  Measured
+-- on a 64 000-byte payload (interpreted): `length` 544 ms/call, `get(last)`
+-- 1063 ms, `slice` 1057 ms.  See specs/plans/2026-08-10-array-backed-bytes-design.md.
+--
+-- The wrapper constructor is deliberately kept (a Bytes value is still a
+-- one-field boxed ADT cell with its payload at offset 16), because
+-- lib/tir/repr.ml, llvm_case.ml and drop.ml all encode assumptions about that
+-- shape, and because the C runtime builds these cells by hand.
+--
+-- to_list/from_list were O(1) under the old representation and are O(n) now.
+-- That is the one regression; see the design doc's audit of the callers.
 --
 -- This module is self-contained: it does not depend on List.* or String.*
 -- being loaded, so it can be tested or used in isolation.
 
 mod Bytes do
 
-type Bytes = Bytes(List(Int))
+  type Bytes = Bytes(String)
 
--- ---- Internal list helpers (self-contained) ----
+  -- ---- Internal helpers (self-contained) ----
 
-pfn rev(xs, acc) do
-  match xs do
-  Nil -> acc
-  Cons(h, t) -> rev(t, Cons(h, acc))
-  end
-end
-
-pfn list_len(xs, n) do
-  match xs do
-  Nil -> n
-  Cons(_, t) -> list_len(t, n + 1)
-  end
-end
-
-pfn list_nth(xs, i) do
-  match xs do
-  Nil -> panic("Bytes.get: index out of bounds")
-  Cons(h, t) -> if i == 0 do h else list_nth(t, i - 1) end
-  end
-end
-
-pfn list_drop(xs, n) do
-  if n <= 0 do xs
-  else match xs do
-    Nil -> Nil
-    Cons(_, t) -> list_drop(t, n - 1)
-    end end
-end
-
-pfn list_take(xs, n, acc) do
-  if n <= 0 do rev(acc, Nil)
-  else match xs do
-    Nil -> rev(acc, Nil)
-    Cons(h, t) -> list_take(t, n - 1, Cons(h, acc))
-    end end
-end
-
-pfn list_append(xs, ys) do
-  fn go(rxs, acc) do
-    match rxs do
+  pfn rev(xs, acc) do
+    match xs do
     Nil -> acc
-    Cons(h, t) -> go(t, Cons(h, acc))
+    Cons(h, t) -> rev(t, Cons(h, acc))
     end
   end
-  go(rev(xs, Nil), ys)
-end
 
-pfn join_strings(xs) do
-  fn go(lst, acc) do
-    match lst do
-    Nil -> acc
-    Cons(s, rest) -> go(rest, acc ++ s)
-    end
+  pfn join_strings(xs) do
+    -- O(total) single-pass join. The old `acc ++ s` left-fold was O(n^2)
+    -- (each ++ copies the whole accumulated string).
+    string_join(xs, "")
   end
-  go(xs, "")
-end
 
--- ---- Construction ----
+  -- ---- Construction ----
 
-doc "Wrap a List(Int) of byte values (0–255) as Bytes."
-fn from_list(xs) do Bytes(xs) end
-
-doc "Unwrap Bytes to the underlying List(Int)."
-fn to_list(b) do
-  match b do
-  Bytes(xs) -> xs
-  end
-end
-
-doc "An empty Bytes value."
-fn empty() do Bytes(Nil) end
-
-doc "Convert a String to Bytes (raw UTF-8 byte values, each 0–255)."
-fn from_string(s) do
-  let chars = string_chars(s)
-  fn go(cs, acc) do
-    match cs do
+  pfn from_list_go(xs, acc) do
+    match xs do
     Nil -> rev(acc, Nil)
-    Cons(c, rest) -> go(rest, Cons(char_to_int(c), acc))
+    Cons(n, rest) -> from_list_go(rest, Cons(byte_to_char(n), acc))
     end
   end
-  Bytes(go(chars, Nil))
-end
 
-doc "Convert Bytes back to a String (bytes interpreted as UTF-8)."
-fn to_string(b) do
-  match b do
-  Bytes(xs) -> do
-    fn go(bs, acc) do
-      match bs do
-      Nil -> rev(acc, Nil)
-      Cons(n, rest) -> go(rest, Cons(byte_to_char(n), acc))
-      end
+  doc "Wrap a List(Int) of byte values (0–255) as Bytes. O(n)."
+  fn from_list(xs) do
+    Bytes(string_from_chars(from_list_go(xs, Nil)))
+  end
+
+  pfn to_list_go(s, i, acc) do
+    if i < 0 do acc
+    else to_list_go(s, i - 1, Cons(string_byte_at(s, i), acc))
     end
-    string_from_chars(go(xs, Nil))
   end
-  end
-end
 
--- ---- Measurement ----
-
-doc "Number of bytes."
-fn length(b) do
-  match b do
-  Bytes(xs) -> list_len(xs, 0)
-  end
-end
-
-doc "True if the Bytes is empty."
-fn is_empty(b) do
-  match b do
-  Bytes(Nil) -> true
-  _          -> false
-  end
-end
-
--- ---- Access ----
-
-doc "Byte at position i (0-based). Panics if out of bounds."
-fn get(b, i) do
-  match b do
-  Bytes(xs) -> list_nth(xs, i)
-  end
-end
-
-doc "Sub-slice: bytes from position start with given length."
-fn slice(b, start, len) do
-  match b do
-  Bytes(xs) -> Bytes(list_take(list_drop(xs, start), len, Nil))
-  end
-end
-
--- ---- Combination ----
-
-doc "Concatenate two Bytes values."
-fn concat(b1, b2) do
-  match (b1, b2) do
-  (Bytes(xs), Bytes(ys)) -> Bytes(list_append(xs, ys))
-  end
-end
-
--- ---- UTF-8 encoding ----
-
-doc "Encode a String as UTF-8 bytes. Equivalent to from_string for March strings."
-fn encode_utf8(s) do from_string(s) end
-
-doc "Decode UTF-8 bytes to a String. Returns Ok(s) always (same as to_string)."
-fn decode_utf8(b) do Ok(to_string(b)) end
-
--- ---- Hex encoding ----
-
-pfn hex_digit(n) do
-  if n < 10 do int_to_string(n)
-  else char_from_int(87 + n)  -- 87 = ord('a') - 10, returns String directly
-  end
-end
-
-pfn byte_to_hex_str(n) do
-  hex_digit(n / 16) ++ hex_digit(n % 16)
-end
-
-doc "Encode Bytes as a lowercase hexadecimal string."
-fn to_hex(b) do
-  match b do
-  Bytes(xs) -> do
-    fn go(bs, acc) do
-      match bs do
-      Nil -> rev(acc, Nil)
-      Cons(n, rest) -> go(rest, Cons(byte_to_hex_str(n), acc))
-      end
+  doc "Unwrap Bytes to a List(Int). O(n)."
+  fn to_list(b) do
+    match b do
+    Bytes(s) -> to_list_go(s, string_byte_length(s) - 1, Nil)
     end
-    join_strings(go(xs, Nil))
   end
+
+  doc "An empty Bytes value."
+  fn empty() do Bytes("") end
+
+  doc "Convert a String to Bytes (raw UTF-8 byte values, each 0–255). O(1)."
+  fn from_string(s) do Bytes(s) end
+
+  doc "Convert Bytes back to a String (bytes interpreted as UTF-8). O(1)."
+  fn to_string(b) do
+    match b do
+    Bytes(s) -> s
+    end
   end
-end
 
-pfn hex_val(c) do
-  let code = char_to_int(c)
-  if code >= 48 && code <= 57 do code - 48        -- '0'–'9'
-  else if code >= 65 && code <= 70 do code - 55   -- 'A'–'F'
-  else if code >= 97 && code <= 102 do code - 87  -- 'a'–'f'
-  else -1 end end end
-end
+  -- ---- Measurement ----
 
-doc "Parse a hex string to Bytes. Returns Err if the input is not valid hex."
-fn from_hex(s) do
-  let chars = string_chars(s)
-  fn go(cs, acc) do
-    match cs do
-    Nil -> Ok(Bytes(rev(acc, Nil)))
-    Cons(hi_c, Cons(lo_c, rest)) -> do
-      let hi = hex_val(hi_c)
-      let lo = hex_val(lo_c)
+  doc "Number of bytes. O(1)."
+  fn length(b) do
+    match b do
+    Bytes(s) -> string_byte_length(s)
+    end
+  end
+
+  doc "True if the Bytes is empty. O(1)."
+  fn is_empty(b) do
+    match b do
+    Bytes(s) -> string_is_empty(s)
+    end
+  end
+
+  -- ---- Access ----
+
+  doc "Byte at position i (0-based). Panics if out of bounds. O(1)."
+  fn get(b, i) do
+    match b do
+    Bytes(s) -> do
+      -- string_byte_at returns -1 out of range (it is built for scanners that
+      -- want end-of-input to fall out of the same comparison as any other
+      -- terminator).  Bytes.get's contract is to panic, so re-impose it here.
+      let v = string_byte_at(s, i)
+      if v < 0 do panic("Bytes.get: index out of bounds") else v end
+    end
+    end
+  end
+
+  doc "Sub-slice: bytes from position start with given length. O(len)."
+  fn slice(b, start, len) do
+    match b do
+    -- string_slice clamps start and len to the buffer, which is the same
+    -- out-of-range behaviour list_drop/list_take gave.
+    Bytes(s) -> Bytes(string_slice(s, start, len))
+    end
+  end
+
+  -- ---- Combination ----
+
+  doc "Concatenate two Bytes values. O(n)."
+  fn concat(b1, b2) do
+    match (b1, b2) do
+    (Bytes(x), Bytes(y)) -> Bytes(string_concat(x, y))
+    end
+  end
+
+  -- ---- UTF-8 encoding ----
+
+  doc "Encode a String as UTF-8 bytes. Equivalent to from_string for March strings."
+  fn encode_utf8(s) do from_string(s) end
+
+  doc "Decode UTF-8 bytes to a String. Returns Ok(s) always (same as to_string)."
+  fn decode_utf8(b) do Ok(to_string(b)) end
+
+  -- ---- Hex encoding ----
+
+  pfn hex_digit(n) do
+    if n < 10 do int_to_string(n)
+    else char_from_int(87 + n)  -- 87 = ord('a') - 10, returns String directly
+    end
+  end
+
+  pfn byte_to_hex_str(n) do
+    hex_digit(n / 16) ++ hex_digit(n % 16)
+  end
+
+  pfn to_hex_go(s, i, acc) do
+    if i < 0 do acc
+    else to_hex_go(s, i - 1, Cons(byte_to_hex_str(string_byte_at(s, i)), acc))
+    end
+  end
+
+  doc "Encode Bytes as a lowercase hexadecimal string."
+  fn to_hex(b) do
+    match b do
+    Bytes(s) -> join_strings(to_hex_go(s, string_byte_length(s) - 1, Nil))
+    end
+  end
+
+  pfn hex_val(code) do
+    if code >= 48 && code <= 57 do code - 48        -- '0'–'9'
+    else if code >= 65 && code <= 70 do code - 55   -- 'A'–'F'
+    else if code >= 97 && code <= 102 do code - 87  -- 'a'–'f'
+    else -1 end end end
+  end
+
+  pfn from_hex_go(s, i, n, acc) do
+    if i >= n do Ok(Bytes(string_from_chars(rev(acc, Nil))))
+    else do
+      let hi = hex_val(string_byte_at(s, i))
+      let lo = hex_val(string_byte_at(s, i + 1))
       if hi < 0 || lo < 0 do Err("invalid hex character")
-      else go(rest, Cons(hi * 16 + lo, acc)) end
+      else from_hex_go(s, i + 2, n, Cons(byte_to_char(hi * 16 + lo), acc)) end
     end
-    _ -> Err("hex string must have even length")
     end
   end
-  go(chars, Nil)
-end
 
--- ---- Base64 encoding ----
+  doc "Parse a hex string to Bytes. Returns Err if the input is not valid hex."
+  fn from_hex(s) do
+    let n = string_byte_length(s)
+    if n % 2 != 0 do Err("hex string must have even length")
+    else from_hex_go(s, 0, n, Nil) end
+  end
 
-let b64_alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+  -- ---- Base64 encoding ----
 
-pfn b64_char(n) do
-  string_slice(b64_alphabet, n, 1)
-end
+  let b64_alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
 
-doc "Encode Bytes as a Base64 string (with padding)."
-fn encode_base64(b) do
-  match b do
-  Bytes(xs) -> do
-    fn go(bs, acc) do
-      match bs do
-      Nil ->
-        join_strings(rev(acc, Nil))
-      Cons(b0, Cons(b1, Cons(b2, rest))) -> do
-        let c0 = b64_char(b0 / 4)
-        let c1 = b64_char((b0 % 4) * 16 + b1 / 16)
-        let c2 = b64_char((b1 % 16) * 4 + b2 / 64)
-        let c3 = b64_char(b2 % 64)
-        go(rest, Cons(c3, Cons(c2, Cons(c1, Cons(c0, acc)))))
-      end
-      Cons(b0, Cons(b1, Nil)) -> do
-        let c0 = b64_char(b0 / 4)
-        let c1 = b64_char((b0 % 4) * 16 + b1 / 16)
-        let c2 = b64_char((b1 % 16) * 4)
-        join_strings(rev(Cons("=", Cons(c2, Cons(c1, Cons(c0, acc)))), Nil))
-      end
-      Cons(b0, Nil) -> do
-        let c0 = b64_char(b0 / 4)
-        let c1 = b64_char((b0 % 4) * 16)
-        join_strings(rev(Cons("=", Cons("=", Cons(c1, Cons(c0, acc)))), Nil))
-      end
-      end
+  pfn b64_char(n) do
+    string_slice(b64_alphabet, n, 1)
+  end
+
+  pfn encode_base64_go(s, i, n, acc) do
+    if i + 3 <= n do do
+      let b0 = string_byte_at(s, i)
+      let b1 = string_byte_at(s, i + 1)
+      let b2 = string_byte_at(s, i + 2)
+      let c0 = b64_char(b0 / 4)
+      let c1 = b64_char((b0 % 4) * 16 + b1 / 16)
+      let c2 = b64_char((b1 % 16) * 4 + b2 / 64)
+      let c3 = b64_char(b2 % 64)
+      encode_base64_go(s, i + 3, n, Cons(c3, Cons(c2, Cons(c1, Cons(c0, acc)))))
     end
-    go(xs, Nil)
+    else if i + 2 == n do do
+      let b0 = string_byte_at(s, i)
+      let b1 = string_byte_at(s, i + 1)
+      let c0 = b64_char(b0 / 4)
+      let c1 = b64_char((b0 % 4) * 16 + b1 / 16)
+      let c2 = b64_char((b1 % 16) * 4)
+      join_strings(rev(Cons("=", Cons(c2, Cons(c1, Cons(c0, acc)))), Nil))
+    end
+    else if i + 1 == n do do
+      let b0 = string_byte_at(s, i)
+      let c0 = b64_char(b0 / 4)
+      let c1 = b64_char((b0 % 4) * 16)
+      join_strings(rev(Cons("=", Cons("=", Cons(c1, Cons(c0, acc)))), Nil))
+    end
+    else join_strings(rev(acc, Nil))
+    end end end
   end
+
+  doc "Encode Bytes as a Base64 string (with padding)."
+  fn encode_base64(b) do
+    match b do
+    Bytes(s) -> encode_base64_go(s, 0, string_byte_length(s), Nil)
+    end
   end
-end
 
-pfn b64_val(c) do
-  let code = char_to_int(c)
-  if code >= 65 && code <= 90 do code - 65          -- A–Z → 0–25
-  else if code >= 97 && code <= 122 do code - 71    -- a–z → 26–51
-  else if code >= 48 && code <= 57 do code + 4      -- 0–9 → 52–61
-  else if c == "+" do 62
-  else if c == "/" do 63
-  else -1 end end end end end
-end
+  pfn b64_val(code) do
+    if code >= 65 && code <= 90 do code - 65          -- A–Z → 0–25
+    else if code >= 97 && code <= 122 do code - 71    -- a–z → 26–51
+    else if code >= 48 && code <= 57 do code + 4      -- 0–9 → 52–61
+    else if code == 43 do 62                          -- '+'
+    else if code == 47 do 63                          -- '/'
+    else -1 end end end end end
+  end
 
-doc "Decode a Base64 string to Bytes. Returns Err on invalid input."
-fn decode_base64(s) do
-  let chars = string_chars(s)
-  fn go(cs, acc) do
-    match cs do
-    Nil -> Ok(Bytes(rev(acc, Nil)))
-    Cons(c0, Cons(c1, Cons(c2, Cons(c3, rest)))) -> do
+  pfn decode_base64_go(s, i, n, acc) do
+    if i >= n do Ok(Bytes(string_from_chars(rev(acc, Nil))))
+    else do
+      let c0 = string_byte_at(s, i)
+      let c1 = string_byte_at(s, i + 1)
+      let c2 = string_byte_at(s, i + 2)
+      let c3 = string_byte_at(s, i + 3)
       let v0 = b64_val(c0)
       let v1 = b64_val(c1)
       if v0 < 0 || v1 < 0 do Err("invalid base64 character")
-      else if c2 == "=" && c3 == "=" do
-        Ok(Bytes(rev(Cons((v0 * 4 + v1 / 16) % 256, acc), Nil)))
-      else if c3 == "=" do
+      else if c2 == 61 && c3 == 61 do
+        Ok(Bytes(string_from_chars(rev(Cons(byte_to_char((v0 * 4 + v1 / 16) % 256), acc), Nil))))
+      else if c3 == 61 do do
         let v2 = b64_val(c2)
         if v2 < 0 do Err("invalid base64 character")
         else do
           let byte0 = (v0 * 4 + v1 / 16) % 256
           let byte1 = ((v1 % 16) * 16 + v2 / 4) % 256
-          Ok(Bytes(rev(Cons(byte1, Cons(byte0, acc)), Nil)))
+          Ok(Bytes(string_from_chars(rev(Cons(byte_to_char(byte1), Cons(byte_to_char(byte0), acc)), Nil))))
         end
         end
+      end
       else do
         let v2 = b64_val(c2)
         let v3 = b64_val(c3)
@@ -295,22 +271,25 @@ fn decode_base64(s) do
           let byte0 = (v0 * 4 + v1 / 16) % 256
           let byte1 = ((v1 % 16) * 16 + v2 / 4) % 256
           let byte2 = ((v2 % 4) * 64 + v3) % 256
-          go(rest, Cons(byte2, Cons(byte1, Cons(byte0, acc))))
+          decode_base64_go(s, i + 4, n,
+            Cons(byte_to_char(byte2), Cons(byte_to_char(byte1), Cons(byte_to_char(byte0), acc))))
         end
         end
       end
-      end
-      end
+      end end end
     end
-    end
-    _ -> Err("invalid base64: length must be a multiple of 4")
     end
   end
-  go(chars, Nil)
-end
 
-impl Eq(Bytes) do
-  fn eq(a, b) do Bytes.to_string(a) == Bytes.to_string(b) end
-end
+  doc "Decode a Base64 string to Bytes. Returns Err on invalid input."
+  fn decode_base64(s) do
+    let n = string_byte_length(s)
+    if n % 4 != 0 do Err("invalid base64: length must be a multiple of 4")
+    else decode_base64_go(s, 0, n, Nil) end
+  end
+
+  impl Eq(Bytes) do
+    fn eq(a, b) do Bytes.to_string(a) == Bytes.to_string(b) end
+  end
 
 end

--- a/share/march/crypto.march
+++ b/share/march/crypto.march
@@ -38,17 +38,16 @@ pfn byte_to_hex(n) do
 end
 
 -- Convert a Bytes value to a lowercase hex string.
+-- Goes through Bytes.to_list rather than destructuring the constructor:
+-- the payload is a String buffer now, not a cons spine.
 pfn bytes_to_hex(b) do
-  match b do
-  Bytes(xs) ->
-    fn go(bs, acc) do
-      match bs do
-      Nil -> string_join(rev_list(acc), "")
-      Cons(n, rest) -> go(rest, Cons(byte_to_hex(n), acc))
-      end
+  fn go(bs, acc) do
+    match bs do
+    Nil -> string_join(rev_list(acc), "")
+    Cons(n, rest) -> go(rest, Cons(byte_to_hex(n), acc))
     end
-    go(xs, Nil)
   end
+  go(Bytes.to_list(b), Nil)
 end
 
 -- Hex character value: returns 0–15, or -1 on invalid input.
@@ -190,7 +189,7 @@ fn verify_password(plain, stored) do
       match hex_str_to_bytes(salt_hex) do
       None -> false
       Some(byte_list) ->
-        let salt_bytes = Bytes(byte_list)
+        let salt_bytes = Bytes.from_list(byte_list)
         match pbkdf2_sha256(plain, salt_bytes, iters, pw_dklen) do
         Ok(new_bytes) ->
           let new_hex = bytes_to_hex(new_bytes)

--- a/share/march/uuid.march
+++ b/share/march/uuid.march
@@ -214,20 +214,20 @@ fn v5(namespace, name) do
       let input = ns_raw ++ name
       -- SHA-1 hash of namespace + name
       let hash_bytes = sha1_bytes(input)
-      match hash_bytes do
-      Bytes(hash_list) ->
-        -- Take first 16 bytes, set version=5 and variant bits
-        fn take16(lst, i, acc) do
-          if i >= 16 do rev_list(acc)
-          else match lst do
-            Nil -> rev_list(acc)
-            Cons(b, rest) -> take16(rest, i + 1, Cons(b, acc))
-            end end
-        end
-        let sixteen = take16(hash_list, 0, Nil)
-        let versioned = set_version_variant(sixteen, 5)
-        UUID(bytes_to_uuid_str(versioned))
+      -- Bytes.to_list, not a `Bytes(hash_list)` destructure: the payload is
+      -- a String buffer now, not a cons spine.
+      let hash_list = Bytes.to_list(hash_bytes)
+      -- Take first 16 bytes, set version=5 and variant bits
+      fn take16(lst, i, acc) do
+        if i >= 16 do rev_list(acc)
+        else match lst do
+          Nil -> rev_list(acc)
+          Cons(b, rest) -> take16(rest, i + 1, Cons(b, acc))
+          end end
       end
+      let sixteen = take16(hash_list, 0, Nil)
+      let versioned = set_version_variant(sixteen, 5)
+      UUID(bytes_to_uuid_str(versioned))
     end
   end
 end

--- a/specs/plans/2026-08-10-array-backed-bytes-design.md
+++ b/specs/plans/2026-08-10-array-backed-bytes-design.md
@@ -14,16 +14,18 @@ so every byte of a payload was one 32-byte heap cons cell holding a
 tagged 63-bit integer. Consequences, all measured rather than assumed
 (interpreted `march`, arm64 macOS, payload = `String.repeat("abcdefghij", n)`):
 
-| operation                | 4 000 B  | 16 000 B | 64 000 B |
-|--------------------------|---------:|---------:|---------:|
-| `Bytes.from_string`      |    47 ms |   189 ms |   810 ms |
-| `Bytes.get(b, len-1)`    |    67 ms |   263 ms |  1063 ms |
-| `Bytes.slice(b, len-100, 100)` | 65 ms | 264 ms |  1057 ms |
-| `Bytes.length` × 100     |  3449 ms | 13383 ms | 54439 ms |
-| 2 000 sequential `get`   | 32810 ms | 32282 ms | 32814 ms |
+| operation                | 4 000 B  | 16 000 B | 64 000 B | 256 000 B |
+|--------------------------|---------:|---------:|---------:|----------:|
+| `Bytes.from_string`      |    47 ms |   189 ms |   810 ms |   4165 ms |
+| `Bytes.length` (once)    |     — ms |     — ms |     — ms |   2373 ms |
+| `Bytes.get(b, len-1)`    |    67 ms |   263 ms |  1063 ms |   4485 ms |
+| `Bytes.slice(b, len-n, n)` |  65 ms |   264 ms |  1057 ms |   4389 ms |
+| `Bytes.length` × 100     |  3449 ms | 13383 ms | 54439 ms |         — |
+| 2 000 sequential `get`   | 32810 ms | 32282 ms | 32814 ms |         — |
 
-`length` is O(n), `get` is O(i), `slice` is O(start+len). A 256 KB
-`from_string` did not finish in ten minutes.
+`length` is O(n), `get` is O(i), `slice` is O(start+len). The 256 KB benchmark
+was killed after 29 minutes wall / 1574 s CPU, still inside its "20 000
+sequential gets" loop.
 
 At the C FFI boundary it was worse: `compress_bytes_from_raw` allocated one
 cons cell per byte, so `march_gzip_decode` of a 12 MB tar allocated ~12M cells
@@ -107,6 +109,38 @@ a `march_string *`. That is deliberate:
 
 Memory per byte of payload drops from ~32 bytes (a cons cell) to 1.
 
+### Measured, after
+
+Same benchmarks, same machine, interpreted. Every operation is now flat in
+payload size, which is the point:
+
+| operation                  | 4 000 B | 64 000 B | 256 000 B | 12 000 000 B |
+|----------------------------|--------:|---------:|----------:|-------------:|
+| `Bytes.from_string`        | 0.045ms |  0.045ms |   0.047ms |      0.048ms |
+| `Bytes.length` (once)      |       — |        — |   0.054ms |            — |
+| `Bytes.get(b, len-1)`      | 0.087ms |  0.087ms |   0.087ms |      0.095ms |
+| `Bytes.slice(b, len-n, n)` | 0.104ms |  0.078ms |   0.078ms |      0.080ms |
+| `Bytes.to_string`          | 0.043ms |  0.044ms |   0.041ms |            — |
+| `Bytes.length` × 100       | 10.5 ms |  10.3 ms |         — |            — |
+| 2 000 sequential `get`     |  218 ms |   220 ms |         — |            — |
+
+At 256 KB that is `from_string` 4165 ms → 0.047 ms (~88 000x), `length`
+2373 ms → 0.054 ms (~44 000x), `get(last)` 4485 ms → 0.087 ms (~52 000x),
+`slice` 4389 ms → 0.078 ms (~56 000x). The whole 256 KB benchmark program,
+which was killed unfinished at 29 minutes, now runs to completion in 3.3 s.
+
+The remaining `get` cost is interpreter dispatch, not the representation:
+2 000 gets take the same 218 ms whether the payload is 4 KB or 64 KB.
+
+Gzip, previously impossible at these sizes (one cons cell per byte on both
+sides of the FFI):
+
+| payload | `Gzip.encode` | `Gzip.decode` |
+|--------:|--------------:|--------------:|
+|    1 MB |       2.04 ms |       0.46 ms |
+|    3 MB |       5.90 ms |       7.84 ms |
+|   12 MB |      23.19 ms |      11.49 ms |
+
 ### The `to_list` / `from_list` regression
 
 These were O(1) — they were the constructor and its inverse. They are now
@@ -147,6 +181,29 @@ conservative choice and it is a deliberate one:
 
 Sharing slices are a plausible follow-up, but they should be a separate
 change with their own RC design, not a rider on this one.
+
+### Consumer-side workarounds are now the bottleneck
+
+Downstream code written to dodge the old costs should be un-written. forgepm's
+tar walker (`lib/forgepm/packages/tarball.march`) was rewritten to consume a
+`List(Int)` CURSOR precisely because `Bytes.get(data, i)` was O(i) — its own
+comment says so. With an array-backed `Bytes` that cursor is not merely
+unnecessary, it is the limiting factor: `Bytes.to_list(tar_data)` on the 5.6 MB
+tar inside a 3.1 MB `.tar.gz` allocates 5.6M cons cells and overflows the
+interpreter stack after 228 s.
+
+Reverting that walker to plain offset indexing (`Bytes.get` / `Bytes.slice`,
+no intermediate list) on the same archive:
+
+| step                    | cursor walker      | offset-indexed |
+|-------------------------|--------------------|---------------:|
+| `Bytes.from_string`     | 0.047 ms           |       0.047 ms |
+| `Tarball.parse`         | stack overflow     |          49 ms |
+| `extract_readme`        | stack overflow     |          77 ms |
+| `extract_march_sources` | stack overflow     |        5 649 ms |
+
+(448 `.march` members.) Total wall time 6.9 s for an archive that could not be
+processed at all before.
 
 ## Streaming
 

--- a/specs/plans/2026-08-10-array-backed-bytes-design.md
+++ b/specs/plans/2026-08-10-array-backed-bytes-design.md
@@ -1,0 +1,184 @@
+# Array-backed `Bytes` — design
+
+Status: implemented (phase 1). 2026-08-10.
+
+## The problem
+
+`stdlib/bytes.march` declared
+
+```march
+type Bytes = Bytes(List(Int))
+```
+
+so every byte of a payload was one 32-byte heap cons cell holding a
+tagged 63-bit integer. Consequences, all measured rather than assumed
+(interpreted `march`, arm64 macOS, payload = `String.repeat("abcdefghij", n)`):
+
+| operation                | 4 000 B  | 16 000 B | 64 000 B |
+|--------------------------|---------:|---------:|---------:|
+| `Bytes.from_string`      |    47 ms |   189 ms |   810 ms |
+| `Bytes.get(b, len-1)`    |    67 ms |   263 ms |  1063 ms |
+| `Bytes.slice(b, len-100, 100)` | 65 ms | 264 ms |  1057 ms |
+| `Bytes.length` × 100     |  3449 ms | 13383 ms | 54439 ms |
+| 2 000 sequential `get`   | 32810 ms | 32282 ms | 32814 ms |
+
+`length` is O(n), `get` is O(i), `slice` is O(start+len). A 256 KB
+`from_string` did not finish in ten minutes.
+
+At the C FFI boundary it was worse: `compress_bytes_from_raw` allocated one
+cons cell per byte, so `march_gzip_decode` of a 12 MB tar allocated ~12M cells
+(hundreds of MB) before any March code ran. `compress_bytes_to_raw` walked the
+whole spine twice.
+
+## The representation actually chosen
+
+`Bytes` is now
+
+```march
+type Bytes = Bytes(String)
+```
+
+A March `String` is already the array-backed byte buffer this change was
+looking for: `march_string` is `{ int64 rc; int32 tag; int32 pad; int64 len;
+char data[] }` — a single `march_alloc` block with a length field and a
+contiguous, NUL-safe, `memcpy`-able payload. It is not a text type in the
+runtime; `march_string_byte_at`, `march_string_slice`, `march_string_chars`
+and `march_char_from_int` are all byte-indexed, not codepoint-indexed
+(`runtime/march_runtime.c:772, 3179, 3235, 3190`).
+
+### Why not a new `ByteBuf` primitive
+
+The obvious alternative was a fresh opaque heap type in the `NativeIntArr`
+mould. It was rejected because it costs strictly more and buys nothing here:
+
+* A new `TCon` has to be threaded through `typecheck.ml` (`builtin_types`,
+  `builtin_bindings`, `non_sendable_types`), `eval.ml` (a new `value`
+  constructor plus every builtin), `llvm_builtins.ml` (table rows *and*
+  `PDeclare` markers), `defun.ml`, `borrow.ml`, `purity.ml`, the golden LLVM
+  preamble in `test_codegen.ml`, and — because it would be a new tag — the
+  message-copy walker in `march_message.c` and the GC's `pass2_visit`.
+* `String` already has every one of those, plus interning, cross-heap copy,
+  hashing, and generic compare, all exercised for years.
+* The FFI layer had **already** unilaterally decided `Bytes` was a flat
+  buffer: `march_bytes_borrow` is literally `march_str_borrow`
+  (`runtime/march_ffi.c:52-58`), `rust/march/src/value.rs:216` borrows
+  `&[u8]` out of one, and the interpreter marshals `Bytes` as an OCaml string
+  (`lib/eval/eval.ml:1859, 1940`). The list representation and the FFI
+  representation disagreed; this change makes them the same thing rather than
+  adding a third.
+
+### Why the wrapper constructor stays
+
+`Bytes` remains a one-field boxed ADT cell — `[rc][tag=0][pad][field@16]` —
+exactly as before. Only the *contents* of field 0 change, from a cons spine to
+a `march_string *`. That is deliberate:
+
+* `lib/tir/repr.ml:18-22` classifies `Bytes` as `Boxed` (not `Newtype`) only
+  because `find_variant` matches type-def names exactly and the non-entry
+  module registers it as `"Bytes.Bytes"`. `llvm_case.ml:80-115` compensates on
+  the destructure side. `drop.ml:67-70` excludes the shape from deep drop
+  precisely because the C runtime builds these cells by hand. Changing the
+  wrapper would relitigate all three, and the last time that classification
+  moved it silently made compiled `Bytes.concat` return empty and hung
+  forgepm's Postgres handshake (`specs/progress_through_july_2026.md:4780`).
+* Keeping the cell means every existing `*(void **)((char *)bytes_val + 16)`
+  in the runtime keeps compiling and keeps pointing at the payload. Only what
+  it *is* changes, so each such site is a small local edit rather than a
+  layout migration.
+* `march_extras.c`'s String-or-Bytes sniff (`:396`, "int64 at offset 8 is zero
+  ⇒ Bytes ctor") still discriminates correctly: a `Bytes` cell has tag 0 and
+  pad 0 there, a `march_string` has `MARCH_STRING_TAG` = -1.
+
+## Complexity, before and after
+
+| operation      | before      | after            | notes |
+|----------------|-------------|------------------|-------|
+| `length`       | O(n)        | **O(1)**         | `string_byte_length` reads the len field |
+| `get`          | O(i)        | **O(1)**         | `string_byte_at` |
+| `slice`        | O(start+len)| **O(len)**       | one `memcpy`, no prefix walk |
+| `concat`       | O(n)        | O(n)             | one `memcpy` pair, ~32× less memory |
+| `to_string`    | O(n)        | **O(1)**         | unwrap |
+| `from_string`  | O(n)        | **O(1)**         | wrap |
+| `is_empty`     | O(1)        | O(1)             | |
+| `to_list`      | **O(1)**    | **O(n)**         | regression — see below |
+| `from_list`    | **O(1)**    | **O(n)**         | regression — see below |
+| C `bytes_to_raw`   | O(n), 2 passes, malloc+copy | **O(1)** borrow | payload is already contiguous |
+| C `bytes_from_raw` | O(n), n allocations | **O(n)** single `memcpy` | |
+
+Memory per byte of payload drops from ~32 bytes (a cons cell) to 1.
+
+### The `to_list` / `from_list` regression
+
+These were O(1) — they were the constructor and its inverse. They are now
+O(n) conversions. This is the one place the change is not a strict
+improvement, and it was audited rather than waved through:
+
+* `stdlib/net_kernel.march:23-24` (`str_to_bytes` / `bytes_to_str`) round-trip
+  through them on the wire path. Both are now expressed directly over
+  `from_string`/`to_string`, which are O(1), so the net-kernel path gets
+  *faster*, not slower.
+* `stdlib/string.march:454-456` uses them on 1–4 byte codepoint encodings.
+* Downstream, the overwhelming majority of `from_list` call sites are test
+  fixtures spelling out literal byte arrays (`depot` has ~940, essentially all
+  in `test/`). Those pay O(n) once on a handful of bytes.
+* The counterweight is `String.to_codepoints` (`stdlib/string.march:478-515`),
+  which called `Bytes.get(b, i)` in a loop and was therefore **O(n²)**. It is
+  now O(n) with no source change.
+
+### Aliasing, sharing and RC
+
+Slices **copy**; they do not share the underlying buffer. This is the
+conservative choice and it is a deliberate one:
+
+* A sharing slice needs an `(owner, offset, len)` triple, which makes the
+  payload cell contain a heap pointer child. `march_decrc`
+  (`runtime/march_runtime.c:330-352`) is *shallow* — it does one `free(p)` and
+  never recurses; child decrements are emitted by Perceus into generated code.
+  A hand-built-in-C cell with a pointer child therefore has no one to drop the
+  owner, and `drop.ml` explicitly refuses to destructure this shape. Getting
+  that right means either a new resource-tagged cell with a destructor or new
+  Perceus knowledge, i.e. exactly the cost the `String` reuse was chosen to
+  avoid.
+* Copying keeps `Bytes` immutable and freely sendable between actors, which
+  the message-copy walker already handles for strings.
+* The asymptotic win is preserved anyway: the old `slice` was O(start+len)
+  because it had to *walk* to `start`. The new one is O(len). For the tar
+  walking that motivated this work, `start` is large and `len` is small.
+
+Sharing slices are a plausible follow-up, but they should be a separate
+change with their own RC design, not a rider on this one.
+
+## Streaming
+
+Out of scope here, and this design does not foreclose it. The shape a chunked
+reader wants is `Seq(Bytes)` (`stdlib/seq.march:308` already documents
+`from_file_chunks` that way, though `file_read_chunk` currently returns
+`Option(String)` — with `Bytes = Bytes(String)` that mismatch becomes a
+one-line wrap instead of an O(n) conversion). A chunked
+`Compress.gzip_decode_chunks : Bytes -> Seq(Bytes)` would drive zlib's
+`inflate` with a fixed output window and yield one `march_string_lit` per
+window, never materialising the whole payload. The 256 MB
+`MAX_DECOMPRESS_SIZE` guard in `march_compress.c` exists precisely because
+today it must.
+
+## Vectorization
+
+The payload is a contiguous `uint8_t` run at a fixed offset in a single
+allocation, so it is directly usable with `memcpy`/SIMD from C. The FFI
+already hands it out as a `march_slice { const uint8_t *; size_t }` with no
+copy. No March-level vector API is added here; this change is what makes one
+possible.
+
+## Compatibility
+
+The public `Bytes` API is unchanged in name, arity and type: `get`, `length`,
+`slice`, `to_list`, `from_list`, `to_string`, `from_string`, `concat`,
+`empty`, `is_empty`, `to_hex`, `from_hex`, `encode_base64`, `decode_base64`,
+`encode_utf8`, `decode_utf8`, `Eq(Bytes)`.
+
+What does break is code that reaches *through* the abstraction and matches the
+constructor's payload as a list. Inside this repo that is
+`stdlib/crypto.march:46,202` and `stdlib/uuid.march:287,291`, both fixed here.
+Outside it, `bastion/lib/security/crypto.march:70,258,325` and
+`bastion/lib/security/hkdf.march:37,49` do the same and will need the same
+one-line change to `Bytes.from_list` / `Bytes.to_list`.

--- a/stdlib/base64.march
+++ b/stdlib/base64.march
@@ -91,7 +91,7 @@ mod Base64 do
   ## Examples
 
       march> Base64.decode("SGVsbG8=")
-      Ok(Bytes([72, 101, 108, 108, 111]))
+      Ok(Bytes("Hello"))
       march> Base64.decode("!!")
       Err(:invalid)
   """
@@ -126,7 +126,7 @@ mod Base64 do
   ## Examples
 
       march> Base64.url_decode("SGVsbG8")
-      Ok(Bytes([72, 101, 108, 108, 111]))
+      Ok(Bytes("Hello"))
       march> Base64.url_decode("!!")
       Err(:invalid)
   """

--- a/stdlib/bytes.march
+++ b/stdlib/bytes.march
@@ -1,64 +1,38 @@
 -- Bytes module: raw byte manipulation.
 --
--- Bytes wraps a List(Int) of byte values in the range 0–255.
--- March strings are UTF-8 byte sequences; Bytes exposes the raw bytes.
--- All encoding functions (hex, base64) are implemented in pure March.
+-- Bytes wraps a String, which in the runtime is an array-backed buffer:
+-- `march_string` is {rc, tag, pad, len, data[]} — one allocation, an explicit
+-- length field, and a contiguous NUL-safe payload.  Nothing here treats a
+-- String as text: `string_byte_at`, `string_slice`, `string_chars` and
+-- `char_from_int` are all byte-indexed in both backends.
+--
+-- This replaced `Bytes(List(Int))`, which cost one ~32-byte cons cell per
+-- byte and made `length` O(n), `get` O(i) and `slice` O(start+len).  Measured
+-- on a 64 000-byte payload (interpreted): `length` 544 ms/call, `get(last)`
+-- 1063 ms, `slice` 1057 ms.  See specs/plans/2026-08-10-array-backed-bytes-design.md.
+--
+-- The wrapper constructor is deliberately kept (a Bytes value is still a
+-- one-field boxed ADT cell with its payload at offset 16), because
+-- lib/tir/repr.ml, llvm_case.ml and drop.ml all encode assumptions about that
+-- shape, and because the C runtime builds these cells by hand.
+--
+-- to_list/from_list were O(1) under the old representation and are O(n) now.
+-- That is the one regression; see the design doc's audit of the callers.
 --
 -- This module is self-contained: it does not depend on List.* or String.*
 -- being loaded, so it can be tested or used in isolation.
 
 mod Bytes do
 
-  type Bytes = Bytes(List(Int))
+  type Bytes = Bytes(String)
 
-  -- ---- Internal list helpers (self-contained) ----
+  -- ---- Internal helpers (self-contained) ----
 
   pfn rev(xs, acc) do
     match xs do
     Nil -> acc
     Cons(h, t) -> rev(t, Cons(h, acc))
     end
-  end
-
-  pfn list_len(xs, n) do
-    match xs do
-    Nil -> n
-    Cons(_, t) -> list_len(t, n + 1)
-    end
-  end
-
-  pfn list_nth(xs, i) do
-    match xs do
-    Nil -> panic("Bytes.get: index out of bounds")
-    Cons(h, t) -> if i == 0 do h else list_nth(t, i - 1) end
-    end
-  end
-
-  pfn list_drop(xs, n) do
-    if n <= 0 do xs
-    else match xs do
-      Nil -> Nil
-      Cons(_, t) -> list_drop(t, n - 1)
-      end end
-  end
-
-  pfn list_take(xs, n, acc) do
-    if n <= 0 do rev(acc, Nil)
-    else match xs do
-      Nil -> rev(acc, Nil)
-      Cons(h, t) -> list_take(t, n - 1, Cons(h, acc))
-      end end
-  end
-
-  pfn list_append_go(rxs, acc) do
-    match rxs do
-    Nil -> acc
-    Cons(h, t) -> list_append_go(t, Cons(h, acc))
-    end
-  end
-
-  pfn list_append(xs, ys) do
-    list_append_go(rev(xs, Nil), ys)
   end
 
   pfn join_strings(xs) do
@@ -69,84 +43,90 @@ mod Bytes do
 
   -- ---- Construction ----
 
-  doc "Wrap a List(Int) of byte values (0–255) as Bytes."
-  fn from_list(xs) do Bytes(xs) end
+  pfn from_list_go(xs, acc) do
+    match xs do
+    Nil -> rev(acc, Nil)
+    Cons(n, rest) -> from_list_go(rest, Cons(byte_to_char(n), acc))
+    end
+  end
 
-  doc "Unwrap Bytes to the underlying List(Int)."
+  doc "Wrap a List(Int) of byte values (0–255) as Bytes. O(n)."
+  fn from_list(xs) do
+    Bytes(string_from_chars(from_list_go(xs, Nil)))
+  end
+
+  pfn to_list_go(s, i, acc) do
+    if i < 0 do acc
+    else to_list_go(s, i - 1, Cons(string_byte_at(s, i), acc))
+    end
+  end
+
+  doc "Unwrap Bytes to a List(Int). O(n)."
   fn to_list(b) do
     match b do
-    Bytes(xs) -> xs
+    Bytes(s) -> to_list_go(s, string_byte_length(s) - 1, Nil)
     end
   end
 
   doc "An empty Bytes value."
-  fn empty() do Bytes(Nil) end
+  fn empty() do Bytes("") end
 
-  pfn from_string_go(cs, acc) do
-    match cs do
-    Nil -> rev(acc, Nil)
-    Cons(c, rest) -> from_string_go(rest, Cons(char_to_int(c), acc))
-    end
-  end
+  doc "Convert a String to Bytes (raw UTF-8 byte values, each 0–255). O(1)."
+  fn from_string(s) do Bytes(s) end
 
-  doc "Convert a String to Bytes (raw UTF-8 byte values, each 0–255)."
-  fn from_string(s) do
-    Bytes(from_string_go(string_chars(s), Nil))
-  end
-
-  pfn to_string_go(bs, acc) do
-    match bs do
-    Nil -> rev(acc, Nil)
-    Cons(n, rest) -> to_string_go(rest, Cons(byte_to_char(n), acc))
-    end
-  end
-
-  doc "Convert Bytes back to a String (bytes interpreted as UTF-8)."
+  doc "Convert Bytes back to a String (bytes interpreted as UTF-8). O(1)."
   fn to_string(b) do
     match b do
-    Bytes(xs) -> string_from_chars(to_string_go(xs, Nil))
+    Bytes(s) -> s
     end
   end
 
   -- ---- Measurement ----
 
-  doc "Number of bytes."
+  doc "Number of bytes. O(1)."
   fn length(b) do
     match b do
-    Bytes(xs) -> list_len(xs, 0)
+    Bytes(s) -> string_byte_length(s)
     end
   end
 
-  doc "True if the Bytes is empty."
+  doc "True if the Bytes is empty. O(1)."
   fn is_empty(b) do
     match b do
-    Bytes(Nil) -> true
-    _          -> false
+    Bytes(s) -> string_is_empty(s)
     end
   end
 
   -- ---- Access ----
 
-  doc "Byte at position i (0-based). Panics if out of bounds."
+  doc "Byte at position i (0-based). Panics if out of bounds. O(1)."
   fn get(b, i) do
     match b do
-    Bytes(xs) -> list_nth(xs, i)
+    Bytes(s) -> do
+      -- string_byte_at returns -1 out of range (it is built for scanners that
+      -- want end-of-input to fall out of the same comparison as any other
+      -- terminator).  Bytes.get's contract is to panic, so re-impose it here.
+      let v = string_byte_at(s, i)
+      if v < 0 do panic("Bytes.get: index out of bounds") else v end
+    end
     end
   end
 
-  doc "Sub-slice: bytes from position start with given length."
+  doc "Sub-slice: bytes from position start with given length. O(len)."
   fn slice(b, start, len) do
     match b do
-    Bytes(xs) -> Bytes(list_take(list_drop(xs, start), len, Nil))
+    -- string_slice clamps start and len to the buffer, which is the same
+    -- out-of-range behaviour list_drop/list_take gave.
+    Bytes(s) -> Bytes(string_slice(s, start, len))
     end
   end
 
   -- ---- Combination ----
 
-  doc "Concatenate two Bytes values."
+  doc "Concatenate two Bytes values. O(n)."
   fn concat(b1, b2) do
     match (b1, b2) do
-    (Bytes(xs), Bytes(ys)) -> Bytes(list_append(xs, ys))
+    (Bytes(x), Bytes(y)) -> Bytes(string_concat(x, y))
     end
   end
 
@@ -170,44 +150,42 @@ mod Bytes do
     hex_digit(n / 16) ++ hex_digit(n % 16)
   end
 
-  pfn to_hex_go(bs, acc) do
-    match bs do
-    Nil -> rev(acc, Nil)
-    Cons(n, rest) -> to_hex_go(rest, Cons(byte_to_hex_str(n), acc))
+  pfn to_hex_go(s, i, acc) do
+    if i < 0 do acc
+    else to_hex_go(s, i - 1, Cons(byte_to_hex_str(string_byte_at(s, i)), acc))
     end
   end
 
   doc "Encode Bytes as a lowercase hexadecimal string."
   fn to_hex(b) do
     match b do
-    Bytes(xs) -> join_strings(to_hex_go(xs, Nil))
+    Bytes(s) -> join_strings(to_hex_go(s, string_byte_length(s) - 1, Nil))
     end
   end
 
-  pfn hex_val(c) do
-    let code = char_to_int(c)
+  pfn hex_val(code) do
     if code >= 48 && code <= 57 do code - 48        -- '0'–'9'
     else if code >= 65 && code <= 70 do code - 55   -- 'A'–'F'
     else if code >= 97 && code <= 102 do code - 87  -- 'a'–'f'
     else -1 end end end
   end
 
-  pfn from_hex_go(cs, acc) do
-    match cs do
-    Nil -> Ok(Bytes(rev(acc, Nil)))
-    Cons(hi_c, Cons(lo_c, rest)) -> do
-      let hi = hex_val(hi_c)
-      let lo = hex_val(lo_c)
+  pfn from_hex_go(s, i, n, acc) do
+    if i >= n do Ok(Bytes(string_from_chars(rev(acc, Nil))))
+    else do
+      let hi = hex_val(string_byte_at(s, i))
+      let lo = hex_val(string_byte_at(s, i + 1))
       if hi < 0 || lo < 0 do Err("invalid hex character")
-      else from_hex_go(rest, Cons(hi * 16 + lo, acc)) end
+      else from_hex_go(s, i + 2, n, Cons(byte_to_char(hi * 16 + lo), acc)) end
     end
-    _ -> Err("hex string must have even length")
     end
   end
 
   doc "Parse a hex string to Bytes. Returns Err if the input is not valid hex."
   fn from_hex(s) do
-    from_hex_go(string_chars(s), Nil)
+    let n = string_byte_length(s)
+    if n % 2 != 0 do Err("hex string must have even length")
+    else from_hex_go(s, 0, n, Nil) end
   end
 
   -- ---- Base64 encoding ----
@@ -218,66 +196,73 @@ mod Bytes do
     string_slice(b64_alphabet, n, 1)
   end
 
-  pfn encode_base64_go(bs, acc) do
-    match bs do
-    Nil ->
-      join_strings(rev(acc, Nil))
-    Cons(b0, Cons(b1, Cons(b2, rest))) -> do
+  pfn encode_base64_go(s, i, n, acc) do
+    if i + 3 <= n do do
+      let b0 = string_byte_at(s, i)
+      let b1 = string_byte_at(s, i + 1)
+      let b2 = string_byte_at(s, i + 2)
       let c0 = b64_char(b0 / 4)
       let c1 = b64_char((b0 % 4) * 16 + b1 / 16)
       let c2 = b64_char((b1 % 16) * 4 + b2 / 64)
       let c3 = b64_char(b2 % 64)
-      encode_base64_go(rest, Cons(c3, Cons(c2, Cons(c1, Cons(c0, acc)))))
+      encode_base64_go(s, i + 3, n, Cons(c3, Cons(c2, Cons(c1, Cons(c0, acc)))))
     end
-    Cons(b0, Cons(b1, Nil)) -> do
+    else if i + 2 == n do do
+      let b0 = string_byte_at(s, i)
+      let b1 = string_byte_at(s, i + 1)
       let c0 = b64_char(b0 / 4)
       let c1 = b64_char((b0 % 4) * 16 + b1 / 16)
       let c2 = b64_char((b1 % 16) * 4)
       join_strings(rev(Cons("=", Cons(c2, Cons(c1, Cons(c0, acc)))), Nil))
     end
-    Cons(b0, Nil) -> do
+    else if i + 1 == n do do
+      let b0 = string_byte_at(s, i)
       let c0 = b64_char(b0 / 4)
       let c1 = b64_char((b0 % 4) * 16)
       join_strings(rev(Cons("=", Cons("=", Cons(c1, Cons(c0, acc)))), Nil))
     end
-    end
+    else join_strings(rev(acc, Nil))
+    end end end
   end
 
   doc "Encode Bytes as a Base64 string (with padding)."
   fn encode_base64(b) do
     match b do
-    Bytes(xs) -> encode_base64_go(xs, Nil)
+    Bytes(s) -> encode_base64_go(s, 0, string_byte_length(s), Nil)
     end
   end
 
-  pfn b64_val(c) do
-    let code = char_to_int(c)
+  pfn b64_val(code) do
     if code >= 65 && code <= 90 do code - 65          -- A–Z → 0–25
     else if code >= 97 && code <= 122 do code - 71    -- a–z → 26–51
     else if code >= 48 && code <= 57 do code + 4      -- 0–9 → 52–61
-    else if c == "+" do 62
-    else if c == "/" do 63
+    else if code == 43 do 62                          -- '+'
+    else if code == 47 do 63                          -- '/'
     else -1 end end end end end
   end
 
-  pfn decode_base64_go(cs, acc) do
-    match cs do
-    Nil -> Ok(Bytes(rev(acc, Nil)))
-    Cons(c0, Cons(c1, Cons(c2, Cons(c3, rest)))) -> do
+  pfn decode_base64_go(s, i, n, acc) do
+    if i >= n do Ok(Bytes(string_from_chars(rev(acc, Nil))))
+    else do
+      let c0 = string_byte_at(s, i)
+      let c1 = string_byte_at(s, i + 1)
+      let c2 = string_byte_at(s, i + 2)
+      let c3 = string_byte_at(s, i + 3)
       let v0 = b64_val(c0)
       let v1 = b64_val(c1)
       if v0 < 0 || v1 < 0 do Err("invalid base64 character")
-      else if c2 == "=" && c3 == "=" do
-        Ok(Bytes(rev(Cons((v0 * 4 + v1 / 16) % 256, acc), Nil)))
-      else if c3 == "=" do
+      else if c2 == 61 && c3 == 61 do
+        Ok(Bytes(string_from_chars(rev(Cons(byte_to_char((v0 * 4 + v1 / 16) % 256), acc), Nil))))
+      else if c3 == 61 do do
         let v2 = b64_val(c2)
         if v2 < 0 do Err("invalid base64 character")
         else do
           let byte0 = (v0 * 4 + v1 / 16) % 256
           let byte1 = ((v1 % 16) * 16 + v2 / 4) % 256
-          Ok(Bytes(rev(Cons(byte1, Cons(byte0, acc)), Nil)))
+          Ok(Bytes(string_from_chars(rev(Cons(byte_to_char(byte1), Cons(byte_to_char(byte0), acc)), Nil))))
         end
         end
+      end
       else do
         let v2 = b64_val(c2)
         let v3 = b64_val(c3)
@@ -286,21 +271,21 @@ mod Bytes do
           let byte0 = (v0 * 4 + v1 / 16) % 256
           let byte1 = ((v1 % 16) * 16 + v2 / 4) % 256
           let byte2 = ((v2 % 4) * 64 + v3) % 256
-          decode_base64_go(rest, Cons(byte2, Cons(byte1, Cons(byte0, acc))))
+          decode_base64_go(s, i + 4, n,
+            Cons(byte_to_char(byte2), Cons(byte_to_char(byte1), Cons(byte_to_char(byte0), acc))))
         end
         end
       end
-      end
-      end
+      end end end
     end
-    end
-    _ -> Err("invalid base64: length must be a multiple of 4")
     end
   end
 
   doc "Decode a Base64 string to Bytes. Returns Err on invalid input."
   fn decode_base64(s) do
-    decode_base64_go(string_chars(s), Nil)
+    let n = string_byte_length(s)
+    if n % 4 != 0 do Err("invalid base64: length must be a multiple of 4")
+    else decode_base64_go(s, 0, n, Nil) end
   end
 
   impl Eq(Bytes) do

--- a/stdlib/crypto.march
+++ b/stdlib/crypto.march
@@ -43,17 +43,16 @@ mod Crypto do
   end
 
   -- Convert a Bytes value to a lowercase hex string.
+  -- Goes through Bytes.to_list rather than destructuring the constructor:
+  -- the payload is a String buffer now, not a cons spine.
   pfn bytes_to_hex(b) do
-    match b do
-    Bytes(xs) ->
-      fn go(bs, acc) do
-        match bs do
-        Nil -> string_join(rev_list(acc), "")
-        Cons(n, rest) -> go(rest, Cons(byte_to_hex(n), acc))
-        end
+    fn go(bs, acc) do
+      match bs do
+      Nil -> string_join(rev_list(acc), "")
+      Cons(n, rest) -> go(rest, Cons(byte_to_hex(n), acc))
       end
-      go(xs, Nil)
     end
+    go(Bytes.to_list(b), Nil)
   end
 
   -- Hex character value: returns 0–15, or -1 on invalid input.
@@ -199,7 +198,7 @@ mod Crypto do
         match hex_str_to_bytes(salt_hex) do
         None -> false
         Some(byte_list) ->
-          let salt_bytes = Bytes(byte_list)
+          let salt_bytes = Bytes.from_list(byte_list)
           match pbkdf2_sha256(plain, salt_bytes, iters, pw_dklen) do
           Ok(new_bytes) ->
             let new_hex = bytes_to_hex(new_bytes)

--- a/stdlib/uuid.march
+++ b/stdlib/uuid.march
@@ -284,23 +284,23 @@ mod UUID do
           Cons(h, t) -> Cons(h, list_append(t, ys))
           end
         end
-        let input = Bytes(list_append(ns_bytes, name_to_bytes(name)))
+        let input = Bytes.from_list(list_append(ns_bytes, name_to_bytes(name)))
         -- SHA-1 hash of namespace || name
         let hash_bytes = sha1_bytes(input)
-        match hash_bytes do
-        Bytes(hash_list) ->
-          -- Take first 16 bytes, set version=5 and variant bits
-          fn take16(lst, i, acc) do
-            if i >= 16 do rev_list(acc)
-            else match lst do
-              Nil -> rev_list(acc)
-              Cons(b, rest) -> take16(rest, i + 1, Cons(b, acc))
-              end end
-          end
-          let sixteen = take16(hash_list, 0, Nil)
-          let versioned = set_version_variant(sixteen, 5)
-          UUID(bytes_to_uuid_str(versioned))
+        -- Bytes.to_list, not a `Bytes(hash_list)` destructure: the payload is
+        -- a String buffer now, not a cons spine.
+        let hash_list = Bytes.to_list(hash_bytes)
+        -- Take first 16 bytes, set version=5 and variant bits
+        fn take16(lst, i, acc) do
+          if i >= 16 do rev_list(acc)
+          else match lst do
+            Nil -> rev_list(acc)
+            Cons(b, rest) -> take16(rest, i + 1, Cons(b, acc))
+            end end
         end
+        let sixteen = take16(hash_list, 0, Nil)
+        let versioned = set_version_variant(sixteen, 5)
+        UUID(bytes_to_uuid_str(versioned))
       end
     end
   end

--- a/test/test_helpers.ml
+++ b/test/test_helpers.ml
@@ -1883,9 +1883,13 @@ let eval_with_regex src =
   let regex_decl = load_stdlib_file_for_test "regex.march" in
   eval_with_stdlib [regex_decl] src
 
+(* [type Bytes = Bytes(String)] — the payload IS the raw byte buffer.  The
+   cons-spine arm is kept so a value produced by an older serialized fixture
+   still reads correctly. *)
 let bytes_val_to_string bv =
   let open March_eval.Eval in
   match bv with
+  | VCon ("Bytes", [VString s]) -> s
   | VCon ("Bytes", [lst]) ->
     let buf = Buffer.create 8 in
     let rec go = function
@@ -1932,15 +1936,23 @@ let eval_with_uri src =
   let decl = load_stdlib_file_for_test "uri.march" in
   eval_with_stdlib [decl] src
 
+(* crypto/compress/uuid all traffic in Bytes, and since Bytes is an
+   array-backed [Bytes(String)] their sources call Bytes.to_list /
+   Bytes.from_list rather than destructuring a cons payload — so bytes.march
+   has to be in the environment.  Under the old representation these suites
+   got away with building `Bytes(Cons(...))` literals, which the interpreter
+   accepts without the module loaded. *)
+let bytes_decl_for_stdlib = lazy (load_stdlib_file_for_test "bytes.march")
+
 let eval_with_crypto src =
   let decl = load_stdlib_file_for_test "crypto.march" in
-  eval_with_stdlib [decl] src
+  eval_with_stdlib [Lazy.force bytes_decl_for_stdlib; decl] src
 
 let load_compress_decl () = load_stdlib_file_for_test "compress.march"
 
 let eval_with_compress src =
   let decl = load_compress_decl () in
-  eval_with_stdlib [decl] src
+  eval_with_stdlib [Lazy.force bytes_decl_for_stdlib; decl] src
 
 let eval_with_compress_and_check src =
   let compress_decl = load_compress_decl () in
@@ -1948,11 +1960,12 @@ let eval_with_compress_and_check src =
   let random_decl = load_stdlib_file_for_test "random.march" in
   let gen_decl    = load_stdlib_file_for_test "gen.march" in
   let check_decl  = load_stdlib_file_for_test "check.march" in
-  eval_with_stdlib [list_decl; random_decl; gen_decl; check_decl; compress_decl] src
+  eval_with_stdlib [Lazy.force bytes_decl_for_stdlib; list_decl; random_decl;
+                    gen_decl; check_decl; compress_decl] src
 
 let eval_with_uuid src =
   let decl = load_stdlib_file_for_test "uuid.march" in
-  eval_with_stdlib [decl] src
+  eval_with_stdlib [Lazy.force bytes_decl_for_stdlib; decl] src
 
 let eval_with_duration src =
   let decl = load_stdlib_file_for_test "duration.march" in

--- a/test/test_stdlib_suite.ml
+++ b/test/test_stdlib_suite.ml
@@ -8184,15 +8184,9 @@ let test_crypto_hmac () =
 
 let test_crypto_random_bytes () =
   let env = eval_with_crypto {|mod Test do
-    pfn count(xs, n) do
-      match xs do
-      Nil -> n
-      Cons(_, t) -> count(t, n + 1)
-      end
-    end
     fn f() do
       let b = Crypto.random_bytes(16)
-      match b do Bytes(xs) -> count(xs, 0) end
+      Bytes.length(b)
     end
   end|} in
   Alcotest.(check int) "random_bytes returns 16 bytes" 16
@@ -8267,7 +8261,7 @@ let test_compress_parse_ok () =
 let test_gzip_encode_returns_bytes () =
   let env = eval_with_compress {|mod Test do
     fn f() do
-      let b = Bytes(Cons(104, Cons(101, Cons(108, Cons(108, Cons(111, Nil))))))
+      let b = Bytes.from_list([104, 101, 108, 108, 111])
       match Compress.Gzip.encode(b) do
       Ok(compressed) -> 1
       Err(_) -> 0
@@ -8279,20 +8273,12 @@ let test_gzip_encode_returns_bytes () =
 let test_gzip_roundtrip () =
   let env = eval_with_compress {|mod Test do
     pfn bytes_eq(a, b) do
-      match (a, b) do
-      (Bytes(xs), Bytes(ys)) ->
-        fn go(ps, qs) do
-          match (ps, qs) do
-          (Nil, Nil) -> true
-          (Cons(x, xr), Cons(y, yr)) -> x == y && go(xr, yr)
-          _ -> false
-          end
-        end
-        go(xs, ys)
-      end
+      -- Compare through the public API: Bytes' payload is a String buffer,
+      -- not a cons spine.
+      Bytes.to_string(a) == Bytes.to_string(b)
     end
     fn f() do
-      let original = Bytes(Cons(104, Cons(101, Cons(108, Cons(108, Cons(111, Nil))))))
+      let original = Bytes.from_list([104, 101, 108, 108, 111])
       match Compress.Gzip.encode(original) do
       Ok(compressed) ->
         match Compress.Gzip.decode(compressed) do
@@ -8308,11 +8294,11 @@ let test_gzip_roundtrip () =
 let test_gzip_empty () =
   let env = eval_with_compress {|mod Test do
     fn f() do
-      let b = Bytes(Nil)
+      let b = Bytes.empty()
       match Compress.Gzip.encode(b) do
       Ok(compressed) ->
         match Compress.Gzip.decode(compressed) do
-        Ok(Bytes(Nil)) -> 1
+        Ok(back) -> if Bytes.is_empty(back) do 1 else 0 end
         _ -> 0
         end
       Err(_) -> 0
@@ -8324,7 +8310,7 @@ let test_gzip_empty () =
 let test_gzip_decode_invalid () =
   let env = eval_with_compress {|mod Test do
     fn f() do
-      let garbage = Bytes(Cons(1, Cons(2, Cons(3, Nil))))
+      let garbage = Bytes.from_list([1, 2, 3])
       match Compress.Gzip.decode(garbage) do
       Ok(_)  -> 0
       Err(_) -> 1
@@ -8341,19 +8327,10 @@ let test_gzip_compressed_smaller () =
       else make_bytes(n - 1, val, Cons(val, acc)) end
     end
     pfn byte_length(b) do
-      match b do
-      Bytes(xs) ->
-        fn go(ys, n) do
-          match ys do
-          Nil -> n
-          Cons(_, t) -> go(t, n + 1)
-          end
-        end
-        go(xs, 0)
-      end
+      Bytes.length(b)
     end
     fn f() do
-      let b = Bytes(make_bytes(100, 65, Nil))
+      let b = Bytes.from_list(make_bytes(100, 65, Nil))
       match Compress.Gzip.encode(b) do
       Ok(compressed) -> byte_length(compressed)
       Err(_) -> 999
@@ -8367,7 +8344,7 @@ let test_gzip_compressed_smaller () =
 let test_gzip_level_explicit () =
   let env = eval_with_compress {|mod Test do
     fn f() do
-      let b = Bytes(Cons(65, Cons(66, Cons(67, Nil))))
+      let b = Bytes.from_list([65, 66, 67])
       match Compress.Gzip.encode_level(b, Gzip.BestSpeed) do
       Ok(_) -> 1
       Err(_) -> 0
@@ -8381,20 +8358,12 @@ let test_gzip_level_explicit () =
 let test_deflate_roundtrip () =
   let env = eval_with_compress {|mod Test do
     pfn bytes_eq(a, b) do
-      match (a, b) do
-      (Bytes(xs), Bytes(ys)) ->
-        fn go(ps, qs) do
-          match (ps, qs) do
-          (Nil, Nil) -> true
-          (Cons(x, xr), Cons(y, yr)) -> x == y && go(xr, yr)
-          _ -> false
-          end
-        end
-        go(xs, ys)
-      end
+      -- Compare through the public API: Bytes' payload is a String buffer,
+      -- not a cons spine.
+      Bytes.to_string(a) == Bytes.to_string(b)
     end
     fn f() do
-      let original = Bytes(Cons(100, Cons(101, Cons(102, Nil))))
+      let original = Bytes.from_list([100, 101, 102])
       match Compress.Deflate.encode(original) do
       Ok(compressed) ->
         match Compress.Deflate.decode(compressed) do
@@ -8410,11 +8379,11 @@ let test_deflate_roundtrip () =
 let test_deflate_empty () =
   let env = eval_with_compress {|mod Test do
     fn f() do
-      let b = Bytes(Nil)
+      let b = Bytes.empty()
       match Compress.Deflate.encode(b) do
       Ok(compressed) ->
         match Compress.Deflate.decode(compressed) do
-        Ok(Bytes(Nil)) -> 1
+        Ok(back) -> if Bytes.is_empty(back) do 1 else 0 end
         _ -> 0
         end
       Err(_) -> 0
@@ -8428,20 +8397,12 @@ let test_deflate_empty () =
 let test_zstd_roundtrip () =
   let env = eval_with_compress {|mod Test do
     pfn bytes_eq(a, b) do
-      match (a, b) do
-      (Bytes(xs), Bytes(ys)) ->
-        fn go(ps, qs) do
-          match (ps, qs) do
-          (Nil, Nil) -> true
-          (Cons(x, xr), Cons(y, yr)) -> x == y && go(xr, yr)
-          _ -> false
-          end
-        end
-        go(xs, ys)
-      end
+      -- Compare through the public API: Bytes' payload is a String buffer,
+      -- not a cons spine.
+      Bytes.to_string(a) == Bytes.to_string(b)
     end
     fn f() do
-      let original = Bytes(Cons(122, Cons(115, Cons(116, Cons(100, Nil)))))
+      let original = Bytes.from_list([122, 115, 116, 100])
       match Compress.Zstd.encode(original) do
       Ok(compressed) ->
         match Compress.Zstd.decode(compressed) do
@@ -8457,7 +8418,7 @@ let test_zstd_roundtrip () =
 let test_zstd_level_best () =
   let env = eval_with_compress {|mod Test do
     fn f() do
-      let b = Bytes(Cons(65, Cons(66, Nil)))
+      let b = Bytes.from_list([65, 66])
       match Compress.Zstd.encode_level(b, Zstd.Best) do
       Ok(_) -> 1
       Err(_) -> 0
@@ -8471,20 +8432,12 @@ let test_zstd_level_best () =
 let test_brotli_roundtrip () =
   let env = eval_with_compress {|mod Test do
     pfn bytes_eq(a, b) do
-      match (a, b) do
-      (Bytes(xs), Bytes(ys)) ->
-        fn go(ps, qs) do
-          match (ps, qs) do
-          (Nil, Nil) -> true
-          (Cons(x, xr), Cons(y, yr)) -> x == y && go(xr, yr)
-          _ -> false
-          end
-        end
-        go(xs, ys)
-      end
+      -- Compare through the public API: Bytes' payload is a String buffer,
+      -- not a cons spine.
+      Bytes.to_string(a) == Bytes.to_string(b)
     end
     fn f() do
-      let original = Bytes(Cons(98, Cons(114, Cons(111, Cons(116, Cons(108, Cons(105, Nil)))))))
+      let original = Bytes.from_list([98, 114, 111, 116, 108, 105])
       match Compress.Brotli.encode(original) do
       Ok(compressed) ->
         match Compress.Brotli.decode(compressed) do
@@ -8500,7 +8453,7 @@ let test_brotli_roundtrip () =
 let test_brotli_mode_text () =
   let env = eval_with_compress {|mod Test do
     fn f() do
-      let b = Bytes(Cons(65, Cons(66, Cons(67, Nil))))
+      let b = Bytes.from_list([65, 66, 67])
       match Compress.Brotli.encode_mode(b, Brotli.Text, Brotli.Level(4)) do
       Ok(_) -> 1
       Err(_) -> 0
@@ -8573,11 +8526,11 @@ let test_gzip_roundtrip_property () =
   let env = eval_with_compress_and_check {|mod Test do
     fn f() do
       Check.all(Gen.list(Gen.int(0, 255)), fn byte_list ->
-        let b = Bytes(byte_list)
+        let b = Bytes.from_list(byte_list)
         match Compress.Gzip.encode(b) do
         Ok(compressed) ->
           match Compress.Gzip.decode(compressed) do
-          Ok(Bytes(restored)) -> restored == byte_list
+          Ok(restored) -> Bytes.to_list(restored) == byte_list
           Err(_) -> false
           end
         Err(_) -> false
@@ -8591,11 +8544,11 @@ let test_deflate_roundtrip_property () =
   let env = eval_with_compress_and_check {|mod Test do
     fn f() do
       Check.all(Gen.list(Gen.int(0, 255)), fn byte_list ->
-        let b = Bytes(byte_list)
+        let b = Bytes.from_list(byte_list)
         match Compress.Deflate.encode(b) do
         Ok(compressed) ->
           match Compress.Deflate.decode(compressed) do
-          Ok(Bytes(restored)) -> restored == byte_list
+          Ok(restored) -> Bytes.to_list(restored) == byte_list
           Err(_) -> false
           end
         Err(_) -> false
@@ -8609,11 +8562,11 @@ let test_zstd_roundtrip_property () =
   let env = eval_with_compress_and_check {|mod Test do
     fn f() do
       Check.all(Gen.list(Gen.int(0, 255)), fn byte_list ->
-        let b = Bytes(byte_list)
+        let b = Bytes.from_list(byte_list)
         match Compress.Zstd.encode(b) do
         Ok(compressed) ->
           match Compress.Zstd.decode(compressed) do
-          Ok(Bytes(restored)) -> restored == byte_list
+          Ok(restored) -> Bytes.to_list(restored) == byte_list
           Err(_) -> false
           end
         Err(_) -> false
@@ -8627,11 +8580,11 @@ let test_brotli_roundtrip_property () =
   let env = eval_with_compress_and_check {|mod Test do
     fn f() do
       Check.all(Gen.list(Gen.int(0, 255)), fn byte_list ->
-        let b = Bytes(byte_list)
+        let b = Bytes.from_list(byte_list)
         match Compress.Brotli.encode(b) do
         Ok(compressed) ->
           match Compress.Brotli.decode(compressed) do
-          Ok(Bytes(restored)) -> restored == byte_list
+          Ok(restored) -> Bytes.to_list(restored) == byte_list
           Err(_) -> false
           end
         Err(_) -> false
@@ -8659,10 +8612,10 @@ let test_gzip_compression_shrinks_repetitive () =
     end
     fn f() do
       Check.all(Gen.int(0, 255), fn v ->
-        let bytes_200 = Bytes(replicate(200, v))
+        let bytes_200 = Bytes.from_list(replicate(200, v))
         match Compress.Gzip.encode(bytes_200) do
-        Ok(Bytes(compressed_list)) ->
-          list_length(compressed_list) < 200
+        Ok(compressed) ->
+          Bytes.length(compressed) < 200
         Err(_) -> false
         end
       )
@@ -8690,7 +8643,7 @@ let test_accept_encoding_trims_spaces () =
 let test_deflate_decode_invalid () =
   let env = eval_with_compress {|mod Test do
     fn f() do
-      let garbage = Bytes(Cons(1, Cons(2, Cons(3, Nil))))
+      let garbage = Bytes.from_list([1, 2, 3])
       match Compress.Deflate.decode(garbage) do
       Ok(_)  -> 0
       Err(_) -> 1
@@ -8702,7 +8655,7 @@ let test_deflate_decode_invalid () =
 let test_zstd_decode_invalid () =
   let env = eval_with_compress {|mod Test do
     fn f() do
-      let garbage = Bytes(Cons(1, Cons(2, Cons(3, Nil))))
+      let garbage = Bytes.from_list([1, 2, 3])
       match Compress.Zstd.decode(garbage) do
       Ok(_)  -> 0
       Err(_) -> 1
@@ -8714,7 +8667,7 @@ let test_zstd_decode_invalid () =
 let test_brotli_decode_invalid () =
   let env = eval_with_compress {|mod Test do
     fn f() do
-      let garbage = Bytes(Cons(1, Cons(2, Cons(3, Nil))))
+      let garbage = Bytes.from_list([1, 2, 3])
       match Compress.Brotli.decode(garbage) do
       Ok(_)  -> 0
       Err(_) -> 1
@@ -8727,20 +8680,12 @@ let test_zstd_fast_negative_level () =
   (* Zstd.Fast(-1) uses a zstd negative level (ultra-fast). Must round-trip. *)
   let env = eval_with_compress {|mod Test do
     pfn bytes_eq(a, b) do
-      match (a, b) do
-      (Bytes(xs), Bytes(ys)) ->
-        fn go(ps, qs) do
-          match (ps, qs) do
-          (Nil, Nil) -> true
-          (Cons(x, xr), Cons(y, yr)) -> x == y && go(xr, yr)
-          _ -> false
-          end
-        end
-        go(xs, ys)
-      end
+      -- Compare through the public API: Bytes' payload is a String buffer,
+      -- not a cons spine.
+      Bytes.to_string(a) == Bytes.to_string(b)
     end
     fn f() do
-      let original = Bytes(Cons(65, Cons(66, Cons(67, Nil))))
+      let original = Bytes.from_list([65, 66, 67])
       match Compress.Zstd.encode_level(original, Zstd.Fast(-1)) do
       Ok(compressed) ->
         match Compress.Zstd.decode(compressed) do


### PR DESCRIPTION
## What

`type Bytes = Bytes(List(Int))` → `type Bytes = Bytes(String)`.

One ~32-byte cons cell per byte becomes a contiguous, length-prefixed,
`memcpy`-able buffer. `length` goes O(n)→O(1), `get` O(i)→O(1), `slice`
O(start+len)→O(len), `to_string`/`from_string` O(n)→O(1), memory per byte 32→1.

Public API unchanged in name, arity and type. Only complexity changes.

Design: `specs/plans/2026-08-10-array-backed-bytes-design.md`.

## Why `String` and not a new `ByteBuf` primitive

`march_string` is already `{rc, tag, pad, len, data[]}` — one allocation, an
explicit length, a contiguous NUL-safe payload — and `string_byte_at`,
`string_slice`, `string_chars` and `char_from_int` are all **byte**-indexed in
both backends, not codepoint-indexed.

A new opaque `TCon` would have to be threaded through `typecheck.ml`
(`builtin_types`, `builtin_bindings`, `non_sendable_types`), `eval.ml`,
`llvm_builtins.ml` (table rows *and* `PDeclare` markers), `defun.ml`,
`borrow.ml`, `purity.ml`, the golden LLVM preamble in `test_codegen.ml`, plus —
because it would be a new tag — `march_message.c`'s copy walker and the GC's
`pass2_visit`. `String` already has all of it, exercised for years.

The FFI layer had also **already** decided unilaterally that `Bytes` was a flat
buffer: `march_bytes_borrow` is literally `march_str_borrow`
(`runtime/march_ffi.c:52`), `rust/march/src/value.rs:216` borrows `&[u8]` out of
one, and the interpreter marshals `Bytes` as an OCaml string
(`lib/eval/eval.ml:1859,1940`). This converges that split rather than adding a
third view of the same type.

**The wrapper constructor is kept on purpose.** A `Bytes` value is still a
one-field boxed ADT cell with its payload at offset 16; only the payload's type
changes. `repr.ml:18` classifies `Bytes` as `Boxed` only because `find_variant`
matches type-def names exactly and misses `"Bytes.Bytes"`; `llvm_case.ml:80`
compensates on destructure; `drop.ml:67` excludes the shape because the C
runtime builds these cells by hand. The last time that classification moved it
silently made compiled `Bytes.concat` return empty and hung forgepm's Postgres
handshake (`specs/progress_through_july_2026.md:4780`). Keeping the cell also
means every existing `*(void **)((char *)bytes_val + 16)` in the runtime stays
correct.

## The FFI boundary is now a memcpy

`bytes_from_raw` (`march_extras.c`), `compress_bytes_from_raw`
(`march_compress.c`) and `make_bytes_from_raw` (`march_http.c`) each allocated
one cons cell per byte — `march_gzip_decode` of a 12 MB tar allocated ~12M cells
(hundreds of MB) before any March code ran. `bytes_to_raw` walked the spine
twice. All three from-raw paths are now one `march_string_lit`; the to-raw paths
are one `memcpy` against an already-contiguous payload.

## Benchmarks

Interpreted, arm64 macOS, payload = `String.repeat("abcdefghij", n)`.

**Before**

| operation | 4 000 B | 16 000 B | 64 000 B | 256 000 B |
|---|---:|---:|---:|---:|
| `from_string` | 47 ms | 189 ms | 810 ms | 4165 ms |
| `length` (once) | — | — | — | 2373 ms |
| `get(b, len-1)` | 67 ms | 263 ms | 1063 ms | 4485 ms |
| `slice(b, len-n, n)` | 65 ms | 264 ms | 1057 ms | 4389 ms |
| `length` × 100 | 3449 ms | 13383 ms | 54439 ms | — |
| 2 000 sequential `get` | 32810 ms | 32282 ms | 32814 ms | — |

The 256 KB benchmark was killed after **29 min wall / 1574 s CPU**, still inside
its 20 000-get loop.

**After**

| operation | 4 000 B | 64 000 B | 256 000 B | 12 000 000 B |
|---|---:|---:|---:|---:|
| `from_string` | 0.045 ms | 0.045 ms | 0.047 ms | 0.048 ms |
| `length` (once) | — | — | 0.054 ms | — |
| `get(b, len-1)` | 0.087 ms | 0.087 ms | 0.087 ms | 0.095 ms |
| `slice(b, len-n, n)` | 0.104 ms | 0.078 ms | 0.078 ms | 0.080 ms |
| `to_string` | 0.043 ms | 0.044 ms | 0.041 ms | — |
| `length` × 100 | 10.5 ms | 10.3 ms | — | — |
| 2 000 sequential `get` | 218 ms | 220 ms | — | — |

At 256 KB: `from_string` **~88 000×**, `length` **~44 000×**, `get(last)`
**~52 000×**, `slice` **~56 000×**. Every operation is now flat in payload size.
The 256 KB program that was killed unfinished at 29 minutes runs to completion
in **3.3 s**. The residual `get` cost is interpreter dispatch, not the
representation — 2 000 gets cost the same 218 ms at 4 KB and at 64 KB.

Gzip, previously impossible at these sizes:

| payload | `Gzip.encode` | `Gzip.decode` |
|---:|---:|---:|
| 1 MB | 2.04 ms | 0.46 ms |
| 3 MB | 5.90 ms | 7.84 ms |
| 12 MB | 23.19 ms | 11.49 ms |

## Downstream validation (forgepm)

`forge check` over forgepm + depot + bastion + march_doc + conduit: **clean**,
zero Bytes-related diagnostics.

The shipped `Forgepm.Packages.Tarball` (`parse`, `extract_readme`,
`extract_march_sources`) produces **byte-identical output** on its gzip fixtures
under the pinned `main-164c6f80` toolchain and under this branch.

The 3.1 MB tarball (5.6 MB uncompressed, 448 `.march` members):

| | pinned toolchain | this branch |
|---|---|---|
| `Bytes.from_string` | never printed | 0.047 ms |
| `Tarball.parse` | — | 49 ms |
| `extract_readme` | — | 77 ms |
| `extract_march_sources` | — | 5 649 ms |
| outcome | **Stack overflow, ~2.5 GB RSS, no result** | 6.9 s, correct |

**Follow-up for forgepm, not this PR:** the consumer-side workaround is now the
bottleneck. `tarball.march` was rewritten to consume a `List(Int)` cursor
specifically because `Bytes.get` was O(i) — its own comment says so. With an
array-backed `Bytes` that cursor is the limiting factor: `Bytes.to_list` on the
5.6 MB tar allocates 5.6M cons cells and overflows the interpreter stack after
228 s. The numbers above are with the walker reverted to plain offset indexing
(`Bytes.get` / `Bytes.slice`, no intermediate list) — that revert is what
forgepm should land next.

## Breaking change

Code that reaches *through* the abstraction and matches the payload as a list
breaks. In-repo that was `stdlib/crypto.march:46,202` and
`stdlib/uuid.march:287,291`, both fixed here.

**Outside the repo, `bastion` needs the same one-line change** before it builds
against this:

- `bastion/lib/security/crypto.march:70,258,325`
- `bastion/lib/security/hkdf.march:37,49`

all `Bytes(xs)` / `Bytes(Nil)` / `Bytes(Cons(i, Nil))` → `Bytes.to_list` /
`Bytes.empty()` / `Bytes.from_list`. depot, conduit and march_doc are clean.

## Regression: `to_list` / `from_list`

O(1) → O(n). They were the constructor and its inverse; they are conversions
now. Callers audited in the design doc. `stdlib/net_kernel.march:23-24` (the
wire path) gets *faster*, because it is re-expressed over `from_string` /
`to_string`, which are now O(1). The counterweight is
`String.to_codepoints` (`stdlib/string.march:478-515`), which called
`Bytes.get(b, i)` in a loop and was **O(n²)**; it is O(n) now with no source
change.

## Aliasing / RC

Slices **copy**; they do not share the buffer. `march_decrc` is shallow — one
`free(p)`, no recursion; child decrements are emitted by Perceus — so a
hand-built-in-C cell with a pointer child has no one to drop the owner, and
`drop.ml` refuses to destructure this shape. A sharing slice needs its own RC
design and should be a separate change. The asymptotic win survives anyway: the
old `slice` was O(start+len) because it had to *walk* to `start`.

## Streaming

Out of scope, not foreclosed. `Seq(Bytes)` is the shape a chunked reader wants;
`seq.march:308` already documents `from_file_chunks` that way, and with
`Bytes = Bytes(String)` the `file_read_chunk : Option(String)` mismatch becomes
a one-line wrap instead of an O(n) conversion. A chunked
`gzip_decode_chunks : Bytes -> Seq(Bytes)` would drive `inflate` with a fixed
output window; the 256 MB `MAX_DECOMPRESS_SIZE` guard exists because today it
cannot.

## Verification

- `dune build --root . @runtest` → **exit 0**. 2740 tests across 7 runners, 0
  failures (incl. `test_stdlib_suite` 834 and the compiled/codegen suite 563).
- `dune build --root . @test/cap_lattice_check` → exit 0. Runtime C changes
  invalidate the CAS `runtime_identity` digest as expected; the freshness check
  still passes.
- Pre-existing on `main`, not touched here: the `demo/` targets fail their
  capability ceiling on `main` as well.

One thing worth flagging for reviewers: `dune build @runtest` initially exited 0
while `test/run_stdlib.exe` had 37 red on its own. The failures were real
(`bytes_val_to_string` in `test_helpers.ml` walked the cons payload; four
`eval_with_*` helpers never loaded `bytes.march`) and are fixed in
`2c37c9c0` — but the alias's exit status did not surface them on the first pass.
