### PR TITLE
fix(codegen): compiled float `!=` on NaN now matches interpreter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,14 @@ git log is authoritative for exact commits.
 
 ### Fixed
 
+- **Compiled `!=` on NaN floats now matches the interpreter.** The native
+  backend lowered float `!=` to LLVM `fcmp one` (ordered-and-not-equal),
+  which per IEEE 754 is `false` whenever either operand is NaN — but the
+  interpreter implements `!=` via OCaml's polymorphic `<>`, under which
+  `nan <> nan` is `true`. `nan != nan` printed `false` compiled and `true`
+  interpreted. Now uses `fcmp une` (unordered-or-not-equal), matching `<>`
+  semantics on both backends.
+
 - **JS backend: `==`/`!=` on a non-primitive operand now compares
   structurally.** A bare `==`/`!=` where either side is an ADT/tuple/record
   (or an erased type variable that may hold one) lowered to JavaScript `===`,

--- a/lib/tir/llvm_emit.ml
+++ b/lib/tir/llvm_emit.ml
@@ -1554,7 +1554,12 @@ let rec emit_expr ctx (e : Tir.expr) : string * string =
           (* Float comparison: use fcmp ordered predicates.
              Coerce both sides to double in case one came from a boxed ptr. *)
           let fpred = match f.Tir.v_name with
-            | "==" -> "oeq" | "!=" -> "one"
+            (* "!=" must match IEEE `<>` semantics used by the interpreter
+               (OCaml's polymorphic `<>` on floats is true whenever either
+               operand is NaN), i.e. "unordered or not equal" ("une"), not
+               "one" (ordered and not equal, which is false for any NaN
+               operand). See eval.ml's cmp_op float branch. *)
+            | "==" -> "oeq" | "!=" -> "une"
             | "<"  -> "olt" | "<=" -> "ole"
             | ">"  -> "ogt" | ">=" -> "oge"
             | s -> failwith ("unknown cmp: " ^ s)

--- a/specs/progress/2026-08-11-float-neq-nan-fcmp-one-vs-une.md
+++ b/specs/progress/2026-08-11-float-neq-nan-fcmp-one-vs-une.md
@@ -1,0 +1,56 @@
+# Compiled `!=` on NaN floats diverged from the interpreter
+
+**Fixed:** 2026-08-11
+
+## Bug
+
+`lib/tir/llvm_emit.ml`'s float comparison codegen (the `fpred` match inside
+the `is_int_cmp` fallback, around line 1556) mapped March's `!=` to LLVM's
+`fcmp one` (ordered-and-not-equal). Per IEEE 754 and the LLVM LangRef, `one`
+is `false` whenever either operand is NaN (it requires both operands to be
+ordered, i.e. non-NaN).
+
+`lib/eval/eval.ml` implements float `!=` via OCaml's polymorphic `<>`
+(`cmp_op` at line 3921), under which `nan <> nan` is `true` — OCaml's
+built-in comparison operators use a total order where NaN compares unequal
+to everything, including itself, under `<>`/`=`, unlike `Stdlib.compare`.
+
+Net effect: `nan != nan` printed `false` compiled, `true` interpreted — a
+backend-observable, program-value-dependent divergence for any float that
+could be NaN (parsed input, `0.0 /. 0.0`-shaped computations that escape the
+runtime's checked-div-by-zero guard via other means, SIMD lane extraction,
+etc).
+
+## Fix
+
+Changed the `"!="` arm of the float `fpred` match from `"one"` to `"une"`
+(unordered-or-not-equal) — `une` is `true` whenever the operands differ OR
+either is NaN, matching `<>`. `"=="` correctly stayed `"oeq"` (both sides
+already agree: `nan == nan` is `false` on both backends, and `oeq` requires
+ordered-and-equal).
+
+## Verification
+
+- Reproduced pre-fix: interpreted `println(x != x)` for `x` bound via
+  `string_to_float("nan")` (avoids the checked-fdiv abort that `0.0 /. 0.0`
+  hits on both backends) printed `true`; compiled printed `false`.
+- Added `test_compiled_float_nan_neq_parity` in `test/test_codegen.ml`
+  (`assert_compiled_interp_parity`), asserting `nan != nan` and `nan != 1.0`
+  both print `true` on interpreted AND compiled output. Confirmed it fails
+  pre-fix (compiled prints `false\ntrue`) and passes post-fix.
+- Grepped `test/*.ml` for existing Float `!=`/NaN assertions before
+  changing — none existed relying on the old (wrong) `one` behavior.
+- Full `scripts/run-tests.sh -q` run: 797 stdlib + 564 codegen tests, all
+  green except two pre-existing/unrelated items — the known-flaky compiled
+  `Signal.watch` repeated-delivery RC test, and `testing_library`'s
+  `run_tests: fail count` self-test (which deliberately triggers and counts
+  a nested test failure; its embedded `FAIL: "bad"` stdout is the *expected*
+  fixture, not an actual alcotest failure — confirmed by re-running the
+  `stdlib` suite in isolation, which shows it `[OK]`).
+
+## Files
+
+- `lib/tir/llvm_emit.ml` — the one-line predicate fix.
+- `test/test_codegen.ml` — new `test_compiled_float_nan_neq_parity` +
+  registration.
+- `CHANGELOG.md` — user-facing `### Fixed` entry.

--- a/test/test_codegen.ml
+++ b/test/test_codegen.ml
@@ -11051,6 +11051,32 @@ let test_compiled_iolist_deep_flatten_parity () =
     ~expected:"25000\n25000"
     ()
 
+(** Float `!=` on NaN: the interpreter implements float `!=` via OCaml's
+    polymorphic `<>`, under which `nan <> nan` is `true`. The compiled
+    backend used LLVM `fcmp one` (ordered-and-not-equal, IEEE 754 semantics)
+    for `!=`, which is `false` whenever either operand is NaN — a
+    interp/compiled divergence. Fixed by using `fcmp une`
+    (unordered-or-not-equal), which matches `<>`: true whenever the operands
+    differ OR either is NaN. `string_to_float("nan")` is used to produce a
+    NaN without hitting the checked-div-by-zero abort that `0.0 /. 0.0`
+    triggers on both backends. *)
+let test_compiled_float_nan_neq_parity () =
+  assert_compiled_interp_parity
+    ~name:"march_float_nan_neq"
+    ~src:"mod FloatNanNeqParity do\n\
+    \  needs IO.Console\n\
+         \  fn main() do\n\
+         \    let x = match string_to_float(\"nan\") do\n\
+         \      Some(v) -> v\n\
+         \      None -> 0.0\n\
+         \    end\n\
+         \    println(x != x)\n\
+         \    println(x != 1.0)\n\
+         \  end\n\
+          end\n"
+    ~expected:"true\ntrue"
+    ()
+
 (** Self-referencing block-`let` shadowing (`let x = x + 5`) must compile to
     the same value the interpreter produces. Pre-fix, `Cprop`'s `ELet` arm
     left the outer binding's literal mapping (`x -> 10`) in scope when the
@@ -14213,6 +14239,8 @@ let codegen_suites =
             test_compiled_deque_pop_parity;
           Alcotest.test_case "compiled self-referencing let-shadowing parity (cprop)" `Quick
             test_compiled_let_shadowing_parity;
+          Alcotest.test_case "compiled float NaN `!=` parity (une vs one)" `Quick
+            test_compiled_float_nan_neq_parity;
           Alcotest.test_case "compiled entry-module self-qualification parity" `Quick
             test_compiled_entry_self_qual_parity;
           Alcotest.test_case "compiled entry-module nested self-qualification parity" `Quick


### PR DESCRIPTION
## Summary
- The native codegen backend lowered float `!=` to LLVM `fcmp one` (ordered-and-not-equal), which per IEEE 754 is `false` whenever either operand is NaN.
- The interpreter implements `!=` via OCaml's polymorphic `<>`, under which `nan <> nan` is `true`.
- Result: `nan != nan` printed `false` compiled but `true` interpreted — a backend-observable divergence. Fixed by switching the `!=` predicate to `fcmp une` (unordered-or-not-equal), which matches `<>` semantics on both backends.

## Test plan
- [x] Reproduced the bug pre-fix (interp `true` / compiled `false`)
- [x] Added `test_compiled_float_nan_neq_parity` in `test/test_codegen.ml`, confirmed red pre-fix / green post-fix
- [x] Full `scripts/run-tests.sh -q`: 795 compiler + 256 eval + 564 codegen + 797 stdlib tests, all green