### PR TITLE
fix(codegen): compiled == on opaque-typed ctor field falls back to march_poly_eq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,16 @@ git log is authoritative for exact commits.
 
 ### Fixed
 
+- **Compiled `==` on a variant/tuple/record field of a type with no `type`
+  declaration now compares by content, not by pointer.** A ctor field typed
+  as a compiler-builtin type constructor (e.g. `Task`, `Pid`, `WorkPool`) —
+  or, on branches carrying SIMD vector types, `F32x4`/`F64x2`/`I32x4`/
+  `I64x2`/`U8x16` — has no derivable structural-equality function, and the
+  codegen fell back to raw pointer identity instead of the runtime
+  polymorphic comparator, so two distinct-but-content-identical values for
+  such a field compared unequal. Now falls back to `march_poly_eq`, matching
+  the existing generic (`TVar`) field arm.
+
 - **Compiled `!=` on NaN floats now matches the interpreter.** The native
   backend lowered float `!=` to LLVM `fcmp one` (ordered-and-not-equal),
   which per IEEE 754 is `false` whenever either operand is NaN — but the

--- a/lib/tir/llvm_eq.ml
+++ b/lib/tir/llvm_eq.ml
@@ -464,12 +464,12 @@ let rec ensure_adt_eq_fn (ctx : Llvm_ctx.ctx) (ty : Tir.ty) : string option =
                   | Some fen ->
                     e (Printf.sprintf "%s = call i64 @%s(ptr %s, ptr %s)" ok fen fva fvb)
                   | None ->
-                    let pa = frsh "pa" in let pb = frsh "pb" in
-                    e (Printf.sprintf "%s = ptrtoint ptr %s to i64" pa fva);
-                    e (Printf.sprintf "%s = ptrtoint ptr %s to i64" pb fvb);
-                    let c = frsh "c" in
-                    e (Printf.sprintf "%s = icmp eq i64 %s, %s" c pa pb);
-                    e (Printf.sprintf "%s = zext i1 %s to i64" ok c))
+                    (* No eq fn derivable (e.g. an opaque builtin type
+                       constructor with no March-level [type] declaration,
+                       like Task/Pid/WorkPool) — fall back to
+                       [march_poly_eq], same as the [TVar] arm just below,
+                       instead of raw pointer identity. *)
+                    e (Printf.sprintf "%s = call i64 @march_poly_eq(ptr %s, ptr %s)" ok fva fvb))
                | _ ->
                  (* Generic (TVar) field: the static type gives no comparison
                     strategy, so dispatch on the runtime shape via march_poly_eq

--- a/specs/progress/2026-08-12-eq-operator-opaque-ctor-field-poly-eq-fallback.md
+++ b/specs/progress/2026-08-12-eq-operator-opaque-ctor-field-poly-eq-fallback.md
@@ -1,0 +1,75 @@
+# `==` on a variant/tuple/record field of an opaque type used pointer identity
+
+**Fixed:** 2026-08-12
+
+## Bug
+
+`lib/tir/llvm_eq.ml`'s per-ctor field-equality codegen (the field-compare
+loop inside the resolved-ctor-table branch of `ensure_adt_eq_fn`, around
+line 462) handles a ctor field typed `TCon _ | TTuple _ | TRecord _` by
+recursively deriving that field's own structural-equality function via
+`ensure_adt_eq_fn`. When that recursive call returns `None` — no `type`
+declaration exists for the field's type, e.g. a compiler-builtin type
+constructor like `Task`, `Pid`, or `WorkPool`, or (on branches carrying the
+SIMD vector-types feature) `F32x4`/`F64x2`/`I32x4`/`I64x2`/`U8x16` — the code
+fell back to a raw pointer-identity compare (`ptrtoint` both operands,
+`icmp eq`) instead of `march_poly_eq`, the runtime-shape-dispatched
+comparator.
+
+The sibling arm ten lines below, for a field typed `TVar` (a truly generic/
+erased field), already used `march_poly_eq` for exactly this "no eq fn
+derivable" situation — added previously to fix `List(a)` structural equality
+for generic containers of strings. The `TCon`/`TTuple`/`TRecord` arm's
+`None` case never got the same treatment, so two distinct heap allocations
+holding identical content for an opaque-typed field compared as NOT equal.
+
+Net effect: `{ v : F32x4 }`-shaped records (or any record/tuple/ADT-ctor
+field whose type has no March-level `type` declaration) would report `==`
+as `false` for two structurally-identical-but-distinct values, unless the
+compiler happened to share the exact same allocation.
+
+## Fix
+
+Changed the `None` branch of the `TCon _ | TTuple _ | TRecord _` field-eq
+arm in `ensure_adt_eq_fn`'s ctor-table field loop to emit a call to
+`march_poly_eq(ptr %fva, ptr %fvb)`, matching the `TVar` arm immediately
+below it.
+
+## Verification
+
+- Added `test_eq_operator_opaque_ctor_field_uses_poly_eq` in
+  `test/test_codegen.ml` (registered under the `newtype_derived_method_crash`
+  suite). This worktree does not carry the SIMD vector-types feature (that
+  lives on a separate branch), so the repro uses `Task(Int)` — a real
+  compiler-builtin type constructor with no March-level `type` declaration —
+  as a ctor field of a two-ctor variant (`Holder = HA(Task(Int)) |
+  HB(Task(Int))`, deliberately non-nullary on both ctors to stay off the
+  Newtype/Niche codegen shortcuts and land in the general ctor-table path).
+  The test compiles to LLVM IR (`emit_actor_ir`, no execution needed — the
+  bug is about which comparator gets emitted, not runtime behavior of
+  `Task`) and asserts the IR contains a `march_poly_eq` call. Confirmed it
+  fails pre-fix (`Received: false` — no `march_poly_eq` call emitted) and
+  passes post-fix.
+- Full `scripts/run-tests.sh`: 845 tests, all green (no regressions).
+
+## Follow-up (not fixed here, out of scope of the reported finding)
+
+Three more instances of the identical `None -> ptrtoint identity` pattern
+exist in `lib/tir/llvm_eq.ml`, none reported by the original finding and
+left untouched to keep this fix minimal:
+
+- ~line 216-225: the niche/Option-shaped ctor field-compare arm (same bug
+  shape as the one fixed here, but for niche-encoded types).
+- ~line 546-563: the standalone tuple/record structural-equality generator's
+  own field-compare loop has the same `TCon _ | TTuple _ | TRecord _ ->
+  None -> ptrtoint` bug, AND its `_` wildcard arm (line 557) does not
+  special-case `TVar` the way the ctor-table version's `_` arm does — it
+  uses pointer identity for every unmatched field type, including generic
+  ones, where it should use `march_poly_eq`.
+
+## Files
+
+- `lib/tir/llvm_eq.ml` — the fallback fix (one field-compare arm).
+- `test/test_codegen.ml` — new `test_eq_operator_opaque_ctor_field_uses_poly_eq`
+  + registration.
+- `CHANGELOG.md` — user-facing `### Fixed` entry.

--- a/test/test_codegen.ml
+++ b/test/test_codegen.ml
@@ -11892,6 +11892,36 @@ let test_newtype_eq_operator_generic_payload_compiled () =
     ~expected:"true\nfalse\ntrue\nfalse"
     ()
 
+(** Bug: a variant field typed as an OPAQUE builtin type constructor (no
+    March-level `type` declaration exists for it — e.g. `Task(a)`) makes
+    [ensure_adt_eq_fn] return [None] for that field's own type. The `==`
+    operator's per-ctor field-compare arm for [TCon _ | TTuple _ | TRecord _]
+    then fell back to raw pointer-identity (ptrtoint + icmp eq) instead of
+    [march_poly_eq] — the runtime-shape-dispatched comparator the sibling
+    [TVar] arm (ten lines below in [llvm_eq.ml]) already uses for exactly
+    this "no eq fn derivable" situation. Two distinct heap cells with
+    identical content would then compare unequal.
+    `Task(Int)` gives a clean repro: `Holder` itself has a `type`
+    declaration (resolvable), but its field type `Task(Int)` does not (Task
+    is a compiler-builtin type constructor never declared in March source) —
+    and two non-nullary single-field ctors keep this off the Newtype/Niche
+    shortcuts, landing in the general ctor-table codegen path where the bug
+    lives. This only checks the emitted IR (no execution needed — the bug is
+    in which comparator gets *called*, not runtime behavior of Task itself). *)
+let test_eq_operator_opaque_ctor_field_uses_poly_eq () =
+  let ir = emit_actor_ir {|mod EqOpaqueCtorField do
+  needs IO.Console
+  type Holder = HA(Task(Int)) | HB(Task(Int))
+  derive Eq for Holder
+  fn main() : Unit do
+    let t = task_spawn(fn n -> n)
+    println(bool_to_string(HA(t) == HA(t)))
+  end
+end|} in
+  Alcotest.(check bool)
+    "opaque ctor field falls back to march_poly_eq, not pointer identity"
+    true (ir_contains ir "call i64 @march_poly_eq")
+
 (** Cross-module ambiguous-constructor resolution (compiled-only regression).
 
     `Msgpack.Value` and `Json.JsonValue` (both stdlib) share the bare constructor
@@ -14305,6 +14335,8 @@ let codegen_suites =
             test_newtype_eq_operator_boxed_payload_compiled;
           Alcotest.test_case "== operator on generic newtype (type_params subst path) (P1)" `Quick
             test_newtype_eq_operator_generic_payload_compiled;
+          Alcotest.test_case "== operator on opaque (undeclared) ctor field falls back to march_poly_eq" `Quick
+            test_eq_operator_opaque_ctor_field_uses_poly_eq;
         ] );
       ( "cross_module_ctor_resolution", [
           Alcotest.test_case "Msgpack vs Json ambiguous ctor: encode/decode parity" `Quick


### PR DESCRIPTION
## Summary
- A variant/tuple/record ctor field typed as a compiler-builtin type with no March-level `type` declaration (`Task`, `Pid`, `WorkPool`, or SIMD vector types on branches carrying that feature) has no derivable structural-equality function.
- `ensure_adt_eq_fn`'s per-ctor field-compare loop (`lib/tir/llvm_eq.ml`) fell back to raw pointer identity for this case instead of `march_poly_eq` (the runtime polymorphic comparator), matching the sibling `TVar` arm a few lines below — so two distinct heap allocations with identical content for such a field compared unequal.
- Fixed by routing the `None` case through `march_poly_eq`, consistent with the `TVar` fallback.

Found while reviewing a SIMD vector-types branch (a different worktree from this one); this worktree doesn't carry that feature, so the regression test uses `Task(Int)` as the repro vehicle instead — a real compiler-builtin type constructor with no stdlib `type` declaration, which hits the exact same code path.

Two sibling instances of the same bug pattern exist elsewhere in the same file (documented in the progress note as out-of-scope follow-up, not fixed here).

## Test plan
- [x] New `test_eq_operator_opaque_ctor_field_uses_poly_eq` in `test/test_codegen.ml`: watched it fail pre-fix (no `march_poly_eq` call emitted), pass post-fix.
- [x] Full `scripts/run-tests.sh`: 845/845 tests pass, no regressions.
- [x] Independent code-review pass confirmed correctness, non-vacuous test, and safety of `march_poly_eq` for the affected field types.