### PR TITLE
docker: add .dockerignore so builds stop shipping _build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# Build context hygiene for `docker build` (ci/Dockerfile.ubuntu).
+#
+# Without this, every build ships the whole working tree to the daemon —
+# _build alone is ~824MB and is rebuilt inside the image anyway, so it is
+# pure transfer cost on each build. .git is similarly large and unused: the
+# Dockerfile COPYs a source tree, it does not run git.
+_build
+.march
+.git
+.superpowers
+docs/_site
+node_modules


### PR DESCRIPTION
`ci/Dockerfile.ubuntu` COPYs the working tree into the image. With no `.dockerignore`, that includes `_build` (~824 MB here) and `.git` — the first is rebuilt inside the image anyway, the second is never used, since the Dockerfile copies a source tree rather than running git. Both are pure transfer cost on every `docker build`.

Also excludes `.march` (the local CAS cache), `.superpowers` (agent scratch), `docs/_site`, and `node_modules`.

No effect outside Docker builds.

### Two other bugs in that image, found while using it — NOT fixed here

Filing them so they're recorded; both are separate from this change and I'd rather not widen the PR:

1. **`ci/Dockerfile.ubuntu` cannot build for amd64**, despite its own header advertising `docker build --platform linux/amd64`. Its BLAKE3 step passes only `-DBLAKE3_USE_NEON=0`, so on x86_64 the dispatcher references SSE2/SSE4.1/AVX2/AVX512 symbols that were never compiled, and linking fails with `undefined reference to blake3_compress_xof_sse41` and friends. Two possible fixes: compile the `blake3_*_x86-64_unix.S` sources (what `.github/actions/march-setup` does), or add `-DBLAKE3_NO_SSE2 -DBLAKE3_NO_SSE41 -DBLAKE3_NO_AVX2 -DBLAKE3_NO_AVX512` to compile the dispatch out.

2. **The image cannot run its own `CMD`.** Its build step is a targetless `dune build`, which fails because the JS-pipeline test rules need `node`, and the image installs no node. So `docker build -f ci/Dockerfile.ubuntu .` fails at the build layer even on native arm64.

Together those mean the contributor-facing "reproduce CI locally" image doesn't currently work in either mode. I worked around both with a throwaway Dockerfile while debugging; happy to fix them properly in a follow-up if you want.
