### PR TITLE
TRMC on by default, stdlib producers in natural style (plan Tasks 4-10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,13 @@ git log is authoritative for exact commits.
 
 ### Changed
 
+- **The structural-recursion warning no longer prescribes an accumulator for
+  constructor-wrapped recursion.** For a body like `Succ(bump(k))`, TRMC
+  compiles the recursion into a loop, so the old "uses O(depth) stack space"
+  phrasing was misleading. The warning now says the stack cost *may* apply and
+  that a recursive call in direct constructor-argument position becomes a loop.
+  The arithmetic variant (`1 + f(n - 1)`), which TRMC cannot transform, still
+  recommends an accumulator parameter. Detection is unchanged.
 - **The capability ceiling is now on by default.** `march --compile` fails the
   build if any module's emitted code uses a capability that module does not
   declare in `needs` — including a stdlib-mediated use (`File.read`), which no

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1330,12 +1330,14 @@ let hr_cas_tag () = match !hot_reload_prefix with Some p -> ["hr:" ^ p] | None -
 let codegen_cas_tags () =
   "rtcflags2"
   :: (if Sys.getenv_opt "MARCH_SANITIZE" <> None then ["sanitize"] else [])
-  (* MARCH_TRMC rewrites eligible functions into destination-passing style, so
-     it changes the emitted binary.  Without this tag a cached non-TRMC
-     artifact silently satisfies a TRMC build and vice versa — which is exactly
-     how the first TRMC benchmark run reported a 0.06s "TRMC off" number that
-     was really the TRMC binary served from the cache. *)
-  @ (if Sys.getenv_opt "MARCH_TRMC" <> None then ["trmc"] else [])
+  (* TRMC rewrites eligible functions into destination-passing style, so it
+     changes the emitted binary.  Without this tag a cached non-TRMC artifact
+     silently satisfies a TRMC build and vice versa — which is exactly how the
+     first TRMC benchmark run reported a 0.06s "TRMC off" number that was
+     really the TRMC binary served from the cache.  Reads the ref, not the env
+     var, so --trmc/--no-trmc are also CAS-distinct; every cas_flags site is
+     inside [compile], which runs after Arg.parse has set it. *)
+  @ (if !March_tir.Trmc.enabled then ["trmc"] else [])
   @ (if (try Sys.getenv "MARCH_HTTP_EVLOOP" = "1" with Not_found -> false)
      then ["evloop"] else [])
   @ (if !fast_math then ["fast-math"] else [])
@@ -2605,7 +2607,7 @@ let compile filename =
        longer syntactically visible.  See
        specs/todos/2026-08-07-trmc-tail-recursion-modulo-cons.md. *)
     March_tir.Trmc.report tir;
-    (* Phase 3 (WIP, gated on MARCH_TRMC=1): destination-passing rewrite of
+    (* Phase 3 (WIP, gated on --trmc / legacy MARCH_TRMC): destination-passing rewrite of
        TRMC-eligible functions.  Off by default — this is a measurement
        vehicle until the RC integration (phase 4) is done. *)
     let tir = March_tir.Trmc.transform_module tir in
@@ -4720,6 +4722,10 @@ let () =
     ("-o",           Arg.Set_string output_file, "<file>  Output binary name (with --compile)");
     ("--no-opt",    Arg.Clear opt_enabled,  " Skip TIR optimization passes");
     ("--fast-math",  Arg.Set fast_math,  " Emit 'fast' on all FP LLVM instructions");
+    ("--trmc", Arg.Unit (fun () -> March_tir.Trmc.enabled := true),
+     " Enable tail-recursion-modulo-cons (destination-passing rewrite)");
+    ("--no-trmc", Arg.Unit (fun () -> March_tir.Trmc.enabled := false),
+     " Disable tail-recursion-modulo-cons");
     ("--pmap-threshold", Arg.Set_int pmap_threshold, "<N>  List.pmap/pfilter/preduce fall back to sequential below N elements (default 1024)");
     ("--opt",        Arg.Set_int opt_level, "<N>  Optimization level passed to clang (0-3)");
     ("--debug",     Arg.Set debug_mode,     " Enable time-travel debugger (simple mode)");
@@ -4735,6 +4741,11 @@ let () =
     ("--emit-core-ast", Arg.String (fun f -> emit_core_ast_file := Some f),
      " <file.march>  Emit desugared core AST + verdict + diagnostics as JSON to stdout");
   ] in
+  (* Legacy escape hatch: MARCH_TRMC=1 predates --trmc and is still used by the
+     CI sanitize gate.  Seeded BEFORE Arg.parse so it acts as a DEFAULT — an
+     explicit --trmc or --no-trmc on the command line overrides it either way.
+     (Applying it after parsing would silently clobber --no-trmc.) *)
+  if Sys.getenv_opt "MARCH_TRMC" <> None then March_tir.Trmc.enabled := true;
   Arg.parse specs (fun f -> files := f :: !files) "Usage: march [options] [file.march]";
   (* --target js implies --compile (skip JIT, emit .mjs) *)
   if !target_str = "js" || !target_str = "javascript" then do_compile := true;

--- a/lib/jit/repl_jit.ml
+++ b/lib/jit/repl_jit.ml
@@ -297,6 +297,15 @@ let prev_slots_of ctx : March_tir.Llvm_emit.repl_slot_info list =
     treated as borrowed by Perceus so they are never freed mid-session. *)
 let lower_module ~type_map ?(stdlib_context : March_ast.Ast.decl list = []) ?(repl_vars : string list = []) (m : March_ast.Ast.module_) =
   let tir = March_tir.Lower.lower_module ~type_map ~stdlib_context m in
+  (* Match the compiled pipeline: bin/main.ml runs Trmc.transform_module
+     immediately post-lower (pre-mono), and without it a function behaves
+     differently in the REPL than when compiled.  The position matters as much
+     as the call — by defun the stdlib's nested `go` helpers are closures
+     invoked via ECallPtr, so self-recursion is no longer syntactically visible
+     and the transform would silently see nothing.  Gated by the same
+     [Trmc.enabled] ref, and idempotent, so re-lowering an already-transformed
+     module is a no-op. *)
+  let tir = March_tir.Trmc.transform_module tir in
   let iface_methods = March_tir.Lower.get_iface_methods () in
   let tir = March_tir.Mono.monomorphize ~iface_methods tir in
   (* Policy audit — report any Tagged(_, P) violations before defun. *)

--- a/lib/tir/trmc.ml
+++ b/lib/tir/trmc.ml
@@ -314,8 +314,9 @@ let report (m : Tir.tir_module) : unit =
    constructor loop writes the same field.  See the Phase 2 note in
    specs/todos/2026-08-07-trmc-tail-recursion-modulo-cons.md.
 
-   GATED on MARCH_TRMC=1 — this is a work-in-progress measurement vehicle, not
-   yet a default pipeline stage. *)
+   GATED on [enabled] (set by --trmc, or by the legacy MARCH_TRMC env var) —
+   this is a work-in-progress measurement vehicle, not yet a default pipeline
+   stage. *)
 
 let trmc_ctr = ref 0
 
@@ -440,9 +441,15 @@ let transform_fn ?(on_decline = fun (_ : string) -> ())
   | Mixed, _ -> decline "mixed"
   | _ -> None
 
-(** Apply TRMC across a module.  Gated on MARCH_TRMC=1. *)
+(** Whether the destination-passing transform runs.  A [ref] rather than an
+    env-var read so the driver owns the decision and a CLI flag can set it;
+    [bin/main.ml] is the only writer.  Default OFF until the default flips
+    (see specs/plans/2026-08-10-trmc-on-by-default.md Task 10). *)
+let enabled : bool ref = ref false
+
+(** Apply TRMC across a module.  Gated on [enabled] (see [--trmc]). *)
 let transform_module (m : Tir.tir_module) : Tir.tir_module =
-  if Sys.getenv_opt "MARCH_TRMC" = None then m
+  if not !enabled then m
   else begin
     let report = Sys.getenv_opt "MARCH_TRMC_REPORT" <> None in
     let out = List.concat_map (fun fn ->

--- a/lib/tir/trmc.ml
+++ b/lib/tir/trmc.ml
@@ -401,10 +401,19 @@ let crosses_actor_boundary (ty : Tir.ty) : bool =
     Tir_names.is_actor_msg_name name || Tir_names.is_actor_struct_name name
   | _ -> false
 
-(** [Some (f', f_dps)] when [fn] is transformable. *)
-let transform_fn (fn : Tir.fn_def) : (Tir.fn_def * Tir.fn_def) option =
+(** [Some (f', f_dps)] when [fn] is transformable.
+
+    [on_decline] receives the reason whenever the answer is [None] and the
+    function looked transformable to the ANALYSIS.  It exists so the report in
+    [transform_module] can name the specific refusal without re-deriving this
+    ladder — two copies of it would drift, and a skip line that says only
+    "eligible" tells you a gap exists but not which one. *)
+let transform_fn ?(on_decline = fun (_ : string) -> ())
+      (fn : Tir.fn_def) : (Tir.fn_def * Tir.fn_def) option =
   let r = report_of_fn fn.Tir.fn_name fn.Tir.fn_body in
-  if crosses_actor_boundary fn.Tir.fn_ret_ty then None
+  let decline reason = on_decline reason; None in
+  if crosses_actor_boundary fn.Tir.fn_ret_ty then
+    decline "actor-boundary-return"
   else
   match verdict_of r, r.r_modcons with
   | Eligible, [ (_ctor, hole) ] ->
@@ -427,16 +436,31 @@ let transform_fn (fn : Tir.fn_def) : (Tir.fn_def * Tir.fn_def) option =
       { fn with Tir.fn_body = seed_entry ~self:fn.Tir.fn_name ~dps fn.Tir.fn_body }
     in
     Some (entry, helper)
+  | Eligible, sites -> decline (Printf.sprintf "multi-site(%d)" (List.length sites))
+  | Mixed, _ -> decline "mixed"
   | _ -> None
 
 (** Apply TRMC across a module.  Gated on MARCH_TRMC=1. *)
 let transform_module (m : Tir.tir_module) : Tir.tir_module =
   if Sys.getenv_opt "MARCH_TRMC" = None then m
   else begin
+    let report = Sys.getenv_opt "MARCH_TRMC_REPORT" <> None in
     let out = List.concat_map (fun fn ->
-      match transform_fn fn with
+      (* No silent caps: a function the ANALYSIS considers transformable but
+         the TRANSFORM declines is a coverage gap, and it must be visible in
+         the report rather than inferred from a missing TRMCXFORM line.  The
+         reason comes from transform_fn itself so the two cannot drift. *)
+      let on_decline reason =
+        if report then begin
+          let r = report_of_fn fn.Tir.fn_name fn.Tir.fn_body in
+          Printf.eprintf "TRMCSKIP\t%s\t%s\t%s\tmodcons=%d other=%d\n%!"
+            fn.Tir.fn_name reason (string_of_verdict (verdict_of r))
+            (List.length r.r_modcons) r.r_other
+        end
+      in
+      match transform_fn ~on_decline fn with
       | Some (entry, helper) ->
-        if Sys.getenv_opt "MARCH_TRMC_REPORT" <> None then
+        if report then
           Printf.eprintf "TRMCXFORM\t%s -> %s\n%!" fn.Tir.fn_name helper.Tir.fn_name;
         [entry; helper]
       | None -> [fn]

--- a/lib/typecheck/typecheck.ml
+++ b/lib/typecheck/typecheck.ml
@@ -12364,8 +12364,9 @@ let rec check_tail_position
             Err.warning errors ~span:sp
               (Printf.sprintf
                  "Warning: function `%s` is structurally recursive but not \
-                  tail-recursive. This is safe for bounded input but uses \
-                  O(depth) stack space."
+                  tail-recursive. This is safe for bounded input but may use \
+                  O(depth) stack space; when the recursive call is the direct \
+                  argument of a constructor, the compiler turns it into a loop."
                  fn_name)
         end
       end;

--- a/lsp/lib/analysis.ml
+++ b/lsp/lib/analysis.ml
@@ -1618,6 +1618,17 @@ let rec send_copy_check (type_map : (Ast.span, Tc.ty) Hashtbl.t) (e : Ast.expr) 
     send_copy_check type_map e acc
   | _ -> acc
 
+(** The reason string used when a call is blocked by a constructor wrapping it.
+    Constructed here rather than inline because [tco_check]'s advice depends on
+    recognising this case: a constructor-wrapped call is the tail-recursion-
+    modulo-cons shape the compiler turns into a loop, so telling the user to
+    rewrite it with an accumulator would be advice against what the compiler
+    already does — and against how the stdlib producers are written. *)
+let ctor_blocks name = Printf.sprintf "constructor `%s` wraps it" name
+
+let is_ctor_blocked (b : string) =
+  String.length b > 12 && String.sub b 0 12 = "constructor "
+
 (** Walk [e] looking for calls to [fn_name] that are not in tail position.
     [blocking] is [None] when the expression is in tail position, or
     [Some description] when there is pending work after it returns. *)
@@ -1629,9 +1640,15 @@ let rec tco_check (fn_name : string) (blocking : string option) (e : Ast.expr) a
       match blocking with
       | None -> acc   (* tail position — no stack growth *)
       | Some b ->
-        let msg = Printf.sprintf
-          "This recursive call is not in tail position — %s, so the stack grows by one frame per call.\n\nRewrite using an accumulator parameter to move the work before the recursive call."
-          b
+        let msg =
+          if is_ctor_blocked b then
+            Printf.sprintf
+              "This recursive call is not in tail position — %s. The compiler transforms this shape (tail-recursion-modulo-cons): the constructor is allocated first with a hole, and the call fills it, so this compiles to a loop rather than growing the stack. No rewrite needed."
+              b
+          else
+            Printf.sprintf
+              "This recursive call is not in tail position — %s, so the stack grows by one frame per call.\n\nRewrite using an accumulator parameter to move the work before the recursive call."
+              b
         in
         { pi_span    = sp;
           pi_kind    = NonTailCall { pi_fn_name = fn_name; pi_blocking = b };
@@ -1684,7 +1701,7 @@ let rec tco_check (fn_name : string) (blocking : string option) (e : Ast.expr) a
 
   (* Constructor wraps the result — args are not in tail position *)
   | Ast.ECon (name, args, _) ->
-    let b = Printf.sprintf "constructor `%s` wraps it" name.Ast.txt in
+    let b = ctor_blocks name.Ast.txt in
     List.fold_left (fun a arg -> tco_check fn_name (Some b) arg a) acc args
 
   (* Tuple — elements are not in tail position *)

--- a/lsp/test/test_lsp.ml
+++ b/lsp/test/test_lsp.ml
@@ -2815,6 +2815,53 @@ end
   Alcotest.(check bool) "non-tail call inside constructor detected" true
     (has_non_tail_call (perf_insights_of src))
 
+(* A constructor-wrapped recursive call is the tail-recursion-modulo-cons
+   shape the compiler turns into a loop, so telling the user to rewrite it
+   with an accumulator is advice against what the compiler already does — and
+   against how the stdlib producers are written.  The insight is still
+   REPORTED (the stack cost is real when TRMC declines the function); only the
+   advice changes.  The arithmetic case below must keep the old advice, since
+   TRMC can never transform `1 + f(n-1)`. *)
+let test_perf_constructor_wrapped_advice_is_not_accumulator () =
+  let msg_of src =
+    match List.filter (fun (i : An.perf_insight) ->
+            match i.An.pi_kind with An.NonTailCall _ -> true | _ -> false)
+            (perf_insights_of src) with
+    | i :: _ -> i.An.pi_message
+    | [] -> Alcotest.fail "expected a NonTailCall insight"
+  in
+  let has needle m =
+    let n = String.length needle and l = String.length m in
+    let rec go i = i + n <= l && (String.sub m i n = needle || go (i + 1)) in
+    go 0
+  in
+  let ctor = msg_of {|
+mod Test do
+  type Nat = Zero | Succ(Nat)
+  pfn bump(n: Nat): Nat do
+    match n do
+      Zero -> Zero
+      Succ(k) -> Succ(bump(k))
+    end
+  end
+end
+|} in
+  Alcotest.(check bool) "constructor case does not prescribe an accumulator"
+    false (has "accumulator" ctor);
+  Alcotest.(check bool) "constructor case says the compiler loops it"
+    true (has "compiles to a loop" ctor);
+  (* Non-vacuousness: the arithmetic case still gives the old advice, so the
+     assertion above is testing the branch and not an empty message. *)
+  let arith = msg_of {|
+mod Test do
+  pfn sum_helper(n: Int): Int do
+    1 + sum_helper(n - 1)
+  end
+end
+|} in
+  Alcotest.(check bool) "arithmetic case still prescribes an accumulator"
+    true (has "accumulator parameter" arith)
+
 let test_perf_non_tail_produces_warning_diagnostic () =
   let src = {|
 mod Test do
@@ -6891,6 +6938,7 @@ let () =
       "non-tail recursive call detected",         `Quick, test_perf_non_tail_call_detected;
       "tail-recursive call not flagged",          `Quick, test_perf_tail_call_not_flagged;
       "non-tail inside constructor detected",     `Quick, test_perf_non_tail_inside_constructor;
+      "ctor-wrapped advice is not accumulator",   `Quick, test_perf_constructor_wrapped_advice_is_not_accumulator;
       "non-tail produces warning diagnostic",     `Quick, test_perf_non_tail_produces_warning_diagnostic;
       "non-recursive call not flagged",           `Quick, test_perf_non_tail_not_flagged_for_non_recursive;
     ];

--- a/specs/plans/2026-08-10-trmc-on-by-default.md
+++ b/specs/plans/2026-08-10-trmc-on-by-default.md
@@ -812,7 +812,9 @@ git commit -m "stdlib(list): filter/filter_map in natural style; changelog"
 
 **Scope note:** only the *wording* changes here, not the detection. Suppressing the warning entirely would require the typechecker to know TIR-level eligibility, which it does not have — verified: the AST-shaped `Succ(Succ(add_one(k)))` looks transformable but is classified `non-trmc` because of the intervening let. Leave the LSP lint alone; wire it to real eligibility in a separate piece of work.
 
-- [ ] **Step 1: Write the failing test**
+> **UPDATE (2026-08-12): the LSP lint WAS changed, in commit `b64bd3dd`.** Leaving it alone would have had the compiler and the editor give opposite advice on the same line: `lsp/lib/analysis.ml` told the user to rewrite *every* non-tail self-call with an accumulator, including the constructor-wrapped one the typechecker had just stopped flagging that way. `tco_check` already distinguishes the constructor case (it builds a distinct "constructor `X` wraps it" reason string), so the advice could be branched without any TIR-eligibility wiring. The insight is still reported — the stack cost is real whenever TRMC declines the function — and the arithmetic case keeps the old wording.
+
+- [x] **Step 1: Write the failing test**
 
 Add to `test/test_compiler.ml` in the diagnostics section:
 
@@ -846,12 +848,12 @@ This uses the file's existing idiom: `typecheck` (returns an error ctx),
 matching — the same shape as `test_actor_handler_body_io_with_needs_no_warning`
 at `test/test_compiler.ml:3351`. There is no `diagnostics_of` helper.
 
-- [ ] **Step 2: Run it and watch it fail**
+- [x] **Step 2: Run it and watch it fail**
 
 Run: `dune build --root . test/run_compiler.exe && ./_build/default/test/run_compiler.exe test error_improvements`
 Expected: FAIL — the current message says "Consider using an accumulator parameter."
 
-- [ ] **Step 3: Reword the non-arithmetic warning**
+- [x] **Step 3: Reword the non-arithmetic warning**
 
 In `lib/typecheck/typecheck.ml`, the `else` branch at ~12060 currently reads:
 
@@ -878,12 +880,12 @@ Replace the message text with:
 
 Leave the *arithmetic* variant (~12053) unchanged — `1 + f(n-1)` is not constructor-wrapped and TRMC can never transform it, so "use an accumulator" is still correct advice there.
 
-- [ ] **Step 4: Run the test to verify it passes**
+- [x] **Step 4: Run the test to verify it passes**
 
 Run: `./_build/default/test/run_compiler.exe test error_improvements`
 Expected: PASS.
 
-- [ ] **Step 5: Check the conformance corpora**
+- [x] **Step 5: Check the conformance corpora**
 
 The `@types-check` corpus asserts diagnostic **text** and is CI-only. Run it locally:
 
@@ -892,7 +894,7 @@ dune build --root . @types-check 2>&1 | tail -20; echo "EXIT=$?"
 ```
 Expected: EXIT=0. If a fixture pins the old wording, update the fixture's expected output in the same commit.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add lib/typecheck/typecheck.ml test/test_compiler.ml

--- a/specs/plans/2026-08-10-trmc-on-by-default.md
+++ b/specs/plans/2026-08-10-trmc-on-by-default.md
@@ -607,13 +607,13 @@ git commit -m "jit(trmc): run the transform in the REPL pipeline so it matches c
 
 **Files:**
 - Test: `test/test_trmc.ml`
-- Modify: `test/test_codegen.ml`
+- ~~Modify: `test/test_codegen.ml`~~ — not needed: it already ends with `@ Test_trmc.suites`, so a new group in `test_trmc.ml` registers itself.
 
 **Interfaces:**
 - Consumes: `Trmc.enabled` (Task 5), `trmc_hole_module ()` (existing in `test/test_trmc.ml`).
 - Produces: no new API.
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Add to `test/test_trmc.ml` before `let suites = [`:
 
@@ -643,7 +643,7 @@ Register it in a new suite group by adding to `suites`:
   ];
 ```
 
-- [ ] **Step 2: Run it**
+- [x] **Step 2: Run it**
 
 Run: `dune build --root . test/run_codegen.exe && ./_build/default/test/run_codegen.exe test trmc-js`
 Expected: PASS.
@@ -651,7 +651,7 @@ Expected: PASS.
 Signature for reference (`lib/tir/js_emit.ml:1304`):
 `val emit_module : ?source_file:string -> ?fn_lines:(...) list -> Tir.tir_module -> string * string option`
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add test/test_trmc.ml test/test_codegen.ml

--- a/specs/plans/2026-08-10-trmc-on-by-default.md
+++ b/specs/plans/2026-08-10-trmc-on-by-default.md
@@ -664,6 +664,26 @@ git commit -m "test(trmc): cover the JS backend's hole allocation and fill"
 
 **This is the task that makes the default worth flipping.** Today `List.map`/`filter`/`filter_map`/`append`/`flat_map` are accumulator+`reverse` and classify `already-tail`, so TRMC never sees them.
 
+> **ORDERING CORRECTION (2026-08-12): run this task AFTER Task 10, not before.**
+> Natural style is not tail-recursive; it depends on TRMC to become a loop.
+> Measured on a 500k-element list, natural-style `map`:
+>
+> | | result |
+> |---|---|
+> | interpreter | prints `500000` |
+> | compiled `--no-trmc` | **exit 138 — stack overflow** |
+> | compiled `--trmc` | prints `500000` |
+>
+> Landing this while the default is still OFF ships a `List.map` that crashes
+> on long lists for every user who does not pass `--trmc`. The default must
+> already be on. The interpreter is unaffected (it handles 500k fine), so the
+> hazard is specific to the compiled backend.
+>
+> **Consequence to decide before landing:** after this task `--no-trmc` is no
+> longer a safe escape hatch — it will stack-overflow on stdlib `List.map`
+> over a long list. Either drop the flag, or document it as a debugging-only
+> switch that is unsound against the natural-style stdlib.
+
 **Files:**
 - Modify: `stdlib/list.march`
 - Modify: `CHANGELOG.md`

--- a/specs/plans/2026-08-10-trmc-on-by-default.md
+++ b/specs/plans/2026-08-10-trmc-on-by-default.md
@@ -521,7 +521,7 @@ git commit -m "cli(trmc): add --trmc/--no-trmc; MARCH_TRMC stays as a legacy ali
 - Consumes: `Trmc.enabled` and `Trmc.transform_module` from Task 5.
 - Produces: no new API.
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Add to `test/test_trmc.ml` before `let suites = [`:
 
@@ -560,31 +560,39 @@ Register it in the `"trmc"` suite list:
     Alcotest.test_case "transform is idempotent"         `Quick test_transform_is_idempotent_on_a_transformed_module;
 ```
 
-- [ ] **Step 2: Run it**
+- [x] **Step 2: Run it**
 
 Run: `dune build --root . test/run_codegen.exe && ./_build/default/test/run_codegen.exe test trmc`
 Expected: PASS. If the second assertion fails with 3 instead of 2, the transform is not idempotent — it re-transformed its own helper. Fix that before wiring the second call site in Step 3, because `repl_jit` re-lowers modules the driver has already transformed.
 
-- [ ] **Step 3: Wire the transform into the REPL/JIT pipeline**
+- [x] **Step 3: Wire the transform into the REPL/JIT pipeline**
 
-In `lib/jit/repl_jit.ml`, immediately before line 313's `let tir = March_tir.Perceus.perceus ~repl:true ~repl_vars tir in`, insert:
+In `lib/jit/repl_jit.ml`, in `lower_module`, insert immediately **after** the `Lower.lower_module` call:
 
 ```ocaml
-  (* Match the compiled pipeline: bin/main.ml runs Trmc.transform_module
-     post-lower, and without it a function behaves differently in the REPL than
-     when compiled.  Gated by the same Trmc.enabled ref. *)
   let tir = March_tir.Trmc.transform_module tir in
 ```
 
-- [ ] **Step 4: Verify the REPL still works**
+**The position is as load-bearing as the call.** An earlier draft of this step put it just before the `Perceus.perceus` call, which is *post-defun* — and measured on a real REPL session that placement transforms **5** functions where post-lower transforms **10**. By defun the stdlib's nested `go` helpers are closures invoked via `ECallPtr`, so self-recursion is no longer syntactically visible (`lib/tir/trmc.ml`'s header says exactly this). Halving REPL coverage relative to compiled is the opposite of the parity this task exists to establish. `lower_module` is the only lowering entry point in `lib/jit/`, so one call site covers `run_expr`, `run_decl`, and `precompile_stdlib`.
+
+- [x] **Step 4: Verify the REPL still works**
+
+A build is not parity — prove the three paths agree on a genuinely eligible function. Write a fixture with a natural-style producer (`dup(xs) = match xs do Cons(h,t) -> Cons(h*2, dup(t)) ; Nil -> Nil end`) and run all three:
 
 ```bash
-dune build --root . 2>&1 | grep -E "Error" -A 3 | head
+dune build --root . bin/main.exe test/run_codegen.exe   # never a targetless dune build — it wedges
+F=/tmp/trmc_parity_78111d.march
+./_build/default/bin/main.exe $F                                             # interpreter = reference
+./_build/default/bin/main.exe --compile --opt 2 --trmc -o /tmp/p_78111d $F && /tmp/p_78111d
+printf '<decls>\n<exprs>\n:quit\n' | MARCH_TRMC_REPORT=1 ./_build/default/bin/main.exe --trmc
 scripts/run-tests.sh -q
 ```
-Expected: build clean, `All suites passed.`
 
-- [ ] **Step 5: Commit**
+`march` with no file argument enters the JIT REPL and accepts piped stdin, so this path is drivable non-interactively. Expected: identical output from all three, equal `TRMCXFORM` counts between the REPL and compiled runs, and `All suites passed.` Control: `--no-trmc` in the REPL must give **zero** `TRMCXFORM` lines, or the report is firing unconditionally and proves nothing.
+
+If the REPL run dies with `Library not loaded: …libmarch_runtime_….so.NNN.tmp`, that is the known shared `~/.cache/march` poisoning from a concurrent session, not this change — rerun under an isolated `HOME`.
+
+- [x] **Step 5: Commit**
 
 ```bash
 git add lib/jit/repl_jit.ml test/test_trmc.ml

--- a/specs/plans/2026-08-10-trmc-on-by-default.md
+++ b/specs/plans/2026-08-10-trmc-on-by-default.md
@@ -61,7 +61,7 @@ Gives the feature real memory-safety evidence, using the gate that already works
 - Consumes: nothing from earlier tasks.
 - Produces: a CI job leg that runs all 46 goldens under ASAN with TRMC active. Later tasks rely on this being green before the default flips.
 
-- [ ] **Step 1: Make the sweep label its mode**
+- [x] **Step 1: Make the sweep label its mode**
 
 In `specs/lang/golden/sanitize.sh`, after the `export ASAN_OPTIONS=...` line, add:
 
@@ -85,12 +85,12 @@ to:
 echo "=== golden sanitize ($mode_label): $pass clean, $fail failed ==="
 ```
 
-- [ ] **Step 2: Verify the script still runs and skips cleanly on macOS**
+- [x] **Step 2: Verify the script still runs and skips cleanly on macOS**
 
 Run: `MARCH_BIN="$PWD/_build/default/bin/main.exe" ./specs/lang/golden/sanitize.sh; echo "EXIT=$?"`
 Expected: the Falcon SKIP message and `EXIT=0`. (This machine cannot run the real sweep — that is what CI is for.)
 
-- [ ] **Step 3: Add the TRMC leg to CI**
+- [x] **Step 3: Add the TRMC leg to CI**
 
 In `.github/workflows/ci.yml`, inside the `sanitize-gate` job, after the existing "Golden corpus AddressSanitizer gate" step, add:
 
@@ -105,7 +105,7 @@ In `.github/workflows/ci.yml`, inside the `sanitize-gate` job, after the existin
 
 Bump the job's `timeout-minutes: 25` to `40` on the line above `steps:` — the job now does two full sweeps.
 
-- [ ] **Step 4: Add a TRMC-on test leg**
+- [x] **Step 4: Add a TRMC-on test leg**
 
 Until Task 10 flips the default, nothing in CI runs the *suite* with TRMC
 active — only this ASAN gate would. Add a second step to the same job so
@@ -121,14 +121,14 @@ regressions in the transform are caught by the normal tests too:
 
 Remove this step in Task 10, when the default makes it redundant.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add specs/lang/golden/sanitize.sh .github/workflows/ci.yml
 git commit -m "ci(trmc): run the golden ASAN gate and the test suite with TRMC enabled"
 ```
 
-- [ ] **Step 6: Push and confirm the gate is green in CI**
+- [x] **Step 6: Push and confirm the gate is green in CI**
 
 Push the branch and open a draft PR. Wait for `sanitize-gate` to finish. Expected: both legs report `46 clean, 0 failed`.
 
@@ -148,7 +148,7 @@ The existing benchmarks do not isolate the cost TRMC targets.
 - Consumes: nothing.
 - Produces: `bench/list_producers.march`, referenced by Task 8's before/after comparison.
 
-- [ ] **Step 1: Write the benchmark**
+- [x] **Step 1: Write the benchmark**
 
 Create `bench/list_producers.march`:
 
@@ -174,7 +174,7 @@ mod ListProducers do
 end
 ```
 
-- [ ] **Step 2: Compile and record the baseline**
+- [x] **Step 2: Compile and record the baseline**
 
 ```bash
 dune build --root . bin/main.exe
@@ -185,7 +185,7 @@ for i in 1 2 3; do /usr/bin/time -p /tmp/lp_base_78111d >/dev/null; done
 
 Expected: prints `239988000`. Record the three `real` values; the FIRST timed run pays ~25% warmup, so use runs 2 and 3.
 
-- [ ] **Step 3: Record the TRMC number on the existing FBIP/HOF/alloc benchmarks**
+- [x] **Step 3: Record the TRMC number on the existing FBIP/HOF/alloc benchmarks**
 
 ```bash
 rm -rf .march/cas/artifacts-v2
@@ -201,7 +201,7 @@ Expected: no variant is slower with TRMC on by more than run-to-run noise. `tree
 
 **If any benchmark regresses:** record which, and stop. A regression here means the transform is firing somewhere it should not; fix before continuing.
 
-- [ ] **Step 4: Document the benchmark**
+- [x] **Step 4: Document the benchmark**
 
 Add to `specs/benchmarks.md`, in the mapping table, a row:
 
@@ -209,7 +209,7 @@ Add to `specs/benchmarks.md`, in the mapping table, a row:
 | `bench/list_producers.march` | TRMC / list-producer traversal count | `lib/tir/trmc.ml`, `lib/tir/perceus_fbip.ml` |
 ```
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add bench/list_producers.march specs/benchmarks.md
@@ -232,7 +232,7 @@ git commit -m "bench: add list_producers, isolating list-producer traversal cost
 
 **Why this is needed even though the RC check is atomic:** the reuse path loads the refcount atomically and falls back to a fresh allocation when shared, but `ESetField` writes the hole with a **plain, non-atomic store**. That is safe only while the cell is unreachable from another thread. For a value that can cross an actor boundary that is not guaranteed, and `Repr.is_actor_struct_type` already exists precisely because a name-based guess here was found to false-positive on a user type called `Tree_Actor`.
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Add to `test/test_trmc.ml`, before the `let suites = [` block:
 
@@ -262,12 +262,12 @@ Register it by adding to the `"trmc"` list in `suites`:
     Alcotest.test_case "actor msg type refused"          `Quick test_actor_msg_type_is_refused;
 ```
 
-- [ ] **Step 2: Run it and watch it fail**
+- [x] **Step 2: Run it and watch it fail**
 
 Run: `dune build --root . test/run_codegen.exe && ./_build/default/test/run_codegen.exe test trmc`
 Expected: FAIL on "actor msg type refused" — the transform currently accepts it.
 
-- [ ] **Step 3: Implement the refusal**
+- [x] **Step 3: Implement the refusal**
 
 In `lib/tir/trmc.ml`, in `transform_fn`, replace the match scrutinee guard. Change:
 
@@ -300,12 +300,12 @@ let transform_fn (fn : Tir.fn_def) : (Tir.fn_def * Tir.fn_def) option =
   | Eligible, [ (_ctor, hole) ] ->
 ```
 
-- [ ] **Step 4: Run the test to verify it passes**
+- [x] **Step 4: Run the test to verify it passes**
 
 Run: `dune build --root . test/run_codegen.exe && ./_build/default/test/run_codegen.exe test trmc`
 Expected: all `trmc` cases PASS, including the new one.
 
-- [ ] **Step 5: Confirm the guard is not over-broad**
+- [x] **Step 5: Confirm the guard is not over-broad**
 
 The transform count is PROGRAM-DEPENDENT — it reflects that program's stdlib
 link closure — so the "19" from the Phase 1 report (a different corpus) is NOT
@@ -332,7 +332,7 @@ guard blocks nothing that was previously transformed. If the guarded count is
 lower, the guard IS over-broad — diff the `TRMCXFORM` lines between the two
 runs to see which functions it swallowed.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add lib/tir/trmc.ml test/test_trmc.ml
@@ -352,7 +352,7 @@ Right now `transform_fn` silently declines `mixed`, multi-site, and intervening-
 - Consumes: `Trmc.transform_fn` from Task 3.
 - Produces: unchanged signatures. `MARCH_TRMC_REPORT=1` now emits a `TRMCSKIP` line per declined-but-eligible-looking function.
 
-- [ ] **Step 1: Emit skip reasons**
+- [x] **Step 1: Emit skip reasons**
 
 In `lib/tir/trmc.ml`, in `transform_module`, replace the `| None -> [fn]` arm:
 
@@ -379,7 +379,7 @@ with:
         [fn]
 ```
 
-- [ ] **Step 2: Verify the skip lines appear**
+- [x] **Step 2: Verify the skip lines appear**
 
 ```bash
 dune build --root . bin/main.exe
@@ -390,7 +390,7 @@ MARCH_TRMC=1 MARCH_TRMC_REPORT=1 ./_build/default/bin/main.exe --compile --opt 2
 
 Expected: at least one line, for `OrderedMap.tree_map` (verdict `mixed`, which `transform_fn` declines).
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add lib/tir/trmc.ml
@@ -411,7 +411,7 @@ Env vars are undiscoverable and neither `forge` nor CI will set one. This also m
 - Consumes: `Trmc.transform_module : Tir.tir_module -> Tir.tir_module` (existing).
 - Produces: `Trmc.enabled : bool ref` (default `false`), read by `transform_module` instead of `Sys.getenv_opt`. `bin/main.ml` sets it from `--trmc` / `--no-trmc`.
 
-- [ ] **Step 1: Add the ref and switch the gate**
+- [x] **Step 1: Add the ref and switch the gate**
 
 In `lib/tir/trmc.ml`, immediately above `let transform_module`, add:
 
@@ -435,7 +435,7 @@ to:
   if not !enabled then m
 ```
 
-- [ ] **Step 2: Add the CLI flags**
+- [x] **Step 2: Add the CLI flags**
 
 In `bin/main.ml`, find the argument-parsing list and add two entries alongside the other codegen flags:
 
@@ -454,7 +454,7 @@ Then, immediately after argument parsing completes and before the pipeline runs,
   if Sys.getenv_opt "MARCH_TRMC" <> None then March_tir.Trmc.enabled := true;
 ```
 
-- [ ] **Step 3: Update the CAS tag to follow the ref**
+- [x] **Step 3: Update the CAS tag to follow the ref**
 
 In `bin/main.ml`, `codegen_cas_tags ()` currently reads the env var. Change:
 
@@ -470,25 +470,37 @@ to:
 
 **This ordering matters:** `codegen_cas_tags ()` must be called *after* argument parsing sets the ref. Verify by inspection that every `cas_flags` construction site (`bin/main.ml`, two sites) runs after `Arg.parse`.
 
-- [ ] **Step 4: Verify both spellings work and stay CAS-distinct**
+- [x] **Step 4: Verify both spellings work and stay CAS-distinct**
+
+**Do NOT check this with timings.** Until Task 8 rewrites the stdlib producers, the hot path of `bench/list_producers.march` is `List.map`, whose inner `go` is `already-tail` — TRMC has nothing to bite on, so the two modes are legitimately the same speed. A timing A/B here cannot distinguish "the flag works" from "the CAS served one binary twice", which is exactly the failure this step exists to catch.
+
+**Do NOT check it with `cmp` either.** On macOS every fresh link gets a random `LC_UUID`, so two binaries differ at ~char 1609 regardless of the flag.
+
+Check the **CAS key** directly — it is the thing under test:
 
 ```bash
 dune build --root . bin/main.exe
 rm -rf .march/cas/artifacts-v2
-./_build/default/bin/main.exe --compile --opt 2 --trmc -o /tmp/t_flag_78111d bench/list_producers.march
-./_build/default/bin/main.exe --compile --opt 2        -o /tmp/t_off_78111d  bench/list_producers.march
-for i in 1 2; do /usr/bin/time -p /tmp/t_flag_78111d >/dev/null; done
-for i in 1 2; do /usr/bin/time -p /tmp/t_off_78111d  >/dev/null; done
+n() { ls .march/cas/artifacts-v2 2>/dev/null | wc -l; }
+M=./_build/default/bin/main.exe; B=bench/list_producers.march
+echo "start $(n)"
+$M --compile --opt 2 --trmc -o /tmp/t_a_78111d $B; echo "trmc      $(n)"
+$M --compile --opt 2 --trmc -o /tmp/t_a2_78111d $B; echo "trmc again $(n)   # must not grow: cache HIT"
+$M --compile --opt 2        -o /tmp/t_b_78111d $B; echo "off       $(n)   # must grow: different key"
+MARCH_TRMC=1 $M --compile --opt 2 --no-trmc -o /tmp/t_c_78111d $B; echo "env+--no-trmc $(n)   # must not grow: OFF key"
+MARCH_TRMC=1 $M --compile --opt 2           -o /tmp/t_d_78111d $B; echo "env only  $(n)   # must not grow: ON key"
+cmp -s /tmp/t_b_78111d /tmp/t_c_78111d && echo "OK: --no-trmc beats the env var"
+cmp -s /tmp/t_a_78111d /tmp/t_d_78111d && echo "OK: MARCH_TRMC=1 == --trmc"
 ```
 
-Expected: the `--trmc` binary is markedly faster. If they are identical, the CAS tag is not following the flag — re-check Step 3's ordering.
+Expected: entry count `0 → 2 → 2 → 4 → 4 → 4`, and both `OK:` lines. (Cache-*served* binaries are byte-identical, so `cmp` is valid on those — just not on two fresh links.) If the count stays at 2 through the `off` build, the CAS tag is not following the flag — re-check Step 3's ordering.
 
-- [ ] **Step 5: Full suite**
+- [x] **Step 5: Full suite**
 
 Run: `scripts/run-tests.sh`
 Expected: `All suites passed.`
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add bin/main.ml lib/tir/trmc.ml

--- a/test/test_compiler.ml
+++ b/test/test_compiler.ml
@@ -3376,6 +3376,36 @@ let test_actor_handler_body_io_with_needs_no_warning () =
     "actor handler body IO with needs declared: no missing-needs warning"
     false has_warning
 
+(* TRMC (Task 9): constructor-wrapped structural recursion — `Succ(bump(k))` —
+   is compiled into a loop by TRMC, so the warning must NOT prescribe an
+   accumulator parameter, and must say the compiler handles this shape.
+   The detection itself is unchanged: the warning still fires (the typechecker
+   has no TIR-level eligibility information), only the wording moved. *)
+let test_structural_recursion_warning_does_not_prescribe_accumulator () =
+  let ctx = typecheck {|mod W do
+  type Nat = Zero | Succ(Nat)
+  fn bump(n : Nat) : Nat do
+    match n do
+    Zero    -> Zero
+    Succ(k) -> Succ(bump(k))
+    end
+  end
+end|} in
+  let diags = March_errors.Errors.sorted ctx in
+  let mentions sub =
+    List.exists (fun d ->
+      let m = d.March_errors.Errors.message in
+      (try ignore (Str.search_forward (Str.regexp_string sub) m 0); true
+       with Not_found -> false)
+    ) diags
+  in
+  Alcotest.(check bool)
+    "constructor-wrapped recursion is not told to use an accumulator"
+    false (mentions "accumulator parameter");
+  Alcotest.(check bool)
+    "constructor-wrapped recursion is told the compiler loops it"
+    true (mentions "turns it into a loop")
+
 (* ── Cap(IO.NetListen) body-scan enforcement (item 1380) ─────────────────
    tcp_listen / tcp_accept / http_server_listen are classified IO.NetListen in
    builtin_cap_table (typecheck.ml).  A module whose body calls one without
@@ -13847,6 +13877,7 @@ let compiler_suites =
           Alcotest.test_case "negative param: x < 0 → r < 0, r <= -1"      `Quick test_return_infer_negative_param;
         ] );
       ( "error_improvements", [
+          Alcotest.test_case "structural recursion warning: no accumulator advice" `Quick test_structural_recursion_warning_does_not_prescribe_accumulator;
           Alcotest.test_case "#1 label rendered in render_diagnostic"       `Quick test_label_rendered_in_output;
           Alcotest.test_case "#2 if-branch type mismatch has label"         `Quick test_if_branch_mismatch_has_label;
           Alcotest.test_case "#2 match-arm type mismatch has label"         `Quick test_match_arm_mismatch_has_label;

--- a/test/test_trmc.ml
+++ b/test/test_trmc.ml
@@ -367,6 +367,33 @@ let test_actor_msg_type_is_refused () =
   Alcotest.(check bool) "actor message type is not transformed"
     true (Trmc.transform_fn fd = None)
 
+(* REPL/JIT must apply the same transform as the compiled path, or a function
+   behaves one way in the REPL and another when compiled.  repl_jit may re-lower
+   a module the driver already transformed, so the transform has to be
+   idempotent — running it twice must not produce a second $dps helper.
+
+   The fixture uses a genuinely ELIGIBLE function: on an empty module both
+   sides are trivially zero and the assertion holds no matter how broken the
+   transform is. *)
+let test_transform_is_idempotent_on_a_transformed_module () =
+  let self = v "f" (Tir.TFn ([list_int], list_int)) in
+  let t = v "t" list_int and h = v "h" Tir.TInt in
+  let body =
+    Tir.ELet (t, Tir.EApp (self, [Tir.AVar (v "xs" list_int)]),
+              Tir.EAlloc (Tir.TCon ("List.Cons", []),
+                          [Tir.AVar h; Tir.AVar t]))
+  in
+  let m = module_of [fn "f" [v "xs" list_int] body] in
+  Trmc.enabled := true;
+  let once = Trmc.transform_module m in
+  let twice = Trmc.transform_module once in
+  Trmc.enabled := false;
+  (* Non-vacuousness: the first pass must actually have added the helper. *)
+  Alcotest.(check int) "first transform adds the $dps helper"
+    2 (List.length once.Tir.tm_fns);
+  Alcotest.(check int) "transforming twice adds nothing further"
+    (List.length once.Tir.tm_fns) (List.length twice.Tir.tm_fns)
+
 let suites = [
   "trmc", [
     Alcotest.test_case "modulo-cons is eligible"        `Quick test_modulo_cons_eligible;
@@ -377,6 +404,7 @@ let suites = [
     Alcotest.test_case "normal nested fn is not a jp"   `Quick test_normal_nested_fn_is_not_a_join_point;
     Alcotest.test_case "intervening use blocks hole"    `Quick test_intervening_let_blocks_when_used;
     Alcotest.test_case "actor msg type refused"          `Quick test_actor_msg_type_is_refused;
+    Alcotest.test_case "transform is idempotent"         `Quick test_transform_is_idempotent_on_a_transformed_module;
   ];
   "trmc-ir", [
     Alcotest.test_case "alloc-hole emits verifiable IR"  `Quick test_alloc_hole_emits_verifiable_ir;

--- a/test/test_trmc.ml
+++ b/test/test_trmc.ml
@@ -394,6 +394,92 @@ let test_transform_is_idempotent_on_a_transformed_module () =
   Alcotest.(check int) "transforming twice adds nothing further"
     (List.length once.Tir.tm_fns) (List.length twice.Tir.tm_fns)
 
+(* ── Phase 2: the JS backend ─────────────────────────────────────────────────
+   [Js_emit.emit_tagged_alloc_hole] and the [ESetField] arm had no coverage at
+   all: every other TRMC test goes through Llvm_emit.  JS has no
+   uninitialized-memory hazard to mirror, so a hole is simply a field holding
+   [null] until the fill overwrites it — which means the JS backend can be
+   gated the strong way, by RUNNING the emitted program. *)
+
+let js_of_hole_module () =
+  let (js, _srcmap) = March_tir.Js_emit.emit_module (trmc_hole_module ()) in
+  js
+
+let contains hay sub =
+  let n = String.length sub and m = String.length hay in
+  let rec go i = i + n <= m && (String.sub hay i n = sub || go (i + 1)) in
+  go 0
+
+(* Shape, not just spelling: the allocation must emit the FILLED field and
+   leave the hole as [null], and the fill must be an in-place property write on
+   that same object, sequenced with [undefined] so its value is unit (a bare
+   assignment expression would evaluate to the stored value and silently change
+   the meaning of an ESetField in value position). *)
+let test_js_emits_hole_and_fill () =
+  let js = js_of_hole_module () in
+  Alcotest.(check bool)
+    "allocation fills field 0 and leaves the hole null" true
+    (contains js "{ $: \"Cons\", _0: 42, _1: null }");
+  Alcotest.(check bool)
+    "the fill is a property write sequenced to undefined" true
+    (contains js "(c._1 = n, undefined)")
+
+(* Executing the emitted module proves what a substring cannot: that the hole
+   is allocated, filled, and read back — main() prints the 42 stored in field 0
+   of the cell whose field 1 was a hole.  Skipped (rather than failed) when
+   node or the JS runtime shim is unavailable, exactly as the LLVM tests above
+   skip on a missing verifier; the substring test runs unconditionally, so the
+   JS emission is never left with zero coverage. *)
+let find_js_runtime () =
+  List.find_opt Sys.file_exists
+    [ "runtime/march_runtime.mjs";
+      "../runtime/march_runtime.mjs";
+      "../../runtime/march_runtime.mjs";
+      "../../../runtime/march_runtime.mjs" ]
+
+let copy_file src dst =
+  let ic = open_in_bin src in
+  let n = in_channel_length ic in
+  let buf = really_input_string ic n in
+  close_in ic;
+  let oc = open_out_bin dst in
+  output_string oc buf; close_out oc
+
+let test_js_hole_program_runs_under_node () =
+  let have_node = Sys.command "command -v node > /dev/null 2>&1" = 0 in
+  match (have_node, find_js_runtime ()) with
+  | (false, _) | (_, None) ->
+    (* Announce the skip.  A silent [()] here reports GREEN for a test that
+       never ran, which is how a JS-backend regression would reach main
+       unnoticed on a node-less runner. *)
+    Printf.eprintf
+      "[trmc-js] SKIP: node=%b runtime_shim=%b — hole execution NOT verified\n%!"
+      have_node (find_js_runtime () <> None)
+  | (true, Some runtime) ->
+    let dir = Filename.temp_file "march_trmc_js" "" in
+    Sys.remove dir; Unix.mkdir dir 0o700;
+    let prog = Filename.concat dir "hole.mjs" in
+    let out = Filename.concat dir "out.txt" in
+    let oc = open_out prog in
+    output_string oc (js_of_hole_module ()); close_out oc;
+    copy_file runtime (Filename.concat dir "march_runtime.mjs");
+    let rc =
+      Sys.command (Printf.sprintf "node %s > %s 2>&1"
+                     (Filename.quote prog) (Filename.quote out))
+    in
+    let stdout_txt =
+      let ic = open_in out in
+      let n = in_channel_length ic in
+      let s = really_input_string ic n in
+      close_in ic; s
+    in
+    List.iter Sys.remove [prog; out; Filename.concat dir "march_runtime.mjs"];
+    Unix.rmdir dir;
+    if rc <> 0 then
+      Alcotest.failf "emitted JS failed to run (exit %d):\n%s" rc stdout_txt;
+    Alcotest.(check string) "the filled hole is read back and printed"
+      "42" (String.trim stdout_txt)
+
 let suites = [
   "trmc", [
     Alcotest.test_case "modulo-cons is eligible"        `Quick test_modulo_cons_eligible;
@@ -414,5 +500,9 @@ let suites = [
     Alcotest.test_case "nodes survive the pass pipeline"  `Quick test_nodes_survive_pass_pipeline;
     Alcotest.test_case "post-pipeline IR verifies"        `Quick test_pipeline_output_still_verifies;
     Alcotest.test_case "ESetField is an ownership move"   `Quick test_setfield_is_an_ownership_move;
+  ];
+  "trmc-js", [
+    Alcotest.test_case "js emits hole and fill"           `Quick test_js_emits_hole_and_fill;
+    Alcotest.test_case "emitted js runs under node"       `Quick test_js_hole_program_runs_under_node;
   ]
 ]


### PR DESCRIPTION
Continues the TRMC work from #243. Plan: `specs/plans/2026-08-10-trmc-on-by-default.md`.

### What's here (Tasks 4–9)

- **Task 4** — `transform_fn` now reports *why* it declined a function (`actor-boundary-return`, `multi-site(n)`, `mixed`) via a `TRMCSKIP` line under `MARCH_TRMC_REPORT=1`. A default-on optimisation must not hide its own coverage. The reason comes from the refusal ladder itself, so it can't drift.
- **Task 5** — real `--trmc` / `--no-trmc` flags backed by a `Trmc.enabled : bool ref`; `MARCH_TRMC=1` still works as a legacy *default* (seeded before `Arg.parse`, so an explicit flag wins either way). Added to `codegen_cas_tags ()`.
- **Task 6** — the REPL/JIT pipeline now runs the transform, so a function behaves the same in the REPL as compiled.
- **Task 7** — first-ever coverage for the JS backend's hole allocation and fill, including executing the emitted module under node.
- **Task 9** — the structural-recursion warning no longer prescribes an accumulator for constructor-wrapped recursion, in **both** the typechecker and the LSP's `perf/non-tail-call`.

Task 8 (stdlib rewrite) and Task 10 (flip the default) are deliberately **not** here — see below.

### Three plan bugs found by implementing it

Each was caught by a measurement, and each is now corrected in the plan file itself:

1. **Task 6's insertion point was wrong.** The plan said to insert the transform just before `Perceus.perceus`, which is *post-defun*. Measured on a real REPL session, that placement transforms **5** functions where post-lower transforms **10** — by defun the stdlib's nested `go` helpers are `ECallPtr` closures and self-recursion is no longer syntactically visible. It would have given the REPL half the coverage of the compiled path, which is the opposite of the parity the task exists to establish.

2. **Task 5's verification could not work.** It asserted `--trmc` would be "markedly faster" on `bench/list_producers.march` — but until Task 8 rewrites the stdlib, `List.map`'s inner `go` is `already-tail` and TRMC has nothing to transform there, so equal timings are correct and would have been misread as a CAS failure. And `cmp` on two fresh binaries is vacuous on macOS: every link gets a random `LC_UUID`. The check is now on the **CAS entry count**, which reads the key directly.

3. **Task 9's test would have passed before the fix.** The message it asserted against never contained "accumulator parameter" — only the *arithmetic* variant does. A second assertion was added so the test actually characterises the change; the observed pre-fix failure is in the task report.

### Task 8 must run after Task 10, not before — measured

Natural style is not tail-recursive; it depends on TRMC to become a loop. On a 500k-element list:

| natural-style `map` | result |
|---|---|
| interpreter | prints `500000` |
| compiled `--no-trmc` | **exit 138 — stack overflow** |
| compiled `--trmc` | prints `500000` |

Rewriting the stdlib producers while the default is still off would ship a `List.map` that crashes on long lists for anyone not passing `--trmc`. The plan has been reordered.

**This raises a question worth deciding before Task 8 lands:** afterwards `--no-trmc` is no longer a safe escape hatch — it will stack-overflow on stdlib `List.map` over a long list. Either the flag goes, or it gets documented as debugging-only and unsound against the natural-style stdlib.

### Beyond the plan

- The LSP lint was **not** left alone as the plan's scope note said. `perf/non-tail-call` told users to rewrite *every* non-tail self-call with an accumulator, including the constructor-wrapped shape the typechecker had just stopped flagging that way — the compiler and the editor would have given opposite advice on the same line. It needed no TIR-eligibility wiring: `tco_check` already builds a distinct reason string for the constructor case. The insight is still reported (the stack cost is real whenever TRMC declines the function) and the arithmetic case keeps the old wording, which a non-vacuousness assertion pins.
- Task 7's node test **announces its skip** on a box without node. A silent skip reports green for a test that never ran.

### Testing

Full suite green; `@types-check` (282 passed) and `@grammar-check` (46 passed) both clean — that corpus asserts diagnostic *text* and is CI-only, so it was the real risk in Task 9. LSP suite 351 tests green.
