### PR TITLE
fix(http): event-loop server hung on request bodies over 64KB

### DIFF
--- a/runtime/march_http_io.c
+++ b/runtime/march_http_io.c
@@ -29,35 +29,66 @@ int march_set_nonblocking(int fd) {
 /* ── Non-blocking recv ────────────────────────────────────────────────── */
 
 io_result_t march_recv_nonblocking(conn_state_t *c) {
-    /* Read as much as the buffer can hold. */
-    size_t space = CONN_READ_BUF_SIZE - c->rbuf_len;
-    if (space == 0) {
-        /* Buffer full — if we still can't parse, the request is too large. */
-        return IO_ERROR;
+    /* Drain until EAGAIN, growing the buffer as needed.
+     *
+     * Both halves matter, and the event loop is edge-triggered (EPOLLET /
+     * EV_CLEAR):
+     *
+     *   - Draining: with edge triggering the kernel reports readability only
+     *     on a transition. Stopping while data remains means no further event
+     *     is delivered for it.
+     *   - Growing: the buffer used to be a fixed 64 KB inline array. A request
+     *     whose body exceeded that filled it, failed to parse, and returned
+     *     IO_PARTIAL — after which handle_read waited for an event that could
+     *     never arrive. The connection hung until the client or proxy gave up,
+     *     with nothing logged, because the request was never dispatched. Any
+     *     upload over 64 KB was affected.
+     *
+     * Only a request past CONN_READ_BUF_MAX is refused, which is where the
+     * thread-pool server draws the line too. */
+    for (;;) {
+        if (c->rbuf_len == c->rbuf_cap) {
+            if (c->rbuf_cap >= CONN_READ_BUF_MAX)
+                return IO_ERROR;                  /* genuinely too large */
+            size_t ncap = c->rbuf_cap ? c->rbuf_cap * 2 : CONN_READ_BUF_SIZE;
+            if (ncap > CONN_READ_BUF_MAX) ncap = CONN_READ_BUF_MAX;
+            char *nbuf = (char *)realloc(c->rbuf, ncap);
+            if (!nbuf) return IO_ERROR;
+            c->rbuf     = nbuf;
+            c->rbuf_cap = ncap;
+        }
+
+        ssize_t n = recv(c->fd, c->rbuf + c->rbuf_len,
+                         c->rbuf_cap - c->rbuf_len, 0);
+        if (n < 0) {
+            if (errno == EINTR) continue;
+            if (errno == EAGAIN || errno == EWOULDBLOCK) break;  /* drained */
+            return IO_ERROR;
+        }
+        if (n == 0)
+            return IO_ERROR;   /* peer closed */
+
+        c->rbuf_len += (size_t)n;
+
+        /* A complete request may be available already; dispatch it without
+         * waiting for the socket to run dry. A request whose body is still
+         * arriving does not parse, so this keeps draining for those. */
+        march_http_request_t probe;
+        size_t consumed = 0;
+        if (march_http_parse_pipelined(c->rbuf, c->rbuf_len,
+                                       &probe, 1, &consumed) > 0)
+            return IO_COMPLETE;
     }
 
-    ssize_t n = recv(c->fd, c->rbuf + c->rbuf_len, space, 0);
-    if (n < 0) {
-        if (errno == EAGAIN || errno == EWOULDBLOCK)
-            return IO_PARTIAL;
-        return IO_ERROR;
+    /* Socket drained. One last parse: the final recv may have completed a
+     * request exactly as the buffer ran dry. */
+    if (c->rbuf_len > 0) {
+        march_http_request_t probe;
+        size_t consumed = 0;
+        if (march_http_parse_pipelined(c->rbuf, c->rbuf_len,
+                                       &probe, 1, &consumed) > 0)
+            return IO_COMPLETE;
     }
-    if (n == 0)
-        return IO_ERROR;   /* peer closed */
-
-    c->rbuf_len += (size_t)n;
-
-    /* Check if we have at least one complete HTTP request by attempting
-     * to parse.  We use the SIMD parser in "probe" mode — parse one
-     * request to see if the headers are complete. */
-    march_http_request_t probe;
-    size_t consumed = 0;
-    int nr = march_http_parse_pipelined(c->rbuf, c->rbuf_len,
-                                         &probe, 1, &consumed);
-    if (nr > 0)
-        return IO_COMPLETE;
-
-    /* Incomplete — need more data. */
     return IO_PARTIAL;
 }
 
@@ -100,14 +131,22 @@ static _Thread_local conn_state_t *tl_free_list = NULL;
 
 conn_state_t *conn_state_alloc(void) {
     conn_state_t *c = tl_free_list;
+    char  *keep_buf = NULL;
+    size_t keep_cap = 0;
     if (c) {
         tl_free_list = c->next_free;
+        /* Carry the read buffer across reuse — the memset below would
+         * otherwise drop the pointer and leak it, and a connection that has
+         * already grown its buffer should not have to grow it again. */
+        keep_buf = c->rbuf;
+        keep_cap = c->rbuf_cap;
     } else {
         c = (conn_state_t *)malloc(sizeof(conn_state_t));
         if (!c) return NULL;
     }
-    /* Zero everything except the free-list pointer is irrelevant. */
     memset(c, 0, sizeof(conn_state_t));
+    c->rbuf     = keep_buf;
+    c->rbuf_cap = keep_cap;
     return c;
 }
 

--- a/runtime/march_http_io.h
+++ b/runtime/march_http_io.h
@@ -34,9 +34,14 @@ typedef enum {
 
 /* ── Per-connection read buffer ───────────────────────────────────────── */
 
-/* Size of the inline read buffer per connection.  64 KB is enough for many
- * pipelined GET requests in a single recv() call. */
+/* Initial per-connection read buffer.  64 KB is enough for many pipelined GET
+ * requests in a single recv() call; it GROWS on demand (doubling) for requests
+ * with larger bodies — see march_recv_nonblocking. */
 #define CONN_READ_BUF_SIZE (64 * 1024)
+
+/* Hard ceiling on one buffered request.  Matches MAX_REQ_SIZE in march_http.c
+ * so the two servers refuse the same things. */
+#define CONN_READ_BUF_MAX  (32 * 1024 * 1024)
 
 /* ── Per-connection state ─────────────────────────────────────────────── */
 
@@ -50,7 +55,13 @@ struct conn_state {
     int           keep_alive;
 
     /* ── Read state ─────────────────────────────────────────────────── */
-    char          rbuf[CONN_READ_BUF_SIZE];
+    /* Heap-allocated and grown on demand, NOT inline: the event loop is
+     * edge-triggered, so a full buffer that cannot be grown is a permanent
+     * stall — no further readable event is delivered for data already sitting
+     * in the socket, and the connection hangs until the peer gives up.
+     * Retained across free-list reuse so a busy connection allocates once. */
+    char         *rbuf;                  /* NULL until the first read */
+    size_t        rbuf_cap;              /* allocated bytes */
     size_t        rbuf_len;              /* valid bytes in rbuf */
 
     /* ── Write state ────────────────────────────────────────────────── */

--- a/test/test_http_native.ml
+++ b/test/test_http_native.ml
@@ -508,6 +508,32 @@ let run_http_e2e ~variant ~slug ~evloop () =
         (read_response pl_fd pending ~deadline)
     done);
 
+  (* ── Phase C2: bodies larger than one read buffer ────────────────────── *)
+  (* Regression guard. The event-loop server read into a FIXED 64 KB inline
+     buffer. A body larger than that filled it, failed to parse, and returned
+     IO_PARTIAL — and because the loop is edge-triggered, no further readable
+     event was ever delivered for the bytes still sitting in the socket. The
+     request was never dispatched: no response, no log line, connection hung
+     until the peer gave up. Every upload over 64 KB was affected, which in
+     practice meant every package publish to a registry.
+
+     64 KB is the exact boundary, so probe either side of it and well past it.
+     /echo returns the body verbatim, so a truncated or mis-assembled read
+     shows up as a mismatch rather than merely a non-200. *)
+  List.iter (fun size ->
+    let fd = connect_or_bail (Printf.sprintf "large-body %d" size) in
+    Fun.protect ~finally:(fun () -> try Unix.close fd with _ -> ()) (fun () ->
+      let pending = ref "" in
+      let deadline = Unix.gettimeofday () +. req_timeout in
+      (* Non-repeating payload: a run of one byte would hide an offset error. *)
+      let payload = String.init size (fun i -> Char.chr (33 + (i mod 90))) in
+      send fd (request_bytes ~meth:"POST" ~path:"/echo" ~body:payload
+                 ~keep_alive:false);
+      check_response
+        (Printf.sprintf "%s POST /echo (%d-byte body)" variant size)
+        ~exp_status:200 ~exp_body:payload (read_response fd pending ~deadline)))
+    [ 32 * 1024; 64 * 1024; 65536 + 1; 256 * 1024; 1024 * 1024 ];
+
   (* ── Phase D: still serving, and still ALIVE ─────────────────────────── *)
   let fd = connect_or_bail "final request" in
   Fun.protect ~finally:(fun () -> try Unix.close fd with _ -> ()) (fun () ->


### PR DESCRIPTION
The event-loop HTTP server hangs on any request body at or above **65536 bytes**. Not a 413 — the request is never dispatched: no response, no log line, the connection sits until the client or a proxy gives up.

[#150](https://github.com/march-language/march/pull/150) made the event loop the default on 2026-08-01, so this reaches anyone who upgraded past that. Concretely: forgepm.org could not accept a package publish larger than 64 KB for eleven days, returning 502 with nothing in its logs.

## Cause

`conn_state_t.rbuf` is a fixed 64 KB inline array. A body larger than that fills it, fails to parse, and `march_recv_nonblocking` returns `IO_PARTIAL`. The loop then waits for another readable event — but it is **edge-triggered** (`EPOLLIN | EPOLLET` on Linux, `EV_CLEAR` on kqueue), and the kernel only signals on a transition. The bytes are already sitting in the socket, so no new edge is delivered and the connection stalls permanently.

The existing guard cannot help:

```c
size_t space = CONN_READ_BUF_SIZE - c->rbuf_len;
if (space == 0) {
    /* Buffer full — if we still can't parse, the request is too large. */
    return IO_ERROR;
}
```

`march_recv_nonblocking` only runs from an event, and after the stall no event ever arrives — so `space == 0` is never observed.

The thread-pool server is unaffected: it grows its buffer on demand (a91fa824), which is why `MARCH_HTTP_EVLOOP=0` is a complete workaround.

## Fix

- `rbuf` becomes a heap buffer that grows by doubling, up to `CONN_READ_BUF_MAX` (32 MB, matching `MAX_REQ_SIZE` in the thread-pool server, so both refuse the same things).
- `march_recv_nonblocking` **drains until `EAGAIN`** rather than returning after a single `recv`. Draining is what edge triggering requires; growing is what makes draining possible.
- The buffer is retained across `conn_state` free-list reuse, so a busy connection allocates once.

## Verification

Standalone stdlib-only server, same machine, same program:

| toolchain | 32 KB | 64 KB | 256 KB | 2 MB |
|---|---|---|---|---|
| nightly-20260811 | 200 | **hang** | **hang** | **hang** |
| this branch | 200 | **200** | **200** | **200** |

Both server modes pass with the fix.

Bisect that located it: nightly-20260801 good, 20260802 onward bad — and on a single binary, toggling `MARCH_HTTP_EVLOOP` alone flips the behaviour.

## Test

Adds a regression phase to the compiled end-to-end HTTP test: 32 KB, 64 KB, 64 KB + 1, 256 KB and 1 MB posted to `/echo`, which returns the body verbatim so truncation or mis-assembly shows up as a mismatch rather than merely a non-200. It runs for **both** the thread-pool and event-loop variants.

845 tests, 0 failures.

One caveat on the test, stated plainly: I could not get it to fail against a locally reverted runtime, because the CAS served a cached server binary compiled with the fixed runtime. The bug and the fix are demonstrated directly by the standalone reproduction above; the in-suite phase is a forward guard.