### PR TITLE
fix(zed): bump grammar rev — pfn/needs highlighting was 4 months stale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3906,6 +3906,14 @@ git log is authoritative for exact commits.
   any `match` in checking position — which is every `match` in a function with
   a return annotation, i.e. most of them — silently skipped the analysis.
 
+- The Zed extension's tree-sitter grammar was pinned to a commit from
+  2026-03-26, four and a half months before `pfn` (private function) and
+  `needs` (capability declaration) support were added to the grammar
+  (#175, 2026-08-04). Editors built against the stale pin showed `pfn` and
+  `needs` as unhighlighted plain text instead of keywords. `rev` in
+  `zed-march/extension.toml` now points at current `main`; reload the dev
+  extension in Zed to pick it up.
+
 ### Documentation
 
 - Migrated 14 language-reference chapters (Type System, Pattern Matching,

--- a/specs/progress/2026-08-12-zed-grammar-rev-stale-pfn-highlighting.md
+++ b/specs/progress/2026-08-12-zed-grammar-rev-stale-pfn-highlighting.md
@@ -1,0 +1,40 @@
+# Zed extension: stale grammar pin left `pfn`/`needs` unhighlighted
+
+**Filed / fixed:** 2026-08-12
+
+## Symptom
+
+`pfn` (and `needs` capability declarations) rendered as plain unhighlighted
+text in a Zed editor running the March extension, even though the compiler
+(`lib/lexer/lexer.mll`) has recognized `PFN` as a distinct token all along.
+
+## Root cause
+
+Not a current grammar bug. `tree-sitter-march/grammar.js` and its
+`highlights.scm` already support `pfn` and `needs` — added in commit
+`fc8f94ae8` (PR #175, 2026-08-04). The bug was in `zed-march/extension.toml`:
+`[grammars.march].rev` was still pinned to `ad60a650` (2026-03-26), a commit
+four and a half months older than the grammar fix. Zed builds the grammar
+from that pinned commit, not from whatever `tree-sitter-march/` currently
+contains on disk, so any editor that built the extension after 2026-03-26
+but is still running that build never picked up the fix.
+
+## Fix
+
+Bumped `rev` in `zed-march/extension.toml` to current `main`
+(`281261a5f46c5bcbcfe12d0526b2b888e286777a`). Users with the dev extension
+installed need to reload/reinstall it in Zed to rebuild against the new pin.
+
+## Note for future sessions
+
+`tree-sitter-march/` exists in two places in this repo tree:
+`/tree-sitter-march/` (canonical, tracked) and
+`zed-march/grammars/march/` (a gitignored local clone Zed's build step
+creates at the pinned `rev`, purely a build cache — never edit it directly).
+When debugging grammar/highlighting issues, confirm `git rev-parse
+--show-toplevel` matches the intended worktree before editing — an earlier
+pass in this same investigation edited `tree-sitter-march/` via an absolute
+path that resolved to a *different* checkout of this repo
+(`/Users/80197052/code/march`, a separate non-worktree clone on an unrelated
+branch) and only discovered the mistake after `git blame` showed the "fix"
+already existed on `main` since 2026-08-04.

--- a/zed-march/extension.toml
+++ b/zed-march/extension.toml
@@ -7,7 +7,7 @@ description = "March language support for Zed"
 
 [grammars.march]
 repository = "file:///Users/80197052/code/march"
-rev = "ad60a650de3abdae96bd479f6d09791a2affcd45"
+rev = "281261a5f46c5bcbcfe12d0526b2b888e286777a"
 path = "tree-sitter-march"
 
 [language_servers.march-lsp]


### PR DESCRIPTION
## Summary
- `zed-march/extension.toml`'s pinned `[grammars.march].rev` (`ad60a650`, 2026-03-26) predates the `pfn`/`needs` grammar support added in `fc8f94ae8` (#175, 2026-08-04) by four and a half months, so any editor built against it still showed `pfn`/`needs` as unhighlighted plain text.
- Bumped `rev` to current `main` (`281261a5`).
- Added `specs/progress/2026-08-12-zed-grammar-rev-stale-pfn-highlighting.md` and a `CHANGELOG.md` entry.

## Test plan
- [x] Confirmed `tree-sitter-march/grammar.js` on `main` already handles `pfn`/`needs` (via `git blame`, commit `fc8f94ae8`)
- [x] Confirmed `git merge-base --is-ancestor fc8f94ae8 ad60a650` fails — the old pin predates the fix
- [x] `tree-sitter parse` on a real `pfn`/`needs`-using file (bastion.march) succeeds 100% against current grammar sources