### PR TITLE
fix(typecheck,refine): branch-exclusive linearity for if/match-do; field actuals and Bool-match path facts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,34 @@ git log is authoritative for exact commits.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`if` and `match do` now treat their branches as mutually exclusive for
+  linear values, the way `match` arms already did.** Consuming the same
+  linear or affine value once in each branch is legal — at most one branch
+  runs — but only `match` implemented the rule; `if`/`else` and
+  `match do cond ->` checked their branches against one shared use-flag, so
+  the second branch saw the first's consumption and reported a spurious
+  "used more than once". This was most visible with session-typed channels,
+  where branching on a protocol decision (`Chan.choose` in each arm) is the
+  normal shape. A value consumed in the CONDITION still counts on every path,
+  so a genuine double-use is unaffected.
+- **A record field passed to a refined parameter is now checked instead of
+  silently skipped.** `takepos(a.rem)` reflected the field access through a
+  resolver that always declined, so the obligation came out "unreflectable"
+  and — since March reports only definite failures — was accepted in silence;
+  the workaround was to bind the field to a local first. The guard and the
+  goal now meet on the same symbol, so `if a.rem >= 0 do takepos(a.rem)`
+  proves, while an unguarded call, or one guarded on a *sibling* field, is
+  still reported.
+- **`match cond do true -> … false -> … end` now establishes the same path
+  facts as the equivalent `if`.** Match narrowing only ever fired for
+  constructor patterns over a variable scrutinee, so a Bool-literal arm
+  contributed nothing and an obligation the `if` spelling discharges came
+  back solver-undecided. The `true` arm learns the scrutinee holds, the
+  `false` arm (and a `_` fallback after a Bool-literal arm) learns its
+  negation. An earlier arm carrying a guard still licenses nothing.
+
 ### Changed
 
 - **BREAKING: a program that performs IO must declare the grant it performs

--- a/lib/refinecheck/refine_check.ml
+++ b/lib/refinecheck/refine_check.ml
@@ -2793,17 +2793,36 @@ let reflect_scalar
     ~(postcond : string -> A.expr list -> (string * A.expr * string option) option)
     ?(foreign_var : (string -> (Smt.term * (string * Smt.sort)) option) option)
     ?(foreign_measure : (string -> string -> Smt.term option) option)
+    ?(foreign_field :
+        (string -> string -> (Smt.term * (string * Smt.sort) list) option) option)
     ?(sort : Smt.sort = Smt.SInt) (sc : scope) (actual : A.expr)
   : (Smt.term * (string * Smt.sort) list * Smt.term list) option =
   let foreign_var = Option.value foreign_var ~default:(fun _ -> None) in
   let foreign_measure =
     Option.value foreign_measure ~default:(fun _ _ -> None)
   in
+  (* A field read in ACTUAL position — `takepos(a.rem)`.  The caller supplies
+     the same selector term its PATH conditions reflect `a.rem` to, so a guard
+     (`if a.rem >= 0`) and this goal meet on one symbol; without it the field
+     access reached [smt_of]'s default resolver, came back None, and took the
+     whole obligation down with it as "unreflectable" — silently, since an
+     undecidable obligation is accepted. Callers that cannot model the record
+     leave it unset and get exactly the old behaviour. *)
+  let foreign_field = Option.value foreign_field ~default:(fun _ _ -> None) in
   (* Reflect an expression with no scope help — also the fallback for a call
      whose callee has no usable postcondition. *)
   let plain e =
-    match smt_of ~resolve_var:(fun _ -> None) ~resolve_measure:(fun _ _ -> None) e with
-    | Some t -> Some (t, [], [])
+    let extra = ref [] in
+    let resolve_field x fname =
+      match foreign_field x fname with
+      | Some (t, ds) ->
+        List.iter (fun d -> if not (List.mem d !extra) then extra := d :: !extra) ds;
+        Some t
+      | None -> None
+    in
+    match smt_of ~resolve_var:(fun _ -> None) ~resolve_measure:(fun _ _ -> None)
+            ~resolve_field e with
+    | Some t -> Some (t, !extra, [])
     | None -> None
   in
   match actual with
@@ -3629,6 +3648,27 @@ let check_call ~root errctx ~span ~(callee : string) ?(subject = Argument)
       | Some (t, d, a) -> decls := d @ !decls; assume := a @ !assume; Some t
       | None -> None
     in
+    (* `a.rem` appearing as an ACTUAL argument.  Deliberately the same
+       construction [path_resolve_field] uses below for `a.rem` in a PATH
+       CONDITION — the record's SMT selector applied to `Const a` — because the
+       guard and the goal only meet if both sides land on the identical term.
+       The declaration is RETURNED (via [reflect_scalar]'s decls channel and
+       [absorb]) rather than pushed straight onto [decls], so a field read that
+       never makes it into the goal contributes no stray declaration.
+       A receiver outside [recenv] (no known record sort) stays None: the
+       obligation is skipped exactly as before, never guessed. *)
+    let arg_resolve_field varname fname =
+      match List.assoc_opt varname re with
+      | None -> None
+      | Some sort_name ->
+        (match make_field_resolver varname sort_name (Smt.Const varname)
+                 varname fname with
+         | None -> None
+         | Some t ->
+           if not (List.mem sort_name !adt_sorts) then
+             adt_sorts := sort_name :: !adt_sorts;
+           Some (t, [ (varname, Smt.SData sort_name) ]))
+    in
     (* Reflection must be stable per binder within one [check_call]: two
        syntactic occurrences of the same binder (or the same cross-argument
        parameter name) in a predicate denote the same value, so they must
@@ -3880,6 +3920,7 @@ let check_call ~root errctx ~span ~(callee : string) ?(subject = Argument)
         absorb
           (reflect_cached "$self" (fun () ->
                reflect_scalar ~postcond ~foreign_var ~foreign_measure
+                 ~foreign_field:arg_resolve_field
                  ~sort:self_scalar sc self_actual))
       else
         match actual_of_name name with
@@ -3887,6 +3928,7 @@ let check_call ~root errctx ~span ~(callee : string) ?(subject = Argument)
           absorb
             (reflect_cached name (fun () ->
                  reflect_scalar ~postcond ~foreign_var ~foreign_measure
+                   ~foreign_field:arg_resolve_field
                    ~sort:(scalar_of_name name) sc a))
         | None ->
           (* a caller-scope variable from the path context *)
@@ -5896,6 +5938,22 @@ let rec visit ~root errctx defs (ctx : rctx) (path : (A.expr * bool) list)
             (tester, false) :: p
           | _ -> p
         in
+        (* A Bool-literal arm — `match cond do true -> … false -> … end`.
+           This is the same branch on the same Bool as an [A.EIf], so it earns
+           the same fact, and it is recorded in the same (condition, negated)
+           form the [A.EIf] arm below uses: the `true` arm learns the
+           scrutinee holds, the `false` arm learns its negation.
+
+           Unlike the constructor narrowing above this needs NO stable name
+           for the scrutinee — a path condition is an arbitrary expression, so
+           an inline `match a >= b do` works exactly as `if a >= b do` does.
+           Gating on the PATTERN being a Bool literal is what keeps it typed:
+           only a Bool scrutinee can be matched against `true`/`false`. *)
+        let p =
+          match br.A.branch_pat with
+          | A.PatLit (A.LitBool bv, _) -> (subj, not bv) :: p
+          | _ -> p
+        in
         (* Arm-order exclusion.  Reaching this arm means every EARLIER arm
            failed to match, so for each of those whose failure is decided purely
            by the tag ([arm_excludes_tag]), the scrutinee is known NOT to carry
@@ -5926,6 +5984,21 @@ let rec visit ~root errctx defs (ctx : rctx) (path : (A.expr * bool) list)
                 | _ -> p)
               p earlier
           | _ -> p
+        in
+        (* Arm-order exclusion for Bool-literal arms, the counterpart of the
+           tag exclusion above: reaching this arm means every earlier
+           `true ->` / `false ->` failed to match, so the scrutinee is known
+           NOT to be that literal — which is what gives the `_` arm of
+           `match cond do true -> … _ -> … end` the negated guard, exactly as
+           an `if`'s else-branch gets it.  An earlier arm carrying a GUARD
+           licenses nothing: it can fail with the literal still matching. *)
+        let p =
+          List.fold_left
+            (fun p (prev : A.branch) ->
+              match prev.A.branch_pat, prev.A.branch_guard with
+              | A.PatLit (A.LitBool bv, _), None -> (subj, bv) :: p
+              | _ -> p)
+            p earlier
         in
         visit ~root errctx defs ctx p lets sc re cb br.A.branch_body;
         br :: earlier)

--- a/lib/typecheck/typecheck.ml
+++ b/lib/typecheck/typecheck.ml
@@ -6565,10 +6565,19 @@ let rec infer_expr env (e : Ast.expr) : ty =
 
     (* ── if/do/else/end ───────────────────────────────────────────── *)
     | Ast.EIf (cond, then_, else_, _sp) ->
+      (* The condition runs on BOTH paths, so it is checked before the
+         mutual-exclusion snapshot below: a linear value consumed here is
+         still consumed inside either branch. *)
       check_expr env cond t_bool
         ~reason:(Some (RBuiltin "The condition of an if expression must be Bool."));
-      let t_then = infer_expr env then_ in
-      let t_else = infer_expr env else_ in
+      (* The two branches are mutually exclusive, so each may consume the same
+         outer linear value once — the same rule match arms get. *)
+      let r_then = ref TError and r_else = ref TError in
+      iter_paths_linear env
+        [ (fun () -> r_then := infer_expr env then_);
+          (fun () -> r_else := infer_expr env else_) ];
+      let t_then = !r_then in
+      let t_else = !r_else in
       (* Point primary error at the else branch; label points at then branch
          (the source of the expected type), making both branches visible. *)
       let then_sp = span_of_expr then_ in
@@ -6587,15 +6596,51 @@ let rec infer_expr env (e : Ast.expr) : ty =
            "A `match do` expression needs at least one arm.";
          TError
        | (first_cond, first_body) :: rest ->
+         (* Only the BODIES are mutually exclusive here, so this cannot use
+            [iter_paths_linear] wholesale. The conditions are evaluated in
+            order until one holds, so a later condition genuinely co-occurs
+            with every earlier one on the fall-through path and they must
+            share linear-use state. A body, by contrast, runs only when its
+            own condition was the first true one — at which point no later
+            condition is ever evaluated — so each body is its own path,
+            starting from the state its own condition left behind.
+
+            Hence: check conditions against the shared state, run each body
+            rolled back, and apply the union of what the bodies consumed
+            once at the end. *)
+         let body_acc =
+           List.map (fun le -> (le, ref false, ref (None : Ast.span option)))
+             env.lin
+         in
+         let run_body body_e =
+           let saved =
+             List.map (fun le -> (le, !(le.le_used), !(le.le_first_use)))
+               env.lin
+           in
+           let ty = infer_expr env body_e in
+           List.iter (fun (le, acc, acc_span) ->
+               if !(le.le_used) then begin
+                 acc := true;
+                 if !acc_span = None then acc_span := !(le.le_first_use)
+               end) body_acc;
+           List.iter (fun (le, was, was_span) ->
+               le.le_used := was; le.le_first_use := was_span) saved;
+           ty
+         in
          check_expr env first_cond t_bool
            ~reason:(Some (RBuiltin "Each condition in `match do` must be Bool."));
-         let result_ty = infer_expr env first_body in
+         let result_ty = run_body first_body in
          List.iter (fun (cond_e, body_e) ->
              check_expr env cond_e t_bool
                ~reason:(Some (RBuiltin "Each condition in `match do` must be Bool."));
-             let arm_ty = infer_expr env body_e in
+             let arm_ty = run_body body_e in
              unify env ~span:sp ~reason:(Some (RMatchArm sp)) result_ty arm_ty
            ) rest;
+         List.iter (fun (le, acc, acc_span) ->
+             if !acc && not !(le.le_used) then begin
+               le.le_used := true;
+               if !(le.le_first_use) = None then le.le_first_use := !acc_span
+             end) body_acc;
          result_ty)
 
     (* ── Pipes / Sigils — must be desugared before reaching us ───── *)
@@ -7025,30 +7070,47 @@ and with_offer_refinement env scrut (br : Ast.branch) (f : unit -> unit) =
     mutable flag would otherwise raise across arms, while still catching a
     genuine double-use WITHIN a single arm. *)
 and iter_arms_linear env (branches : Ast.branch list) (f : Ast.branch -> unit) : unit =
-  (* For each outer linear entry track (entry, pre-match flag, union accumulator). *)
+  iter_paths_linear env (List.map (fun br () -> f br) branches)
+
+(** The mutual-exclusion discipline itself, over an arbitrary list of paths.
+    Every branching construct in the language shares it — [EMatch] arms via
+    [iter_arms_linear], the two branches of an [EIf], and the bodies of an
+    [ECond] — because "at most one of these runs" is the only property it
+    needs.  Each path is run with the linear-use flags reset to their state
+    on entry, and the union of what the paths consumed is applied once at the
+    end.
+
+    What this deliberately does NOT cover is code that runs on EVERY path: an
+    [EIf]'s condition, or an [ECond]'s conditions, must be checked OUTSIDE the
+    paths (before the relevant snapshot is taken), so that a value consumed
+    there is still seen as consumed inside each branch.  Resetting around the
+    condition too would turn a genuine double-use into an accepted program —
+    the one way this helper can be misused. *)
+and iter_paths_linear env (paths : (unit -> unit) list) : unit =
+  (* For each outer linear entry track (entry, pre-branch flag, union accumulator). *)
   (* [le_first_use] is saved and restored alongside [le_used]. If it were not,
-     the first arm to consume a value would leave its span behind, and a genuine
-     double-use in a LATER arm would point at a line in a sibling arm that never
-     ran on the same path — a confidently wrong "already consumed here". *)
+     the first path to consume a value would leave its span behind, and a genuine
+     double-use in a LATER path would point at a line in a sibling path that never
+     ran on the same execution — a confidently wrong "already consumed here". *)
   let snapshot =
     List.map (fun le ->
         (le, !(le.le_used), ref !(le.le_used),
              !(le.le_first_use), ref !(le.le_first_use)))
       env.lin
   in
-  List.iter (fun br ->
-      (* Reset each entry to its pre-match state so this arm sees a fresh path. *)
+  List.iter (fun run_path ->
+      (* Reset each entry to its pre-branch state so this path starts fresh. *)
       List.iter (fun (le, was, _acc, was_span, _acc_span) ->
           le.le_used := was; le.le_first_use := was_span) snapshot;
-      f br;
-      (* Fold whatever this arm consumed into the union accumulator. *)
+      run_path ();
+      (* Fold whatever this path consumed into the union accumulator. *)
       List.iter (fun (le, _was, acc, _was_span, acc_span) ->
           if !(le.le_used) then begin
             acc := true;
             if !acc_span = None then acc_span := !(le.le_first_use)
           end) snapshot
-    ) branches;
-  (* Final: consumed iff consumed before the match OR in some arm. *)
+    ) paths;
+  (* Final: consumed iff consumed before the branch OR on some path. *)
   List.iter (fun (le, _was, acc, _was_span, acc_span) ->
       le.le_used := !acc; le.le_first_use := !acc_span) snapshot
 

--- a/specs/progress/2026-08-12-branch-facts-and-linearity-symmetry.md
+++ b/specs/progress/2026-08-12-branch-facts-and-linearity-symmetry.md
@@ -1,0 +1,82 @@
+# `if` vs `match`: branch-exclusive linearity and Bool path facts
+
+**Date:** 2026-08-12
+**Status:** shipped
+
+## What was wrong
+
+Three gaps, found while scoping a cookbook chapter that combines session types,
+refinement types, capabilities and actors. Two of them are exact mirrors of each
+other, which is why the combination had no workaround inside a single construct:
+
+|                          | refinement path facts | linear branch-exclusivity |
+|--------------------------|-----------------------|---------------------------|
+| `if cond do … else … end`| yes                   | **no**                    |
+| `match b do true/false`  | **no**                | yes                       |
+
+1. **Linearity.** `iter_arms_linear` (snapshot / reset-per-arm / union) gave
+   `EMatch` the mutually-exclusive-paths rule. `EIf` and `ECond` inferred their
+   branches sequentially against the shared `le_used` flag, so consuming one
+   linear value once per branch was reported as "used more than once". That the
+   intended semantics is the other way round was already written down — in the
+   comment on `test_linear_match_arms_each_consume_once_ok`, an explicit
+   regression guard for the match-arm snapshot. `if` was simply never wired to
+   it.
+
+2. **Field as a refined actual.** `reflect_scalar`'s `plain` fallback called
+   `smt_of` with no `resolve_field`, so the (already-present) `EField` arm always
+   hit the `None` default. `takepos(a.rem)` therefore produced an unreflectable
+   goal, and an undecidable obligation is accepted in silence. Note this was
+   never actor-specific: a plain record behaved identically, and the actor
+   `state.field` case was one instance of it.
+
+3. **Bool-scrutinee match.** `visit`'s `EMatch` arm narrows only on constructor
+   patterns over a variable scrutinee, so `match cond do true -> …` pushed no
+   path condition at all while `EIf` pushed `(c, negated)`.
+
+## What shipped
+
+- `iter_arms_linear` generalised to `iter_paths_linear` over a list of path
+  thunks; `EMatch` keeps its behaviour as a pure refactor. `EIf` runs its two
+  branches as paths — **after** checking the condition, so a value consumed in
+  the condition still counts on both paths. `ECond` gets a hand-rolled variant
+  because only its *bodies* are mutually exclusive: its conditions chain, so a
+  later condition genuinely co-occurs with earlier ones on the fall-through
+  path and they must share use-state.
+- `reflect_scalar` gained an optional `foreign_field`; `check_call` supplies
+  `arg_resolve_field`, deliberately building the *same* selector term
+  `path_resolve_field` builds for path conditions — the guard and the goal only
+  close if both land on one symbol. A receiver outside `recenv` still yields
+  `None` (skipped, never guessed).
+- `visit` pushes `(subj, not bv)` for a Bool-literal arm, and `(subj, bv)` for
+  each earlier Bool-literal arm that failed, giving a `_` fallback the negation.
+  A guarded earlier arm licenses nothing — it can fail with the literal still
+  matching.
+
+## Why it is not over-permissive
+
+Each fix ships with a negative control, because "the obligation now passes" and
+"the obligation now proves nothing" look identical from a green test:
+
+- a value used in an `if` condition *and* a branch is still a double-use;
+  two uses within one branch are still a double-use;
+- an unguarded `takepos(a.rem)` is still reported, and a guard on a *sibling*
+  field proves nothing about this one;
+- the `false` arm does not inherit the `true` arm's fact.
+
+The refinement tests run under `cap verified`, which turns an undischarged
+obligation into a hard error — so "no error" there means *proved*, not merely
+*unreported*.
+
+## Verification
+
+Full suite (incl. Slow) green; `dune build @types-check` 291/291 with a
+deliberately cold `.march/cas/vc` (a warm VC cache content-addresses verdicts
+and would have masked a changed one).
+
+## Consequence for the cookbook
+
+The pure-decision-core / effectful-shell split that the actor+session+refinement
+chapter was forced into is now a design *choice* rather than a workaround: `if`
+carries both properties, so refined arithmetic and linear channel branching can
+live in the same construct.

--- a/test/test_compiler.ml
+++ b/test/test_compiler.ml
@@ -1597,6 +1597,87 @@ let test_linear_match_arms_each_consume_once_ok () =
   end|} in
   Alcotest.(check bool) "one consumption per arm is accepted" false (has_errors ctx)
 
+(* Same mutual-exclusion rule as the match-arm guard above, for the OTHER two
+   branching constructs. `if`/`else` and `match do cond ->` are exactly as
+   mutually exclusive as match arms, so consuming an outer linear value once
+   per branch is equally legal. Both used to infer their branches against the
+   shared [le_used] flag, so the else-branch saw the then-branch's
+   consumption and reported a spurious "used more than once". *)
+let test_linear_if_branches_each_consume_once_ok () =
+  let ctx = typecheck {|mod Test do
+  needs IO.Console
+    fn consume(s : String) : Int do
+      String.byte_size(s)
+    end
+
+    fn main(_cap_console : Cap(IO.Console)) do
+      linear let token = "secret"
+      let flag = true
+      let r = if flag do consume(token) else consume(token) end
+      println(int_to_string(r))
+    end
+  end|} in
+  Alcotest.(check bool) "one consumption per if-branch is accepted" false
+    (has_errors ctx)
+
+let test_linear_cond_arms_each_consume_once_ok () =
+  let ctx = typecheck {|mod Test do
+  needs IO.Console
+    fn consume(s : String) : Int do
+      String.byte_size(s)
+    end
+
+    fn main(_cap_console : Cap(IO.Console)) do
+      linear let token = "secret"
+      let flag = true
+      let r = match do
+        flag -> consume(token)
+        true -> consume(token)
+      end
+      println(int_to_string(r))
+    end
+  end|} in
+  Alcotest.(check bool) "one consumption per `match do` arm is accepted" false
+    (has_errors ctx)
+
+(* The other half of the contract: branch exclusivity must NOT weaken the
+   check. A value consumed in the CONDITION is consumed on every path, so a
+   further use inside either branch is a genuine double-use and must still be
+   rejected. This is what distinguishes "reset the flag per branch" (correct)
+   from "reset the flag around the whole if" (unsound). *)
+let test_linear_use_in_if_condition_then_branch_is_error () =
+  let ctx = typecheck {|mod Test do
+  needs IO.Console
+    fn consume(s : String) : Int do
+      String.byte_size(s)
+    end
+
+    fn main(_cap_console : Cap(IO.Console)) do
+      linear let token = "secret"
+      let r = if consume(token) > 0 do consume(token) else 0 end
+      println(int_to_string(r))
+    end
+  end|} in
+  Alcotest.(check bool) "condition use + branch use is still a double use" true
+    (has_errors ctx)
+
+let test_linear_double_use_within_if_branch_is_error () =
+  let ctx = typecheck {|mod Test do
+  needs IO.Console
+    fn consume(s : String) : Int do
+      String.byte_size(s)
+    end
+
+    fn main(_cap_console : Cap(IO.Console)) do
+      linear let token = "secret"
+      let flag = true
+      let r = if flag do consume(token) + consume(token) else 0 end
+      println(int_to_string(r))
+    end
+  end|} in
+  Alcotest.(check bool) "two uses within one branch is still an error" true
+    (has_errors ctx)
+
 let test_linear_double_use_within_arm_labels_same_arm () =
   (* The arrangement that actually catches a missing save/restore: an EARLIER
      arm consumes the value legally (line 10), and a LATER arm double-uses it
@@ -14072,6 +14153,10 @@ let compiler_suites =
           Alcotest.test_case "linear pattern match double"   `Quick test_linear_pattern_match_double_use;
           Alcotest.test_case "double use labels first use"   `Quick test_linear_double_use_points_at_first_use;
           Alcotest.test_case "match arms each consume once"  `Quick test_linear_match_arms_each_consume_once_ok;
+          Alcotest.test_case "if branches each consume once" `Quick test_linear_if_branches_each_consume_once_ok;
+          Alcotest.test_case "match-do arms each consume once" `Quick test_linear_cond_arms_each_consume_once_ok;
+          Alcotest.test_case "if condition use + branch use errors" `Quick test_linear_use_in_if_condition_then_branch_is_error;
+          Alcotest.test_case "double use within if branch errors" `Quick test_linear_double_use_within_if_branch_is_error;
           Alcotest.test_case "double use in arm stays in arm" `Quick test_linear_double_use_within_arm_labels_same_arm;
           Alcotest.test_case "linear closure capture"        `Quick test_linear_closure_capture_error;
           Alcotest.test_case "linear field let binding"       `Quick test_linear_field_let_binding;

--- a/test/test_refinecheck.ml
+++ b/test/test_refinecheck.ml
@@ -4303,6 +4303,106 @@ let refine_error_texts src =
    Verified empirically by running this group with z3 removed from PATH:
      env PATH=/usr/bin:/bin ./_build/default/test/test_refinecheck.exe \
        test cap-verified -e *)
+(* A record FIELD as the actual argument of a refined parameter.  `r.count` is
+   an ordinary pure read of an immutable record, and a guard on it is the same
+   evidence a guard on a plain local is — but the argument side used to reflect
+   through [smt_of]'s DEFAULT field resolver, which always answers None, so the
+   whole goal came out unreflectable and the obligation was skipped in silence.
+   The guard and the goal must meet on ONE symbol for the proof to close, which
+   is what these two cases pin: the guarded call verifies, and the UNguarded
+   one is still reported (so the first is not passing because field access
+   quietly proves everything). *)
+let field_actual_suite =
+  [ gated "a guarded record field discharges a precondition" (fun () ->
+        Alcotest.(check bool) "no error" false
+          (has_refine_error
+             "mod F1 do\n\
+             \  cap verified\n\
+             \  type Acct = { rem : Int }\n\
+             \  fn takepos(k : {Int | _ >= 0}) : Int do k end\n\
+             \  fn go(a : Acct) : Int do\n\
+             \    if a.rem >= 0 do takepos(a.rem) else 0 end\n\
+             \  end\n\
+              end\n"));
+
+    gated "an UNguarded record field is still reported" (fun () ->
+        Alcotest.(check bool) "error" true
+          (has_refine_error
+             "mod F2 do\n\
+             \  cap verified\n\
+             \  type Acct = { rem : Int }\n\
+             \  fn takepos(k : {Int | _ >= 0}) : Int do k end\n\
+             \  fn go(a : Acct) : Int do takepos(a.rem) end\n\
+              end\n"));
+
+    (* The guard is about a DIFFERENT field, so it proves nothing about this
+       one: field symbols must be per-field, not per-record. *)
+    gated "a guard on a sibling field proves nothing" (fun () ->
+        Alcotest.(check bool) "error" true
+          (has_refine_error
+             "mod F3 do\n\
+             \  cap verified\n\
+             \  type Acct = { rem : Int, other : Int }\n\
+             \  fn takepos(k : {Int | _ >= 0}) : Int do k end\n\
+             \  fn go(a : Acct) : Int do\n\
+             \    if a.other >= 0 do takepos(a.rem) else 0 end\n\
+             \  end\n\
+              end\n"));
+  ]
+
+(* `match cond do true -> … false -> … end` is the same branch on the same
+   Bool as `if cond do … else … end`, so it must establish the same facts. It
+   used to establish NONE: the match path-narrowing only ever fired for
+   CONSTRUCTOR patterns over a variable scrutinee, so a Bool-literal arm
+   contributed nothing and an obligation the `if` spelling discharges was
+   reported as solver-undecided. *)
+let bool_match_path_suite =
+  [ gated "a true-arm learns its Bool scrutinee holds" (fun () ->
+        Alcotest.(check bool) "no error" false
+          (has_refine_error
+             "mod B1 do\n\
+             \  cap verified\n\
+             \  fn takepos(k : {Int | _ >= 0}) : Int do k end\n\
+             \  fn go(n : Int) : Int do\n\
+             \    match n >= 0 do\n\
+             \      true -> takepos(n)\n\
+             \      false -> 0\n\
+             \    end\n\
+             \  end\n\
+              end\n"));
+
+    (* The negation half: reaching `_` means the guard was false. *)
+    gated "a wildcard arm after a true-arm learns the negation" (fun () ->
+        Alcotest.(check bool) "no error" false
+          (has_refine_error
+             "mod B2 do\n\
+             \  cap verified\n\
+             \  fn takeneg(k : {Int | _ < 0}) : Int do k end\n\
+             \  fn go(n : Int) : Int do\n\
+             \    match n >= 0 do\n\
+             \      true -> 0\n\
+             \      _ -> takeneg(n)\n\
+             \    end\n\
+             \  end\n\
+              end\n"));
+
+    (* Guard against proving too much: the arm that does NOT establish the
+       fact must still be reported. *)
+    gated "the false-arm does not inherit the true-arm's fact" (fun () ->
+        Alcotest.(check bool) "error" true
+          (has_refine_error
+             "mod B3 do\n\
+             \  cap verified\n\
+             \  fn takepos(k : {Int | _ >= 0}) : Int do k end\n\
+             \  fn go(n : Int) : Int do\n\
+             \    match n >= 0 do\n\
+             \      true -> 0\n\
+             \      false -> takepos(n)\n\
+             \    end\n\
+             \  end\n\
+              end\n"));
+  ]
+
 let cap_verified_suite =
   [ Alcotest.test_case "cap verified: an unreflectable predicate is an ERROR" `Quick
       (fun () ->
@@ -9493,6 +9593,8 @@ let () =
       ("obligations", obligation_suite);
       ("obligation-reasons", reason_suite);
       ("cap-verified", cap_verified_suite);
+      ("field-actual", field_actual_suite);
+      ("bool-match-path", bool_match_path_suite);
       ("alias-attribution", alias_attribution_suite);
       ("divsafety-hole", divsafety_hole_suite);
       ("divsafety-entailment", divsafety_entailment_suite);


### PR DESCRIPTION
## Summary

Three compiler gaps, each root-caused before implementing. They surfaced while scoping a cookbook chapter that combines session types, refinement types, capabilities and actors — and two of them turn out to be exact mirrors, which is why that combination had no workaround inside a single construct:

|                           | refinement path facts | linear branch-exclusivity |
|---------------------------|-----------------------|---------------------------|
| `if cond do … else … end` | ✅                    | ❌ (fixed here)           |
| `match b do true/false`   | ❌ (fixed here)       | ✅                        |

### 1. `if` / `match do` now treat branches as mutually exclusive for linear values

Only `EMatch` arms got the snapshot/reset/union rule (`iter_arms_linear`). `EIf` and `ECond` inferred their branches sequentially against one shared `le_used` flag, so consuming a linear value once per branch was reported as "used more than once". Most visible with session-typed channels, where branching on a protocol decision (`Chan.choose` per arm) is the normal shape.

That the intended semantics is the other way round was **already written down** — in the comment on `test_linear_match_arms_each_consume_once_ok`, an explicit regression guard for the match-arm snapshot. `if` was simply never wired to it.

`iter_arms_linear` is generalised to `iter_paths_linear` over path thunks (`EMatch` behaviour is a pure refactor). `EIf` runs its branches as paths **after** checking the condition, so a value consumed in the condition still counts on both. `ECond` needs its own variant: only its *bodies* are exclusive — its conditions chain, so a later condition genuinely co-occurs with earlier ones on the fall-through path.

### 2. A record field as a refined actual is checked, not silently skipped

`reflect_scalar`'s `plain` fallback called `smt_of` without a `resolve_field`, so the already-present `EField` arm always hit the `None` default; `takepos(a.rem)` produced an unreflectable goal, and an undecidable obligation is accepted in silence. `check_call` now supplies the **same** selector term `path_resolve_field` builds for path conditions — the guard and the goal only close if both land on one symbol.

Worth noting: this was never actor-specific. A plain record behaved identically; the actor `state.field` case was one instance of it.

### 3. Bool-scrutinee `match` establishes the same path facts as `if`

`visit`'s match narrowing fired only for constructor patterns over a variable scrutinee, so `match cond do true -> …` pushed nothing and an obligation the `if` spelling discharges came back solver-undecided. The `true` arm now learns the scrutinee holds; the `false` arm — and a `_` fallback after a Bool-literal arm — learns the negation. A guarded earlier arm still licenses nothing (it can fail with the literal still matching).

## Not over-permissive

Each fix ships a negative control, because "the obligation now passes" and "the obligation now proves nothing" look identical from a green test:

- a value used in an `if` **condition** and a branch is still a double-use; two uses within one branch are still a double-use;
- an **unguarded** `takepos(a.rem)` is still reported, and a guard on a **sibling** field proves nothing about this one;
- the `false` arm does not inherit the `true` arm's fact.

The refinement tests run under `cap verified`, which turns an undischarged obligation into a hard error — so "no error" there means *proved*, not merely *unreported*.

## Test plan

- 4 new linearity tests (`test/test_compiler.ml`), 6 new refinement tests (`test/test_refinecheck.ml`) — verified red before the fix, green after.
- `scripts/run-tests.sh` full suite (incl. Slow) green; compiler and refinecheck suites exit 0.
- `dune build @types-check` **291/291** with a deliberately cold `.march/cas/vc` — a warm VC cache content-addresses verdicts and would have masked a changed one.
- `scripts/check-docs.sh` green.
- Independent review pass over the diff for soundness (branch interleavings for `ECond`, receiver shadowing/rebinding for the field term, fact polarity and arm-order exclusion for Bool arms): no unsoundness found.

## Consequence

The pure-decision-core / effectful-shell split that the actor+session+refinement cookbook chapter was forced into becomes a design *choice* rather than a workaround — `if` now carries both properties, so refined arithmetic and linear channel branching can live in the same construct.