### PR TITLE
specs: actor-model gap analysis vs BEAM/Akka/Orleans + named-registry design

### DIFF
--- a/specs/2026-08-12-named-registry-design.md
+++ b/specs/2026-08-12-named-registry-design.md
@@ -1,0 +1,241 @@
+# Named process registry — design
+
+**Date:** 2026-08-12
+**Status:** design, not yet implemented
+**Todo:** `specs/todos/2026-08-12-actor-named-registry.md`
+
+## 1. The problem, precisely
+
+Supervision self-heals: a crashed child is respawned with backoff, and
+`march_respawn_child` writes the new child's `pid_index` into the supervisor's
+own state. That repairs the **inside** of the tree.
+
+It does nothing for anyone **outside** it. A `Pid` is a handle to one
+*incarnation*. After a restart every external holder has a handle to a dead
+actor, and:
+
+- `send` to it returns `None` (correct, and useless — there is no next step);
+- `get_cap` correctly reports the capability as stale via the epoch counter —
+  again detection with no recovery;
+- nothing maps "the thing that plays this role" to "the incarnation currently
+  playing it".
+
+So the healing is invisible from outside. The fix every comparable runtime
+reaches for is the same: **hold a name, resolve it at use time.**
+
+## 2. What we are copying, and what we are not
+
+- **BEAM** — `register(Name, Pid)` / `whereis(Name)`, plus `{via, Module, Term}`
+  so a gen_server can be addressed through any registry. Names are atoms and
+  the table is global to the node. Elixir's `Registry` adds unique-vs-duplicate
+  keys, arbitrary term keys, and automatic cleanup on death.
+- **Akka** — the actor *path* is the stable identity; an incarnation is
+  addressed through it.
+- **Orleans** — the strongest version: you never hold a reference at all, you
+  address a grain by identity and the runtime activates one on demand.
+
+We copy BEAM/Elixir's shape: an explicit registry with automatic cleanup.
+Orleans-style virtual activation is a much larger commitment (placement,
+activation lifecycle, single-activation guarantees) and is **not** proposed
+here — but note the design below does not foreclose it.
+
+### Relationship to the existing distributed registry
+
+`stdlib/global_registry.march` already exists and is a *CRDT over names* —
+`Map(String, Entry)` where `Entry` carries `node_id`, `pid`, a `VectorClock`
+and a tombstone flag, with `merge`, `root_hash` and `diff_entries` for
+anti-entropy between nodes. It is a pure data structure: it stores a `pid : Int`
+but has no way to reach a live process.
+
+This design is deliberately its **local counterpart**, and the two compose:
+the local registry answers "which live actor on *this* node has this name",
+`global_registry` answers "which node claims this name, and whose claim wins".
+Keep the vocabulary aligned — `register` / `unregister` / `lookup` / `names` —
+so the eventual `:global` variant is a routing decision rather than a second
+vocabulary. **Names are `String` here for exactly that reason** (that is what
+`global_registry` keys on), not atoms.
+
+## 3. Where it lives: C runtime, not a March actor
+
+The obvious cheap implementation is a registry *actor* holding a `Map`. Reject
+it:
+
+- every lookup becomes a message round-trip and a scheduling hop;
+- it is a single-actor bottleneck on a path that wants to be as cheap as
+  `send`;
+- it cannot be consulted from inside the runtime's own send path;
+- and it cannot be cleaned up automatically on death, because `do_actor_death`
+  runs in the runtime and would have to *message* the registry to unregister —
+  during teardown, into a mailbox that may be bounded or full.
+
+So: a C table beside `g_actor_tbl` in `runtime/march_runtime.c`, following the
+discipline Task 10 established for the actor table.
+
+## 4. Data structure and concurrency
+
+```c
+typedef struct march_name_entry {
+    char                     *name;        /* owned copy */
+    void                     *actor;       /* actor record ptr, NULL = free slot */
+    _Atomic(struct march_name_entry *) next;
+} march_name_entry;
+
+static _Atomic(march_name_entry *) g_name_tbl[MARCH_NAME_BUCKETS];  /* 256 */
+static pthread_mutex_t g_name_mu = PTHREAD_MUTEX_INITIALIZER;
+```
+
+Discipline, mirroring `find_meta` (Task 10):
+
+- **Writers** (`register`, `unregister`, death cleanup) take `g_name_mu`.
+- **Readers** (`whereis`) take **no lock**: acquire-load the bucket head and
+  walk. Safe because entries are **insert-only** — see below.
+- Publication is a release-store of the bucket head after `next` is written.
+
+### Unregistration without unlinking
+
+Names must be *removable* (an actor dies, a name is reused), but unlinking
+breaks the lock-free reader. Resolve it the same way the actor table does —
+never unlink. An entry is **retired by clearing `actor` to NULL** (a release
+store) rather than removing the node; `whereis` treats NULL as absent, and
+`register` reuses a retired entry with a matching name instead of allocating.
+
+This bounds table growth by *distinct names ever used*, not by registrations —
+the natural shape, since names are a small fixed vocabulary in practice
+("ledger", "gateway") re-registered across many incarnations. It also keeps
+the reader honest without hazard pointers or epochs.
+
+## 5. Semantics
+
+**Uniqueness.** One actor per name (Elixir's `:unique`). A second `register`
+for a live name fails rather than overwriting — silently stealing a name is
+the kind of thing you debug at 3am. Duplicate/group registration is explicitly
+out of scope: `stdlib/pubsub.march` already covers fan-out to many actors.
+
+**One name per actor?** No — permit an actor to hold several names. Nothing in
+the structure needs the restriction, and forbidding it costs a reverse index.
+Death cleanup must therefore retire *all* of an actor's names (see §6).
+
+**Automatic cleanup on death is mandatory, not optional.** Without it a name
+resolves to a corpse and the whole point is lost.
+
+**Registering a dead actor** fails. **`whereis` of a name whose actor has since
+died** returns `None` — check liveness (`fields[3]`) at lookup, don't trust the
+entry alone, since death cleanup and lookup race by nature.
+
+## 6. Death cleanup
+
+`do_actor_death` gains a call to retire the dying actor's names.
+
+The cost to watch: with only a name→actor table, cleanup is an O(buckets ×
+chain) scan for the dying actor. That is a full table walk **per actor death**,
+and the churn scenario in `scripts/actor-load.sh` kills 40 000 actors — this
+would reintroduce exactly the O(n)-per-death cost Task 15 removed from
+supervisor lookups. So: keep a **reverse pointer on the actor's meta** — a
+small list of the names it holds (`march_actor_meta` already carries per-actor
+side data such as `monitor_head`, `cleanup_head`). Cleanup then touches only
+this actor's own names.
+
+Ordering inside `do_actor_death` matters. Retire names **before** the monitor
+Down notifications fire: a watcher woken by a Down that immediately does
+`whereis(name)` must not see the dead incarnation. (This ordering constraint
+lands in the same function as the reason-carrying Down work — see
+`specs/todos/2026-08-12-monitor-down-carries-no-reason.md`; do them together.)
+
+## 7. Surviving a restart — the actual point
+
+Two candidate mechanisms:
+
+1. **The child re-registers itself** in its `init`. Rejected: `init` takes no
+   parameters, so the name would have to be baked into the actor definition,
+   which makes it a property of the *type* rather than of the instance — wrong
+   for a pool of N workers.
+2. **The supervisor re-registers the replacement.** `march_respawn_child`
+   already runs on every restart and already knows the crashed child's
+   `pid_index`. Have it read the names held by the crashed incarnation (via the
+   reverse pointer from §6, captured before cleanup retires them) and register
+   the new child under the same names.
+
+Take (2). It needs **no syntax change** to `supervise` blocks: a child that was
+registered stays registered across restarts because the supervisor carries the
+name forward, and a child that was never registered is unaffected.
+
+The sequencing must be deliberate, since §6 retires the names during
+`do_actor_death` and the restart may be *delayed* by up to ~3.2s of backoff
+(Task 16). During that window the name correctly resolves to `None` — the actor
+genuinely does not exist yet. Callers must handle `None` from `whereis`; this
+is the honest signal that the service is mid-restart, and is strictly better
+than the current situation (a `Pid` that looks fine and silently drops).
+
+## 8. Surface API
+
+New builtins (each needs all four sites — typecheck / defun / llvm_builtins /
+eval — per the `compiler-builtin` skill):
+
+| Builtin | Type | Notes |
+|---|---|---|
+| `actor_register` | `String -> Pid(a) -> Bool` | false if name taken or actor dead |
+| `actor_unregister` | `String -> Bool` | false if not registered |
+| `actor_whereis` | `String -> Option(Pid(a))` | `a` fresh, as `spawn`'s Pid is |
+| `actor_registered` | `Unit -> List(String)` | live names; feeds the introspection todo |
+
+Stdlib wrapper, `stdlib/actor.march`:
+
+```march
+Actor.register(name, pid)   -- Bool
+Actor.unregister(name)      -- Bool
+Actor.whereis(name)         -- Option(Pid(a))
+Actor.registered()          -- List(String)
+```
+
+`Actor.whereis` returning `Option` rather than a bare `Pid` is load-bearing —
+it forces the caller to handle the mid-restart window from §7.
+
+Deliberately **not** proposed: making `send` accept a name. Overloading `send`
+would hide a fallible lookup inside an operation whose failure mode is already
+subtle (`None` for a dead actor); an explicit `whereis` keeps the two failures
+distinguishable. A `Actor.cast_named` / `call_named` convenience can follow
+later if the explicit form proves noisy in practice.
+
+## 9. Interpreter parity
+
+The interpreter keeps its own registry (a `Hashtbl` beside `actor_registry`)
+with the same semantics. Both backends must agree, pinned by a golden test —
+this is exactly the class of divergence that bit compiled `mailbox_size`
+(returning the monitor Down count instead of queue depth) before the 2026-08-12
+hardening caught it.
+
+## 10. Test plan
+
+Beyond unit coverage of register/whereis/unregister:
+
+- **The restart witness**, which is the whole feature: register a supervised
+  child, kill it repeatedly, and reach it by name after every restart *from a
+  holder that never sees the new Pid*. This must be a native golden, since the
+  supervision plane is where interpreted and compiled have historically
+  diverged.
+- **Death cleanup**: `whereis` returns `None` after a kill with no restart.
+- **Name reuse**: register → kill → register a *different* actor under the same
+  name succeeds (proves retire-and-reuse, not permanent occupancy).
+- **Churn cost**: extend `bench/actors/spawn_churn.march` with registrations to
+  confirm death cleanup stays O(names held) and does not reintroduce a
+  per-death table walk (§6).
+- **Send path unaffected**: the fan-in scenario in `scripts/actor-load.sh` must
+  not regress — the registry must not put a lock anywhere `send` touches.
+
+## 11. Open questions
+
+1. **Should `whereis` check liveness, or is the retire-on-death race tight
+   enough?** Proposed: check. It is one load of `fields[3]` on a path that is
+   not per-message hot.
+2. **Case sensitivity / name validation** — presumably raw `String`, no
+   validation, matching `global_registry`.
+3. **Should the supervisor re-register names for a child it did not itself
+   register?** §7 says yes (it carries forward whatever the incarnation held).
+   The alternative — only names the supervisor knows about — needs a child-spec
+   field and is worth revisiting if child specs grow anyway for restart types
+   (`specs/todos/2026-08-12-supervisor-restart-types-and-child-specs.md`).
+4. **Distributed seam**: when a name is registered locally, should it
+   automatically be announced to `global_registry`? Proposed: no, not
+   implicitly — keep local and global explicit, and design the bridge when the
+   distributed-plane work (`specs/todos/2026-08-11-actor-hardening-distributed-plane.md`)
+   is picked up.

--- a/specs/todos/2026-08-12-actor-named-registry.md
+++ b/specs/todos/2026-08-12-actor-named-registry.md
@@ -1,0 +1,40 @@
+`[P1]` # Named process registry: hold names across a restart, not stale Pids
+
+**Design spec:** [`specs/2026-08-12-named-registry-design.md`](../2026-08-12-named-registry-design.md)
+
+## The gap
+
+Supervision now self-heals with exponential backoff (2026-08-12 hardening,
+Tasks 14-16), but a restarted child gets a **new** Pid. The supervisor writes
+the new `pid_index` into its own state, so the *inside* of the tree recovers —
+every holder **outside** it is left pointing at a dead incarnation. `get_cap`'s
+epoch mechanism correctly *detects* the staleness, but nothing lets a holder
+**re-resolve**: there is no local name → Pid mapping.
+
+This is the missing half of the self-heal story. A supervision tree that heals
+internally while every caller holds a dead handle has not healed the system.
+
+## What every comparable runtime provides
+
+- **BEAM:** `register/2` + `whereis/1`, `{via, Registry, …}`, `:global`.
+  Elixir's `Registry` adds unique/duplicate keys and automatic cleanup.
+- **Akka:** actor paths — the path outlives the incarnation.
+- **Orleans:** goes furthest — you never hold a reference at all; you address a
+  grain by identity and the runtime activates it on demand.
+
+March has `stdlib/global_registry.march` and `stdlib/peer_registry.march` for
+the **distributed** plane, but no local registry. The local plane is the weaker
+one, which is backwards.
+
+## Sketch
+
+Full design in the spec above. In brief: a C-runtime name table beside
+`g_actor_tbl` (so lookups don't need a message round-trip and can be reached
+from the send path), automatic unregistration in `do_actor_death`, and
+re-registration inside `march_respawn_child` so a restart reuses the crashed
+incarnation's name without any child-spec syntax change.
+
+## Acceptance
+
+A supervised child registered under a name, killed repeatedly, is reachable by
+that name after every restart — from a holder that never saw the new Pid.

--- a/specs/todos/2026-08-12-graceful-shutdown-and-drain.md
+++ b/specs/todos/2026-08-12-graceful-shutdown-and-drain.md
@@ -1,0 +1,47 @@
+`[P2]` # No graceful shutdown: death discards the mailbox instead of draining it
+
+## The gap
+
+Actor death is immediate and lossy. The 2026-08-12 hardening (Task 14) added a
+reap-time mailbox drain, but that drain **disposes** queued messages — it frees
+them to fix a leak, it does not process them. There is also:
+
+- no `terminate`-style callback (an actor cannot flush, checkpoint, or hand
+  work back before dying);
+- no shutdown *timeout* — nothing waits for an actor to finish the message it
+  is currently handling;
+- no ordered shutdown of a supervision tree (OTP stops children in reverse
+  start order; March has no ordering at all).
+
+## Why it matters
+
+This is the deploy story. Rolling a node means: stop accepting new work, let
+in-flight work finish, then exit. Today the only way to stop an actor is
+`kill`, which drops whatever was queued — so a deploy loses exactly the
+requests that were waiting. The bounded-mailbox work made overload *survivable*;
+this is the other half, making shutdown *lossless*.
+
+Note the interaction with hot code reload (`runtime/march_reload.c`): migration
+already has a story for carrying state across a code swap, but not for draining
+the queue first.
+
+## Sketch
+
+A `stop(pid)` distinct from `kill(pid)`: mark the actor as draining (rejects
+new sends with a distinct result — cf. the `MARCH_SEND_*` codes added in Task
+7), let the recv loop run until the mailbox empties or a deadline passes, then
+die. The Task 2 timer heap gives the deadline for free.
+
+For trees, shutdown order needs the child ordering the supervisor already
+stores (`sup_children` is in declaration order — the same order
+`rest_for_one` relies on), walked in reverse.
+
+Interacts with `2026-08-12-supervisor-restart-types-and-child-specs.md`: OTP
+packages the per-child shutdown timeout in the same child spec as the restart
+type, so design them together.
+
+## Acceptance
+
+An actor with N queued messages that is `stop`ped processes all N (or hits a
+stated deadline) before dying; a supervision tree stops children in reverse
+declaration order; `kill` keeps today's immediate semantics.

--- a/specs/todos/2026-08-12-language-level-timers.md
+++ b/specs/todos/2026-08-12-language-level-timers.md
@@ -1,0 +1,50 @@
+`[P2]` # No `send_after` / `cancel_timer`: the timer heap exists but isn't exposed
+
+## The gap
+
+March has no way to schedule a message. There is no `send_after`,
+`cancel_timer`, or `Process.sleep`. An actor that wants to poll, retry, time
+something out, or tick has to burn a task green thread in a yield loop.
+
+## Why this is the cheapest item on the list
+
+The hard part is already built and shipped. The 2026-08-12 hardening (Task 2)
+added a real timer subsystem to the scheduler:
+
+- a mutex-guarded binary min-heap of `(deadline_ms, proc, park_gen)`
+  (`runtime/march_scheduler.c`), serviced every `MARCH_QUANTUM_US` from the
+  preemption daemon;
+- `march_sched_park_self_until(deadline_ms)` and `march_now_ms()`;
+- lazy cancellation via `park_gen`, so a woken-early proc's stale entry is
+  skipped rather than firing (added in Task 16's review round).
+
+That machinery is entirely runtime-internal: it backs `Actor.call` deadlines and
+supervisor restart backoff. Nothing surfaces it to March.
+
+## Sketch
+
+`send_after(pid, msg, delay_ms) : TimerRef` — enqueue into the same heap with a
+payload variant that performs a `march_sched_send` on fire, instead of only
+waking a parked proc. `cancel_timer(ref)` can reuse the `park_gen` trick
+(bump a generation, let the stale entry fire into nothing) rather than needing
+real heap removal.
+
+Two things to decide:
+
+1. **Ownership/RC of the pending message.** The heap would hold a March value
+   between now and the deadline — it needs a reference, and a cancelled or
+   dead-target timer must dispose it. The `march_sched_set_msg_dtor` hook added
+   in Task 14 is exactly the disposal channel to reuse.
+2. **Timer entries pin their target proc.** Procs are leak-don't-free, so a
+   long timer cannot dangle — but a long timer *does* keep the scheduler from
+   going idle, which now matters because `march_sched_wait_idle` counts live
+   timer entries as busy (Task 16). A one-hour `send_after` would keep
+   `run_until_idle()` from returning. Decide whether scheduled sends count as
+   "work pending" (they do for a server; they probably should not for
+   `run_until_idle` in a test).
+
+## Acceptance
+
+`send_after` delivers after the delay and not before; `cancel_timer` before the
+deadline delivers nothing and leaks nothing; a cancelled or dead-target timer's
+message is disposed through the registered dtor.

--- a/specs/todos/2026-08-12-links-and-exit-signals-unreachable.md
+++ b/specs/todos/2026-08-12-links-and-exit-signals-unreachable.md
@@ -1,0 +1,56 @@
+`[P2]` # `link` is implemented but unreachable; no exit signals, no trap-exit
+
+## The gap
+
+`lib/eval/eval.ml:4238` defines a `link` builtin (and `link_actors` /
+`ai_links` machinery backs it), but **there is no entry in the typechecker's
+builtin table**, so the function does not exist as far as typed March is
+concerned:
+
+```
+    link(a, b)
+         ^^^^
+    I cannot find `link`.
+```
+
+(verified 2026-08-12 against a two-actor program). `unlink` is in the same
+position. There is also no `trap_exit` / exit-signal propagation of any kind.
+
+So the runtime carries half an implementation of a fault-propagation model that
+no program can reach.
+
+## Why it matters
+
+Links + exit signals + trap-exit are BEAM's *core* fault model — they are how
+supervisors are built and how "let it crash" composes beyond a single
+supervision tree. March currently has monitors (one-directional, and see
+`2026-08-12-monitor-down-carries-no-reason.md`) plus built-in supervisors, and
+nothing else.
+
+## The decision to make, deliberately
+
+This is genuinely a design fork, not an obvious omission:
+
+- **Akka** deliberately dropped links in favour of DeathWatch (monitor-style) +
+  supervision strategies, and is none the worse for it.
+- **BEAM** treats links as foundational.
+
+Either answer is defensible. What is *not* defensible is the current state: an
+accidental answer produced by an unreachable builtin. Pick one:
+
+1. **Expose it** — type `link`/`unlink`, define exit-signal propagation
+   (a linked actor's death kills its peer unless the peer traps exits), add
+   `trap_exit` so a trapping actor receives an Exit message instead of dying.
+2. **Remove it** — delete the interpreter builtin and `ai_links`, and state in
+   `specs/lang/actors.md` that March's fault model is monitors + supervisors,
+   Akka-style, so the absence is documented rather than discovered.
+
+Option 2 is cheaper and loses nothing that supervisors + a reason-carrying
+monitor do not already provide. Option 1 is the right call only if bidirectional
+failure propagation between *peers* (not parent/child) turns out to be a real
+need.
+
+## Acceptance
+
+Either `link` type-checks and its exit semantics are specified and tested, or
+the builtin is gone and the actors chapter says why.

--- a/specs/todos/2026-08-12-monitor-down-carries-no-reason.md
+++ b/specs/todos/2026-08-12-monitor-down-carries-no-reason.md
@@ -1,0 +1,47 @@
+`[P1]` # A local monitor delivers a COUNT, not a Down message with a reason
+
+## The gap
+
+`march_monitor` (`runtime/march_runtime.c`) registers the watcher on the
+target's `monitor_head`; when the target dies, `do_actor_death` walks that list
+and does nothing but `atomic_fetch_add(&watcher_meta->down_count, 1)`. The
+watcher can learn only *how many* monitored actors have died — never **which**
+one, under which monitor ref, or **why**.
+
+`march_mailbox_size` returns `queue depth + down_count`, which is the only way
+the count surfaces at all.
+
+## Why it matters
+
+- A watcher cannot distinguish a normal stop from a crash from a kill, so
+  user-written supervision-like logic (retry on crash, accept a normal exit)
+  is impossible to write correctly.
+- `Actor.call` cannot tell "the actor died" from "the deadline passed" — both
+  surface as the same timeout `Err`, which the 2026-08-12 hardening documented
+  but could not fix for want of a reason channel.
+
+## The inconsistency to close
+
+The **distributed** plane already models this properly:
+`stdlib/dist_link.march` defines `DownReason = Normal | Killed | Crash(String)
+| NodeDown` and delivers `Down(ref, pid, reason)`. So a cross-node monitor is
+strictly more informative than a local one. Close the gap in the *local*
+direction — reuse `DownReason` rather than inventing a second vocabulary.
+
+## Sketch
+
+Deliver a real message into the watcher's mailbox instead of bumping a counter:
+`do_actor_death` already knows the reason it was called with (explicit
+`march_kill` vs the crash trap in `actor_green_thread` vs normal loop exit), so
+the information exists at the call site and is currently discarded. Monitor
+nodes already carry `mon_ref`, so the ref is available too.
+
+Interacts with the mailbox work: a Down message is an ordinary message and must
+respect the target's queue limit — decide deliberately whether a Down is
+control-plane traffic that bypasses the limit (cf. the scheduler-stack bypass
+in `march_sched_send`) or ordinary traffic that can be dropped.
+
+## Acceptance
+
+A watcher receives a `Down` carrying the monitor ref, the dead Pid, and a
+reason that distinguishes normal / killed / crashed, on both backends.

--- a/specs/todos/2026-08-12-per-actor-introspection-and-alarms.md
+++ b/specs/todos/2026-08-12-per-actor-introspection-and-alarms.md
@@ -1,0 +1,57 @@
+`[P2]` # Observability is aggregate-only: no process enumeration, no slow-mailbox alarm
+
+## The gap
+
+The 2026-08-12 hardening added the counters (`Scheduler.live_procs`,
+`total_spawned`, `runq_depth`, `dropped_messages`) and fixed compiled
+`mailbox_size` to report real queue depth. That answers *"is the system
+behind?"* — it cannot answer **"which actor is behind?"**, which is the
+question you actually have at 3am.
+
+Specifically missing:
+
+- **Process enumeration.** There is no way to list live actors from March. You
+  can only call `mailbox_size(pid)` on a Pid you already hold, so finding the
+  hot actor requires already knowing which one it is.
+- **Per-actor state inspection.** No equivalent of `sys:get_state/1`.
+  `get_actor_field` exists but needs a Pid and a field index.
+- **A growing-mailbox alarm.** BEAM's `erlang:system_monitor` has a
+  `long_message_queue` trigger that tells you *when* a process crosses a
+  threshold. Ours must be polled, and polling requires enumeration (above), so
+  the loop cannot currently be closed at all.
+- **Tracing.** No `erlang:trace` equivalent — no way to watch one actor's
+  message flow without editing the program.
+
+## Why it matters now specifically
+
+The whole point of the bounded-mailbox work is deciding *when to shed*, and
+`docs/overload-resilience.md` tells readers to poll `Scheduler` counters and
+`mailbox_size` to make that decision. For a real service that guidance is
+incomplete: the counters are global, and `mailbox_size` needs a Pid the
+monitoring code has no way to obtain. The shedding story needs the enumeration
+to be genuinely actionable.
+
+## Sketch
+
+The runtime already holds everything needed. `g_actor_tbl` (256 buckets, keyed
+by actor pointer) and the growable proc registry (Task 13) between them know
+every live actor, and `march_sched_mbox_count` gives depth. What's missing is a
+March-visible walk.
+
+Design questions: a snapshot list of Pids is racy by nature (an actor can die
+between enumeration and inspection) — probably fine, since every consumer
+already handles a dead Pid. A `Scheduler.top_by_mailbox(n)` that does the walk
+*inside* the runtime and returns only the worst N avoids materialising a list
+of every actor and is the more useful shape for the alarm case.
+
+Watch the lock discipline: enumeration walks the same structures the send path
+touches, and Task 10 deliberately took `find_meta` off `g_tbl_mu` to keep sends
+lock-free. An enumeration that takes that mutex on a monitoring timer would
+re-serialise the very path that work freed. Use the same lock-free
+bucket-head walk.
+
+## Acceptance
+
+A monitoring loop written in March can identify the deepest-mailbox actors
+without holding their Pids in advance, and does not measurably slow the send
+path while doing it.

--- a/specs/todos/2026-08-12-selective-receive-or-stash.md
+++ b/specs/todos/2026-08-12-selective-receive-or-stash.md
@@ -1,0 +1,46 @@
+`[P3]` # No selective receive, stash, or `become`
+
+## The gap
+
+`receive()` pops the **oldest** message with no pattern selection, and
+`specs/lang/actors.md` documents a further restriction: only the *first*
+`receive()` in a handler is safe to block on — a second blocking `receive()`
+loses the message the first one already popped, because the scheduler's re-queue
+only restores the outer triggering message.
+
+So an actor that needs "wait for *this particular* message next" has no
+mechanism. There is no stash/unstash, and no `become`-style handler swap.
+
+## Why it matters
+
+Selective receive is how BEAM expresses a protocol step inline (`receive {ok,
+Ref, Reply} -> …`), which is what makes multi-step conversations readable
+without hand-rolling a state machine. Akka doesn't have selective receive
+either — it has `stash`/`unstash` plus `become`/`context.become`, which covers
+the same ground differently: park the messages you can't handle yet, swap the
+handler when the state changes.
+
+March today has neither, so the only tool is the actor's state record plus
+handler dispatch — i.e. every protocol becomes an explicit state machine the
+author writes by hand. That is workable but verbose, and it interacts badly
+with session types (`specs/lang/session-types.md`), whose whole selling point
+is expressing a conversation in order.
+
+## The realistic option
+
+Full selective receive is expensive: it implies scanning the mailbox and
+preserving skipped messages in order, which the current single-linked-list
+mailbox with an O(1) FIFO pop is not shaped for, and it has a well-known
+quadratic blow-up when a long queue is scanned repeatedly.
+
+`stash` / `unstash_all` + a handler swap is the cheaper and more March-shaped
+answer: the stash is an ordinary list in actor state, the swap is a field. It
+may not even need runtime support — it could be a stdlib pattern plus a
+documented idiom, in which case the deliverable is a cookbook recipe rather
+than a compiler change. Establish that first before building anything.
+
+## Acceptance
+
+Either a stash/become idiom is documented (with a worked multi-step protocol),
+or `receive` grows pattern selection with its complexity cost measured against
+a long mailbox.

--- a/specs/todos/2026-08-12-supervisor-restart-types-and-child-specs.md
+++ b/specs/todos/2026-08-12-supervisor-restart-types-and-child-specs.md
@@ -1,0 +1,44 @@
+`[P1]` # No restart types: a supervised child can never be retired
+
+## The gap
+
+`march_kill` → `do_actor_death` → `march_supervisor_notify` fires for **every**
+death of a supervised child, with no way to distinguish "this child crashed"
+from "this child was deliberately stopped". Every child is therefore
+`permanent` in OTP's vocabulary, and:
+
+**`kill(pid)` on a supervised child restarts it.** There is no way to
+deliberately retire one. A worker that finishes its assignment and stops is
+brought back, forever, until the restart budget escalates and takes down the
+supervisor.
+
+## What OTP child specs carry that March's `supervise` block does not
+
+| Field | OTP values | March today |
+|---|---|---|
+| `restart` | `permanent` \| `transient` (restart only on *abnormal* exit) \| `temporary` (never) | always permanent |
+| `shutdown` | `brutal_kill` \| timeout ms \| `infinity` | always brutal |
+| `type` | `worker` \| `supervisor` | n/a (nesting works, but untyped) |
+| `significant` | bool | n/a |
+
+`transient` is the common case this blocks: a job worker that exits normally
+when its work is done, and is restarted only when it dies badly.
+
+## Sketch
+
+The runtime already distinguishes the two death paths — `march_kill` (explicit)
+vs the crash trap in `actor_green_thread` (panic) — it simply collapses them at
+the notify call. Thread a reason through `do_actor_death` (shared with
+`2026-08-12-monitor-down-carries-no-reason.md`, which needs exactly the same
+information) and consult the child's restart type before notifying.
+
+Surface syntax is the open design question: `supervise` blocks name children as
+`Name = spawn(Actor)`, with no slot for per-child options. Options include a
+trailing modifier (`child = spawn(W) restart transient`) or an options record.
+Decide alongside the `shutdown` field so the child spec grows once, not twice.
+
+## Acceptance
+
+`kill()` on a `transient`/`temporary` child stops it for good; a crash still
+restarts a `transient` child; existing `supervise` blocks keep working
+unchanged (permanent stays the default).


### PR DESCRIPTION
## Summary

Docs/specs only — no code. A comparison of the hardened actor system (PR #258) against BEAM/OTP, Akka/Pekko and Orleans, with each remaining gap filed one-per-file, plus a design spec for the highest-priority one.

**Where the hardening left us ahead:** bounded mailboxes with a blocking policy (BEAM has no bounded mailboxes at all), exponential restart backoff with jitter (stock OTP has restart intensity only), and a saturation harness as a merge gate. Correlation-checked calls put us level with BEAM's ref-based `gen_server:call`.

## Filed (8 todos)

| Item | P | Why |
|---|---|---|
| Named registry | P1 | A restart yields a **new Pid**, so every holder outside the tree is stale. `get_cap`'s epoch *detects* this with no way to re-resolve. The missing half of self-heal. |
| Monitor Down carries no reason | P1 | Local monitors bump `down_count`; the **distributed** plane already models `Normal \| Killed \| Crash \| NodeDown`. |
| Links/exit signals unreachable | P2 | `link` is in `eval.ml:4238` with **no typechecker entry** — verified: `I cannot find \`link\``. |
| Restart types | P1 | Every child is `permanent`: `kill()` on a supervised child restarts it. |
| Graceful shutdown | P2 | Death discards the mailbox. No terminate hook, no ordered tree shutdown. |
| Language-level timers | P2 | Task 2 of the hardening built the timer heap; nothing exposes `send_after`. |
| Selective receive / stash | P3 | Establish whether a stash+become idiom suffices first. |
| Per-actor introspection | P2 | Counters answer "is the system behind", not "which actor". |

Deliberate non-goals named so they don't read as omissions: Orleans-style virtual activation, and persistence/event-sourcing.

## The registry design

`specs/2026-08-12-named-registry-design.md`, built on **Vault** (March's ETS) — mirroring how Elixir's `Registry` is built on ETS, verified against v1.20.3 source. That reading also established two things the design depends on: lookups read ETS directly from the calling process under `read_concurrency: true`, and the reverse pid→keys index is not something a KV store lets you avoid (`:ets.take(ets, pid)`).

The companion todo `specs/todos/2026-08-12-vault-toward-ets-semantics.md` records what Vault needs to be that substrate, including the decision that in-memory **reads should need no capability** while naming ops and writes keep `IO.Mut`.

**Implementation follows separately** — the Vault work is in a follow-up PR, and the registry itself after it.

## Test plan

`scripts/check-docs.sh` green. No code touched.