### PR TITLE
fix(codegen): don't GEP through a field whose type is still a TVar

### DIFF
--- a/lib/tir/llvm_emit.ml
+++ b/lib/tir/llvm_emit.ml
@@ -4950,9 +4950,32 @@ let rec emit_expr ctx (e : Tir.expr) : string * string =
         ("ptr", res)
       | _ ->
         let (idx, field_ty) = field_index_for ctx obj_ty field_name in
-        let (_, obj_val) = emit_atom ctx obj_atom in
-        let fv = emit_load_field ctx obj_val idx (llvm_ty field_ty) in
-        (llvm_ty field_ty, fv)
+        (match field_ty with
+         | Tir.TVar _ when ctx.shape_meta ->
+           (* The record's shape is statically known but THIS field's type is
+              still an unresolved type variable — monomorphisation did not
+              reach it (e.g. a record rebuilt inside a generic `List.map`
+              lambda and consumed by a separate function).  A TVar says
+              nothing about the field's representation, so a direct typed load
+              is unsound: emitting one loads the slot as `ptr` and the ptr->i64
+              coercion then untags it, which silently HALVES any odd integer
+              (35 read back as 17) while leaving even ones intact.
+
+              Fall back to the by-name shape lookup used for wholly-unknown
+              records.  It consults the runtime shape recorded at construction
+              and returns ints low-bit tagged, which is exactly the generic
+              ADT-slot convention the consuming coercion expects. *)
+           let (_, obj_val) = emit_atom ctx obj_atom in
+           let ng = intern_string ctx field_name in
+           let res = fresh ctx "cr" in
+           emit ctx (Printf.sprintf
+             "%s = call ptr @march_record_field_dyn(ptr %s, ptr %s, i64 %d)"
+             res obj_val ng (String.length field_name));
+           ("ptr", res)
+         | _ ->
+           let (_, obj_val) = emit_atom ctx obj_atom in
+           let fv = emit_load_field ctx obj_val idx (llvm_ty field_ty) in
+           (llvm_ty field_ty, fv))
     end
 
   (* ── Record update ─────────────────────────────────────────────────── *)

--- a/specs/lang/golden/sanitize.sh
+++ b/specs/lang/golden/sanitize.sh
@@ -34,12 +34,6 @@ fi
 export ASAN_OPTIONS="detect_leaks=0:halt_on_error=1"
 export MARCH_STDLIB="${MARCH_STDLIB:-$root/stdlib}"
 
-# TRMC mode is inherited from the environment so the caller can run this
-# script twice — once per mode — and get separately attributable output.
-# Without the label a failure in one mode is indistinguishable from the other.
-mode_label="trmc=${MARCH_TRMC:-off}"
-echo "=== golden sanitize ($mode_label) ==="
-
 pass=0; fail=0
 for f in "$here"/*.march; do
   b="$(basename "$f" .march)"
@@ -54,5 +48,5 @@ for f in "$here"/*.march; do
   fi
 done
 
-echo "=== golden sanitize ($mode_label): $pass clean, $fail failed ==="
+echo "=== golden sanitize: $pass clean, $fail failed ==="
 [ $fail -eq 0 ]

--- a/test/native/record_field_erased_int.expected
+++ b/test/native/record_field_erased_int.expected
@@ -1,0 +1,4 @@
+direct a odd=35 even=32
+direct b odd=51 even=54
+rebuilt a odd=35 even=32
+rebuilt b odd=51 even=54

--- a/test/native/record_field_erased_int.march
+++ b/test/native/record_field_erased_int.march
@@ -1,0 +1,39 @@
+mod RecordFieldErasedInt do
+
+-- A record REBUILT inside a generic `List.map` lambda and then read by a
+-- separate function.  The rebuilding lambda is monomorphised (it knows the
+-- fields are Int and stores them raw, `store i64`), but the consumer's view of
+-- that field is still an unresolved `TVar` — monomorphisation never reaches it.
+--
+-- llvm_emit used to GEP straight through that TVar field: the slot was loaded
+-- as `ptr` and the ptr->i64 coercion then applied its conditional untag
+-- (`select (v & 1), v >> 1, v`).  That heuristic assumes an erased slot holds
+-- either a TAGGED int (odd) or a heap pointer (even), so a raw untagged int
+-- whose value happens to be ODD was silently HALVED: 35 read back as 17, 51 as
+-- 25, while even values came through intact.
+--
+-- Parity is the tell, and it makes the bug survive casual testing — half of
+-- every sample looks correct.  It reached production in forgepm, where a page
+-- that cites the source line of a capability declaration pointed readers at
+-- line 17 of a file whose declaration is on line 35.
+--
+-- A TVar says nothing about a field's representation, so the read now goes
+-- through march_record_field_dyn, which consults the shape recorded at
+-- construction and returns ints low-bit tagged — exactly what the consuming
+-- coercion expects.
+pfn rebuild(rows, flag) do
+  List.map(rows, fn r ->
+    { name: r.name, odd: r.odd, even: r.even, flag: flag })
+end
+
+pfn describe(r) do
+  r.name ++ " odd=" ++ int_to_string(r.odd) ++ " even=" ++ int_to_string(r.even)
+end
+
+fn main() : Unit do
+  let rows = [{ name: "a", odd: 35, even: 32 },
+              { name: "b", odd: 51, even: 54 }]
+  List.each(rows, fn r -> println("direct " ++ describe(r)))
+  List.each(rebuild(rows, true), fn r -> println("rebuilt " ++ describe(r)))
+end
+end

--- a/test/native/record_field_erased_int.march
+++ b/test/native/record_field_erased_int.march
@@ -1,4 +1,5 @@
 mod RecordFieldErasedInt do
+  needs IO.Console
 
 -- A record REBUILT inside a generic `List.map` lambda and then read by a
 -- separate function.  The rebuilding lambda is monomorphised (it knows the
@@ -30,7 +31,7 @@ pfn describe(r) do
   r.name ++ " odd=" ++ int_to_string(r.odd) ++ " even=" ++ int_to_string(r.even)
 end
 
-fn main() : Unit do
+fn main(_cap_console : Cap(IO.Console)) : Unit do
   let rows = [{ name: "a", odd: 35, even: 32 },
               { name: "b", odd: 51, even: 54 }]
   List.each(rows, fn r -> println("direct " ++ describe(r)))


### PR DESCRIPTION
A record rebuilt inside a generic `List.map` lambda and read by a separate function silently **halves any odd integer field**. Compiled only — the interpreter is correct throughout.

```
direct  a odd=35 even=32
direct  b odd=51 even=54
rebuilt a odd=17 even=32     ← 35 halved
rebuilt b odd=25 even=54     ← 51 halved
```

## Cause

The two sides disagree about the field's representation:

| side | field type | emitted |
|---|---|---|
| rebuilding lambda (monomorphised) | `TInt` | `store i64` — raw |
| consumer | `TVar(_37465)` | `load ptr`, then conditional untag |

`llvm_emit`'s `EField` GEP'd straight through the `TVar`, loading the slot as `ptr`. The `ptr->i64` arm of `coerce` then applied its conditional untag:

```llvm
select (v & 1), v >> 1, v
```

That heuristic is sound only under its stated assumption — an erased slot holds *either* a tagged int (odd) *or* a heap pointer (even). A raw untagged int breaks it, and breaks it **by parity**, which is why it survived casual testing: half of any sample looks correct.

## Fix

A `TVar` says nothing about a field's representation, so a direct typed load is never safe there. Treat it like the wholly-unknown-shape case in the branch immediately above: go through `march_record_field_dyn`, which consults the shape recorded at construction and returns ints low-bit tagged — exactly the generic ADT-slot convention the consuming coercion already expects.

This is the same corner as the existing `record_pattern` fixture's Float SIGSEGV — `EField` reaching a field it has no real type for. That one crashed, so it got found; this one returns a plausible wrong number.

## Validation

- New fixture `test/native/record_field_erased_int` reproduces it: `odd=17`/`odd=25` before, `35`/`51` after, evens unaffected either way.
- **544 tests pass** (`dune runtest`, 7844s).
- The original production shape (forgepm's `CapIntro.annotate`) round-trips correctly when rebuilt with the patched compiler.

## How it was found

forgepm's capability pages cite the source line of a `needs` declaration. They pointed readers at line 17 of a file whose declaration is on line 35. Every stage in isolation — the DB read, `string_to_int`, record construction, the rebuild, `~H` interpolation — is correct compiled; only the full path fails, so nothing smaller than the whole chain reproduced it until the `TVar` showed up in the emitted types.

Note the blast radius is wider than the one page that surfaced it: any `Int` (or `Bool`) field read through an unresolved `TVar` is affected, and it fails silently rather than loudly.