### PR TITLE
test(actor): pin the dispatch RC window itself, not just its restore

### DIFF
--- a/specs/todos/2026-08-14-deterministic-premature-free-reproducer.md
+++ b/specs/todos/2026-08-14-deterministic-premature-free-reproducer.md
@@ -6,6 +6,44 @@ regression test**. If someone reintroduces an RC-conditional reuse of the actor
 record — the exact thing the deleted `a[0] = 1` clobber existed to enable — the
 suite will stay green.
 
+## Update 2026-08-14 (second pass) — the window itself is now pinned
+
+`test/native/actor_dispatch_rc_window.march` closes the gap the section below
+describes. It is option (1)'s invariant, reached without option (1)'s machinery:
+**no second thread is required to observe the window.**
+
+The clobber installed the forged `1` *before* the dispatch call, so the lie is
+already published by the time the handler body runs. A `ffi_test_actor_rc` probe
+called from **inside** the handler therefore reads exactly what a concurrent
+thread would read — on one scheduler thread, with no race. The bug needs a
+second thread to be *harmed* by the lie; it does not need one to *observe* it.
+That is what turns "statistical repro" into a unit test.
+
+The victim is a supervised child, so its true refcount exceeds 1 by
+construction; the test's first line is the non-vacuity guard on that, and its
+third line guards against a probe that silently never fired.
+
+Verified adversarially by reinstating the `a[0] = 1` / `a[0] = saved_rc` pair
+into `actor_green_thread` on top of current `main` (i.e. reverting only
+`a9032530`'s hunks, keeping `acfa832c`):
+
+| runtime | runs | result |
+|---|---|---|
+| clobber reinstated | 20 | 20/20 **RED** (`rc inside handler matches rc outside: false`) |
+| clobber absent (`main`) | 20 | 20/20 **GREEN** |
+
+Crucially this fails for a clobber that restores correctly on *every* exit path,
+including the crash trap — the case `actor_crash_rc_restore.march` cannot see.
+The two tests are complements: that one pins the failure to close the window,
+this one pins the window being open at all.
+
+**Still open: option (2)**, the source-level guard against a plain store to an
+actor record's `a[0]`. Not done here deliberately — it is new machinery (nothing
+in the suite currently greps runtime C source), it is trivially evadable by a
+reintroduction that spells the store differently, and its value is only for
+clobbers on dispatch paths this test has no window on. Worth doing, but it is a
+different change than "pin the bug", which is now done.
+
 ## Partially covered as of 2026-08-14 — the deterministic red now exists
 
 `test/native/actor_crash_rc_restore.march` asserts, through the test-only
@@ -73,12 +111,15 @@ instance was found (`native_int_arr_set` and friends *read* `->rc` rather than
 forging it), but the pattern is attractive enough to recur, and a guard of shape
 (2) would catch the next one for free.
 
-## Acceptance (revised 2026-08-14)
+## Acceptance (revised 2026-08-14, second pass)
 
 Original criterion — "reverting `a9032530` turns something red deterministically"
 — is **met** by `test/native/actor_crash_rc_restore.march`.
 
-Remaining: a test that fails when the refcount word is written non-atomically
-even if every exit path restores it correctly — i.e. one that observes the
-window from another thread (option 1), and/or a guard that rejects the pattern
-in source (option 2).
+The sharper criterion — "fails when the refcount word is written non-atomically
+even if every exit path restores it correctly" — is **met** by
+`test/native/actor_dispatch_rc_window.march` (20/20 red with the clobber, 20/20
+green without; see the second-pass section at the top).
+
+Remaining: only option (2), the source-level guard. This file stays open for
+that alone; the testing question it was filed for is answered.

--- a/test/dune
+++ b/test/dune
@@ -2803,6 +2803,39 @@ printf 'mod CsHelper do\\n\\n  fn double(x : Int) : Int do\\n    x * 2\\n  end\\
  (alias runtest)
  (action (diff native/actor_crash_rc_restore.expected native_actor_crash_rc_restore.out)))
 
+; ── Regression: the dispatch loop must not clobber the actor record's
+; refcount for the DURATION of a handler.  The neighbouring test above pins
+; the crash trap's failure to RESTORE the refcount; this one pins the open
+; WINDOW itself, so a future clobber that restores correctly on every exit
+; path still fails.  No race is needed to observe it: the forged 1 is
+; published before the dispatch call, so the ffi_test_actor_rc probe called
+; from INSIDE the handler reads the same lie a concurrent thread would.
+; Verified adversarially: reinstating the a[0] = 1 / a[0] = saved_rc pair
+; turns this red 20/20, and it is green 20/20 without it.
+(rule
+ (targets native_actor_dispatch_rc_window native_actor_dispatch_rc_window.out)
+ (deps (file %{exe:../bin/main.exe})
+       (file ../runtime/march_runtime.c) (file ../runtime/march_runtime.h)
+       (file ../runtime/march_ffi.c) (file ../runtime/march_ffi.h)
+       (file ../runtime/march_scheduler.c) (file ../runtime/march_scheduler.h)
+       (file ../runtime/march_heap.c) (file ../runtime/march_heap.h)
+       (file ../runtime/march_gc.c) (file ../runtime/march_gc.h)
+       (file ../runtime/march_message.c) (file ../runtime/march_message.h)
+       (file ../runtime/march_deque.h)
+       (file ../runtime/march_extras.c) (file ../runtime/march_ctx_escape.c) (file ../runtime/march_compress.c)
+       (file ../runtime/base64.c) (file ../runtime/sha1.c)
+       (file native/actor_dispatch_rc_window.march))
+ (action
+  (progn
+   (run %{exe:../bin/main.exe} --compile -o native_actor_dispatch_rc_window
+        native/actor_dispatch_rc_window.march)
+   (with-stdout-to native_actor_dispatch_rc_window.out
+        (system "./native_actor_dispatch_rc_window")))))
+
+(rule
+ (alias runtest)
+ (action (diff native/actor_dispatch_rc_window.expected native_actor_dispatch_rc_window.out)))
+
 ; ── Regression: a panic inside a SUPERVISED actor's message handler must
 ; not exit(1) the whole process — it must crash-isolate to that actor's own
 ; green thread and trigger a one_for_one restart (before this fix, kill()

--- a/test/native/actor_dispatch_rc_window.expected
+++ b/test/native/actor_dispatch_rc_window.expected
@@ -1,0 +1,3 @@
+victim is multiply owned: true
+rc inside handler matches rc outside: true
+handler observed something: true

--- a/test/native/actor_dispatch_rc_window.march
+++ b/test/native/actor_dispatch_rc_window.march
@@ -1,0 +1,106 @@
+-- Regression: an actor record's refcount must tell the truth WHILE its
+-- handler is running, not just before and after.
+--
+-- actor_green_thread used to bracket every message dispatch with
+--     int64_t saved_rc = a[0];
+--     a[0] = 1;              // "FBIP: force RC=1 for in-place reuse"
+--     ...dispatch...
+--     a[0] = saved_rc;
+-- a[0] is the actor record's refcount, which every other thread mutates
+-- atomically through march_incrc/march_decrc.  Those plain stores published a
+-- LIE: for the whole duration of a handler, every other thread saw the
+-- refcount as 1.  A concurrent march_decrc then observed prev == 1, concluded
+-- "last reference", and freed a record that still had live owners
+-- (specs/progress/2026-08-14-actor-dispatch-rc-clobber-uaf.md).
+--
+-- test/native/actor_crash_rc_restore.march already pins the neighbouring case:
+-- a panic()'s longjmp skipping the `a[0] = saved_rc` epilogue.  But a future
+-- clobber that restored correctly on EVERY exit path — crash trap included —
+-- would pass that test and still be exactly as unsafe, because the danger is
+-- the OPEN WINDOW, not the failure to close it.  This test pins the window
+-- itself.
+--
+-- The window is observable without any race, which is what makes this a unit
+-- test rather than a stress harness.  The clobber is installed BEFORE the
+-- dispatch call, so the forged 1 is already published by the time the handler
+-- body runs: a probe called from INSIDE the handler reads the same lie a
+-- concurrent thread would, on a single scheduler thread, on every run.  The
+-- real bug needs a second thread to be HARMED by the lie; it does not need one
+-- to OBSERVE it.
+--
+-- `ffi_test_actor_rc` is the test-only runtime probe (runtime/march_ffi.c)
+-- also used by actor_crash_rc_restore.march.  The refcount is invisible from
+-- the March surface, and every March-level symptom of this bug is a
+-- use-after-free — i.e. undefined behavior, and therefore a flaky test.  The
+-- refcount IS the invariant, so assert on it directly.
+--
+-- The victim is a SUPERVISED child so that its refcount exceeds 1 by
+-- construction (the supervisor holds a reference alongside main's).  The first
+-- line is the non-vacuity guard: if the observed-from-outside count is not > 1
+-- then a forged 1 would be indistinguishable from the truth, the second line
+-- has stopped proving anything, and this test needs a new shape rather than a
+-- new .expected.
+mod Main do
+  needs IO.Console
+  needs Ffi
+  needs IO.Foreign
+
+  extern "rt" : Cap(Ffi) do
+    fn actor_rc(pid : Int) : Int = "ffi_test_actor_rc"
+  end
+
+  actor Victim do
+    state { seen : Int }
+    init  { seen: 0 }
+
+    -- The pid index arrives in the message rather than via `self`, which is
+    -- bound as an opaque Pid inside a handler; the probe wants the raw index.
+    on Look(idx : Int) do
+      { seen: actor_rc(idx) }
+    end
+  end
+
+  actor Boss do
+    state { child : Int }
+    init  { child: 0 }
+
+    supervise do
+      strategy one_for_one
+      max_restarts 10 within 60
+      Victim child
+    end
+  end
+
+  fn current_child(boss) do
+    match get_actor_field(boss, "child") do
+      None    -> -1
+      Some(n) -> n
+    end
+  end
+
+  fn seen_by(child) do
+    match get_actor_field(pid_of_int(child), "seen") do
+      None    -> -1
+      Some(n) -> n
+    end
+  end
+
+  fn main(_c : Cap(IO.Console), _f : Cap(IO.Foreign)) do
+    let boss = spawn(Boss)
+    let victim = current_child(boss)
+    let rc_outside = actor_rc(victim)
+    println("victim is multiply owned: " ++ bool_to_string(rc_outside > 1))
+
+    send(pid_of_int(victim), Look(victim))
+    run_until_idle()
+
+    -- The load-bearing line.  With the clobber present this reads 1 while
+    -- rc_outside reads the true owner count, on every single run.
+    println("rc inside handler matches rc outside: "
+            ++ bool_to_string(seen_by(victim) == rc_outside))
+
+    -- And the handler really did run, so a probe that silently never fired
+    -- cannot masquerade as a pass.
+    println("handler observed something: " ++ bool_to_string(seen_by(victim) > 0))
+  end
+end


### PR DESCRIPTION
## What

Adds `test/native/actor_dispatch_rc_window.march` — a **deterministic** regression test for the actor-refcount premature-free fixed in `a9032530`.

## Why the existing test isn't enough

`test/native/actor_crash_rc_restore.march` (from #276) pins the neighbouring case: `panic()`'s `longjmp` skipping the `a[0] = saved_rc` epilogue. It cannot catch a clobber that restores correctly on *every* exit path, crash trap included — and that variant is exactly as unsafe. The hazard is the **open window** publishing a forged `rc == 1` to a word other threads concurrently RMW via `march_incrc`/`march_decrc`; it is not the failure to close it.

`specs/todos/2026-08-14-deterministic-premature-free-reproducer.md` filed this as option (1): observe the window from another thread.

## The shortcut that makes it a unit test

No second thread is needed. The clobber installed the forged `1` **before** the dispatch call, so the lie is already published by the time the handler body runs. An `ffi_test_actor_rc` probe called from **inside** the handler therefore reads exactly what a concurrent thread would read — one scheduler thread, no race, every run.

> The bug needs a second thread to be *harmed* by the lie. It does not need one to *observe* it.

That is what turns the statistical `bench/actors/spawn_churn.march` repro (6/30 pre-fix) into something that belongs in `runtest`.

The victim is a supervised child so its true refcount exceeds 1 by construction. Line 1 is the non-vacuity guard on that; line 3 guards against a probe that silently never fired.

## Adversarial verification

Reinstated the `a[0] = 1` / `a[0] = saved_rc` pair into `actor_green_thread` on top of this branch — reverting only `a9032530`'s hunks, keeping `acfa832c` — rebuilt via `dune build --root . @bin/warm-cache` with `.march/cas/artifacts-v2/` cleared:

| runtime | runs | result |
|---|---|---|
| clobber reinstated | 20 | **20/20 RED** — `rc inside handler matches rc outside: false` |
| clobber absent (this branch) | 20 | **20/20 GREEN** |

Zero variance in either direction.

## Cost

One small compiled binary, no loop, no sleep — same shape and cost as the `actor_crash_rc_restore` rule it sits beside. No case for a separate alias.

## Still open

The todo stays open for its **option (2)** alone: a source-level guard rejecting a plain store to an actor record's `a[0]`. Deliberately not bundled here — nothing in the suite currently greps runtime C source, it is trivially evadable by a differently-spelled store, and its only marginal value is for dispatch paths this test has no window on. Worth doing as its own change.

## Verification

- `dune build --root .` — clean
- `dune build @test/runtest --root .` — exit 0; new rule's `.out` byte-identical to `.expected`
- `scripts/run-tests.sh` — exit 0, 2646 tests, zero failures

No `CHANGELOG.md` entry: test-only, no user-visible behavior change.
