### PR TITLE
feat(lsp): parity for the prelude/entry-fn name-collision check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,10 @@ git log is authoritative for exact commits.
   `march dap`. Shadowing a Prelude/builtin name Prelude never calls
   internally — `head`, `map`, `unwrap`, `file_read`, and most of the rest —
   remains legal and unaffected; that's a documented, separately-tested
-  feature, not part of this bug.
+  feature, not part of this bug. **The editor (LSP) now reports this the
+  same way `march --compile`/`--check` do** — previously the language
+  server's own independent analysis pipeline didn't run this check, so a
+  colliding function showed no squiggle at all until you actually compiled.
 - **`simd_leak_probe`'s CI leak guard no longer false-positives on Linux.**
   The guard for the per-call SIMD vector temp-box leak
   (`test/native/simd_leak_probe.march`) asserted an absolute peak-RSS

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -36,28 +36,17 @@ let severity_word (sev : March_errors.Errors.severity) : string =
    see a collision with them on its own; it needs this list. Sourced from
    the SAME table the typechecker itself resolves ordinary builtin calls
    against, so this can never drift from what the compiler actually treats
-   as a builtin. Dotted names (there are none in [builtin_bindings] today,
-   but filtering is cheap insurance) are excluded — a user's top-level [fn]
-   can never be named with a `.`, so they could never collide with one. *)
-let ordinary_builtin_collision_names : string list =
-  List.filter_map (fun (name, _) -> if String.contains name '.' then None else Some name)
-    March_typecheck.Typecheck.builtin_bindings
-
-(* [show]/[eq]/[compare]/[hash] are NOT in the list above — they are
-   structural interface methods with their OWN type-directed dispatch
-   (Typecheck.builtin_interface_bindings), and a bare top-level [fn] of the
-   right ARITY legitimately participates in it (regression-tested by
-   test/native/iface_method_collision.march). Only a WRONG-arity same-name
-   function is a genuine collision — see Prelude_collision's doc comment. *)
-let iface_method_collision_arities : (string * int) list =
-  [ ("eq", 2); ("compare", 2); ("show", 1); ("hash", 1) ]
-
+   as a builtin. Sourced from [Typecheck.prelude_collision_builtin_names]/
+   [Typecheck.prelude_collision_iface_arities] — the SAME shared values the
+   LSP's own [lsp/lib/analysis.ml] uses, so the two can never independently
+   drift from each other or from what the typechecker treats as a builtin. *)
 let check_no_prelude_collision_decls ~(stdlib_decls : March_ast.Ast.decl list)
     (entry_decls : March_ast.Ast.decl list) : unit =
   let errors = March_errors.Errors.create () in
   March_modules.Prelude_collision.check ~prelude_decls:stdlib_decls
-    ~ordinary_builtin_names:ordinary_builtin_collision_names
-    ~iface_method_arities:iface_method_collision_arities ~entry_decls errors;
+    ~ordinary_builtin_names:March_typecheck.Typecheck.prelude_collision_builtin_names
+    ~iface_method_arities:March_typecheck.Typecheck.prelude_collision_iface_arities
+    ~entry_decls errors;
   if March_errors.Errors.has_errors errors then begin
     List.iter (fun (d : March_errors.Errors.diagnostic) ->
         Printf.eprintf "%s:%d:%d: %s: %s\n"

--- a/lib/typecheck/typecheck.ml
+++ b/lib/typecheck/typecheck.ml
@@ -3255,6 +3255,27 @@ let builtin_bindings : (string * scheme) list =
     [infer_app]'s [| [], t -> t] base case cannot tell these apart from its
     types alone (both look like "call site with 0 args, callee type is
     non-arrow"), so [Ast.EApp]'s handler special-cases names in this set. *)
+(* Shared source of truth for [Modules.Prelude_collision.check]'s two
+   builtin-name inputs, used by every caller (bin/main.ml, the LSP's
+   lsp/lib/analysis.ml) so they can never independently drift from what the
+   typechecker itself treats as a builtin — see
+   specs/plans/2026-08-13-prelude-entry-fn-name-collision.md §4.1/§4.2.
+   [prelude_collision_builtin_names] excludes qualified forms (containing
+   '.'): a user's bare top-level [fn] can never be named with a dot, so they
+   could never collide with one anyway. *)
+let prelude_collision_builtin_names : string list =
+  List.filter_map (fun (name, _) -> if String.contains name '.' then None else Some name)
+    builtin_bindings
+
+(* [show]/[eq]/[compare]/[hash] are NOT in the list above — they are
+   structural interface methods with their OWN type-directed dispatch
+   ([builtin_interface_bindings]), and a bare top-level [fn] of the right
+   ARITY legitimately participates in it (regression-tested by
+   test/native/iface_method_collision.march). Only a WRONG-arity same-name
+   function is a genuine collision — see Prelude_collision's doc comment. *)
+let prelude_collision_iface_arities : (string * int) list =
+  [ ("eq", 2); ("compare", 2); ("show", 1); ("hash", 1) ]
+
 let noncallable_builtin_values = StringSet.of_list [ "root_cap" ]
 
 let builtin_types : (string * int) list =

--- a/lsp/lib/analysis.ml
+++ b/lsp/lib/analysis.ml
@@ -2960,6 +2960,24 @@ let analyse ~filename ~src : t =
     (* Merge desugar diagnostics into the typecheck context so they surface
        through the same diag_to_lsp path (user-file filter, span ordering). *)
     List.iter (Err.report errors) (Err.sorted desugar_errors);
+    (* Parity with the compiler's own prelude-collision check (bin/main.ml /
+       lib/modules/prelude_collision.ml) — otherwise the editor shows no
+       diagnostic at all for a top-level fn the compiler now hard-rejects.
+       Skip when this file IS a shipped stdlib module (matches
+       [is_shipped_stdlib_file] in bin/main.ml): a stdlib file's own
+       top-level names (e.g. List.reverse) are only ever loaded namespaced,
+       never flattened, in real use — the LSP treats the OPEN file as an
+       "entry" purely as an artifact of single-file analysis, exactly as
+       `--check` does on the CLI, so the exemption is needed for the same
+       reason there. *)
+    let is_shipped_stdlib_file =
+      List.mem (Filename.basename filename) March_modules.Stdlib_manifest.all_known
+    in
+    if not is_shipped_stdlib_file then
+      March_modules.Prelude_collision.check ~prelude_decls:stdlib_decls
+        ~ordinary_builtin_names:Tc.prelude_collision_builtin_names
+        ~iface_method_arities:Tc.prelude_collision_iface_arities
+        ~entry_decls:desugared.Ast.mod_decls errors;
     let def_map        = Hashtbl.create 64 in
     let use_map        = Hashtbl.create 64 in
     let doc_map        = Hashtbl.create 16 in

--- a/lsp/lib/dune
+++ b/lsp/lib/dune
@@ -8,6 +8,7 @@
   march_lexer
   march_desugar
   march_typecheck
+  march_modules
   march_errors
   march_format
   march_resolver

--- a/lsp/test/test_lsp.ml
+++ b/lsp/test/test_lsp.ml
@@ -182,6 +182,53 @@ end|} in
   (* Valid code should have zero errors — we care about count only *)
   Alcotest.(check int) "no errors" 0 (count_errors a)
 
+(* LSP parity with the compiler's prelude-collision check
+   (bin/main.ml / lib/modules/prelude_collision.ml, specs/plans/
+   2026-08-13-prelude-entry-fn-name-collision.md §4.2 Stage 2). Before this,
+   `march --compile`/`--check` rejected a top-level fn colliding with a name
+   Prelude relies on internally, but the LSP's own independent
+   parse/desugar/stdlib-merge pipeline never ran the same check — so the
+   editor showed no diagnostic at all for code the compiler now hard-rejects,
+   a compiler/LSP disagreement this codebase treats as a real bug class. *)
+let test_analyse_prelude_collision_produces_diagnostic () =
+  (* `print` is in the true "Prelude calls this internally" set: println's
+     own body calls it bare. A same-named user fn hijacks that call
+     program-wide — see the two original repros in
+     specs/progress/2026-08-14-prelude-entry-fn-name-collision.md.
+     Filename deliberately NOT "test.march" — that basename collides with
+     the real shipped `stdlib/test.march` (the `Test` module) and would
+     trip the shipped-stdlib-file exemption meant for exactly that file,
+     silently suppressing this check (confirmed live: this test read
+     `is_shipped=true` for "test.march" the first time it was written). *)
+  let src = {|mod Shadow do
+  fn print(x : Int) : Unit do
+    ()
+  end
+end|} in
+  let a = An.analyse ~filename:"shadow_repro.march" ~src in
+  Alcotest.(check bool) "collision on `print` is reported" true
+    (count_errors a > 0);
+  Alcotest.(check bool) "message names the collision" true
+    (List.exists (fun (d : Lsp.Types.Diagnostic.t) ->
+         match d.message with
+         | `String s ->
+           (try ignore (Str.search_forward (Str.regexp_string "redefines") s 0); true
+            with Not_found -> false)
+         | _ -> false)
+       a.diagnostics)
+
+let test_analyse_safe_shadow_no_collision_diagnostic () =
+  (* `head` is declared by Prelude but never called FROM WITHIN another
+     Prelude function's own body — shadowing it is a documented, intentional,
+     already-regression-tested feature (specs/lang/types/accept/
+     t126_entry_module_shadows_list_length.march), not a collision. *)
+  let src = {|mod Shadow do
+  fn head(xs : List(Int)) : List(Int) do xs end
+end|} in
+  let a = An.analyse ~filename:"shadow_safe.march" ~src in
+  Alcotest.(check int) "no collision diagnostic for a safe shadow" 0
+    (count_errors a)
+
 let test_analyse_notes_appended_to_message () =
   (* A diagnostic with notes should include "note:" in its message. *)
   (* We can't easily manufacture a note without triggering a specific
@@ -6764,6 +6811,8 @@ let () =
       Alcotest.test_case "arity mismatch has relatedInformation" `Quick test_analyse_arity_mismatch_has_related_information;
       Alcotest.test_case "diagnostics from user file"            `Quick test_multiple_errors_all_from_user_file;
       Alcotest.test_case "src field matches input"               `Quick test_analyse_src_field_matches_input;
+      Alcotest.test_case "prelude collision → diagnostic"         `Quick test_analyse_prelude_collision_produces_diagnostic;
+      Alcotest.test_case "safe builtin shadow → no diagnostic"    `Quick test_analyse_safe_shadow_no_collision_diagnostic;
     ];
     "document-symbols", [
       Alcotest.test_case "fn name in symbols"            `Quick test_document_symbols_fn;

--- a/specs/plans/2026-08-13-prelude-entry-fn-name-collision.md
+++ b/specs/plans/2026-08-13-prelude-entry-fn-name-collision.md
@@ -1,9 +1,10 @@
 # Fix: user top-level function names silently collide with Prelude
 
 Design spec for `specs/todos/2026-08-13-user-fn-name-collides-with-prelude-internal-call.md`.
-Status: root cause traced to a specific structural gap, with the exact
-overwrite site in each backend still to be confirmed by the implementer (see
-§4). Fix design and staging are settled; not yet implemented.
+Status: fully implemented and shipped — the compiler-side fix landed via
+PR #274 (merged 2026-08-14, `specs/progress/2026-08-14-prelude-entry-fn-name-collision.md`),
+including two post-merge CI-driven corrections (§2.5b, §2.5c); Stage 2 LSP
+parity landed the same day (`specs/progress/2026-08-14-lsp-prelude-collision-parity.md`).
 
 ---
 
@@ -415,7 +416,7 @@ a replacement for §4.1.
   entry module). Every other stdlib file keeps its `DMod` wrapper (§2.1), so
   this specific unprotected-flat-scope mechanism doesn't apply to them.
 
-## 5. Verification — done for Stage 1, Stage 2 (LSP) not yet started
+## 5. Verification — Stage 1 AND Stage 2 (LSP) done
 
 Followed this session's own methodology: golden repros, checked both
 interpreted and compiled, plus a check that the fix doesn't reject anything
@@ -454,12 +455,17 @@ it shouldn't.
    because a checker that never false-positives on the two repros could
    still false-positive on ordinary code; this rules that out directly
    rather than by inference from the corpus alone.
-7. **NOT DONE — LSP parity (Stage 2 of §4.2)**. `lsp/lib/analysis.ml`
-   independently reimplements the same prelude-unwrap-and-merge sequence
-   (§2.3) and has not been touched. Until it is, the LSP will show no
-   diagnostic for code `march --compile`/`march --check` now reject — a
-   known compiler/LSP disagreement class this codebase treats seriously.
-   Filed as follow-up work, not closed here.
+7. **DONE (2026-08-14) — LSP parity (Stage 2 of §4.2)**. `lsp/lib/analysis.ml`
+   now runs `Prelude_collision.check` after merging desugar diagnostics,
+   against a new shared `Typecheck.prelude_collision_builtin_names`/
+   `prelude_collision_iface_arities` (also adopted by `bin/main.ml`, which
+   previously held its own independent copy — removed to eliminate the
+   drift risk). Same shipped-stdlib-file exemption as `bin/main.ml`'s
+   `is_shipped_stdlib_file` (§2.5c), matched by basename. Two new TDD
+   cases in `lsp/test/test_lsp.ml`'s `"diagnostics"` group, both watched
+   RED before the fix and GREEN after; full LSP suite (353 tests) and full
+   compiler suite green. Detail: `specs/progress/
+   2026-08-14-lsp-prelude-collision-parity.md`.
 
 ## 6. Why this outranks the `Parse` throughput work
 

--- a/specs/progress/2026-08-14-lsp-prelude-collision-parity.md
+++ b/specs/progress/2026-08-14-lsp-prelude-collision-parity.md
@@ -1,0 +1,58 @@
+`[P2]` - [x] **LSP parity for the prelude/entry-fn name-collision check (Stage 2 of `specs/plans/2026-08-13-prelude-entry-fn-name-collision.md` §4.2). Fixed 2026-08-14.**
+
+**Fixed.** `lsp/lib/analysis.ml` independently reimplements the same
+parse/desugar/stdlib-merge sequence as `bin/main.ml` (§2.3 of the design
+spec), and until now had not been updated to run the prelude-collision
+check landed for PR #274. That meant a user's editor showed no diagnostic
+at all for a top-level `fn` colliding with a name Prelude relies on
+internally (e.g. `print`, `reverse`), even though `march --compile`/
+`--check` now hard-rejects it — a compiler/LSP disagreement this codebase
+treats as a real bug class, not a cosmetic gap.
+
+**What changed:**
+
+- `lib/typecheck/typecheck.ml`: added `prelude_collision_builtin_names` and
+  `prelude_collision_iface_arities`, the shared source of truth both
+  `bin/main.ml` and `lsp/lib/analysis.ml` now call into, so the two can
+  never independently drift from each other or from what the typechecker
+  itself treats as a builtin. `bin/main.ml`'s own previously-duplicated
+  `ordinary_builtin_collision_names`/`iface_method_collision_arities`
+  values were removed in favor of these.
+- `lsp/lib/analysis.ml`: after merging desugar diagnostics into the
+  typecheck error context, runs `March_modules.Prelude_collision.check`
+  against the same `stdlib_decls`/`desugared.mod_decls` the rest of the
+  analysis already computes, reporting into the same `errors` context so
+  it surfaces through the existing `diag_to_lsp` path (user-file filter,
+  span ordering) with no new plumbing.
+- Skips the check when the open file IS itself a shipped stdlib module
+  (matched by basename against `Stdlib_manifest.all_known`) — mirrors
+  `bin/main.ml`'s `is_shipped_stdlib_file` exemption (added the same day
+  for CI's `--refine-report stdlib/list.march` ratchet) for the identical
+  reason: a stdlib file's own top-level names are only ever loaded
+  namespaced in real use, and only collide when the file is itself treated
+  as the flattened "entry" — which single-file LSP analysis does exactly
+  as much as `--check` does on the CLI.
+- `lsp/lib/dune`: added `march_modules` to the library's dependencies.
+
+**Verification:**
+
+- TDD: `lsp/test/test_lsp.ml`'s `"diagnostics"` group gained two cases —
+  `test_analyse_prelude_collision_produces_diagnostic` (a bare `fn print`
+  shadow, which IS in the dangerous set since `println` calls `print`
+  internally, must produce an Error diagnostic naming "redefines") and
+  `test_analyse_safe_shadow_no_collision_diagnostic` (a bare `fn head`
+  shadow, which is NOT dangerous — nothing in Prelude calls `head`
+  internally — must produce zero diagnostics). Watched both RED against
+  the pre-fix `analysis.ml` before implementing; watched both GREEN after.
+- Caught a test-authorship trap live: the first version of the positive
+  test used the shared `analyse` helper's default filename `"test.march"`,
+  which collides with the real shipped `stdlib/test.march` (the `Test`
+  module) and silently tripped the shipped-stdlib-file exemption meant for
+  exactly that file — the test read `is_shipped=true` and suppressed its
+  own diagnostic. Confirmed via a temporary debug print, then fixed by
+  giving both new tests explicit, non-colliding filenames
+  (`shadow_repro.march`/`shadow_safe.march`).
+- Full LSP suite: 353 tests, all green (`lsp/test/test_lsp.exe -e`).
+- Full compiler suite (`scripts/run-tests.sh`): green — confirms the
+  `bin/main.ml` de-duplication onto the new shared `Typecheck` values
+  didn't change compiler-side behavior.


### PR DESCRIPTION
## Summary
- Stage 2 (deferred, not skipped) of `specs/plans/2026-08-13-prelude-entry-fn-name-collision.md` — `lsp/lib/analysis.ml` now runs the same prelude-collision check `bin/main.ml` runs (landed in #274), so the editor shows a diagnostic for a colliding top-level `fn` instead of staying silent until the user actually compiles.
- Added `Typecheck.prelude_collision_builtin_names`/`prelude_collision_iface_arities` as the single shared source of truth for both callers, removing `bin/main.ml`'s own previously-duplicated copies.
- Same shipped-stdlib-file exemption as `bin/main.ml`'s `is_shipped_stdlib_file`, so opening a real stdlib module (e.g. `stdlib/list.march`) in the editor doesn't self-flag on its own namespaced `reverse`/`fold_left`.

## Test plan
- [x] TDD: two new cases in `lsp/test/test_lsp.ml`'s `"diagnostics"` group — watched RED against the pre-fix `analysis.ml`, GREEN after.
- [x] Full LSP suite: 353 tests, green (`lsp/test/test_lsp.exe -e`).
- [x] Full compiler suite: green (`scripts/run-tests.sh`).