### PR TITLE
docs: file Config erased-value safety finding

### DIFF
--- a/specs/progress/2026-08-15-config-erased-values.md
+++ b/specs/progress/2026-08-15-config-erased-values.md
@@ -1,0 +1,9 @@
+`[P2]` **Config erased-value boundary finding (2026-08-15).** `Vault(v)` now
+rejects the old typed-handle confusion, but `Config` intentionally annotates
+its heterogeneous global table as `Vault(v)`. Consequently `Config.get` can
+still be instantiated as `Option(Pid)` after an `Int` was stored. The minimal
+witness typechecks and the interpreter reaches `is_alive` with the wrong
+representation, reporting `is_alive: expected Pid`. Closing this needs a
+tagged/dynamic value representation or a checked typed Config API; adding
+another phantom Vault parameter cannot solve it. No runtime change is included
+in this finding.

--- a/specs/todos/2026-08-15-config-erased-values.md
+++ b/specs/todos/2026-08-15-config-erased-values.md
@@ -1,0 +1,44 @@
+# Config needs a tagged value boundary
+
+`Vault(v)` now carries a phantom element type, so a bound Vault handle rejects
+storing an `Int` and reading it as a `Pid`. `Config` deliberately opts out of
+that rule: its process-global table is heterogeneous, and `Config.get` remains
+polymorphic at every call site.
+
+That leaves the old erased-value confusion reachable through the public Config
+API. The following witness typechecks, then fails at runtime when `is_alive`
+receives the stored `Int` as though it were a `Pid`:
+
+```march
+mod M do
+  needs IO.Console
+  needs IO.Mut
+
+  fn main(_cap_console : Cap(IO.Console), _cap_mut : Cap(IO.Mut)) do
+    Config.put(:config_erased_witness, :value, 42)
+    match Config.get(:config_erased_witness, :value) do
+      Some(p) -> println(bool_to_string(is_alive(p)))
+      None    -> println("missing")
+    end
+  end
+end
+```
+
+Observed on 2026-08-15:
+
+- `--check` succeeds.
+- Interpretation reaches `is_alive` and reports `is_alive: expected Pid`.
+
+This is not fixed by adding another phantom parameter to Vault. Config needs a
+tagged/dynamic value representation and checked extraction or an explicitly
+typed Config API. Any future fix must preserve heterogeneous storage while
+making an `Int`-as-`Pid` read fail before an actor builtin receives the value.
+
+## Acceptance criteria
+
+- The witness no longer reaches `is_alive` with an unchecked value.
+- Heterogeneous Config storage continues to support existing Int/String/Bool
+  use cases.
+- The failure is explicit and recoverable rather than a runtime representation
+  error or process crash.
+- Both interpreter and compiled execution agree on the behavior.


### PR DESCRIPTION
Documents and pins the remaining Config type-erasure hole: Config can store an Int and let a later call site read it as a Pid. The witness type-checks and reaches is_alive with the wrong representation, which reports is_alive: expected Pid. This PR records acceptance criteria for a future tagged/dynamic Config boundary and intentionally makes no runtime change. Verification: scripts/check-docs.sh and git diff --check.