### PR TITLE
docs: file unattributed test runner failure finding

### DIFF
--- a/specs/progress/2026-08-15-test-runner-unattributed-failure.md
+++ b/specs/progress/2026-08-15-test-runner-unattributed-failure.md
@@ -1,0 +1,9 @@
+`[P2]` **Test runner unattributed non-zero exit finding (2026-08-15).**
+`scripts/run-tests.sh` collapses all runner failures into one `FAILED` bit and
+prints only `One or more suites FAILED.` It does not preserve the runner name,
+original exit status, signal, or whether a later suite was reached. Therefore
+a runner can emit `Test Successful` and still make the script exit 1 without a
+`[FAIL]` line or an attributable diagnostic. The loop was audited directly;
+the exact historical CI occurrence was not reproduced. A future fix should
+add per-runner status capture, an explicit failure summary, and a regression
+harness for a success-printing/non-zero fake runner.

--- a/specs/todos/2026-08-15-test-runner-unattributed-failure.md
+++ b/specs/todos/2026-08-15-test-runner-unattributed-failure.md
@@ -1,0 +1,40 @@
+# Test runner must attribute non-zero suite exits
+
+`scripts/run-tests.sh` aggregates suite failures into one `FAILED` integer.
+When a runner exits non-zero, the script records `FAILED=1` but does not print
+the runner name, raw exit status, signal, or a diagnostic. The final line is
+only `One or more suites FAILED.`
+
+This permits a misleading CI result: every Alcotest runner can print
+`Test Successful`, while a runner invocation still returns non-zero (for
+example, a wrapper/launcher failure after the test process has emitted its
+summary). The script exits 1 without naming the failed invocation, and the
+reported output contains no `[FAIL]` line. A failure before or around the
+stdlib runners is therefore especially difficult to distinguish from a test
+failure or a runner that was never reached.
+
+## Audit evidence
+
+The current execution loop is:
+
+```bash
+if ! $TIMEOUT_CMD ./_build/default/test/${runner}.exe -e $QUICK_FLAG; then
+  FAILED=1
+fi
+```
+
+The only information retained is the aggregate bit. The shell's `!` also
+removes the original status from the conditional unless it is captured inside
+the branch. No per-runner failure list is emitted before the aggregate exit.
+
+## Acceptance criteria
+
+- Every non-zero runner invocation reports the runner name and original exit
+  status, including signal-derived statuses.
+- The final summary lists all failed or unstarted suites, while preserving the
+  existing non-zero exit behavior.
+- A successful test summary followed by a launcher failure is visibly
+  attributed to that runner rather than reported as an anonymous suite
+  failure.
+- A regression test exercises a fake runner that prints `Test Successful` and
+  exits non-zero, proving the script reports it.


### PR DESCRIPTION
Audits scripts/run-tests.sh and documents a reporting gap: it collapses runner failures into one FAILED bit, so a runner can print Test Successful yet return non-zero without naming the runner, status, signal, or whether later suites ran. The exact historical CI occurrence was not reproduced; the shell audit confirms the attribution gap. Includes acceptance criteria and a future regression-harness requirement. Verification: scripts/check-docs.sh and git diff --check.