### PR TITLE
docs(actor): complete the local-monitor verification ledger

### DIFF
--- a/docs/superpowers/plans/2026-08-15-local-monitor-down-reasons.md
+++ b/docs/superpowers/plans/2026-08-15-local-monitor-down-reasons.md
@@ -41,25 +41,25 @@
 - The tests require interpreter `Down` values shaped as `VCon ("Down", [VInt ref; VInt target; reason])`.
 - The native fixture requires a watcher actor that calls `receive()` and pattern-matches `Down(ref, target, reason)`.
 
-- [ ] **Step 1: Write the failing interpreter assertions.**
+- [x] **Step 1: Write the failing interpreter assertions.**
 
 Change the existing `test_down_message_format` assertion to require the monitor ref, target pid, and a reason constructor/value. Add separate cases for explicit kill and crash so the test distinguishes `Killed` from `Crash("bang")`; add an already-dead target case that checks the documented fallback reason.
 
-- [ ] **Step 2: Run the focused interpreter tests and verify the expected failure.**
+- [x] **Step 2: Run the focused interpreter tests and verify the expected failure.**
 
 Run: `dune exec --root . test/run_tests.exe -- --help` to identify the repository’s test executable if needed, then run the exact supervision/stdlib test target from `test/dune` with its Alcotest filter.
 
 Expected: the new assertions fail because the interpreter currently emits `Down(ref, reason)` and strings rather than the three-field reason value.
 
-- [ ] **Step 3: Write the native fixture before runtime changes.**
+- [x] **Step 3: Write the native fixture before runtime changes.**
 
 Create a small actor program with a worker that panics under a handler and a watcher that receives `Down(ref, target, Crash(msg))`; print `ref`, target identity, and the reason tag. Include a second worker killed explicitly and assert `Killed`. The fixture must fail on the current compiled runtime because it only exposes mailbox depth and drops unknown control values.
 
-- [ ] **Step 4: Run the fixture and record the red failure.**
+- [x] **Step 4: Run the fixture and record the red failure.**
 
 Build/run it through the repository’s native actor fixture driver after `dune build --root . @bin/warm-cache`. Expected: no matching three-field Down value is observed.
 
-- [ ] **Step 5: Commit only the failing witnesses.**
+- [x] **Step 5: Commit only the failing witnesses.**
 
 Run `git diff --check`, then stage the named test files and commit with `test(actor): pin local monitor down payload`.
 
@@ -74,19 +74,19 @@ Run `git diff --check`, then stage the named test files and commit with `test(ac
 - Add an interpreter reason representation matching `Normal | Killed | Crash(String)`.
 - Queue `Down(ref, target_pid, reason)` for both death and already-dead monitor registration.
 
-- [ ] **Step 1: Implement the smallest reason constructor representation.**
+- [x] **Step 1: Implement the smallest reason constructor representation.**
 
 Use `VCon ("Normal", [])`, `VCon ("Killed", [])`, and `VCon ("Crash", [VString msg])` inside the `Down` payload. Preserve the existing crash message and map `crash_actor ... "killed"` to `Killed` only at the explicit kill call site rather than guessing from arbitrary strings.
 
-- [ ] **Step 2: Run the focused interpreter tests.**
+- [x] **Step 2: Run the focused interpreter tests.**
 
 Run the exact Alcotest filters from Task 1. Expected: the new interpreter payload tests pass while unrelated tests remain unchanged.
 
-- [ ] **Step 3: Refactor only duplicated message construction.**
+- [x] **Step 3: Refactor only duplicated message construction.**
 
 Extract one local helper for constructing the `Down` value and use it for death delivery and already-dead registration. Re-run the same focused tests.
 
-- [ ] **Step 4: Commit the interpreter implementation.**
+- [x] **Step 4: Commit the interpreter implementation.**
 
 Stage `lib/eval/eval.ml` and the two test files explicitly and commit with `feat(actor): add reasoned interpreter monitor down`.
 
@@ -103,27 +103,27 @@ Stage `lib/eval/eval.ml` and the two test files explicitly and commit with `feat
 - Store the terminal reason/message in `march_actor_meta` before detaching monitors.
 - Construct a boxed reserved Down message with fields `(monitor_ref, target_pid, reason)` and enqueue it through a control-plane scheduler path that cannot be dropped by user mailbox policy.
 
-- [ ] **Step 1: Add the reserved ABI constants and type registrations.**
+- [x] **Step 1: Add the reserved ABI constants and type registrations.**
 
 Choose tag values outside the user actor-message range, register the Down/reason constructors in the compiler’s builtin constructor metadata, and ensure the generated match code can inspect the boxed message. Add compile-time checks that the reserved tag cannot be allocated by ordinary constructor numbering.
 
-- [ ] **Step 2: Run the native fixture before the runtime path is wired.**
+- [x] **Step 2: Run the native fixture before the runtime path is wired.**
 
 Run the fixture from Task 1 after `dune build --root . @bin/warm-cache`. Expected: it still fails, now demonstrating that type/lowering registration alone does not deliver a message.
 
-- [ ] **Step 3: Add reason storage and thread reasons through every death caller.**
+- [x] **Step 3: Add reason storage and thread reasons through every death caller.**
 
 Pass `Killed` from `march_kill`, `Crash` plus the panic text from the supervised crash-trap branch, and `Normal` from the normal loop-exit path. Set the reason before `registry_retire_actor`; keep supervisor restart behavior unchanged.
 
-- [ ] **Step 4: Replace `down_count` with control-plane Down enqueue.**
+- [x] **Step 4: Replace `down_count` with control-plane Down enqueue.**
 
 Construct one message per monitor node, retain/copy the target Pid and crash string according to the existing RC contract, enqueue it even when the watcher’s user mailbox is at capacity, and remove `down_count` from `mailbox_size`. Ensure already-dead `march_monitor` emits the stored reason and target identity.
 
-- [ ] **Step 5: Run the native fixture and focused compiled tests.**
+- [x] **Step 5: Run the native fixture and focused compiled tests.**
 
 Run `dune build --root . @bin/warm-cache`, then the native actor monitor fixture and the compiler/codegen tests owning monitor builtins. Expected: the fixture observes both `Killed` and `Crash(message)` with the correct monitor ref and target Pid.
 
-- [ ] **Step 6: Commit the compiled runtime implementation.**
+- [x] **Step 6: Commit the compiled runtime implementation.**
 
 Run `git diff --check`; stage only the runtime/compiler files and commit with `feat(actor): deliver reasoned compiled monitor downs`.
 
@@ -139,23 +139,23 @@ Run `git diff --check`; stage only the runtime/compiler files and commit with `f
 - A watcher configured with `drop_new` at capacity must still receive Down.
 - `mailbox_size` must count the actual queued Down message exactly once.
 
-- [ ] **Step 1: Add the bounded-mailbox failing regression test if the control-plane path is not yet covered.**
+- [x] **Step 1: Add the bounded-mailbox failing regression test if the control-plane path is not yet covered.**
 
 Fill the watcher mailbox to its configured limit, kill the monitored actor, and assert that the watcher’s next received message is Down rather than an overflow drop.
 
-- [ ] **Step 2: Run the focused test and verify it passes.**
+- [x] **Step 2: Run the focused test and verify it passes.**
 
 Run the relevant stdlib/native test target. Expected: the test passes with one Down message and no side-band count.
 
-- [ ] **Step 3: Add repeated-monitor and already-dead assertions.**
+- [x] **Step 3: Add repeated-monitor and already-dead assertions.**
 
 Assert that multiple monitors receive distinct refs and the same target identity/reason, and that registering after death immediately delivers the stored reason.
 
-- [ ] **Step 4: Run the actor test drivers owned by `test/dune`.**
+- [x] **Step 4: Run the actor test drivers owned by `test/dune`.**
 
 Run the monitor/supervision Alcotest executables, not a neighboring driver; check each exit code directly without piping output.
 
-- [ ] **Step 5: Commit the regression coverage.**
+- [x] **Step 5: Commit the regression coverage.**
 
 Stage explicit test files and commit with `test(actor): cover monitor down delivery semantics`.
 
@@ -171,23 +171,23 @@ Stage explicit test files and commit with `test(actor): cover monitor down deliv
 **Interfaces:**
 - Docs must state `Down(ref, target_pid, reason)`, the three local reasons, mailbox-limit bypass, and backend parity.
 
-- [ ] **Step 1: Update both actor documentation copies.**
+- [x] **Step 1: Update both actor documentation copies.**
 
 Replace the old count-only monitor description and any two-field examples with the three-field signal and a short `receive()` pattern-match example.
 
-- [ ] **Step 2: Add the Unreleased changelog entry.**
+- [x] **Step 2: Add the Unreleased changelog entry.**
 
 Describe reason-carrying local monitor Down messages and control-plane delivery in one user-visible bullet.
 
-- [ ] **Step 3: Move the todo to progress.**
+- [x] **Step 3: Move the todo to progress.**
 
 Use `git mv` for the completed todo, preserving its acceptance details and adding the implementation date, files, tests, and backend-parity result after verification.
 
-- [ ] **Step 4: Run documentation and full actor verification.**
+- [x] **Step 4: Run documentation and full actor verification.**
 
 Run `scripts/check-docs.sh`, regenerate the search index if the script requires it, run the interpreter/compiler/codegen/stdlib actor suites, and run the native monitor fixture. Capture direct exit codes and report any known host-load flakes separately.
 
-- [ ] **Step 5: Review the final diff and commit documentation.**
+- [x] **Step 5: Review the final diff and commit documentation.**
 
 Run `git diff --check`, inspect `git diff --stat` and `git status --short`, stage only the named documentation/ledger files, and commit with `docs(actor): document local monitor down reasons`.
 

--- a/specs/progress/2026-08-12-monitor-down-carries-no-reason.md
+++ b/specs/progress/2026-08-12-monitor-down-carries-no-reason.md
@@ -58,10 +58,37 @@ retains the same shape and adds `NodeDown`.
 Files documented: `docs/actors.md`, `specs/lang/actors.md`, and `CHANGELOG.md`.
 The native monitor witness is `test/native/actor_monitor_down_reason.march`.
 
-Verification: `scripts/check-docs.sh` passed. The required combined
-`scripts/run-tests.sh compiler eval codegen stdlib` run was started, and
-compiler/eval/codegen completed. `run_stdlib` recorded four undiagnosed
-failures (HCR dispatch, HCR manifest caps, `MARCH_SANITIZE` clean exit, and
-string-statistics bytes-copied) before the run was terminated; `test_stdlib_march`
-never started. Full-suite completion is not claimed. The focused native monitor
-fixture and final documentation checks are recorded in the task report.
+Verification (completed 2026-08-15 on a quiet box, load avg ~9.5, after the
+initial run was terminated mid-flight under a load-250 episode):
+
+| suite / gate | result |
+|---|---|
+| `run_compiler` | 915 tests, 0 failures |
+| `run_eval` | 256 tests, 0 failures |
+| `run_codegen` | 583 tests, 0 failures |
+| `run_stdlib` | 863 tests, 0 failures |
+| `test_stdlib_march` | 59 tests, 0 failures |
+| TIR snapshots | 33 tests, 0 failures; `git diff test/snapshots/` empty |
+| `@types-check` (CI-only, `--force`) | 293 passed, 0 failed |
+| `@grammar-check` (CI-only, `--force`) | 46 passed, 0 failed |
+| `scripts/check-docs.sh` | passed |
+
+The four `run_stdlib` failures recorded in the first attempt (HCR versioned
+dispatch, HCR manifest capabilities, `MARCH_SANITIZE` clean exit, and
+string-statistics bytes-copied) were **environmental, not caused by this
+change**: the same suite that recorded them now passes in full, and
+`test_stdlib_march`, which never started, passes too. They were not assumed to
+be flakes — this change reallocates constructor tags (reserved range
+`0x7f00_0000+`) and HCR dispatch is tag-sensitive, so a genuine regression was
+plausible and had to be ruled out by re-running rather than by inspection.
+
+The TIR snapshots were run deliberately rather than skipped: this change edits
+`lower.ml`, `lower_match.ml`, `lower_state.ml` and `lower_actor.ml` while
+updating no `.expected` file, which is the profile of a stale-snapshot failure.
+They pass, and the snapshot diff is genuinely empty — the monitor lowering does
+not perturb the pinned corpus.
+
+Both CI-only gates were run with `--force`; without it `@types-check` exits 0
+with a zero-byte log and proves nothing.
+
+The native monitor witness is `test/native/actor_monitor_down_reason.march`.


### PR DESCRIPTION
## Complete the local-monitor verification ledger

Documentation only — two files, no code, no tests.

The feature (`Down(ref, target_pid, reason)` for local monitors on both backends)
shipped in #284. Its progress entry still ends with *"Full-suite completion is not
claimed"* and lists four undiagnosed `run_stdlib` failures. That was accurate when
written and is not accurate now, so it would otherwise stand as the permanent record
for a fully verified feature.

### What actually happened

The original verification ran during a load-250 episode on the dev box and was
terminated mid-flight, leaving four failures — HCR versioned dispatch, HCR manifest
capabilities, `MARCH_SANITIZE` clean exit, string-statistics bytes-copied — and
`test_stdlib_march` never started.

Re-run on a quiet box (load ~9.5):

| suite / gate | result |
|---|---|
| `run_compiler` | 915 / 0 |
| `run_eval` | 256 / 0 |
| `run_codegen` | 583 / 0 |
| `run_stdlib` — the suite that recorded the 4 failures | **863 / 0** |
| `test_stdlib_march` — never started before | **59 / 0** |
| TIR snapshots | 33 / 0, snapshot diff empty |
| `@types-check` (CI-only, `--force`) | 293 / 0 |
| `@grammar-check` (CI-only, `--force`) | 46 / 0 |
| `scripts/check-docs.sh` | pass |

The four failures were environmental.

### Why they weren't written off as flakes

#284 reallocates constructor tags into a reserved `0x7f00_0000+` range, and HCR
dispatch — two of the four failures — is tag-sensitive. A genuine regression was
plausible, so it was ruled out by re-running the suite that recorded them, not by
inspecting the diff.

The TIR snapshots were run for the same reason: #284 edits `lower.ml`,
`lower_match.ml`, `lower_state.ml` and `lower_actor.ml` while updating no `.expected`
file, which is the profile of a stale-snapshot failure. They pass, and the snapshot
diff is genuinely empty — the monitor lowering does not perturb the pinned corpus.

Both CI-only gates were run with `--force`; without it `@types-check` exits 0 on a
zero-byte log and proves nothing.

### Also

Ticks the plan's 25 step checkboxes, which tracked the work but were never marked.

Supersedes #288, which after merging `main` contained only these same two files
behind six commits of already-merged history.
