### PR TITLE
refactor(caps): unify the two capability-chain renderers

### DIFF
--- a/lib/refinecheck/cap_infer.ml
+++ b/lib/refinecheck/cap_infer.ml
@@ -369,7 +369,12 @@ let rec check_decls ?(graph : (string, string list) Hashtbl.t option)
       (match call_path g ~entry:"main" ~target:enclosing with
        | None | Some [ _ ] -> ""
        | Some path ->
-         chain_marker ^ String.concat " → " path)
+         (* [path] already has `main` (the entry) as its first element —
+            [render_cap_chain] (lib/typecheck/typecheck.ml), shared with the
+            sibling grant-violation diagnostic in [Typecheck.check_main_
+            grant], just joins the given chain, so no `main ::` prepend is
+            needed here the way the typecheck side needs one. *)
+         chain_marker ^ March_typecheck.Typecheck.render_cap_chain path)
   in
   let emit_if_missing enclosing call_name call_span =
     match cap_of_call call_name with

--- a/lib/typecheck/typecheck.ml
+++ b/lib/typecheck/typecheck.ml
@@ -13652,6 +13652,26 @@ let prebind_fn_scheme (def : Ast.fn_def) : scheme option =
    paths. Used by [check_main_grant] to attribute a grant violation to the
    user's own call chain instead of only the stdlib function that directly
    holds the capability. *)
+(* The single shared rendering of a capability call chain, used by both
+   diagnostics in the compiler that print one to a user: this module's own
+   [check_main_grant] (a grant-violation attribution) and
+   [March_refinecheck.Cap_infer.chain_note] (a missing-`needs` body-scan
+   attribution). [chain] is the full path from the entry point, with `main`
+   (or whichever entry) as its first element — callers that compute a path
+   NOT including the entry (like [cap_reach_chain] below) must prepend it
+   before calling this.
+
+   Before this function existed the two call sites each built the string
+   inline and happened to agree only by construction; they diverged once
+   (one truncated past 4 frames with an ASCII `->` and dropped the entry
+   frame, the other did not) before being brought back in sync by hand. This
+   is the one place both now go through, so a future format change (e.g. a
+   frame cap) is made once and both diagnostics move together. Deciding
+   whether to add such a cap is intentionally NOT done here — see
+   specs/progress/2026-08-17-capability-chain-rendering-unify-elision.md. *)
+let render_cap_chain (chain : string list) : string =
+  String.concat " \xe2\x86\x92 " chain
+
 let cap_reach_chain (env : env) ~(from : string) ~(cap : string)
   : string list option =
   let holds k =
@@ -13879,17 +13899,17 @@ let check_main_grant ?rows (env : env) (decls : Ast.decl list) : unit =
                  `fn main(…, %s)`), or widen the whole grant to `Cap(IO)`, \
                  or remove the use."
                 show_grant c
-                (* Render exactly like the sibling missing-`needs` diagnostic's
-                   [Cap_infer.chain_note] (lib/refinecheck/cap_infer.ml): the
-                   FULL chain (no elision — neither diagnostic elides today;
-                   see specs/todos/2026-08-14-capability-chain-rendering-unify-elision.md
-                   for unifying the two under a shared, capped renderer),
-                   `main` included as the first frame, joined with `→`. Both
-                   read as a matched pair, so they must render the same way. *)
+                (* Renders exactly like the sibling missing-`needs`
+                   diagnostic's [Cap_infer.chain_note]
+                   (lib/refinecheck/cap_infer.ml) through the shared
+                   [render_cap_chain] above: the FULL chain (no elision —
+                   neither diagnostic elides today), `main` included as the
+                   first frame, joined with `→`. Both read as a matched
+                   pair, so they must render the same way. *)
                 (match cap_reach_chain env ~from:"main" ~cap:c with
                  | Some (_ :: _ as chain) ->
                    Printf.sprintf " (reached from `main`: %s)"
-                     (String.concat " \xe2\x86\x92 " ("main" :: chain))
+                     (render_cap_chain ("main" :: chain))
                  | _ -> "")
                 c c param_hint))
       (List.sort_uniq String.compare closure)

--- a/specs/progress/2026-08-17-capability-chain-rendering-unify-elision.md
+++ b/specs/progress/2026-08-17-capability-chain-rendering-unify-elision.md
@@ -1,4 +1,24 @@
-# Unify the two capability-chain renderers under one (capped) implementation
+# LANDED 2026-08-17 — capability-chain renderers share one implementation
+
+**Status: shipped, pure refactor, no behavior change.** `Typecheck.
+render_cap_chain : string list -> string` (`lib/typecheck/typecheck.ml`,
+next to `cap_reach_chain`) now does the actual `" → "` join; both call
+sites — `check_main_grant`'s violation branch and `Cap_infer.chain_note`
+(`lib/refinecheck/cap_infer.ml`, which already depended on `march_typecheck`
+per its `dune` file, confirming the todo's guess about the build graph) —
+call it instead of each independently concatenating with `String.concat
+" → "`. `chain_note`'s BFS path already includes the entry (`main`) as its
+first element; `check_main_grant`'s does not, so that call site still does
+`"main" :: chain` itself before handing the full list to the shared
+function. Deciding whether a frame cap belongs in the shared renderer is
+still open — not part of this change; see the "Proposed fix" note below,
+kept as the historical record of what was filed. Output is byte-identical
+before and after: verified against `test_grant_violation_names_the_user_
+module` (typecheck side) and `test_cap_chain_crosses_module_boundary` /
+`test_cap_chain_absent_*` (refinecheck side) in `test/test_compiler.ml`,
+all unchanged and passing.
+
+---
 
 Filed during Task 8 fix round 1 of `specs/2026-08-13-capability-ux-plan.md`.
 The task-8 brief asserted that the grant-violation chain


### PR DESCRIPTION
Small, low-risk refactor filed as `specs/todos/2026-08-14-capability-chain-rendering-unify-elision.md`.

## Why

Two diagnostics print a capability call chain to the user (`main → helper → File.read`):

1. `check_main_grant`'s grant-violation branch (`lib/typecheck/typecheck.ml`)
2. `Cap_infer.chain_note` (`lib/refinecheck/cap_infer.ml:365`)

Each built its `" → "`-joined string independently, and they diverged once before — one truncated at 4 frames with an ASCII `->` and dropped the entry frame, the other didn't. They were brought back in sync by hand, but nothing prevented it happening again on the next edit to either.

## What changed

Extracted `Typecheck.render_cap_chain : string list -> string` as the single place both diagnostics render through. `cap_infer.ml` already depends on `march_typecheck` (confirmed via its `dune` file), so no new dependency edge was needed — the todo's guess about the build graph was right.

`chain_note`'s BFS path already includes `main` as its first element; `check_main_grant`'s does not, so that call site still prepends `"main" ::` before handing the chain to the shared function.

**Pure refactor — output is byte-identical to before at both call sites**, verified against both diagnostics' rendered text:

```
`main` is granted `Cap(IO.Console)`, but the program reaches `IO.FileWrite` (reached from `main`: main → leak). ...
```
```
hint: ... (reached from `main`: main → outer → inner)
```

No behavior change, so no CHANGELOG entry (per this repo's convention of skipping purely internal refactors).

## Testing

`cap_grant` 25/0, `cap_ceiling` 27/0, `bin/main.exe` build clean.

Deciding whether a frame cap belongs in the shared renderer is still open — intentionally not part of this change; the todo (now moved to `specs/progress/`) is kept as the record of what was filed and what's still open.