### PR TITLE
docs: declare the capabilities the CLI notebooks actually use

### DIFF
--- a/docs/build-a-cli.md
+++ b/docs/build-a-cli.md
@@ -73,6 +73,7 @@ A CLI needs its arguments. `System.argv()` returns the full argument vector as a
 ```march
 mod Mcount do
   needs IO.Console
+  needs IO.Process
   fn main() do
     match System.argv() do
       [_exe, path] -> println("counting " ++ path)
@@ -152,6 +153,8 @@ Putting it together — replace `lib/mcount.march` with:
 ```march
 mod Mcount do
   needs IO.Console
+  needs IO.FileRead
+  needs IO.Process
 
   -- Count lines, words, and bytes in a string.
   fn count(text : String) : (Int, Int, Int) do

--- a/docs/cookbook/cli.md
+++ b/docs/cookbook/cli.md
@@ -132,6 +132,8 @@ for streaming side effects.
 ```march
 mod Cat do
   needs IO.Console
+  needs IO.FileRead
+  needs IO.Process
 
   fn dump(path : String) do
     match File.read(path) do


### PR DESCRIPTION
## Declare the capabilities the CLI notebooks actually use

`main` is currently red on `conformance` (both platforms). #299 made `march --check` enforce the capability ceiling, and two doc notebooks declare only `needs IO.Console` while calling `System.argv`, `System.exit`, and `File.read`:

```
module `Mcount` uses `IO.FileRead` but does not declare `needs IO.FileRead`.
module `Mcount` uses `IO.Process`  but does not declare `needs IO.Process`.
module `Cat`    uses `IO.FileRead` but does not declare `needs IO.FileRead`.
module `Cat`    uses `IO.Process`  but does not declare `needs IO.Process`.
```

**The notebooks were wrong, not the checker.** Those calls genuinely require those capabilities; `--check` simply was not enforcing the ceiling before #299, so the omission went unnoticed.

Five lines, each added to the module that actually uses the capability:

| module | added |
|---|---|
| `Mcount` (build-a-cli, first cell) | `IO.Process` — `System.argv`/`System.exit` |
| `Mcount` (build-a-cli, second cell) | `IO.FileRead` + `IO.Process` — also `File.read` |
| `Cat` (cookbook/cli) | `IO.FileRead` + `IO.Process` |

`Repeat`, `TopWords` and `McountTest` need nothing extra and are untouched.

### Verification

`MARCH_BIN=… python3 scripts/gen-scrollmd.py --check` → **exit 0, "all notebooks compile"**, against exit 1 with 2 failures before. `scripts/check-docs.sh` exit 0.

I confirmed this breakage predates the PRs it was blocking, rather than assuming: built pristine `origin/main` in a separate worktree and ran the same check — **byte-identical failures**. It has already cost diagnosis time on #298 and #300.

### Note for reviewers

I initially added the capabilities to the wrong module in `cookbook/cli.md` — line-number arithmetic put them on `Repeat` rather than `Cat`. The re-run caught it because `Cat` kept failing. The final diff was verified by walking each `needs` line back to its enclosing `mod`, not by line number.
