### PR TITLE
fix(runtime): Vault.ns_get returns None on a never-written namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ git log is authoritative for exact commits.
 
 ### Fixed
 
+- **`Vault.ns_get` on a namespace that was never written now correctly
+  returns `None` instead of `Some(<garbage>)` in compiled binaries.** The
+  namespace-missing path hand-built a boxed "Option" (a non-NULL allocation
+  with a tag word of 0), but Option is niche-encoded everywhere else in the
+  runtime — `None` is the NULL pointer itself. The non-NULL stand-in decoded
+  as `Some` of an uninitialized pointer, so destructuring it could hang or
+  crash. The tree-walking interpreter uses a separate code path and was
+  unaffected.
 - The whole-program capability grant now bounds actor message handlers. A handler's body
   was invisible to `main`'s grant reachability walk, so a program granted only
   `Cap(IO.Console)` could `file_write` inside an actor handler — and it compiled, ran, and

--- a/runtime/march_extras.c
+++ b/runtime/march_extras.c
@@ -1334,10 +1334,11 @@ void *march_vault_ns_get(void *ns_val, void *key_val) {
     }
     pthread_mutex_unlock(&vault_registry_mutex);
     free(name);
-    /* Namespace doesn't exist — return None (boxed: tag=0) */
-    void *none = march_alloc(16);
-    *(int32_t *)((char *)none + 8) = 0;
-    return none;
+    /* Namespace doesn't exist — return None.  Option is niche-encoded
+     * (see make_some/make_none above): None = NULL, Some(v) = v itself.
+     * A boxed tag=0 allocation here is a non-NULL pointer, which the niche
+     * encoding decodes as Some(<garbage>) instead of None. */
+    return make_none();
 }
 
 void *march_vault_ns_drop(void *ns_val, void *key_val) {

--- a/specs/progress/2026-08-17-vault-ns-get-missing-namespace-niche-encoding.md
+++ b/specs/progress/2026-08-17-vault-ns-get-missing-namespace-niche-encoding.md
@@ -1,0 +1,29 @@
+# Vault.ns_get on a never-written namespace returned Some(garbage), not None
+
+`march_vault_ns_get` (`runtime/march_extras.c`) took a shortcut on the
+namespace-missing path: it hand-built an "Option" by `march_alloc(16)` with a
+tag word of 0 at offset 8, mimicking a boxed `None`. But Option is
+niche-encoded across the whole runtime (see `make_some`/`make_none` in the
+same file, ~line 299): `None` is the NULL pointer itself, `Some(v)` is `v`
+itself — there is no boxed tag/payload struct. The hand-built value was a
+non-NULL pointer, so every read of it decoded as `Some(<uninitialized
+pointer>)` instead of `None`. Destructuring that `Some` payload dereferences
+garbage — hangs or OOMs in compiled binaries. The tree-walking interpreter
+takes a separate `march_vault_get`/registry path and was unaffected.
+
+Fix: return the real `make_none()` (NULL) on that path, mirroring what
+`march_vault_get` already does for a missing key.
+
+Added a compiled regression test (`test_compiled_vault_ns_get_missing_namespace`
+in `test/test_stdlib_suite.ml`, `adversarial-regressions` suite, `Slow`):
+compiles a program that calls `Vault.ns_get` on a namespace that was never
+written and asserts the match arm taken is `None`, exiting nonzero if `Some`
+is (wrongly) taken. Passes with the fix; the bug only manifests when
+compiled, so no interpreter-level (`eval_with_vault`) test would have caught
+it.
+
+Separately noted but not fixed here: `forge test` (`forge/lib/cmd_test.ml`
+~163-192) uses the first test file as the sole compile entry and silently
+skips test modules that fail to compile — the suite still reports 0 failures
+with a lower test count. Filed as a todo:
+`specs/todos/2026-08-17-forge-test-silent-skip-on-compile-failure.md`.

--- a/specs/todos/2026-08-17-forge-test-silent-skip-on-compile-failure.md
+++ b/specs/todos/2026-08-17-forge-test-silent-skip-on-compile-failure.md
@@ -1,0 +1,26 @@
+# forge test silently drops test modules that fail to compile
+
+`forge/lib/cmd_test.ml` (compiled path, ~163-192) picks `List.hd test_files`
+as the sole compile entry point and relies on `MARCH_LIB_PATH` (test/ dir
+included) to auto-discover every other `*.march` file under `test/` as an
+import. If one of those non-entry test modules fails to typecheck/compile,
+`invoke_compiled` only sees the compiler's diagnostics for whatever import
+graph it manages to resolve — in practice a broken test module can be
+dropped from the run entirely rather than surfacing as a build failure, and
+the suite reports `0 failures` with a silently lower test count than the
+source actually contains.
+
+Found while adding a compiled regression test for the `Vault.ns_get`
+niche-encoding bug (see
+`specs/progress/2026-08-17-vault-ns-get-missing-namespace-niche-encoding.md`)
+— not itself blocking, since the test suite in question
+(`test/test_stdlib_suite.ml`) is alcotest/OCaml-driven and doesn't go through
+`forge test`, but worth hardening so a March-side `forge test` test suite
+can't develop the same blind spot.
+
+Fix direction: treat a non-zero/errored compile of *any* discovered test file
+under `test/` as a hard failure of the `forge test` invocation, not just a
+failure of files reachable from the chosen entry's import graph. Needs a
+repro case first (a `test/` dir with two `*.march` test files, one of which
+has a deliberate compile error) to confirm the current silent-skip behavior
+before changing `cmd_test.ml`.

--- a/test/test_stdlib_suite.ml
+++ b/test/test_stdlib_suite.ml
@@ -12034,6 +12034,47 @@ let test_compiled_vault_scalar_roundtrip () =
     Alcotest.(check int)
       "compiled Vault scalar (Bool/Int) round-trips correctly" 0 run_rc
 
+(* Regression: Vault.ns_get on a namespace that was never written returned
+   Some(<garbage>) instead of None when compiled.  Root cause: the
+   namespace-missing path in march_vault_ns_get (runtime/march_extras.c)
+   built a boxed "Option" by hand — march_alloc(16) with tag word 0 at
+   offset 8 — but Option is niche-encoded (see make_some/make_none in the
+   same file): None is the NULL pointer itself, Some(v) is v itself, with
+   no boxed tag/payload struct at all.  The hand-built value was a non-NULL
+   pointer, so the niche encoding decoded it as Some(<uninitialized/garbage
+   pointer>) rather than None.  Destructuring that Some payload dereferences
+   garbage, hanging or crashing.  Fix: return the real make_none() (NULL) on
+   that path, mirroring march_vault_get.  End-to-end guard: ns_get a key from
+   a namespace that has never been written, and exit 0 only if it is None. *)
+let test_compiled_vault_ns_get_missing_namespace () =
+  let main_exe = find_main_exe () in
+  let tmp = Filename.temp_file "march_vaultnsget" "" in
+  Sys.remove tmp;
+  Unix.mkdir tmp 0o755;
+  let src = Filename.concat tmp "v.march" in
+  let oc = open_out src in
+  output_string oc
+    "mod VaultNsGetMissing do\n\
+    \  needs IO.Process\n\
+    \  needs IO.Mut\n\
+    \  fn main(_cap_mut : Cap(IO.Mut), _cap_process : Cap(IO.Process)) : Unit do\n\
+    \    match Vault.ns_get(\"never_written_ns_xyz\", \"k\") do\n\
+    \      None -> ()\n\
+    \      Some(_) -> process_exit(1)\n\
+    \    end\n\
+    \  end\n\
+     end\n";
+  close_out oc;
+  let bin = Filename.concat tmp "vnsbin" in
+  match compile_march_or_skip ~cmd_prefix:(Printf.sprintf "cd %s && " (Filename.quote tmp))
+          ~main_exe ~bin ~src () with
+  | None -> ()  (* legitimate, counted skip: no clang on PATH *)
+  | Some bin ->
+    let run_rc = Sys.command (Printf.sprintf "%s >/dev/null 2>&1"
+                                (Filename.quote bin)) in
+    Alcotest.(check int)
+      "compiled Vault.ns_get on never-written namespace is None" 0 run_rc
+
 (* Regression: march_vault_update SIGSEGV'd (exit 139) when compiled — no
    compiled test exercised Vault.update before this, only Vault.set/get (see
    test_compiled_vault_scalar_roundtrip above).  Root cause was two stacked
@@ -14121,6 +14162,8 @@ let stdlib_suites =
           test_compiled_recursive_closure_capture;
         Alcotest.test_case "Vault scalar (Bool/Int) round-trips correctly when compiled" `Slow
           test_compiled_vault_scalar_roundtrip;
+        Alcotest.test_case "Vault.ns_get on never-written namespace is None (compiled)" `Slow
+          test_compiled_vault_ns_get_missing_namespace;
         Alcotest.test_case "Vault.update applies fn for Int/String, no SIGSEGV (compiled)" `Slow
           test_compiled_vault_update;
         Alcotest.test_case "Vault.update applies fn for Int/String, no SIGSEGV (compiled, --opt 0)" `Slow


### PR DESCRIPTION
## Summary
- `march_vault_ns_get`'s namespace-missing path hand-built a boxed "Option" (`march_alloc(16)` with tag word 0), but Option is niche-encoded across the runtime (`None` = NULL, `Some(v)` = `v` itself — see `make_some`/`make_none`). The non-NULL stand-in decoded as `Some(<garbage>)`, so destructuring `Vault.ns_get` on a namespace that was never written hangs or OOMs in **compiled** binaries. The tree-walking interpreter takes a separate path and was unaffected.
- Fix returns the real `make_none()` on that path, mirroring `march_vault_get`'s missing-key handling.
- Adds a compiled regression test (`adversarial-regressions` suite, `Slow`) that calls `Vault.ns_get` on a never-written namespace and asserts `None`.
- Files a follow-up todo: `forge test` picks the first test file as the sole compile entry and silently drops non-entry test modules that fail to compile — noticed while adding this test, not itself fixed here.

## Test plan
- [x] `dune build --root . test/run_stdlib.exe`
- [x] `./_build/default/test/run_stdlib.exe test adversarial-regressions` — new test passes (`Vault.ns_get on never-written namespace is None (compiled)`), 53 tests run, suite green