### PR TITLE
fix(forge): pass forge.toml [ffi] sources through interpreted `forge run`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ git log is authoritative for exact commits.
 
 ### Fixed
 
+- **`forge run` now passes `forge.toml`'s `[ffi]` sources to the compiler, so an app
+  that uses FFI can be run interpreted.** Previously the interpreted path built its
+  `march` command line with no `--ffi-c` flags at all, so the compiler built no shim
+  `.so` and every `extern` call failed at runtime with "symbol not found for
+  interpreter FFI (build the runtime, or run with `--compile`)" — an app declaring
+  `[ffi]` sources could only be run with `--compile`. `forge build` and `forge test`
+  already threaded these flags through; `forge run` now matches them. Note that FFI
+  arguments of function type (callbacks/upcalls) still require `--compile`, and a
+  project declaring only `[ffi.rust]` (no C sources) is still interpreter-unsupported.
+
 - Two actors with the same name in different modules no longer share one capability
   closure. Handler closures were keyed by the actor's bare `<Actor>_<Msg>` name, so
   `Safe.Worker` and `Danger.Worker` collided on `Worker_Go` and their capabilities were

--- a/forge/lib/cmd_run.ml
+++ b/forge/lib/cmd_run.ml
@@ -38,8 +38,17 @@ let run ?(dump_phases=false) ?(compiled=false) ?target () =
            prepends the resolved toolchain to PATH. *)
         let lib_path_env = Cmd_build.lib_path_env proj in
         let dump_flag = if dump_phases then " --dump-phases" else "" in
-        let cmd = Printf.sprintf "%smarch%s %s"
-          lib_path_env dump_flag (Filename.quote entry) in
+        (* Link the same FFI shims as `forge build` and interpreted
+           `forge test` (see Cmd_test.invoke_march_interp).  Without these,
+           the compiler never receives --ffi-c, so setup_interpreter_ffi
+           builds no shim .so and every extern call into it dies with
+           "symbol not found for interpreter FFI" — making an app with
+           [ffi] sources impossible to run interpreted at all. *)
+        match Cmd_build.ffi_flags_full proj with
+        | Error msg -> Error msg
+        | Ok ffi_flags ->
+        let cmd = Printf.sprintf "%smarch%s%s %s"
+          lib_path_env dump_flag ffi_flags (Filename.quote entry) in
         let rc = Sys.command cmd in
         if rc = 0 then Ok ()
         else Error (Printf.sprintf "program exited with code %d" rc)

--- a/forge/test/test_build_check.ml
+++ b/forge/test/test_build_check.ml
@@ -549,6 +549,81 @@ let test_project_env_walks_transitive_path_deps () =
                   "transitive dep leafc's lib/ is on the test MARCH_LIB_PATH"
                   true (List.mem c_lib all_lib_paths))))
 
+(* --------------------------------------------------------------- forge run *)
+
+(** [forge run] (INTERPRETED) must pass forge.toml's [[ffi]] sources through to
+    the compiler as --ffi-c, exactly as `forge build` and interpreted
+    `forge test` already do.
+
+    Without them the compiler's [setup_interpreter_ffi] sees an empty
+    [ffi_c_files], builds no shim .so, and every extern call dies at RUNTIME
+    with "symbol not found for interpreter FFI (build the runtime, or run with
+    --compile)" — i.e. an app declaring [[ffi]] sources could not be run
+    interpreted AT ALL, only via --compile.
+
+    This asserts on the PROGRAM'S OUTPUT (42), not merely on an Ok result:
+    the extern is only actually resolved and called if the shim was built and
+    dlopened, so a constant/short-circuit cannot satisfy it.  A status-only
+    assertion would also be satisfied by a run that never reached the extern. *)
+let test_run_interpreted_passes_ffi_sources () =
+  with_project ~project_type:Project.App (fun name root ->
+      (* A C shim OUTSIDE the runtime: the symbol exists nowhere unless
+         forge passes --ffi-c and the compiler builds the shim .so. *)
+      let c_dir = Filename.concat root "c" in
+      Unix.mkdir c_dir 0o755;
+      write_file (Filename.concat c_dir "shim.c")
+        "#include <stdint.h>\nint64_t forge_run_ffi_triple(int64_t x) { return x * 3; }\n";
+      let toml_path = Filename.concat root "forge.toml" in
+      let oc = open_out_gen [Open_append] 0o644 toml_path in
+      Printf.fprintf oc "\n[ffi]\nsources = [\"c/shim.c\"]\n";
+      close_out oc;
+      (* Overwrite the scaffolded entry with one that calls the extern. *)
+      let entry = Filename.concat root (Filename.concat "lib" (name ^ ".march")) in
+      let mod_name =
+        String.mapi (fun i c -> if i = 0 then Char.uppercase_ascii c else c) name in
+      write_file entry (Printf.sprintf
+        "mod %s do\n\
+        \  needs IO.Console\n\
+        \  needs Ffi\n\
+        \  needs IO.Foreign\n\n\
+        \  extern \"shim\" : Cap(Ffi) do\n\
+        \    fn triple(x: Int): Int = \"forge_run_ffi_triple\"\n\
+        \  end\n\n\
+        \  fn main(_c : Cap(IO.Console), _f : Cap(IO.Foreign)) : Unit do\n\
+        \    println(int_to_string(triple(14)))\n\
+        \  end\n\
+         end\n" mod_name);
+      (* Capture stdout: the assertion is on the VALUE the extern returned. *)
+      let out_file = Filename.concat root "run.out" in
+      let saved = Unix.dup Unix.stdout in
+      let fd = Unix.openfile out_file [ Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC ] 0o644 in
+      Unix.dup2 fd Unix.stdout;
+      Unix.close fd;
+      let result =
+        Fun.protect
+          ~finally:(fun () ->
+              flush stdout; Unix.dup2 saved Unix.stdout; Unix.close saved)
+          (fun () -> let r = Cmd_run.run () in flush stdout; r)
+      in
+      let output =
+        try
+          let ic = open_in_bin out_file in
+          let n = in_channel_length ic in
+          let s = really_input_string ic n in
+          close_in ic; s
+        with _ -> "(no output captured)"
+      in
+      (match result with
+       | Error m ->
+         Alcotest.fail
+           ("forge run (interpreted) with [ffi] sources failed: " ^ m
+            ^ "\n--- program output ---\n" ^ output)
+       | Ok () -> ());
+      Alcotest.(check bool)
+        ("the extern actually ran and returned 14*3=42 (got: "
+         ^ String.trim output ^ ")")
+        true (contains output "42"))
+
 (* -------------------------------------------------------------------- suite *)
 
 let () =
@@ -584,5 +659,9 @@ let () =
         test_project_env_honors_toolchain_pin;
       Alcotest.test_case "project_env walks transitive path deps" `Quick
         test_project_env_walks_transitive_path_deps;
+    ];
+    "forge run", [
+      Alcotest.test_case "interpreted run passes [ffi] sources to the compiler" `Quick
+        test_run_interpreted_passes_ffi_sources;
     ];
   ]

--- a/specs/progress/2026-08-18-forge-run-interpreted-drops-ffi-sources.md
+++ b/specs/progress/2026-08-18-forge-run-interpreted-drops-ffi-sources.md
@@ -1,0 +1,79 @@
+# `forge run` (interpreted) never passed forge.toml `[ffi]` sources to the compiler
+
+An app whose `forge.toml` declares `[ffi] sources = [...]` could not be run
+interpreted at all. Every extern call died at runtime with:
+
+```
+extern sqlite:depot_sqlite_open — symbol not found for interpreter FFI
+(build the runtime, or run with --compile)
+```
+
+## Root cause
+
+The compiler resolves interpreter-FFI symbols by building a shim `.so` from
+the `--ffi-c` sources it is given (`setup_interpreter_ffi`, `bin/main.ml`
+~999-1062) and registering it as `Eval.ffi_shim_so`. That function correctly
+no-ops when it receives no C sources (`bin/main.ml:1003`) — with nothing to
+compile there is genuinely no shim to build. `march --ffi-c foo.c app.march`
+has always worked.
+
+The break was entirely on the forge side. Every other command that shells out
+to `march` threads the manifest's FFI flags through:
+
+- `forge build`      → `forge/lib/cmd_build.ml:751-763`
+- `forge test` (compiled)    → `forge/lib/cmd_test.ml:189-192`
+- `forge test` (interpreted) → `forge/lib/cmd_test.ml:158-161`
+
+`forge run`'s interpreted branch did not — it built its command line as
+`"%smarch%s %s"` (lib-path env, dump flag, entry) with no FFI flags at all
+(`forge/lib/cmd_run.ml:41-42`). So `ffi_c_files` arrived empty, no shim was
+built, and `dynamic_ffi_call` failed both its `dlsym` lookups
+(`lib/eval/eval.ml:2145-2150`) and raised the message above.
+
+`forge run --compiled` was never affected: it delegates to `Cmd_build.build`.
+There is no evidence `run` was ever *intended* to be FFI-less — `cmd_run.ml`
+simply predates the wiring `cmd_test.ml` received.
+
+## Fix
+
+`forge/lib/cmd_run.ml`: call `Cmd_build.ffi_flags_full proj` in the
+interpreted branch and splice the flags into the command, mirroring
+`Cmd_test.invoke_march_interp` exactly. `ffi_flags_full` (rather than the
+cheaper `ffi_flags_of`) is deliberate — it is what interpreted `forge test`
+uses, so `run` and `test` now behave identically on the same manifest, and a
+`[ffi.rust]` crate is built rather than silently ignored.
+
+## Regression test
+
+`forge/test/test_build_check.ml`, suite `"forge run"`, case
+`"interpreted run passes [ffi] sources to the compiler"`. It scaffolds a real
+app with a C shim (`forge_run_ffi_triple`) that exists **nowhere in the
+runtime**, declares it under `[ffi]`, and calls it via `extern`.
+
+The assertion is on the program's **stdout** (`14 * 3 = 42`), not on
+`Cmd_run.run` returning `Ok`: the extern is only reached and executed if the
+shim was actually built and dlopened, so no constant or short-circuit
+satisfies it, and a run that never reached the extern cannot pass.
+
+Verified non-vacuous: with the two-line fix reverted the test fails with the
+exact production error (`extern shim:forge_run_ffi_triple — symbol not found
+for interpreter FFI`); with it restored the test passes. It rides in
+`test_build_check.exe`, which is hermetic (the dune rule passes the
+just-built compiler as `MARCH_TEST_BIN`), so it exercises the build under
+test rather than an installed release.
+
+## Known remaining gaps (not fixed here)
+
+1. **Closure/callback arguments still require `--compile`.** `lib/eval/eval.ml`
+   ~2124-2131 rejects any `TyArrow` FFI argument, so a shim taking a callback
+   remains compile-only. Pre-existing and separately documented as "Gap 2".
+2. **`[ffi.rust]`-only projects remain broken under the interpreter.**
+   `ffi_flags_full` contributes only `--ffi-link <archive>` for a Rust crate
+   (`cmd_build.ml:464`), but the shim gate keys on `ffi_c_files` alone
+   (`bin/main.ml:1003`). With no C source nothing is built, and a `.a` cannot
+   be `dlopen`ed regardless — it would need to be a `cdylib`.
+3. **`forge bench` still hardcodes `~ffi_flags:""`** (`forge/lib/cmd_bench.ml:61`),
+   so benchmarks of FFI code have the same gap.
+4. A shim that fails to compile is only a **warning** (`bin/main.ml:1052-1054`),
+   so a broken shim degrades into this same "symbol not found" message rather
+   than a clear `cc` error.

--- a/specs/todos/2026-08-18-ffi-rust-only-projects-cannot-run-interpreted.md
+++ b/specs/todos/2026-08-18-ffi-rust-only-projects-cannot-run-interpreted.md
@@ -1,0 +1,30 @@
+`[P3]` # A `[ffi.rust]`-only project still cannot run interpreted
+
+Follow-up to `specs/progress/2026-08-18-forge-run-interpreted-drops-ffi-sources.md`,
+which fixed the C-source half of this (`forge run` now passes `--ffi-c`).
+
+A project that declares **only** `[ffi.rust]` and no `[ffi] sources` remains
+broken under the interpreter:
+
+- `Cmd_build.ffi_flags_full` contributes only `--ffi-link <archive>` for a Rust
+  crate (`forge/lib/cmd_build.ml:464`).
+- The compiler's interpreter-FFI shim gate keys on `ffi_c_files` alone
+  (`bin/main.ml:1003`). With no C source there is nothing to `cc -shared`, so
+  `Eval.ffi_shim_so` stays `None` and every extern fails to resolve.
+
+Fixing it needs more than a flag: `cargo build --release` produces a **static**
+`lib<name>.a`, and a `.a` cannot be `dlopen`ed. Options:
+
+1. Have `[ffi.rust]` also emit a `cdylib` and dlopen that under the interpreter
+   (needs a `crate-type` requirement on the user's crate, or a generated
+   wrapper).
+2. Generate a tiny C shim that links the archive and `cc -shared` that, so the
+   existing `ffi_c_files` path is reused.
+3. Document it as compile-only and make the diagnostic say so explicitly
+   instead of the generic "symbol not found for interpreter FFI".
+
+Option 3 is the cheap honest floor and should land regardless — right now the
+failure mode is indistinguishable from a genuinely missing symbol.
+
+Related: `forge bench` hardcodes `~ffi_flags:""` (`forge/lib/cmd_bench.ml:61`),
+so benchmarks of any FFI code have the same gap as `forge run` did.


### PR DESCRIPTION
## Summary

An app whose `forge.toml` declares `[ffi] sources = [...]` could not be run interpreted **at all**. Every extern call died at runtime with:

```
extern sqlite:depot_sqlite_open — symbol not found for interpreter FFI (build the runtime, or run with --compile)
```

The compiler side was already correct. `setup_interpreter_ffi` (`bin/main.ml` ~999-1062) builds a shim `.so` from the `--ffi-c` sources it is handed and registers it as `Eval.ffi_shim_so`; it rightly no-ops when handed none. `march --ffi-c foo.c app.march` has always worked.

The break was entirely in forge. Every other command that shells out to `march` threads the manifest's FFI flags through:

| command | call site |
|---|---|
| `forge build` | `forge/lib/cmd_build.ml:751-763` |
| `forge test` (compiled) | `forge/lib/cmd_test.ml:189-192` |
| `forge test` (interpreted) | `forge/lib/cmd_test.ml:158-161` |
| **`forge run` (interpreted)** | **— none —** |

`forge run` built its command line as `"%smarch%s %s"` (lib-path env, dump flag, entry) with no FFI flags, so `ffi_c_files` arrived empty, no shim was built, and both `dlsym` lookups in `dynamic_ffi_call` failed (`lib/eval/eval.ml:2145-2150`).

`forge run --compiled` was never affected — it delegates to `Cmd_build.build`. Nothing suggests `run` was *meant* to be FFI-less; `cmd_run.ml` simply predates the wiring `cmd_test.ml` received.

## Fix

Call `Cmd_build.ffi_flags_full proj` in the interpreted branch and splice the flags in, mirroring `Cmd_test.invoke_march_interp`.

Using `ffi_flags_full` rather than the cheaper `ffi_flags_of` is deliberate: it is what interpreted `forge test` already uses, so `run` and `test` now behave identically on the same manifest, and an `[ffi.rust]` crate gets built rather than silently ignored.

## Regression test

`forge/test/test_build_check.ml`, new suite `"forge run"`. It scaffolds a real app with a C shim (`forge_run_ffi_triple`) that exists **nowhere in the runtime**, declares it under `[ffi]`, and calls it via `extern`.

The assertion is on the program's **stdout** (`14 * 3 = 42`), not on `Cmd_run.run` returning `Ok`. The extern is only reached and executed if the shim was actually built and dlopened, so no constant or short-circuit satisfies it, and a run that never reached the extern cannot pass.

**Verified non-vacuous** — with the two-line fix reverted:

```
[FAIL]  forge run  0  interpreted run passes [ffi] sources...
extern shim:forge_run_ffi_triple — symbol not found for interpreter FFI
```

and green with it restored. It rides in `test_build_check.exe`, which is hermetic (the dune rule passes the just-built compiler as `MARCH_TEST_BIN`), so it exercises the build under test rather than an installed release.

## Testing

Green locally: `test_build_check` 17/17 (including the new case), `test_forge` 133/133, `scripts/check-docs.sh`.

I could **not** get a trustworthy local run of the four main suites — another session was concurrently building and running tests in the same shared worktree, which makes any number from it unreliable, so I stopped rather than report a contaminated result. The change is confined to `forge/lib/cmd_run.ml` and no test in those suites calls `Cmd_run`, so no impact is expected — but that is reasoning, not a measurement. **Relying on CI for the full suite.**

## Known gaps left open

Filed as `specs/todos/2026-08-18-ffi-rust-only-projects-cannot-run-interpreted.md`:

1. **`[ffi.rust]`-only projects remain interpreter-broken.** `ffi_flags_full` contributes only `--ffi-link <archive>`, but the shim gate keys on `ffi_c_files` alone (`bin/main.ml:1003`) — and a `.a` cannot be `dlopen`ed regardless.
2. **`forge bench` hardcodes `~ffi_flags:""`** (`forge/lib/cmd_bench.ml:61`) — same gap `run` just lost.
3. Closure/callback FFI arguments still require `--compile` (pre-existing "Gap 2", `lib/eval/eval.ml` ~2124-2131).

## Note on the originally-reported HTTP crash

This PR does **not** touch the runtime. The reported "compiled Bastion server serves one request then dies with SIGBUS in `___chkstk_darwin`" was investigated and is **not** a lazy-green-stack-growth bug — it is the already-fixed pipeline-closure refcount UAF (`a18780c0`), reappearing because the local dev toolchain's `runtime/` snapshot predated that commit while its `bin/march` did not. Fixed by resyncing the toolchain, not by a code change. `runtime/` is untouched here.
