### PR TITLE
fix(tir): an actor handler binder must shadow a same-named top-level fn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,21 @@ git log is authoritative for exact commits.
 
 ### Fixed
 
+- **An actor message-handler binder now shadows a same-named top-level function
+  when compiled.** A handler param whose name matched ANY top-level function
+  linked into the program — no `import` of that module required — was silently
+  discarded, and the bare reference in the handler body resolved to the FUNCTION
+  instead, emitting its raw code address where the bound value belonged. Found in
+  the wild as `on Deliver(session_id, kind, text, approved)` colliding with stdlib
+  `HttpServer.text`: the compiled server passed the function's address as the
+  message text, and refcounting that code address wrote into read-only `__TEXT` —
+  SIGBUS, exit 138, presenting misleadingly as "the actor spawned in this handler
+  never starts". Params that happened not to collide worked only by name
+  coincidence with the TIR param var. The interpreter was always correct, so this
+  was compiled-only. `lower_fn_def` already registered a function's params in the
+  local-name scope that `resolve_use_alias` consults before rewriting a bare name
+  into a qualified global; `lower_handler` now does the same for `ah_params`.
+
 - **`forge` no longer pairs one install's compiler with another install's stdlib.**
   `forge` set `MARCH_STDLIB` from its OWN executable location
   (`<forge>/../share/march`) while running the `march` chosen by toolchain

--- a/lib/tir/lower_actor.ml
+++ b/lib/tir/lower_actor.ml
@@ -110,8 +110,32 @@ let lower_actor (env : Lower_state.env) ~hot_reload (name : string) (actor : Ast
     (* Load each state field from actor struct and let-bind it.
        Build the continuation bottom-up: first build inner body, wrap in lets. *)
 
-    (* Step 1: lower the handler body (uses `state` variable) *)
+    (* Step 1: lower the handler body (uses `state` variable).
+
+       The handler's own params must be registered in [_fn_param_types] for the
+       duration of that lowering, exactly as [lower_fn_def] does for a normal
+       function's parameters and as lower.ml's [EBlock]/[ELet] case does for
+       let-bound names.  That table is the shield [resolve_use_alias] checks
+       FIRST: without it, a bare reference to a param whose name matches any
+       top-level function linked into the program is rewritten into a qualified
+       GLOBAL reference (e.g. `text` -> `HttpServer.text`), silently dropping the
+       binder and emitting the function's raw code address as the value.  Params
+       that happen not to collide worked only by name coincidence with the TIR
+       param var.  Additive save/restore (not [lower_fn_def]'s clear-all) so no
+       entry the enclosing scope relies on is removed. *)
+    let saved_shadowed : (string * Tir.ty) list =
+      List.filter_map (fun (v : Tir.var) ->
+          match Hashtbl.find_opt Lower_state._fn_param_types v.Tir.v_name with
+          | Some ty -> Some (v.Tir.v_name, ty)
+          | None -> None) params
+    in
+    List.iter (fun (v : Tir.var) ->
+        Hashtbl.replace Lower_state._fn_param_types v.Tir.v_name v.Tir.v_ty) params;
     let body_tir = Lower_match.lower_expr env h.ah_body in
+    List.iter (fun (v : Tir.var) ->
+        Hashtbl.remove Lower_state._fn_param_types v.Tir.v_name) params;
+    List.iter (fun (n, ty) ->
+        Hashtbl.replace Lower_state._fn_param_types n ty) saved_shadowed;
 
     let state_ty = Tir.TCon (name ^ Tir_names.actor_state_suffix, []) in
     (* Step 2: let $result = body_tir *)

--- a/specs/progress/2026-08-19-actor-handler-binder-shadowing.md
+++ b/specs/progress/2026-08-19-actor-handler-binder-shadowing.md
@@ -1,0 +1,62 @@
+# An actor handler binder did not shadow a same-named top-level function (compiled only)
+
+`lower_actor.ml`'s `lower_handler` lowered a handler body with
+`Lower_match.lower_expr env h.ah_body` without first registering the handler's
+own params in `Lower_state._fn_param_types`.
+
+That table is the shield `resolve_use_alias` (`lib/tir/lower_state.ml`) consults
+FIRST, before rewriting a bare name into a qualified global. `lower_fn_def`
+(`lib/tir/lower_decls.ml`) already establishes it for a normal function's
+parameters, and lower.ml's `EBlock`/`ELet` case does the same for let-bound
+names — its comment names this exact failure mode ("turning a local into a
+global function reference"). Actor handlers were the one binder form with no
+such scope.
+
+Consequence: a handler param whose name matched ANY top-level function linked
+into the program — no `import` of the declaring module required, since the
+program-global `_use_aliases` fallback fires for unqualified names — was
+silently discarded, and the bare reference resolved to the FUNCTION. Lowering
+then emitted the function's raw code address where the bound value belonged.
+Params that happened not to collide worked only by name coincidence with the
+TIR param var of the same name.
+
+Found in the wild 2026-08-19 in a compiled Bastion/Envoy HTTP server. The actor
+
+    on Deliver(session_id, kind, text, approved) do
+      Envoy.SessionRegistry.deliver_here(session_id, kind, text, approved)
+
+collided with stdlib `HttpServer.text`, and the emitted IR read:
+
+    call ptr @Envoy.SessionRegistry.deliver_here(ptr %ld, ptr %ld,
+                                                 ptr @HttpServer.text, i64 %cv)
+
+The decode DID extract field 2 into `%$Deliver_text.addr`; the body simply never
+loaded it (locals were created for `session_id_i18572`, `kind_i18573`,
+`approved_i18575` — id 18574 skipped).
+
+Symptom: the callee dropped that param, `march_decrc_local` wrote the refcount
+at ptr+0 into read-only `__TEXT`, and the process died with SIGBUS via
+`march_scheduler.c`'s `fatal:` `_exit(128+signo)` — exit 138. `IS_HEAP_PTR`
+cannot filter this: a code address is aligned, >= 4096 and positive, so it
+passes all three guards. It presented misleadingly as "an actor spawned inside
+this handler never runs and the process dies as its green thread starts" — the
+fault is in the SENDING actor's handler, before the spawned actor is scheduled.
+A String-typed use instead gives `march: out of memory` (garbage length).
+
+The tree-walking interpreter binds handler params directly (`eval.ml`) and was
+always correct, so this was a compiled-only miscompile.
+
+Scope, established empirically against the same toolchain: ONLY actor-handler
+binders. Plain `fn` params, `let` bindings, `match` binders and lambda params
+named `text` all resolved correctly.
+
+Fix: register `params` in `_fn_param_types` around the body lowering, with
+additive save/restore of shadowed entries (not `lower_fn_def`'s clear-all, so no
+entry the enclosing scope relies on is removed).
+
+Regression test: `test_actor_handler_binder_shadows_toplevel_fn` in
+`test/test_codegen.ml` (`actor_dispatch_codegen` suite). An actor whose handler
+binds `text` while an imported `Helper.text` exists must not emit
+`, ptr @Helper.text` as a call argument. Verified non-vacuous: the test fails on
+the parent commit and passes with the fix. The TIR golden snapshots are
+unchanged, confirming the fix is inert for non-colliding names.

--- a/test/test_codegen.ml
+++ b/test/test_codegen.ml
@@ -660,6 +660,53 @@ let test_actor_struct_ereuse_unconditional () =
   Alcotest.(check bool) "no atomic RC load guarding the actor-struct reuse"
     false (ir_contains ir "load atomic i64")
 
+(** An actor message-handler binder must SHADOW a same-named top-level function.
+
+    [lower_fn_def] registers a function's parameters in [_fn_param_types] for the
+    duration of lowering its body; that table is the shield [resolve_use_alias]
+    consults before rewriting a bare name into a qualified global. [lower_handler]
+    did not do the same for [ah_params], so a handler binder whose name matched
+    ANY top-level function linked into the program was silently discarded and the
+    bare reference resolved to the FUNCTION — emitting its raw code address where
+    the bound value belonged.
+
+    Found in the wild 2026-08-19: an Envoy actor with
+    [on Deliver(session_id, kind, text, approved)] collided with stdlib
+    [HttpServer.text], so the compiled server passed [ptr @HttpServer.text] as the
+    message text. Refcounting that code address writes at ptr+0 into read-only
+    __TEXT — SIGBUS, exit 138 — while the INTERPRETER handled the same program
+    correctly (a compiled-only miscompile). Non-colliding binders worked only by
+    name coincidence with the TIR param var.
+
+    Witness: the handler passes its own binder, never the imported function. *)
+let test_actor_handler_binder_shadows_toplevel_fn () =
+  let ir = emit_actor_ir {|mod Test do
+  needs IO.Console
+    mod Helper do
+      fn text(s : String) : String do s end
+    end
+    import Helper
+    fn emit(label : String, v : String) : String do label ++ v end
+    actor Host do
+      state { n : Int }
+      init  { n: 0 }
+      on Msg(text) do
+        let _ = emit("got: ", text)
+        { n: state.n + 1 }
+      end
+    end
+    fn main(_cap_console : Cap(IO.Console)) : Unit do
+      let pid = spawn(Host)
+      let _ = send(pid, Msg("hello"))
+      run_until_idle()
+    end
+  end|} in
+  (* The bug emitted the function's address as a call argument. Match the
+     ARGUMENT form (comma-preceded) so this cannot alias the `define` line. *)
+  Alcotest.(check bool)
+    "handler binder is not replaced by the imported Helper.text function"
+    false (ir_contains ir ", ptr @Helper.text")
+
 (** Finding 20 follow-up (adversarial-review Critical, fixed): the actor-struct
     always-in-place gate must be STRUCTURAL (does this type's field 0 carry
     the compiler-only "$d_dispatch" marker lower_actor.ml alone can construct
@@ -13906,6 +13953,8 @@ let codegen_suites =
             `Quick test_actor_struct_ereuse_unconditional;
           Alcotest.test_case "finding-20 follow-up: a `_Actor`-suffixed user type is NOT treated as an actor struct"
             `Quick test_actor_suffix_named_user_type_not_treated_as_actor;
+          Alcotest.test_case "handler binder shadows a same-named top-level fn"
+            `Quick test_actor_handler_binder_shadows_toplevel_fn;
         ] );
       ( "tco_codegen", [
           Alcotest.test_case "factorial loop emitted"   `Quick test_tco_factorial_has_loop;


### PR DESCRIPTION
## The bug

An actor message-handler binder whose name matches **any** top-level function linked into the program — no `import` of the declaring module required — was silently discarded when compiled. The bare reference in the handler body resolved to the **function** instead, emitting its raw code address where the bound value belonged.

Found in the wild in a compiled Bastion/Envoy HTTP server. This handler:

```march
on Deliver(session_id, kind, text, approved) do
  Envoy.SessionRegistry.deliver_here(session_id, kind, text, approved)
```

collided with stdlib `HttpServer.text`, and the emitted IR read:

```llvm
call ptr @Envoy.SessionRegistry.deliver_here(ptr %ld, ptr %ld,
                                             ptr @HttpServer.text, i64 %cv)
```

The decode *did* extract field 2 into `%$Deliver_text.addr` — the body simply never loaded it (locals were created for `session_id_i18572`, `kind_i18573`, `approved_i18575`; id `18574` skipped).

The callee then dropped that param, `march_decrc_local` wrote the refcount at ptr+0 into read-only `__TEXT`, and the process died with **SIGBUS → exit 138** via `march_scheduler.c`'s `fatal:` `_exit(128+signo)`. `IS_HEAP_PTR` cannot filter this: a code address is aligned, `>= 4096` and positive, so it passes all three guards.

It presented misleadingly as *"an actor spawned inside this handler never runs, and the process dies as its green thread starts"* — the fault is actually in the **sending** actor's handler, before the spawned actor is ever scheduled. A `String`-typed use instead gives `march: out of memory` (garbage length).

The tree-walking interpreter binds handler params directly and was always correct, so this was a **compiled-only miscompile**.

## Root cause

`lower_actor.ml`'s `lower_handler` lowered the body with `Lower_match.lower_expr env h.ah_body` without registering the handler's params in `Lower_state._fn_param_types`.

That table is the shield `resolve_use_alias` consults *first*, before rewriting a bare name into a qualified global. `lower_fn_def` already establishes it for a normal function's parameters, and lower.ml's `EBlock`/`ELet` case does the same for let-bound names — its comment names this exact failure mode ("turning a local into a global function reference"). Actor handlers were the one binder form with no such scope. Params that happened not to collide worked only by name coincidence with the TIR param var.

## Scope

Established empirically: **only** actor-handler binders. Plain `fn` params, `let` bindings, `match` binders and lambda params named `text` all resolve correctly.

## Fix

Register `params` in `_fn_param_types` around the body lowering, with **additive** save/restore of shadowed entries — not `lower_fn_def`'s clear-all — so no entry the enclosing scope relies on is removed.

## Testing

- New `test_actor_handler_binder_shadows_toplevel_fn` (`test/test_codegen.ml`, `actor_dispatch_codegen`). **Verified non-vacuous**: fails on the parent commit, passes with the fix.
- **TIR golden snapshots unchanged**, confirming the fix is inert for non-colliding names.
- Full suite green: compiler 885, eval 256, codegen 577, snapshots 33, stdlib 860, stdlib_march 59.
- End-to-end: the original Envoy reproducer (`GET /sessions/:id` → exit 138) and a minimal standalone repro both compile and run correctly with the fixed compiler.
- `scripts/check-docs.sh` passes.
