### PR TITLE
fix(runtime): a wake with an empty mailbox must not kill a live actor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,26 @@ git log is authoritative for exact commits.
 
 ### Fixed
 
+- **A message arriving while an actor was already being woken no longer kills
+  that actor.** `march_sched_send` pushes under the mailbox lock but wakes after
+  releasing it, so two senders racing one receiver could issue two wakes for
+  messages the receiver drained as a single batch — the second wake then landed
+  after it had re-parked, resuming it with a legitimately empty mailbox. The
+  untimed receive reported that as "no message", which the actor dispatch loop
+  reads as "I was killed": it exited and ran the death path on an actor whose
+  `$alive` word was still 1. A later `Actor.call` on that pid then failed with
+  `actor not alive` — no crash, no diagnostic, exit code 0. A blocking receive
+  now re-parks on a wake it cannot attribute to a message, and "no message" is
+  reserved for a real stop request (shutdown, or actor death). Only reachable
+  compiled, with more than one scheduler thread; a bounded mailbox under the
+  `block` policy made it far likelier, because releasing blocked senders wakes
+  the whole herd at once — which is exactly the burst of concurrent senders the
+  race needs. Measured at ~4% of runs of `bench/actors/fanin_flood.march`, one
+  of the `scripts/actor-load.sh` gates. Note this broke the guarantee
+  `Actor.set_queue_limit`'s own documentation makes for policy 3, that no
+  request or reply is ever silently discarded. See
+  `specs/progress/2026-08-19-fanin-blocked-mailbox-spurious-actor-death.md`.
+
 - **An actor message-handler binder now shadows a same-named top-level function
   when compiled.** A handler param whose name matched ANY top-level function
   linked into the program — no `import` of that module required — was silently

--- a/runtime/march_runtime.c
+++ b/runtime/march_runtime.c
@@ -3982,7 +3982,11 @@ static void do_actor_death(void *actor, march_death_reason reason,
     if (meta) {
         march_proc *gt = atomic_load_explicit(&meta->green_thread,
                                               memory_order_acquire);
-        if (gt) march_sched_wake(gt);
+        /* request_stop, not a bare wake: since the untimed recv re-parks on a
+         * wake it cannot attribute to a message (see march_proc.stop_requested),
+         * a plain march_sched_wake would leave a killed actor parked forever
+         * instead of letting actor_green_thread observe NO_MSG and exit. */
+        if (gt) march_sched_request_stop(gt);
     }
 
     if (meta && meta->supervisor && reason != MARCH_DEATH_NORMAL) {

--- a/runtime/march_scheduler.c
+++ b/runtime/march_scheduler.c
@@ -1221,7 +1221,7 @@ static int wake_idle_daemons(void) {
         if (!q || !q->is_daemon) continue;
         if (atomic_load_explicit(&q->status, memory_order_acquire) == PROC_WAITING
                 && !mbox_waiting_has_deliverable(q)) {
-            march_sched_wake(q);
+            march_sched_request_stop(q);
             woken++;
         }
     }
@@ -1577,6 +1577,15 @@ static void *sched_thread_entry(void *arg) {
 
 void march_sched_request_shutdown(void) {
     atomic_store_explicit(&g_sched_shutdown, 1, memory_order_release);
+}
+
+/* See the header for the contract. The release store pairs with the acquire
+ * load in march_sched_recv_mode's loop, which re-reads this on every wake;
+ * the wake that follows is what gets a currently-parked p to look. */
+void march_sched_request_stop(march_proc *p) {
+    if (!p) return;
+    atomic_store_explicit(&p->stop_requested, 1, memory_order_release);
+    march_sched_wake(p);
 }
 
 void march_sched_run(void) {
@@ -2240,6 +2249,36 @@ int64_t march_sched_mbox_count(march_proc *p) {
     return atomic_load_explicit(&p->mbox_count, memory_order_relaxed);
 }
 
+/* One park + resume for march_sched_recv_mode's loop, in its OWN NOINLINE
+ * function so the `tl_sched` read happens FRESH on every iteration.
+ *
+ * This split is load-bearing, not style -- exactly the same hazard (and the
+ * same remedy) as mbox_block_register_and_park, whose comment spells it out:
+ * a proc that parks here is resumed by whichever scheduler wins the wake, so
+ * it can come back on a DIFFERENT OS thread than the one it parked from.
+ * `tl_sched` is _Thread_local. With the swapcontext written inline in the
+ * caller's loop, the optimizer is free to load tl_sched once and reuse that
+ * register on later iterations (noinline on the caller only stops ITS callers
+ * from hoisting, not the caller's own loop-invariant code motion) -- so after
+ * a migration, iteration 2 would swapcontext into a STALE scheduler's
+ * sched_ctx. The real scheduler then never runs the PROC_PARKED -> PROC_WAITING
+ * transition for this proc, every waker spins on PROC_PARKED forever, and the
+ * program deadlocks with a message sitting undelivered in the mailbox.
+ * (Observed exactly that way while fixing the spurious-death bug: sink stuck
+ * at status=PROC_PARKED, mbox_count=1, all scheduler threads idle.)
+ *
+ * Caching `p` across iterations IS fine: the proc object is the same one
+ * regardless of which OS thread resumes it. Only the per-thread scheduler
+ * pointer must be re-read. */
+__attribute__((noinline))
+static void mbox_recv_park_once(march_proc *p) {
+    march_scheduler *s = tl_sched;
+    MARCH_ASAN_SWITCH_TO_SCHED(p);
+    MARCH_TSAN_SWITCH_TO_SCHED(s);
+    swapcontext(&p->ctx, &s->sched_ctx);
+    MARCH_ASAN_SWITCH_DONE(p);
+}
+
 /* NOINLINE: migration barrier, same rationale as march_sched_yield — a proc
  * that parks here can be woken and re-dispatched on a different OS thread.
  * The body reads tl_sched only BEFORE the swapcontext (safe); noinline
@@ -2262,47 +2301,76 @@ static void *march_sched_recv_mode(int user_only) {
      * seemingly-random locations under load). The lock is cheap when
      * uncontended (the common case), so always taking it here is the
      * correct, minimal fix. */
-    mbox_lock_acquire(p);
-    if (user_only ? p->mailbox != NULL
-                  : (p->control_mailbox != NULL || p->mailbox != NULL)) {
-        void *msg = user_only ? mbox_pop_user(p) : mbox_pop_any(p);
-        mbox_wake_send_waiters_if_low(p);
+    /* Park in a LOOP, re-checking the mailbox on every wake.
+     *
+     * A wake is NOT proof that a message is waiting for us. march_sched_send
+     * pushes under mbox_lock, then wakes AFTER releasing it, so two senders
+     * racing one receiver routinely produce two wakes for what the receiver
+     * drains as a single batch: sender A's wake resumes us, we pop A's and
+     * B's messages and run the handlers, we come back here and re-park —
+     * and only THEN does sender B's already-issued wake land, resuming us
+     * with a legitimately empty mailbox. Nothing is wrong; we simply have
+     * nothing to do and must park again.
+     *
+     * This function used to return MARCH_RECV_NO_MSG for that case, which
+     * actor_green_thread reads as "I was killed": it broke its dispatch loop
+     * and called do_actor_death on an actor whose $alive word was still 1.
+     * The visible symptom was a later Actor.call on that pid failing with
+     * "actor not alive" (bench/actors/fanin_flood.march, ~4% of runs, only
+     * with >1 scheduler thread and only under a bounded MARCH_MBOX_BLOCK
+     * mailbox — the wake-all in mbox_wake_send_waiters_if_low releases a
+     * herd of blocked senders at once, which is what makes the window
+     * reachable so often). march_actor_call's TIMED path already looped for
+     * exactly this reason ("Woken with an empty mailbox but time remains");
+     * the untimed path is now consistent with it.
+     *
+     * MARCH_RECV_NO_MSG is therefore reserved for a real stop request —
+     * see march_proc.stop_requested and march_sched_request_stop. Both
+     * callers that must be able to end a blocking receive without a message
+     * (the shutdown endgame in wake_idle_daemons, and actor death in
+     * do_actor_death) go through that flag.
+     *
+     * No lost wakeup is introduced by looping: the emptiness check and the
+     * PROC_PARKED store below both happen under mbox_lock, which senders
+     * also hold across push-then-read-status, so the two critical sections
+     * are serialized. Either the sender pushes first (we see a non-empty
+     * mailbox and never park) or we publish PROC_PARKED first (the sender
+     * reads it and wakes us). */
+    for (;;) {
+        mbox_lock_acquire(p);
+        if (user_only ? p->mailbox != NULL
+                      : (p->control_mailbox != NULL || p->mailbox != NULL)) {
+            void *msg = user_only ? mbox_pop_user(p) : mbox_pop_any(p);
+            mbox_wake_send_waiters_if_low(p);
+            atomic_store_explicit(&p->mbox_wait_mode, 0, memory_order_relaxed);
+            mbox_lock_release(p);
+            return msg;
+        }
+        /* Checked under the same lock as the emptiness test, and re-checked
+         * on every iteration: a stop can be requested while we are parked. */
+        if (atomic_load_explicit(&p->stop_requested, memory_order_acquire)
+                || atomic_load_explicit(&p->status, memory_order_acquire) == PROC_DEAD) {
+            atomic_store_explicit(&p->mbox_wait_mode, 0, memory_order_relaxed);
+            mbox_lock_release(p);
+            return MARCH_RECV_NO_MSG;
+        }
+        /* PROC_PARKED: we're about to call swapcontext but haven't yet saved our
+         * context.  Wakers that see PROC_PARKED must spin-wait until the
+         * scheduler transitions us to PROC_WAITING (context saved) before
+         * pushing us to a run-deque.  Without this, a waker could push us
+         * while we are still executing, causing two schedulers to resume the
+         * same process concurrently. */
+        atomic_store_explicit(&p->mbox_wait_mode, user_only ? 2 : 1,
+                              memory_order_relaxed);
+        atomic_store_explicit(&p->status, PROC_PARKED, memory_order_release);
         mbox_lock_release(p);
-        return msg;
-    }
-    /* PROC_PARKED: we're about to call swapcontext but haven't yet saved our
-     * context.  Wakers that see PROC_PARKED must spin-wait until the
-     * scheduler transitions us to PROC_WAITING (context saved) before
-     * pushing us to a run-deque.  Without this, a waker could push us
-     * while we are still executing, causing two schedulers to resume the
-     * same process concurrently. */
-    atomic_store_explicit(&p->mbox_wait_mode, user_only ? 2 : 1,
-                          memory_order_relaxed);
-    atomic_store_explicit(&p->status, PROC_PARKED, memory_order_release);
-    mbox_lock_release(p);
 
-    MARCH_ASAN_SWITCH_TO_SCHED(p);
-    MARCH_TSAN_SWITCH_TO_SCHED(tl_sched);
-    swapcontext(&p->ctx, &tl_sched->sched_ctx);
-    MARCH_ASAN_SWITCH_DONE(p);
-    /* Context is now saved.  The scheduler (sched_loop) transitions us from
-     * PROC_PARKED to PROC_WAITING immediately after swapcontext returns on
-     * its side, making it safe for a waker to push us to a deque. */
-
-    /* Resumed — a sender woke us.  Pop under lock; return sentinel if empty
-     * (the actor was woken for a reason other than a new message, e.g. kill). */
-    mbox_lock_acquire(p);
-    atomic_store_explicit(&p->mbox_wait_mode, 0, memory_order_relaxed);
-    void *msg;
-    if (user_only ? p->mailbox != NULL
-                  : (p->control_mailbox != NULL || p->mailbox != NULL)) {
-        msg = user_only ? mbox_pop_user(p) : mbox_pop_any(p);
-        mbox_wake_send_waiters_if_low(p);
-    } else {
-        msg = MARCH_RECV_NO_MSG;
+        mbox_recv_park_once(p);
+        /* Context is now saved.  The scheduler (sched_loop) transitions us from
+         * PROC_PARKED to PROC_WAITING immediately after swapcontext returns on
+         * its side, making it safe for a waker to push us to a deque. */
+        atomic_store_explicit(&p->mbox_wait_mode, 0, memory_order_relaxed);
     }
-    mbox_lock_release(p);
-    return msg;
 }
 
 __attribute__((noinline))
@@ -2594,7 +2662,7 @@ static void timer_service(int64_t now_ms) {
         pthread_mutex_unlock(&g_timer_mu);
         if (!have_ent) return;
         if (ent.kind == MARCH_TIMER_WAKE) {
-            if (!stale) march_sched_wake(ent.proc);   /* outside the lock: wake can spin */
+            if (!stale) march_sched_wake(ent.proc);   /* outside the lock: wake can spin */   /* outside the lock: wake can spin */
             continue;
         }
         /* MARCH_TIMER_SEND: deliver, or dispose msg if cancelled/dead. Both

--- a/runtime/march_scheduler.h
+++ b/runtime/march_scheduler.h
@@ -242,6 +242,22 @@ typedef struct march_proc {
                                               * procs remain and nothing is runnable, parked
                                               * daemons are woken without a message so their
                                               * loops exit and the process can terminate. */
+    /* Set (via march_sched_request_stop) by the ONLY two callers entitled to
+     * end a blocking receive without delivering a message: the shutdown
+     * endgame (wake_idle_daemons) and actor death (do_actor_death, i.e.
+     * kill/crash/supervised stop). It is what makes MARCH_RECV_NO_MSG mean
+     * "you were told to stop" rather than "you happened to wake with an
+     * empty mailbox".
+     *
+     * Load-bearing: march_sched_send deposits a wake AFTER pushing, so two
+     * senders racing one receiver can produce a SECOND wake whose message
+     * the receiver already consumed on the first — it then resumes from a
+     * fresh park with a legitimately empty mailbox. Without this flag the
+     * untimed recv reported that as NO_MSG and actor_green_thread killed a
+     * perfectly live actor (bench/actors/fanin_flood.march, ~4% of runs; see
+     * specs/progress/2026-08-19-fanin-blocked-mailbox-spurious-actor-death.md).
+     * march_sched_recv_mode now re-parks unless this is set. */
+    _Atomic int                stop_requested;
     /* Compiled actor supervision: set (to a jmp_buf on THIS proc's own
      * green-thread stack) only while dispatching a message to an actor
      * that is a supervised child. march_panic longjmp's here instead of
@@ -326,6 +342,15 @@ void         march_sched_run(void);
  * Must be called before march_sched_run() (inline path) or before
  * joining the background scheduler thread (background path). */
 void         march_sched_request_shutdown(void);
+
+/* Ask `p`'s blocking receive to give up and return MARCH_RECV_NO_MSG rather
+ * than re-parking, then wake it so it observes that.  This is the ONLY way
+ * to end an untimed march_sched_recv/_user without delivering a message:
+ * plain march_sched_wake no longer suffices, because a wake with an empty
+ * mailbox is indistinguishable from the benign send/consume race described
+ * on march_proc.stop_requested and is therefore treated as spurious.
+ * Idempotent; safe to call on a proc that is already dead or running. */
+void         march_sched_request_stop(march_proc *p);
 
 /* Spawn a new green thread.  Returns the new process, or NULL on failure.
  * Safe to call from within a running process (nested spawn). */

--- a/specs/progress/2026-08-19-fanin-blocked-mailbox-spurious-actor-death.md
+++ b/specs/progress/2026-08-19-fanin-blocked-mailbox-spurious-actor-death.md
@@ -1,0 +1,143 @@
+# A wake with an empty mailbox killed a live actor (compiled, multi-scheduler)
+
+**Fixed 2026-08-19.** Found during a pre-0.3.0 actor stress sweep.
+
+## Symptom
+
+`bench/actors/fanin_flood.march` — one of the four gates `scripts/actor-load.sh`
+runs — intermittently printed `call failed: actor not alive` instead of
+`delivered 400000`, with exit code **0**, no crash, no signal, empty stderr. The
+`Sink` actor it calls is never killed, never supervised, never crashes.
+
+Measured **4 failures in 100 runs (~4%)** on the compiled binary. A single clean
+run — all the harness or a developer normally does — does not catch it.
+
+Two variables each fully suppressed it, which is what scoped the search:
+
+| Variable | Result |
+|---|---|
+| Remove `Actor.set_queue_limit(pid, 1024, 3)` (drop the BLOCK policy) | 0/30 failures |
+| `MARCH_NUM_SCHEDULERS=1` | 0/30 failures |
+
+## Root cause
+
+`march_sched_send` pushes the message under `mbox_lock` but issues its wake
+**after** releasing the lock. Two senders racing one receiver therefore produce
+two wakes for messages the receiver drains as a single batch:
+
+1. Sender A pushes `msg1`, reads `status == PROC_PARKED`, releases the lock.
+2. Sender B pushes `msg2`, reads `status == PROC_PARKED`, releases the lock.
+3. A's `march_sched_wake` resumes the receiver, which pops **both** messages,
+   runs both handlers, returns to `recv`, finds the mailbox empty, and re-parks.
+4. B's already-issued wake now lands, resuming the receiver with a
+   **legitimately empty** mailbox.
+
+`march_sched_recv_mode` returned `MARCH_RECV_NO_MSG` for step 4.
+`actor_green_thread` (`runtime/march_runtime.c`) reads that as "I was killed":
+
+```c
+void *msg = march_sched_recv_user();
+if (msg == MARCH_RECV_NO_MSG) break;  /* woken without message (killed) */
+```
+
+so it broke its dispatch loop and ran `do_actor_death` on an actor whose
+`$alive` word was still **1** — confirmed by instrumentation printing
+`alive=1` at the death site. A later `Actor.call` on that pid then failed the
+`actor_alive_load` check in `march_actor_call` with `"actor not alive"`.
+
+The BLOCK policy made the window reachable so often because
+`mbox_wake_send_waiters_if_low` is a wake-**all**: it releases a whole herd of
+blocked senders at once, which is precisely the many-concurrent-senders burst
+step 1–2 needs. `MARCH_NUM_SCHEDULERS=1` suppressed it because the sender's
+wake and the receiver's re-park cannot then interleave across OS threads.
+
+### How it was pinned (not deduced)
+
+Argument-by-elimination was not trusted. A temporary `g_dbg_wake_src` tag was
+set at each of the six `march_sched_wake` call sites and printed at the
+`NO_MSG` decision point. All three captured failures reported `wake_src=1` =
+`march_sched_send`, ruling out `wake_idle_daemons` (the one path whose
+*documented purpose* is ending a daemon's recv without a message), the timer
+service, control sends, and the send-waiter drains.
+
+Note `march_actor_call`'s **timed** path already looped for exactly this reason
+("Woken with an empty mailbox but time remains"). Two of the three `NO_MSG`
+consumers coped with spurious wakes; the actor dispatch loop and the
+wait-forever path did not.
+
+## Fix
+
+`MARCH_RECV_NO_MSG` from the untimed receive is now reserved for a **real stop
+request**, rather than meaning "you happened to wake with an empty mailbox":
+
+- New `march_proc.stop_requested` + `march_sched_request_stop(p)`
+  (`runtime/march_scheduler.{h,c}`).
+- `march_sched_recv_mode` parks in a **loop**, re-checking the mailbox on every
+  wake and re-parking unless `stop_requested` (or `PROC_DEAD`) is set.
+- The only two callers entitled to end a blocking receive without a message now
+  go through the flag: the shutdown endgame (`wake_idle_daemons`) and actor
+  death (`do_actor_death`, i.e. kill/crash/supervised stop).
+
+No lost wakeup is introduced: the emptiness check and the `PROC_PARKED` store
+both happen under `mbox_lock`, which senders also hold across
+push-then-read-status, so the two critical sections are serialized.
+
+### The regression this fix introduced first, and why it is worth recording
+
+The first version of the loop wrote `swapcontext(&p->ctx, &tl_sched->sched_ctx)`
+inline in the loop body. That traded the 4% death for a **~2.5% hard deadlock**.
+
+`tl_sched` is `_Thread_local`, and a proc that parks is resumed by whichever
+scheduler wins the wake — possibly on a **different OS thread**. `noinline` on
+`march_sched_recv_mode` only stops *its callers* from hoisting the TLS read; it
+does nothing about the function's own loop-invariant code motion. So the
+compiler cached `tl_sched` in a register, and after a migration iteration 2
+swapcontext'd into a **stale scheduler's** `sched_ctx`. The real scheduler then
+never ran that proc's `PROC_PARKED → PROC_WAITING` transition, so every waker
+spun on `PROC_PARKED` forever.
+
+Diagnosed from a live hang with a spin-timeout dump:
+
+```
+[wake] STUCK >3s target=0x1015fa890 status=4 wake_pending=1 daemon=1
+       wait_mode=2 mbox_count=1 send_waiters=0x0
+```
+
+`status=4` is `PROC_PARKED`, `mbox_count=1` — a message sitting undelivered
+while every scheduler thread was idle.
+
+This is the same hazard `mbox_block_register_and_park` already documents, with
+the same remedy: the park now lives in its own `NOINLINE` helper
+(`mbox_recv_park_once`) that the loop calls fresh every iteration, so the
+`tl_sched` read cannot be hoisted across the migration. Caching `p` across
+iterations remains fine — the proc object is the same one whichever thread
+resumes it.
+
+## Verification
+
+| Check | Result |
+|---|---|
+| `fanin_flood`, 120 bounded runs post-fix | 120/120, 0 deaths, 0 hangs |
+| `fanin_flood` pre-fix baseline | 4/100 failed |
+| First (inline-swapcontext) attempt | 1 hang in 40 — rejected, see above |
+| `test_scheduler_mbox` post-fix | passes |
+| `test_scheduler_mbox` against **pre-fix** `march_scheduler.c` | fails on `g_sw_got_nomsg == 0`, exit 134 |
+
+## Regression test
+
+`test/test_scheduler_mbox.c` → `test_spurious_wake_does_not_end_recv()`.
+
+**Deterministic, no race required** — which is the point, per
+`specs/todos/2026-08-14-deterministic-premature-free-reproducer.md`'s argument
+that a test which only fails statistically is not a regression guard. The
+prodder spins until it *observes* the receiver in `PROC_WAITING`, then issues a
+bare `march_sched_wake` with no message pushed at all, reproducing the exact
+state the send/consume race produces without having to win that race. It then
+asserts the receiver returned to `PROC_WAITING` under its own steam (it
+re-parked rather than reporting `NO_MSG` and dying) and still received a
+subsequent real message.
+
+Non-vacuity was confirmed by compiling the same test against the pre-fix
+`runtime/march_scheduler.c` from `git show HEAD:` — it aborts on the first
+assertion. The file's existing `alarm(30)` watchdog also converts the
+deadlock-regression variant into a test failure rather than a wedged run.

--- a/test/test_scheduler_mbox.c
+++ b/test/test_scheduler_mbox.c
@@ -139,6 +139,83 @@ static void test_block_spurious_wake_while_linked(void) {
      * this regression guards against. */
 }
 
+/* ── A wake with an empty mailbox must NOT end a blocking receive ────────
+ *
+ * march_sched_send pushes under mbox_lock but wakes AFTER releasing it, so
+ * two senders racing one receiver routinely issue two wakes for messages the
+ * receiver drains as a single batch. The second wake then lands after the
+ * receiver has already re-parked, resuming it with a legitimately empty
+ * mailbox. That is benign and must be treated as spurious: the receiver has
+ * to park again, NOT report MARCH_RECV_NO_MSG.
+ *
+ * It used to report NO_MSG, which actor_green_thread (march_runtime.c) reads
+ * as "I was killed" — it broke its dispatch loop and ran do_actor_death on an
+ * actor whose $alive word was still 1, so a later Actor.call on that pid
+ * failed with "actor not alive". Live-fire repro was
+ * bench/actors/fanin_flood.march at ~4% of runs; this is its deterministic
+ * form. NO_MSG is now reserved for a real stop request (see
+ * march_proc.stop_requested / march_sched_request_stop).
+ *
+ * Deterministic by construction, no race needed: the prodder spins until it
+ * OBSERVES the receiver in PROC_WAITING before issuing a bare wake (no
+ * message pushed at all), so the wake is guaranteed to hit a genuinely parked
+ * receiver with an empty mailbox — exactly the state the send/consume race
+ * produces, reached without needing to win that race.
+ *
+ * Both spin loops also break on PROC_DEAD, so the PRE-FIX binary fails fast
+ * on the assertion instead of grinding through the full bound: pre-fix the
+ * receiver returns NO_MSG on the bare wake and its proc dies, so it never
+ * returns to PROC_WAITING and g_sw_got_nomsg is set. */
+static _Atomic int g_sw_got_nomsg = 0;
+static _Atomic int g_sw_got_real  = 0;
+static _Atomic int g_sw_reparked  = 0;
+static march_proc *g_sw_rx = NULL;
+
+static void sw_rx_loop(void *arg) {
+    (void)arg;
+    void *m = march_sched_recv();
+    if (m == MARCH_RECV_NO_MSG) atomic_store(&g_sw_got_nomsg, 1);
+    else                        atomic_store(&g_sw_got_real, 1);
+}
+
+/* Spin (yielding, so the receiver actually gets turns even if this lands on
+ * its scheduler thread) until rx reaches PROC_WAITING. Returns 1 if it did. */
+static int sw_wait_until_parked(void) {
+    for (int i = 0; i < 200000; i++) {
+        march_proc_status st = atomic_load_explicit(&g_sw_rx->status,
+                                                    memory_order_acquire);
+        if (st == PROC_WAITING) return 1;
+        if (st == PROC_DEAD)    return 0;   /* pre-fix: it died on the wake */
+        march_sched_yield();
+    }
+    return 0;
+}
+
+static void sw_prodder_loop(void *arg) {
+    (void)arg;
+    if (!sw_wait_until_parked()) return;
+    /* The bare spurious wake: deliberately NO march_sched_send, so the
+     * mailbox is empty when the receiver resumes. */
+    march_sched_wake(g_sw_rx);
+    /* It must come back to WAITING under its own steam (i.e. it re-parked
+     * rather than reporting NO_MSG and exiting). */
+    if (sw_wait_until_parked()) atomic_store(&g_sw_reparked, 1);
+    /* Now a real delivery, to prove the receiver is still functional and the
+     * re-park did not cost us the message. */
+    march_sched_send(g_sw_rx, (void *)0x2);
+}
+
+static void test_spurious_wake_does_not_end_recv(void) {
+    march_sched_init();
+    g_sw_rx = march_sched_spawn(sw_rx_loop, NULL);
+    march_sched_spawn(sw_prodder_loop, NULL);
+    march_sched_request_shutdown();
+    march_sched_run();
+    assert(atomic_load(&g_sw_got_nomsg) == 0);  /* the wake was not fatal   */
+    assert(atomic_load(&g_sw_reparked)  == 1);  /* it genuinely re-parked   */
+    assert(atomic_load(&g_sw_got_real)  == 1);  /* and still got the message*/
+}
+
 /* ── Reserved control FIFO: policy isolation + dispatch isolation ──────
  *
  * A control value must survive DROP_OLD user traffic and actor dispatch's
@@ -304,6 +381,7 @@ int main(void) {
 
     test_block_live_scheduler();
     test_block_spurious_wake_while_linked();
+    test_spurious_wake_does_not_end_recv();
     test_control_fifo_bypasses_user_policy();
     test_cross_plane_global_fifo();
     test_dead_reap_drain();


### PR DESCRIPTION
Found during a pre-0.3.0 actor stress sweep. A live, never-killed actor could
silently die, so a later `Actor.call` on it failed with `actor not alive` — no
crash, no diagnostic, exit code 0.

Measured at **4 failures in 100 runs** of `bench/actors/fanin_flood.march`, one
of the `scripts/actor-load.sh` gates. A single clean run — all the harness or a
developer normally does — does not catch it.

## Root cause

`march_sched_send` pushes the message under `mbox_lock` but issues its wake
**after** releasing it. Two senders racing one receiver therefore produce two
wakes for messages the receiver drains as a single batch:

1. Sender A pushes `msg1`, reads `status == PROC_PARKED`, releases the lock.
2. Sender B pushes `msg2`, reads `status == PROC_PARKED`, releases the lock.
3. A's wake resumes the receiver; it pops **both** messages, runs both handlers,
   returns to `recv`, finds the mailbox empty, and re-parks.
4. B's already-issued wake lands, resuming it with a **legitimately empty** mailbox.

`march_sched_recv_mode` returned `MARCH_RECV_NO_MSG` for step 4, which
`actor_green_thread` reads as *"I was killed"*:

```c
void *msg = march_sched_recv_user();
if (msg == MARCH_RECV_NO_MSG) break;  /* woken without message (killed) */
```

so it broke its dispatch loop and ran `do_actor_death` on an actor whose
`$alive` word was still **1** — confirmed by instrumentation printing `alive=1`
at the death site.

Only reachable compiled, and only with more than one scheduler thread. A bounded
mailbox under `MARCH_MBOX_BLOCK` made it far likelier, because
`mbox_wake_send_waiters_if_low` is a wake-**all**: it releases a whole herd of
blocked senders at once, which is exactly the burst of concurrent senders steps
1–2 need. Note this broke the guarantee `Actor.set_queue_limit`'s own
documentation makes for policy 3, that no request or reply is ever silently
discarded.

**The waker was pinned positively, not by elimination.** A temporary
`g_dbg_wake_src` tag on each of the six `march_sched_wake` call sites, printed at
the `NO_MSG` decision point, reported `march_sched_send` on all three captured
failures — ruling out `wake_idle_daemons` (the one path whose *documented
purpose* is ending a daemon's recv without a message), the timer service, control
sends, and the send-waiter drains.

`march_actor_call`'s **timed** path already looped for exactly this reason
("Woken with an empty mailbox but time remains"). Two of the three `NO_MSG`
consumers coped with spurious wakes; the actor dispatch loop did not.

## Fix

`MARCH_RECV_NO_MSG` is now reserved for a **real stop request**, rather than
meaning "you happened to wake with an empty mailbox":

- new `march_proc.stop_requested` + `march_sched_request_stop(p)`
- `march_sched_recv_mode` parks in a **loop**, re-checking the mailbox on every
  wake and re-parking unless `stop_requested` (or `PROC_DEAD`) is set
- the only two callers entitled to end a blocking receive without a message go
  through the flag: the shutdown endgame (`wake_idle_daemons`) and actor death
  (`do_actor_death`, i.e. kill/crash/supervised stop)

No lost wakeup is introduced: the emptiness check and the `PROC_PARKED` store
both happen under `mbox_lock`, which senders also hold across
push-then-read-status, so the two critical sections are serialized.

## Reviewer note: the deadlock the first attempt introduced

Worth a close look, because it is subtle and the next person will hit it.

The first version wrote `swapcontext(&p->ctx, &tl_sched->sched_ctx)` inline in
the loop body. That traded the 4% death for a **~2.5% hard deadlock**.

`tl_sched` is `_Thread_local`, and a parked proc is resumed by whichever
scheduler wins the wake — possibly on a **different OS thread**. `noinline` on
`march_sched_recv_mode` only stops *its callers* from hoisting the TLS read; it
does nothing about the function's own loop-invariant code motion. The compiler
cached `tl_sched` in a register, so after a migration iteration 2 swapcontext'd
into a **stale scheduler's** `sched_ctx`. The real scheduler then never ran that
proc's `PROC_PARKED → PROC_WAITING` transition, and every waker spun on
`PROC_PARKED` forever. Diagnosed from a live hang with a spin-timeout dump:

```
[wake] STUCK >3s target=0x1015fa890 status=4 wake_pending=1 daemon=1
       wait_mode=2 mbox_count=1 send_waiters=0x0
```

`status=4` is `PROC_PARKED`, `mbox_count=1` — a message sitting undelivered while
every scheduler thread was idle.

The park now lives in its own `NOINLINE` helper (`mbox_recv_park_once`) that the
loop calls fresh every iteration, so the `tl_sched` read cannot be hoisted across
the migration. Same hazard and same remedy as `mbox_block_register_and_park`,
whose comment already spells this out. Caching `p` across iterations remains fine
— the proc object is the same one whichever thread resumes it.

## Regression test

`test_spurious_wake_does_not_end_recv()` in `test/test_scheduler_mbox.c`.

**Deterministic, no race required** — per the argument in
`specs/todos/2026-08-14-deterministic-premature-free-reproducer.md` that a test
which only fails statistically is not a regression guard. The prodder spins until
it *observes* the receiver in `PROC_WAITING`, then issues a bare
`march_sched_wake` with no message pushed at all, reproducing the exact state the
send/consume race produces without having to win that race. It then asserts the
receiver returned to `PROC_WAITING` under its own steam (it re-parked rather than
reporting `NO_MSG` and dying) and still received a subsequent real message.

Non-vacuity confirmed by compiling the same test against the pre-fix
`runtime/march_scheduler.c` from `git show HEAD:` — it aborts on the first
assertion (exit 134). The file's existing `alarm(30)` watchdog also converts the
deadlock-regression variant into a test failure rather than a wedged run.

## Verification

| Check | Result |
|---|---|
| `fanin_flood`, 250 bounded runs post-fix | **250/250**, 0 deaths, 0 hangs |
| `fanin_flood` pre-fix baseline | 4/100 failed |
| First (inline-swapcontext) attempt | 1 hang in 40 — rejected |
| `dune runtest` (exit code read unpiped) | **0** — 584 codegen tests; 1 pre-existing env skip (cross sysroot) |
| `scripts/run-tests.sh` full alcotest suite | All suites passed |
| All 5 C scheduler tests | 5/5 pass |
| `scripts/actor-load.sh` all 4 gates | PASS — incl. `crashloop` (kill + supervised restart) |
| Native actor/supervisor goldens | 15/15 pass |
| `actor_monitor_down_reason` (5 grep assertions) | all 5 OK |
| New regression test vs pre-fix runtime | fails, exit 134 (non-vacuous) |
| `scripts/check-docs.sh` | doc-lint passed |

ThreadSanitizer segfaults on these green-thread tests (ucontext/fiber
limitation) — verified **identical on baseline**, so it is pre-existing tooling,
not this change.

Docs: `specs/progress/2026-08-19-fanin-blocked-mailbox-spurious-actor-death.md`
(full root-cause writeup, including the deadlock detour) and a `CHANGELOG.md`
entry under `[Unreleased] / Fixed`.
