### PR TITLE
fix(ctxesc): ~H rendered an interpolated value as executable JavaScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,31 @@ git log is authoritative for exact commits.
 
 ### Fixed
 
+- **Security: `~H` no longer renders an interpolated value as executable
+  JavaScript, and its URL-attribute list no longer misses live vectors.** Found
+  and fixed pre-release; no tagged version shipped it. Three defects, all in the
+  context table rather than in any escaper:
+  `<script>var x = ${p}</script>` and `<button onclick="n = ${p}">` gave every
+  script context the JS *string* escaper, which only stops a value ENDING a
+  string literal — at an expression position there is no literal, so
+  `alert(document.cookie)` passed through as code (and, in the other direction,
+  honest arithmetic came out a syntax error). `xlink:href`, `object data` and
+  `ping` were absent from the URL-attribute list, so they fell through to plain
+  attribute escaping and passed `javascript:` untouched. `srcdoc` was correctly
+  entity-escaped as an attribute, but browsers HTML-decode it and parse the
+  result as a document, so the escaping is undone before the markup is read.
+  The table now models JS positions properly — string literal, expression,
+  comment, regex literal, template literal — with a new JS-expression escaper
+  that renders a value as an inert quoted string rather than as code;
+  `xlink:href`, `data`, `ping`, `manifest` and `longdesc` are classified as
+  URLs; and `srcdoc`, `srcset`, JS comments, regex and template literals are
+  compile errors that say why. `Html.trust_js` still inserts trusted JS
+  verbatim. **Note for template authors:** a hole at a JS expression position
+  now renders as a JS string, so `<script>var n = ${count}</script>` yields
+  `'42'`, not `42` — put the value in a quoted JS string, or use
+  `Html.trust_js`, if you need its JS type. See
+  `specs/progress/2026-08-20-h-sigil-js-and-url-attr-xss.md`.
+
 - **A message arriving while an actor was already being woken no longer kills
   that actor.** `march_sched_send` pushes under the mailbox lock but wakes after
   releasing it, so two senders racing one receiver could issue two wakes for

--- a/lib/ctxesc/automaton.ml
+++ b/lib/ctxesc/automaton.ml
@@ -143,13 +143,32 @@ let consume_literal t (start : C.t) (src : string) =
 (* ── Consuming a hole ─────────────────────────────────────────────────── *)
 
 (* The escaper is implied by the SUCCESSOR context rather than named in the
-   row, so the table cannot drift out of sync with the escaper set. *)
+   row, so the table cannot drift out of sync with the escaper set.
+
+   JS has TWO positions and they are not interchangeable. Until 2026-08-20 both
+   arms below said [EscJsString] unconditionally, which is correct only inside a
+   string literal: at an expression position it escaped the quotes of a value
+   that had no quotes around it, so `alert(document.cookie)` went through
+   untouched as executable code — and, in the other direction, honest
+   arithmetic came out as a syntax error. See
+   specs/progress/2026-08-20-h-sigil-js-and-url-attr-xss.md. The table now
+   tracks JS string literals, so the two positions arrive here distinguished.
+
+   The rejected JS sub-positions (comment, regex, template literal) never reach
+   this function — the table carries a diagnostic for each, and [consume_interp]
+   returns [Error] before asking for an escaper. They still map to the strictest
+   JS escaper here rather than being left to a catch-all, so that adding an
+   accepting row for one of them by mistake fails closed. *)
 let escaper_for (c : C.t) =
+  let js = function
+    | C.AtJsString -> C.EscJsString
+    | _ -> C.EscJsExpr
+  in
   match c.C.state with
   | C.Pcdata -> C.EscHtml
   | C.Rcdata ->
     (match c.C.element with
-     | C.ElScript -> C.EscJsString
+     | C.ElScript -> js c.C.attr
      | C.ElStyle ->
        (* a url() inside a <style> body is a URL, not a CSS value *)
        if c.C.attr = C.AtCssUrl then C.EscCssUrl else C.EscCssDecl
@@ -161,8 +180,12 @@ let escaper_for (c : C.t) =
      | C.AtStyle -> C.EscCssDecl
      | C.AtStyleValue -> C.EscCssValue
      | C.AtCssUrl -> C.EscCssUrl
-     | C.AtScript -> C.EscJsString
-     | C.AtNormal -> C.EscAttr)
+     | (C.AtScript | C.AtJsString | C.AtJsComment | C.AtJsRegex
+       | C.AtJsTemplate) as a -> js a
+     (* srcset and srcdoc are rejected by the table; EscAttr is what they were
+        getting before, and is what makes srcdoc's escaped markup come back to
+        life once the browser decodes the attribute. Never reached. *)
+     | C.AtSrcset | C.AtHtmlDoc | C.AtNormal -> C.EscAttr)
   | _ -> C.EscAttr  (* unreachable: every other state rejects holes *)
 
 let consume_interp t (c : C.t) =

--- a/lib/ctxesc/context.ml
+++ b/lib/ctxesc/context.ml
@@ -46,6 +46,45 @@ type attr =
           the paper's subsidiary automata genuinely earn their keep — see
           [EscCssUrl]. *)
   | AtScript
+      (** JS at an EXPRESSION position — a `<script>` body outside any string
+          literal, or an `on*` handler attribute at the same. A hole here is a
+          whole JS expression, NOT a string body: see [EscJsExpr]. *)
+  | AtJsString
+      (** JS inside a quote-delimited string literal (`'…'` or `"…"`). This is
+          the ONLY JS position [EscJsString] is correct for, and until
+          2026-08-20 it was not distinguished from [AtScript] at all — every
+          script context got [EscJsString], so `<script>var x = ${p}</script>`
+          rendered `p` as bare code. See
+          specs/progress/2026-08-20-h-sigil-js-and-url-attr-xss.md. *)
+  | AtJsComment
+      (** inside a `//` or `/* */` JS comment. A hole here is always a mistake,
+          exactly as in an HTML comment, so the table rejects it. Tracking
+          comments is not a nicety: an apostrophe in one (`// don't`) would
+          otherwise desynchronise the string tracker and make the NEXT hole
+          look like it sat inside a string literal. *)
+  | AtJsRegex
+      (** inside a JS regular-expression literal. Rejected: a hole cannot be
+          escaped safely here (an unescaped `/` ends the literal and everything
+          after it is code), and `/` is also where the table gives up on telling
+          a regex apart from division — which is why this class is entered by
+          ANY `/` in expression position. Misreading division as a regex costs a
+          compile error; misreading a regex as division would cost a quote
+          desynchronisation, so the bias is deliberate. *)
+  | AtJsTemplate
+      (** inside a backtick-delimited JS template literal. Rejected: neither
+          the backtick nor `${` is escaped by [EscJsString], so a hole could
+          close the literal or open a substitution — and a substitution is
+          arbitrary code. *)
+  | AtSrcset
+      (** an `srcset` attribute value. Rejected: the value is a comma-separated
+          list of candidates, so the whole-URL escaper's contract ("this hole
+          IS the URL") does not hold — it would validate the first candidate's
+          scheme and wave the rest through. *)
+  | AtHtmlDoc
+      (** an `srcdoc` attribute value. Rejected: the browser HTML-DECODES the
+          attribute and then parses the result as a whole document, so entity
+          escaping — correct for every other attribute — is undone before the
+          markup is parsed and `&lt;img onerror=…&gt;` fires. *)
 
 type delim =
   | DlNone
@@ -70,7 +109,8 @@ let all_states =
 
 let all_elements = [ ElNormal; ElScript; ElStyle; ElTextarea; ElTitle ]
 let all_attrs =
-  [ AtNormal; AtUrl; AtUrlMid; AtStyle; AtStyleValue; AtCssUrl; AtScript ]
+  [ AtNormal; AtUrl; AtUrlMid; AtStyle; AtStyleValue; AtCssUrl; AtScript;
+    AtJsString; AtJsComment; AtJsRegex; AtJsTemplate; AtSrcset; AtHtmlDoc ]
 let all_delims = [ DlNone; DlSingle; DlDouble; DlUnquoted; DlDoubleSubst ]
 
 let state_name = function
@@ -99,6 +139,12 @@ let attr_name = function
   | AtStyleValue -> "stylevalue"
   | AtCssUrl -> "cssurl"
   | AtScript -> "script"
+  | AtJsString -> "jsstring"
+  | AtJsComment -> "jscomment"
+  | AtJsRegex -> "jsregex"
+  | AtJsTemplate -> "jstemplate"
+  | AtSrcset -> "srcset"
+  | AtHtmlDoc -> "htmldoc"
 
 let delim_name = function
   | DlNone -> "none"
@@ -116,8 +162,21 @@ let attr_of_string = lookup all_attrs attr_name
 let delim_of_string = lookup all_delims delim_name
 
 let describe c =
+  (* The JS sub-positions are named explicitly rather than folded into "inside
+     a <script> element's body", because the whole point of the 2026-08-20 fix
+     is that those positions are NOT interchangeable — a diagnostic that says
+     only "in a script body" would leave the author unable to tell why the same
+     hole is fine two characters to the left. *)
   match c.state, c.attr, c.delim with
   | Pcdata, _, _ -> "in element content"
+  | Rcdata, AtJsString, _ -> "inside a JS string literal in a <script> body"
+  | Rcdata, AtJsComment, _ -> "inside a JS comment in a <script> body"
+  | Rcdata, AtJsRegex, _ ->
+    "inside a JS regular-expression literal in a <script> body"
+  | Rcdata, AtJsTemplate, _ ->
+    "inside a JS template literal in a <script> body"
+  | Rcdata, _, _ when c.element = ElScript ->
+    "at a JS expression position in a <script> body"
   | Rcdata, _, _ ->
     Printf.sprintf "inside a <%s> element's body" (element_name c.element)
   | Tagname, _, _ | Closetagname, _, _ -> "in an element name"
@@ -129,7 +188,18 @@ let describe c =
   | Attrvalue, AtStyle, _ -> "at a declaration position in a style attribute"
   | Attrvalue, AtStyleValue, _ -> "at a value position in a style attribute"
   | Attrvalue, AtCssUrl, _ -> "inside a CSS url() in a style attribute"
-  | Attrvalue, AtScript, _ -> "in an event-handler attribute value"
+  | Attrvalue, AtScript, _ ->
+    "at a JS expression position in an event-handler attribute"
+  | Attrvalue, AtJsString, _ ->
+    "inside a JS string literal in an event-handler attribute"
+  | Attrvalue, AtJsComment, _ ->
+    "inside a JS comment in an event-handler attribute"
+  | Attrvalue, AtJsRegex, _ ->
+    "inside a JS regular-expression literal in an event-handler attribute"
+  | Attrvalue, AtJsTemplate, _ ->
+    "inside a JS template literal in an event-handler attribute"
+  | Attrvalue, AtSrcset, _ -> "in a `srcset` attribute value"
+  | Attrvalue, AtHtmlDoc, _ -> "in a `srcdoc` attribute value"
   | Attrvalue, _, DlUnquoted -> "in an unquoted attribute value"
   | Attrvalue, _, _ -> "in an attribute value"
   | Comment, _, _ -> "inside an HTML comment"
@@ -148,6 +218,10 @@ type escaper =
       (** a single CSS value: identifiers, numbers, colours, and calls to an
           allowlisted set of functions (`var`, `rgb`, `calc`, ...) *)
   | EscJsString
+      (** a hole INSIDE a JS string literal — the delimiters come from the
+          template, this escaper only makes the body unable to end it. Correct
+          ONLY at [AtJsString]; using it at [AtScript] is what made
+          `<script>var x = ${p}</script>` execute `p`. *)
   | EscNone
   | EscCssDecl
       (** a CSS declaration LIST: as EscCssValue, plus `:` and `;` so a hole can
@@ -162,6 +236,30 @@ type escaper =
           Neither the CSS nor the URL escaper alone is right: CSS escaping
           mangles the slashes, and URL escaping leaves `)` free to close the
           construct. *)
+  | EscJsExpr
+      (** a hole at a JS EXPRESSION position. There are no delimiters in the
+          template to hide behind, so this escaper supplies its own: it renders
+          the value as a complete, single-quoted JS string literal. An
+          expression-position hole therefore lands as an inert string rather
+          than as code — the same move every other escaper here makes when a
+          value cannot be admitted as-is (a disallowed URL becomes
+          `about:invalid#zSoyz`, an unrecognised CSS value becomes hex
+          escapes), and the same one go's html/template and Closure Templates
+          make in this position.
+
+          It escapes BOTH quote characters numerically, so the only raw quotes
+          in its output are its own two delimiters. That is what lets ONE
+          escaper serve a `<script>` body and a double-quoted `on*` attribute:
+          the body can close neither the JS literal nor the HTML attribute. A
+          SINGLE-quoted `on*` attribute is the one context whose delimiter
+          would collide, and the table rejects a hole there rather than
+          emitting something that breaks out.
+
+          A value that must reach JS as CODE rather than as data goes through
+          `Html.trust_js`, which bypasses this escaper entirely — see the
+          trusted-id tables in lib/tir/llvm_emit.ml and lib/eval/eval.ml.
+          Appended rather than inserted so the existing ids stay stable: they
+          are shared verbatim with the C runtime's MARCH_ESC_* defines. *)
 
 let escaper_id = function
   | EscHtml -> 0
@@ -173,6 +271,7 @@ let escaper_id = function
   | EscNone -> 6
   | EscCssDecl -> 7
   | EscCssUrl -> 8
+  | EscJsExpr -> 9
 
 let escaper_name = function
   | EscHtml -> "html"
@@ -184,3 +283,4 @@ let escaper_name = function
   | EscNone -> "none"
   | EscCssDecl -> "css_decl"
   | EscCssUrl -> "css_url"
+  | EscJsExpr -> "js_expr"

--- a/lib/ctxesc/escape.ml
+++ b/lib/ctxesc/escape.ml
@@ -87,7 +87,18 @@ let url_whole s =
 
 (* `</script` ends the element even inside a JS string literal, and U+2028 /
    U+2029 are line terminators in JS though legal in a JSON string — so a
-   JSON-safe encoder is not JS-safe. *)
+   JSON-safe encoder is not JS-safe.
+
+   Both quote characters are escaped NUMERICALLY rather than with a backslash.
+   That matters because a JS string can live inside an HTML attribute
+   (`onclick="f('${x}')"`), and a backslash-escaped quote still contains the
+   quote BYTE — HTML has never heard of the backslash, so the attribute simply
+   ends there. The \\u00XX spellings mean exactly the same thing to a JS parser
+   and contain no quote byte at all, which makes "an escaped hole never emits a
+   raw quote" hold for every escaper here without exception. (Escaping `=` is
+   what kept the backslash spelling from being exploitable: a value that broke
+   out of the attribute still could not write `onerror=`. Relying on a second
+   line of defence for the first one's failure is not a position to stay in.) *)
 let js_string s =
   let n = String.length s in
   let b = Buffer.create n in
@@ -104,8 +115,8 @@ let js_string s =
     end
     else begin
       (match c with
-       | '"' -> Buffer.add_string b "\\\""
-       | '\'' -> Buffer.add_string b "\\'"
+       | '"' -> Buffer.add_string b "\\u0022"
+       | '\'' -> Buffer.add_string b "\\u0027"
        | '\\' -> Buffer.add_string b "\\\\"
        | '\n' -> Buffer.add_string b "\\n"
        | '\r' -> Buffer.add_string b "\\r"
@@ -121,6 +132,33 @@ let js_string s =
     end
   done;
   Buffer.contents b
+
+(* A hole at a JS EXPRESSION position — `<script>var x = ${p}</script>`, or an
+   `on*` handler outside any string literal. Mirrors esc_js_expr in
+   runtime/march_ctx_escape.c.
+
+   `js_string` is WRONG here and was what shipped until 2026-08-20: it escapes
+   the delimiters of a literal the template never opened, so a payload made of
+   nothing but identifiers, dots and parens — `alert(document.cookie)` — went
+   through untouched and ran. There is no escaping that makes an arbitrary
+   string safe as bare JS *code*; the only sound move is to stop it being code.
+
+   So the escaper supplies the delimiters the template did not, and the value
+   lands as a JS string literal: inert, and still readable at the far end.
+   `1 < 2 && 3 > 2` becomes the string `'1 < 2 ...'` rather than the
+   syntax error the old escaper produced, so this fixes the honest-input case
+   as well as the hostile one.
+
+   Single quotes. [js_string] escapes both quote characters numerically, so the
+   output carries exactly two raw quote bytes — the two this function adds. In
+   a `<script>` body that is simply a JS string; in a double-quoted `on*`
+   attribute the `'` cannot close the attribute and nothing inside can either.
+   A SINGLE-quoted `on*` attribute is rejected by the table instead, since
+   these delimiters would end it.
+
+   Code that genuinely needs to reach JS as code uses `Html.trust_js`, which
+   never gets here. *)
+let js_expr s = "'" ^ js_string s ^ "'"
 
 (* CSS -- two positions, two escapers; mirrors runtime/march_ctx_escape.c.
    Both allow calls to an ALLOWLISTED set of functions. Escaping every `(` is
@@ -225,13 +263,14 @@ let apply (e : C.escaper) s =
   | C.EscCssDecl -> css ~decl:true s
   | C.EscCssUrl -> css_url s
   | C.EscJsString -> js_string s
+  | C.EscJsExpr -> js_expr s
   | C.EscNone -> s
 
 let apply_id id s =
   match List.find_opt (fun e -> C.escaper_id e = id)
           [ C.EscHtml; C.EscAttr; C.EscUrlComponent; C.EscUrlWhole;
             C.EscCssValue; C.EscJsString; C.EscNone; C.EscCssDecl;
-            C.EscCssUrl ] with
+            C.EscCssUrl; C.EscJsExpr ] with
   | Some e -> apply e s
   | None ->
     invalid_arg

--- a/lib/eval/eval.ml
+++ b/lib/eval/eval.ml
@@ -4803,7 +4803,11 @@ let base_env : env =
          | VCon ("TrustedAttr", [VString s]) when id = 1 -> VString s
          | VCon ("TrustedUrl", [VString s]) when id = 2 || id = 3 -> VString s
          | VCon ("TrustedCss", [VString s]) when id = 4 || id = 7 -> VString s
-         | VCon ("TrustedJs", [VString s]) when id = 5 -> VString s
+         (* Both JS escapers: 5 inside a string literal, 9 at an expression
+            position. They differ in POSITION within one language, like the
+            url and css pairs above, and expression position is the only place
+            trusted JS is worth inserting at all. *)
+         | VCon ("TrustedJs", [VString s]) when id = 5 || id = 9 -> VString s
          (* Trusted, but not for THIS context -- escape it like anything else. *)
          | VCon (("Safe" | "TrustedHtml" | "TrustedAttr" | "TrustedUrl"
                  | "TrustedCss" | "TrustedJs"), [VString s]) ->

--- a/lib/tir/llvm_emit.ml
+++ b/lib/tir/llvm_emit.ml
@@ -2014,7 +2014,15 @@ let rec emit_expr ctx (e : Tir.expr) : string * string =
         | "TrustedAttr" -> Some [ 1 ]
         | "TrustedUrl" -> Some [ 2; 3 ]
         | "TrustedCss" -> Some [ 4; 7 ]
-        | "TrustedJs" -> Some [ 5 ]
+        (* A js trust covers BOTH JS escapers. 5 is a hole inside a string
+           literal, 9 a hole at an expression position; they differ in
+           POSITION within one language, exactly as the url and css pairs
+           above do, and trusting a string as JS trusts it as JS wherever JS
+           is being written. This is also what keeps `Html.trust_js` usable at
+           all after the 2026-08-20 fix: expression position is the only place
+           trusted JS is ever worth inserting, and it is precisely the place
+           an untrusted value now gets quoted into inertness. *)
+        | "TrustedJs" -> Some [ 5; 9 ]
         | _ -> None
     in
     let trusted_ids =

--- a/runtime/march_ctx_escape.c
+++ b/runtime/march_ctx_escape.c
@@ -128,12 +128,24 @@ static void esc_url_whole(sink *s, const char *src, size_t len) {
 }
 
 /* ── JS string ─────────────────────────────────────────────────────────────
- * For a hole inside a JS string literal. Beyond the usual escapes:
+ * For a hole inside a JS string literal -- a position the context table now
+ * proves, rather than assumes. Beyond the usual escapes:
  *  - `</script` ends the element even inside a string literal, and `<!--`
  *    starts an HTML comment that some parsers honour inside <script>; both are
  *    neutralised by escaping `<` and `>`.
  *  - U+2028 and U+2029 are line terminators in JS but legal inside a JSON
- *    string, so a JSON-safe encoder is not JS-safe. */
+ *    string, so a JSON-safe encoder is not JS-safe.
+ *
+ * Both quote characters are escaped NUMERICALLY rather than with a backslash,
+ * because a JS string can live inside an HTML attribute
+ * (onclick="f('${x}')") and a backslash-escaped quote still contains the quote
+ * BYTE -- HTML has never heard of the backslash, so the attribute just ends
+ * there. The \u00XX spellings mean the same thing to a JS parser and contain
+ * no quote byte, which makes "an escaped hole never emits a raw quote" hold
+ * for every escaper here without exception. (Escaping `=` is what kept the
+ * backslash spelling from being exploitable -- a value that broke out still
+ * could not write onerror= -- and relying on the second line of defence for
+ * the first one's failure is not a position to stay in.) */
 static void esc_js_string(sink *s, const char *src, size_t len) {
     for (size_t i = 0; i < len; i++) {
         unsigned char c = (unsigned char)src[i];
@@ -147,8 +159,8 @@ static void esc_js_string(sink *s, const char *src, size_t len) {
             continue;
         }
         switch (c) {
-        case '"':  put_str(s, "\\\""); break;
-        case '\'': put_str(s, "\\'"); break;
+        case '"':  put_str(s, "\\u0022"); break;
+        case '\'': put_str(s, "\\u0027"); break;
         case '\\': put_str(s, "\\\\"); break;
         case '\n': put_str(s, "\\n"); break;
         case '\r': put_str(s, "\\r"); break;
@@ -162,6 +174,36 @@ static void esc_js_string(sink *s, const char *src, size_t len) {
             else put1(s, (char)c);
         }
     }
+}
+
+/* ── JS expression position ────────────────────────────────────────────────
+ * For a hole that is NOT inside a string literal: `<script>var x = ${p}` or an
+ * `on*` handler outside any literal. Mirrors Escape.js_expr in
+ * lib/ctxesc/escape.ml.
+ *
+ * esc_js_string is WRONG here, and shipping it here was the 2026-08-20
+ * vulnerability: it escapes the delimiters of a literal the template never
+ * opened, so a payload built from identifiers, dots and parens --
+ * alert(document.cookie) -- contains nothing it touches and runs as written.
+ * No encoding makes an arbitrary string safe as bare JS CODE. The only sound
+ * move is to stop it being code, so this escaper supplies the delimiters the
+ * template did not and the value lands as a JS STRING: inert, and still
+ * legible at the far end. That also repairs the honest-input direction of the
+ * same bug, where the string escaper turned `1 < 2` into `1 < 2`.
+ *
+ * Single quotes. esc_js_string escapes both quote characters numerically, so
+ * the output contains exactly two raw quote bytes -- the two added here. That
+ * is what lets ONE escaper serve a <script> body and a double-quoted on* attr:
+ * the body can close neither the JS literal nor the HTML attribute. A
+ * SINGLE-quoted on* attribute is the one context these delimiters would break
+ * out of, and the context table rejects a hole there at compile time instead.
+ *
+ * Values that must reach JS as code go through Html.trust_js, which bypasses
+ * escaping entirely and never arrives here. */
+static void esc_js_expr(sink *s, const char *src, size_t len) {
+    put1(s, '\'');
+    esc_js_string(s, src, len);
+    put1(s, '\'');
 }
 
 /* CSS -- two positions, two escapers; see march_ctx_escape.h.
@@ -322,6 +364,7 @@ size_t march_ctx_escape(int escaper_id, const char *src, size_t len, char *out) 
     case MARCH_ESC_CSS_DECL:      esc_css(&s, src, len, 1); break;
     case MARCH_ESC_CSS_URL:       esc_css_url(&s, src, len); break;
     case MARCH_ESC_JS_STRING:     esc_js_string(&s, src, len); break;
+    case MARCH_ESC_JS_EXPR:       esc_js_expr(&s, src, len); break;
     case MARCH_ESC_NONE:          put(&s, src, len); break;
     default:
         /* An id the runtime does not know means the emitter and the runtime

--- a/runtime/march_ctx_escape.h
+++ b/runtime/march_ctx_escape.h
@@ -5,6 +5,15 @@
  * lib/ctxesc/automaton.ml and inlined as a constant id at the call site, so
  * nothing here ever inspects a value to decide what it is.
  *
+ * JS has two escapers for the same reason CSS has two, and learning that cost
+ * a real vulnerability. A hole INSIDE a JS string literal only has to be unable
+ * to end that literal (MARCH_ESC_JS_STRING). A hole at an EXPRESSION position
+ * has no literal around it at all and cannot be made safe as code, so
+ * MARCH_ESC_JS_EXPR supplies its own quotes and renders the value as an inert
+ * string. Until 2026-08-20 every script context got the string escaper, so
+ * `<script>var x = ${p}</script>` executed p; see
+ * specs/progress/2026-08-20-h-sigil-js-and-url-attr-xss.md.
+ *
  * CSS has two escapers because a style attribute alternates between two
  * positions with different syntax: a DECLARATION list (`color:red;...`), where
  * `:` and `;` are structural, and a VALUE (`#fff`, `var(--x)`), where either
@@ -32,7 +41,8 @@
 #define MARCH_ESC_NONE          6
 #define MARCH_ESC_CSS_DECL      7
 #define MARCH_ESC_CSS_URL       8
-#define MARCH_ESC__COUNT        9
+#define MARCH_ESC_JS_EXPR       9
+#define MARCH_ESC__COUNT        10
 
 /* What a URL that failed the scheme allowlist is replaced with. Chosen to be
  * inert in every context: it navigates nowhere and executes nothing. */

--- a/specs/progress/2026-08-20-h-sigil-js-and-url-attr-xss.md
+++ b/specs/progress/2026-08-20-h-sigil-js-and-url-attr-xss.md
@@ -1,0 +1,244 @@
+# `~H` auto-escaping executed attacker JS in three contexts — FIXED
+
+**Found:** 2026-08-20, during a pre-0.3.0 adversarial sweep.
+**Fixed:** 2026-08-20, same day. Pre-release; no tagged version shipped it.
+
+Reproduced first-hand on both backends before the fix; interpreted and
+`--compile --opt 2` output was byte-identical, so this was a context-table /
+automaton design gap, not a codegen bug.
+
+`~H`'s promise is compile-time *contextual* auto-escaping: a `${hole}` is made
+safe for the context it lands in. In the cases below it was not, and the result
+was attacker-controlled script execution.
+
+## What was wrong, and what it renders now
+
+Probe values: `p = "alert(document.cookie)"`, `u = "javascript:alert(1)"`,
+`h = "<img src=x onerror=alert(1)>"`, `j = "1 < 2 && 3 > 2"`.
+
+| # | Template | Before | After |
+|---|---|---|---|
+| 1 | `<script>var x = ${p};</script>` | `var x = alert(document.cookie);` **XSS** | `var x = 'alert(document.cookie)';` |
+| 2 | `<button onclick="n = ${p}">` | `onclick="n = alert(document.cookie)"` **XSS** | `onclick="n = 'alert(document.cookie)'"` |
+| 3 | `<script>var x = "${s}";</script>` | `var x = "hello";` correct | unchanged |
+| 4 | `<a href="${u}">` | `about:invalid#zSoyz` correct | unchanged |
+| 5 | `<a xlink:href="${u}">` | `javascript:alert(1)` **XSS (SVG)** | `about:invalid#zSoyz` |
+| 6 | `<object data="${u}">` | `javascript:alert(1)` **XSS** | `about:invalid#zSoyz` |
+| 7 | `<a ping="${u}">` | `javascript:alert(1)` unvalidated fetch | `about:invalid#zSoyz` |
+| 8 | `<iframe srcdoc="${h}">` | `&lt;img …&gt;` **XSS** (decoded, then parsed) | **compile error** |
+| 9 | `<div>${h}</div>` | entity-encoded, correct | unchanged |
+| 10 | `<script>var y = ${j};</script>` | `var y = 1 < 2 …` JS syntax error | `var y = '1 < 2 …';` valid JS |
+
+Rows 3, 4 and 9 are the regression guard: they were already right, and the fix
+had to leave them alone. It did.
+
+## The three defects
+
+### A. A hole in a bare-JS position got the JS *string* escaper
+
+`escaper_for` in `lib/ctxesc/automaton.ml` mapped every script context to
+`EscJsString`, and there was no JS sub-automaton distinguishing "inside a string
+literal" from "expression position". The C comment even said "For a hole inside
+a JS string literal" — nothing checked that it was.
+
+`EscJsString` makes a value unable to END a string literal. At an expression
+position the template opened no literal, so it was escaping delimiters that were
+not delimiting anything: it escapes quotes and angle brackets, and does not
+touch parens, dots, identifiers or `;`, so `alert(document.cookie)` passed
+through intact. Row 10 is the same mismatch in the other direction — in
+expression position the escaper corrupted legitimate arithmetic into a syntax
+error. **The escaper was wrong for the position both ways, from one root cause.**
+
+There was also no JS value escaper anywhere in the escaper set — the ability to
+escape an expression-position hole correctly did not exist at all.
+
+Row 2 is the same defect via `on*` handler attributes.
+
+### B. The URL-attribute allowlist missed live vectors
+
+`[attrs]` listed only `on* href src action formaction poster cite background
+style`. `Tbl_parse.classify` is exact-match unless glob, so anything absent fell
+to `*` → `normal` → `EscAttr`, which passes `javascript:` through untouched.
+Confirmed live for `xlink:href` (executes in SVG), `object data` and `ping`.
+
+### C. `srcdoc` was entity-escaped, which is not enough
+
+`EscAttr` is correct *as an attribute*, but the browser HTML-decodes `srcdoc`
+and then parses the result as a document, so `&lt;img …&gt;` decodes back to
+live markup and fires.
+
+## What shipped
+
+### 1. A JS sub-automaton in the context table
+
+`specs/security/html-contexts.tbl` now tracks JS position in both a `<script>`
+body and an `on*` attribute, using the existing flat context tuple: `attr`
+carries the position, and in a script body `delim` — free there, since no HTML
+attribute surrounds it — carries the open string literal's quote.
+
+New `attr` classes: `jsstring`, `jscomment`, `jsregex`, `jstemplate` (plus
+`srcset` and `htmldoc` for defect C).
+
+The block is arranged around one invariant, stated in the table itself:
+
+> the walk must never land at `jsstring` when the hole is really in expression
+> position.
+
+That is the dangerous direction — it is defect A, reached by a different route.
+The reverse costs an over-strict escaper or a compile error, both loud and
+harmless. So every construct that can hide a stray quote is tracked: a comment
+(`// don't`), a template literal (`` `it's` ``), and a regex literal (`/'/`).
+Each would otherwise leave the quote count off by one and hand the NEXT hole the
+string escaper while it sat in open code.
+
+`jsregex` is entered by ANY `/` in expression position, because the table cannot
+tell a regex from division without a JS parser. Deliberately biased: misreading
+division as a regex costs a compile error; misreading a regex as division costs
+a quote desynchronisation, which is unsafe.
+
+### 2. A new escaper: `EscJsExpr` / `MARCH_ESC_JS_EXPR` (id 9)
+
+There is no encoding that makes an arbitrary string safe as bare JS *code*, so
+this escaper does not try. It stops the value being code: it supplies the quotes
+the template did not and renders the value as a JS **string literal**. A payload
+lands as inert data; honest input survives as text, which is also how row 10 got
+fixed. This is what go's `html/template` and Closure Templates do in the same
+position.
+
+Both quote characters are escaped numerically (`"` / `'`), so the only
+raw quotes in the output are the escaper's own two delimiters — which is what
+lets ONE escaper serve a `<script>` body and a double-quoted `on*` attribute.
+
+**The same numeric escaping was applied to `EscJsString`.** It previously emitted
+`\"`, which still contains a raw `"` byte, and HTML has never heard of the
+backslash — so a JS string inside `onclick="f('${x}')"` could end the attribute.
+That was not exploitable, because escaping `=` stopped the escapee writing
+`onerror=`, but relying on the second line of defence for the first one's failure
+is not a position to stay in. Now "an escaped hole never emits a raw quote" holds
+for every escaper without exception, which the corpus asserts as one sweep.
+
+### 3. Rejections where no escaper would be honest
+
+Compile errors, each carrying its reason: a hole inside a JS comment, regex
+literal or template literal; a JS expression hole in a **single-quoted** `on*`
+attribute (where `EscJsExpr`'s own `'` delimiters would end the attribute — use
+a double-quoted attribute); `srcdoc`; and `srcset`.
+
+### 4. Table contents
+
+`xlink:href`, `data`, `ping`, `manifest`, `longdesc` → `url`. `data` is matched
+EXACTLY, so the whole `data-*` family keeps the ordinary attribute escaper; the
+conformance test pins that. `stdlib/html.march` carries a hand-written second
+copy of these classifications for the deprecated `Html.tag`, and it was updated
+in step, including a runtime refusal for `srcset` / `srcdoc`.
+
+## Why NOT a compile-time rejection for expression position
+
+The original write-up recommended rejecting a bare-JS hole outright. That was
+the right instinct and it is not what shipped, for a reason found only by
+reading the code:
+
+**`Html.trust_js` exists, and its only meaningful position is exactly the one
+that would be rejected.** `test/native/h_trusted_context.march:39` is
+`~H"<script>${j}</script>"` with a `TrustedJs` value, and context-indexed trust
+is resolved AFTER typechecking — in `lib/tir/llvm_emit.ml` for the compiled
+backend and in `lib/eval/eval.ml` for the interpreter, both by matching the
+value's type against the folded escaper id. The desugar, where a `.tbl`
+diagnostic fires, has no types. It cannot tell a trusted value from an untrusted
+one, so rejecting there would have deleted a shipped, golden-tested feature
+inside a security patch.
+
+Giving expression position its own escaper id solves it: `TrustedJs` now maps to
+`[5; 9]`, so trusted JS still inserts verbatim (the golden is unchanged), while
+an untrusted value is quoted into inertness.
+
+The cost is honest and worth writing down: **a hole at a JS expression position
+is now rendered as a string, not as the value's own JS type.**
+`<script>var n = ${count}</script>` yields `'42'`, not `42`. That is a silent
+change of meaning rather than a loud one. Making it loud needs the typechecker to
+learn the `Trusted*` types so it can reject an untrusted value here and point at
+`Html.trust_js` — recorded in
+`specs/todos/2026-08-06-ctxesc-no-subsidiary-automata.md`.
+
+## Why the existing tests did not catch it — and what was added
+
+This is the part worth keeping.
+
+The leaf escapers **were** adversarially tested: `test/test_ctx_escape.c` had
+~90 checks with real payloads (`JaVaScRiPt:`, `java\tscript:`,
+`\x01javascript:`, `data:text/html,<script>`, `expression()`, `</script>`,
+U+2028, quote breakouts). `test/test_ctxesc.ml` asserted which escaper each
+context SELECTS.
+
+Both layers were green while row 1 executed. The escaper *was* the one the table
+named, and it *did* escape exactly what it promised to. **The defect was the
+pairing, and nothing anywhere put an attack string through a template and looked
+at what came out.** `test/test_ctxesc.ml:229` went further and asserted the
+buggy mapping — the bug written down as an expectation.
+
+So the missing coverage class was added: a **rendered-output attack corpus** in
+`test/test_ctxesc.ml`, 17 payloads × 21 accepting contexts, driven by a `render`
+helper that is the desugar's own loop reduced to one hole. Four properties:
+
+1. no escaped value emits a raw `<`, `>` or `"` (nor a `'`, except the JS
+   expression escaper's own delimiters);
+2. the paper's soundness property checked on real output — re-walking the
+   escaped value must leave the parser's state, element and delimiter unchanged;
+3. the rendered document still re-parses and still ends in a valid terminal
+   state;
+4. a JS expression hole is exactly one string literal.
+
+Plus exact-output assertions for every row of the table above, and a reject
+corpus that grew from three strings to nine.
+
+**Non-vacuity was verified, and it changed the design of the tests.** Against a
+control with `html-contexts.tbl` and `automaton.ml` reverted to their pre-fix
+versions, 9 cases go red — including property 4 and every exact-output row.
+Properties 1–3 stay GREEN against the pre-fix tree, which is worth knowing: the
+original bug is *semantic*, not structural. The payload never moved the HTML
+parser and never emitted a structural byte; it was simply admitted as code. A
+structural invariant, however carefully stated, could not have caught this.
+Property 4 and the exact-output rows are what carry the weight.
+
+## Whose gap was this — the paper's, or ours? Ours.
+
+`specs/todos/2026-08-06-ctxesc-no-subsidiary-automata.md` recorded that this
+implementation matches the paper "on transition tables, the context tuple,
+substitutions, terminal validity and diagnostics" and **diverges on exactly one
+element: subsidiary automata** — *"Subsidiary automata handle processing of
+nested content languages."* A JS sub-automaton is precisely what distinguishes
+inside-a-string-literal from expression position.
+
+Each nested language had been flattened into the `attr` field with hand-rolled
+positions, and the refinement was very uneven: URL had two positions and two
+escapers, CSS had three and three, **JS had one and one.**
+
+The flattening was a deliberate, documented trade-off. **The miss was the risk
+assessment.** That todo was rated `P3 — "a correctness/usability defect, not a
+known vulnerability"`, and its "cost, measured" section reasoned through URL and
+CSS only, concluding "not currently reachable" / "not exploitable as it stands".
+It never analysed JS — the one nested language where the same divergence WAS
+exploitable. A divergence from a security design is only as safe as its worst
+instance, and the instance nobody examined is not evidence of safety. That file
+has been re-rated and now carries this argument.
+
+The attribute-allowlist gap (defect B) was not a model question at all — it was
+table CONTENTS. `srcdoc` (defect C) is arguably a third instance of the
+subsidiary-automata divergence, since HTML nested inside an HTML attribute is
+exactly the codec case the paper describes; rejecting is the honest answer until
+that exists.
+
+## Files
+
+- `specs/security/html-contexts.tbl` — JS sub-automaton, new URL attributes,
+  rejections
+- `specs/security/README.md` — JS positions, "What is rejected", known
+  limitations; also corrected a stale pointer to an `emit_tables.exe` that was
+  planned and never built
+- `lib/ctxesc/context.ml` — 6 new `attr` classes, `EscJsExpr` (id 9), `describe`
+- `lib/ctxesc/automaton.ml` — `escaper_for` splits the two JS positions
+- `lib/ctxesc/escape.ml`, `runtime/march_ctx_escape.{c,h}` — the new escaper,
+  and numeric quote escaping in the old one
+- `lib/tir/llvm_emit.ml`, `lib/eval/eval.ml` — `TrustedJs` covers both JS ids
+- `stdlib/html.march` — the second copy of `[attrs]`, and `Html.tag` refusals
+- `test/test_ctxesc.ml`, `test/test_ctx_escape.c` — the corpus

--- a/specs/security/README.md
+++ b/specs/security/README.md
@@ -10,8 +10,9 @@ arXiv:2605.16561v1. The implementation plan is
 `specs/plans/2026-08-05-contextual-autoescaping.md`.
 
 **This file and `html-contexts.tbl` are meant to be edited by someone reasoning
-about HTML parsing and injection, not about OCaml.** A build step generates the
-compiler's table from the `.tbl`; a CI check fails if the generated copy drifts.
+about HTML parsing and injection, not about OCaml.** A dune rule embeds the
+`.tbl` into the compiler on every build, so the two cannot drift; see
+"Regenerating".
 
 ## Why a table
 
@@ -47,13 +48,51 @@ Four fields, exactly as the paper describes:
 |---|---|
 | `state` | `pcdata` `rcdata` `tagname` `closetagname` `beforeattrname` `afterattrname` `beforeattrvalue` `attrvalue` `comment` |
 | `element` | `normal` `script` `style` `textarea` `title` |
-| `attr` | `normal` `url` `urlmid` `style` `stylevalue` `cssurl` `script` |
+| `attr` | `normal` `url` `urlmid` `style` `stylevalue` `cssurl` `script` `jsstring` `jscomment` `jsregex` `jstemplate` `srcset` `htmldoc` |
 | `delim` | `none` `single` `double` `unquoted` `doublesubst` |
 
 `element` tracks which element's content we are inside, because `<script>` and
 `<style>` bodies are not HTML. `attr` is set when an attribute name is read, and
 selects the subsidiary language for its value (`href` → URL, `style` → CSS,
 `on*` → JS). `delim` tracks how an attribute value is quoted.
+
+### JS positions
+
+`script` is JS at an **expression** position; `jsstring` is JS inside a
+quote-delimited **string literal**. The distinction is load-bearing in the same
+way `url` / `urlmid` is, and getting it wrong was a real vulnerability: the JS
+string escaper only makes a value unable to END a string literal, so at an
+expression position — where the template opened no literal at all — it escapes
+delimiters that are not delimiting anything and lets `alert(document.cookie)`
+through as code. See `specs/progress/2026-08-20-h-sigil-js-and-url-attr-xss.md`.
+
+Inside a `<script>` body the `delim` field is free (there is no HTML attribute
+around it) and carries the open literal's quote, so `'` closes only a `'` string.
+Inside an `on*` attribute `delim` is taken by the HTML delimiter, and none is
+needed: a raw `"` ends a double-quoted ATTRIBUTE, so the only JS string a
+double-quoted handler can hold is a single-quoted one, and vice versa.
+
+`jscomment`, `jsregex` and `jstemplate` exist to keep ONE invariant:
+
+> the walk must never land at `jsstring` when the hole is really in expression
+> position.
+
+That is the dangerous direction — it is the bug above, reached by a different
+route. Each of those three constructs can hide a stray quote (`// don't`,
+`/'/`, `` `it's` ``) that would otherwise leave the quote count off by one and
+hand the NEXT hole the string escaper while it sat in open code. All three
+reject a hole outright: a comment hides the value until it stops being a
+comment, a regex literal ends at an unescaped `/` that no escaper here escapes,
+and a template literal reads `${` as a substitution — arbitrary code — and a
+backtick as its terminator, neither of which the JS string escaper touches.
+
+`jsregex` is entered by ANY `/` in expression position, because the table cannot
+tell a regex literal from division without a JS parser. That bias is
+deliberate: misreading division as a regex costs a compile error, while
+misreading a regex as division costs a quote desynchronisation, which is the
+unsafe direction.
+
+`srcset` and `htmldoc` are not positions but refusals; see "What is rejected".
 
 `urlmid` is `url` after at least one literal character of the value has been
 seen. The distinction is load-bearing: a hole at the *start* of a URL attribute
@@ -146,7 +185,28 @@ row — one less thing to get out of sync:
 | `attrvalue` with `attr = style`, or `rcdata` in `style` | CSS **declaration** escape |
 | `attrvalue` with `attr = stylevalue` | CSS **value** escape |
 | `attr = cssurl`, or `rcdata` in `style` inside `url(` | CSS **url** escape |
-| `attrvalue` with `attr = script`, or `rcdata` in `script` | JS string escape |
+| `attrvalue` with `attr = jsstring`, or `rcdata` in `script` inside a string literal | JS **string** escape |
+| `attrvalue` with `attr = script`, or `rcdata` in `script` at expression position | JS **expression** escape |
+
+## What is rejected
+
+Some holes get no escaper at all, because none would be honest. These are
+compile errors carrying the reason:
+
+| Position | Why no escaper works |
+|---|---|
+| element name, attribute name | nothing to escape — `onerror` has no special character |
+| inside an HTML comment | comment-ending sequences vary between parsers |
+| inside a JS comment | the value is dead text until a newline or `*/` moves it into live code |
+| inside a JS regex literal | an unescaped `/` ends the literal and everything after it is code |
+| inside a JS template literal | a backtick ends it and `${` opens a substitution — arbitrary code |
+| JS expression position in a **single-quoted** `on*` attribute | the JS-expression escaper's own `'` delimiters would end the attribute; use a double-quoted attribute |
+| `srcset` | the value is a comma-separated candidate LIST, so a whole-URL scheme check validates only the first entry. Interpolate a single URL into `src` instead |
+| `srcdoc` | the browser HTML-DECODES the attribute and parses the result as a whole DOCUMENT, so the entity escaping that makes every other attribute safe is undone before the markup is read, and `&lt;img onerror=…&gt;` fires |
+
+`srcdoc` is arguably a third instance of the subsidiary-automata divergence —
+HTML nested inside an HTML attribute is exactly the codec case the paper
+describes. Rejecting is the honest answer until that exists.
 
 ## Escaper implementations
 
@@ -157,6 +217,19 @@ buffers, two-pass: measure, then write).
 Two notes on what they refuse, since both are deliberately stricter than they
 might first appear:
 
+- **JS expression** does not escape a value into safety — there is no encoding
+  that makes an arbitrary string safe as bare JS *code*. It stops the value
+  being code: it supplies the quotes the template did not and renders the value
+  as a JS **string literal**, so a payload lands as inert data and honest input
+  survives as text. Both quote characters are escaped numerically, so the only
+  raw quotes in its output are its own two delimiters — which is what lets one
+  escaper serve a `<script>` body and a double-quoted `on*` attribute. A value
+  that must reach JS as CODE goes through `Html.trust_js`, which bypasses
+  escaping; that is the explicit opt-in, and it is why this position is escaped
+  rather than rejected.
+- **JS string** escapes both quote characters numerically too, for the same
+  reason: a JS string can live inside an HTML attribute, and a backslash-escaped
+  quote still contains the quote byte, which HTML has never heard of.
 - **Whole-URL** is an allowlist (`http` `https` `mailto` `tel` `ftp`, plus any
   relative reference), not a `javascript:` denylist. Browsers strip leading
   whitespace and C0 control bytes before parsing a URL and ignore them *inside*
@@ -193,21 +266,33 @@ it explicitly. A mismatch would silently apply the wrong escaper.
 
 ## Regenerating
 
-The `.tbl` is the source of truth. After editing it:
-
-```bash
-dune build --root . lib/ctxesc/emit_tables.exe
-./_build/default/lib/ctxesc/emit_tables.exe
-```
-
-That rewrites `lib/ctxesc/table_data.ml` and `stdlib/ctx_table.march`. Both are
-generated — do not edit them. A CI freshness check regenerates into a temporary
-prefix and fails on any difference, so a forgotten regeneration cannot merge.
+Nothing to do. `lib/ctxesc/table_data.ml` embeds the `.tbl` verbatim and is
+generated by a dune rule in `lib/ctxesc/dune` on every build, so drift is
+structurally impossible and no freshness check is needed. Do not edit the
+generated file. (An `emit_tables.exe` and a March-side `stdlib/ctx_table.march`
+were planned and never built — neither exists. `stdlib/html.march` does carry a
+hand-written second copy of the `[attrs]` classifications for the deprecated
+`Html.tag`, kept honest by a conformance test in `test/test_ctxesc.ml` rather
+than by generation.)
 
 ## Known limitations
 
 - No regex; see the pattern table above.
 - Attribute classification is by name only. An attribute whose safety depends on
-  the element it is on (`<meta http-equiv>` vs elsewhere) is not modelled.
+  the element it is on (`<meta http-equiv>` vs elsewhere) is not modelled. `data`
+  is classified as a URL everywhere, though only `<object data>` is one.
 - Only the subsidiary languages HTML strictly requires are covered: URL, CSS and
-  JS-string. There is no SQL or shell table yet.
+  JS. There is no SQL or shell table yet.
+- The JS position tracker is not a JS parser. It reads any `/` in expression
+  position as the start of a regex literal, so a template that uses `/` as
+  DIVISION before a hole gets a compile error rather than an escaper. The bias
+  is towards the error on purpose — see "JS positions".
+- A hole at a JS expression position is rendered as a string, not as the value's
+  own JS type: `<script>var n = ${count}</script>` yields `'42'`, not `42`.
+  That is deliberate (a number is a program fragment, and admitting program
+  fragments is the vulnerability), but it is a silent change of meaning rather
+  than a loud one. Making it loud needs the typechecker to know the `Trusted*`
+  types so it can reject an untrusted value here and point at `Html.trust_js`;
+  see `specs/todos/2026-08-06-ctxesc-no-subsidiary-automata.md`.
+- `srcset` is rejected rather than escaped. A per-candidate URL escaper would be
+  a new escaper, not a table edit; rejecting is the conservative placeholder.

--- a/specs/security/html-contexts.tbl
+++ b/specs/security/html-contexts.tbl
@@ -17,14 +17,30 @@ title              | title
 
 [attrs]
 # attr-name-pattern | attr class    (first match wins -- keep on* first)
+#
+# EVERY attribute whose value a browser will FETCH or NAVIGATE TO belongs here.
+# Classification is exact-match unless the pattern ends in `*`, so an attribute
+# that is missing falls through to `*` -> normal -> the plain attribute escaper,
+# which entity-encodes quotes and angle brackets and passes `javascript:`
+# through untouched. That is how `xlink:href`, `object data` and `ping` were
+# live XSS/SSRF vectors until 2026-08-20; see
+# specs/progress/2026-08-20-h-sigil-js-and-url-attr-xss.md. A miss here is
+# silent, so err towards listing an attribute.
 on*                 | script
 href                | url
+xlink:href          | url    # the SVG spelling of href -- executes javascript:
 src                 | url
 action              | url
 formaction          | url
 poster              | url
 cite                | url
 background          | url
+data                | url    # <object data="javascript:..."> executes. EXACT match, so data-* attributes are untouched.
+ping                | url    # fetched on click, so an unvalidated value is an outbound request the page never showed
+manifest            | url
+longdesc            | url
+srcset              | srcset   # a candidate LIST, not one URL -- rejected, see below
+srcdoc              | htmldoc  # HTML-decoded, then parsed as a document -- rejected, see below
 style               | style
 *                   | normal
 
@@ -134,6 +150,49 @@ attrvalue,*,stylevalue,*  | lit:";"        |  | =,=,style,=              |
 attrvalue,*,style,*       | interp         |  | =,=,=,=                  |
 attrvalue,*,stylevalue,*  | interp         |  | =,=,=,=                  |
 
+# -- JS position tracking inside an on* handler attribute --
+# Same split as a <script> body below, and for the same reason: the JS string
+# escaper is correct ONLY inside a string literal. `onclick="n = ${p}"` used to
+# get it, so `alert(document.cookie)` -- which contains no quote, no angle
+# bracket and nothing else that escaper touches -- passed through as code.
+#
+# The JS string delimiter is implied by the HTML one, and cannot be recorded in
+# `delim` because the HTML delimiter is already there. That is not a
+# limitation: inside a double-quoted attribute a raw `"` ends the ATTRIBUTE
+# (the rows at the top of this section, which run first), so the only JS string
+# a double-quoted handler can contain is a single-quoted one, and vice versa.
+attrvalue,*,script,double   | lit:"'"        |  | =,=,jsstring,=           |
+attrvalue,*,script,single   | lit:"\""       |  | =,=,jsstring,=           |
+attrvalue,*,jsstring,double | lit:"\\'"      |  | =,=,=,=                  |
+attrvalue,*,jsstring,single | lit:"\\\""     |  | =,=,=,=                  |
+attrvalue,*,jsstring,*      | cls+:[\\]      |  | =,=,=,=                  |
+attrvalue,*,jsstring,double | lit:"'"        |  | =,=,script,=             |
+attrvalue,*,jsstring,single | lit:"\""       |  | =,=,script,=             |
+attrvalue,*,script,*        | lit:"//"       |  | =,=,jscomment,=          |
+attrvalue,*,script,*        | lit:"/*"       |  | =,=,jscomment,=          |
+attrvalue,*,script,*        | lit:"/"        |  | =,=,jsregex,=            |
+attrvalue,*,script,*        | lit:"`"        |  | =,=,jstemplate,=         |
+attrvalue,*,jscomment,*     | lit:"\n"       |  | =,=,script,=             |
+attrvalue,*,jscomment,*     | lit:"*/"       |  | =,=,script,=             |
+attrvalue,*,jsregex,*       | cls+:[\\]      |  | =,=,=,=                  |
+attrvalue,*,jsregex,*       | lit:"/"        |  | =,=,script,=             |
+attrvalue,*,jstemplate,*    | cls+:[\\]      |  | =,=,=,=                  |
+attrvalue,*,jstemplate,*    | lit:"`"        |  | =,=,script,=             |
+attrvalue,*,jsstring,*      | interp         |  | =,=,=,=                  |
+# A single-quoted handler is the ONE context the JS-expression escaper cannot
+# serve: it renders the value as a single-quoted JS string, and those
+# delimiters would close the attribute. Everywhere else its output contains no
+# raw quote at all.
+attrvalue,*,script,single   | interp         |  | =,=,=,=                  | Cannot interpolate at a JavaScript expression position inside a SINGLE-quoted event-handler attribute. The value is rendered as a single-quoted JS string, and its delimiters would close the attribute. Use a double-quoted attribute, or put the hole inside a double-quoted JS string: onclick='f("${x}")'.
+attrvalue,*,script,*        | interp         |  | =,=,=,=                  |
+attrvalue,*,jscomment,*     | interp         |  | =,=,=,=                  | Cannot interpolate inside a JavaScript comment. The value is dead text until a newline or an unbalanced */ moves it into live code, so a hole here is always a mistake -- move it into the code the comment describes.
+attrvalue,*,jsregex,*       | interp         |  | =,=,=,=                  | Cannot interpolate inside a JavaScript regular-expression literal: an unescaped / in the value ends the literal and everything after it is parsed as code, and no escaping fixes that. If this / was meant as division, note the table cannot tell the two apart and deliberately assumes the regex -- move the arithmetic out of the template.
+attrvalue,*,jstemplate,*    | interp         |  | =,=,=,=                  | Cannot interpolate inside a JavaScript template literal: a backtick closes it and ${ opens a substitution, which is arbitrary code, and the JS string escaper escapes neither. Use a single- or double-quoted JS string instead.
+
+# -- URL-ish attributes that no escaper can serve --
+attrvalue,*,srcset,*      | interp         |  | =,=,=,=                  | Cannot interpolate into a srcset attribute: the value is a comma-separated list of candidates, so the whole-URL scheme check would validate only the first one and wave the rest through. Interpolate a single URL into src instead, or assemble the candidate list from values you already control.
+attrvalue,*,htmldoc,*     | interp         |  | =,=,=,=                  | Cannot interpolate into a srcdoc attribute: the browser HTML-decodes the attribute and then parses the result as a whole DOCUMENT, so the entity escaping that makes every other attribute safe is undone before the markup is parsed and an onerror handler fires. Point the iframe at a src URL instead.
+
 # -- generic within-value rows --
 attrvalue,*,*,*           | interp         |  | =,=,=,=                  |
 attrvalue,*,*,*           | any            |  | =,=,=,=                  |
@@ -147,10 +206,92 @@ rcdata,style,*,*      | ilit:"url("       |  | =,=,cssurl,=            |
 rcdata,style,cssurl,* | lit:")"           |  | =,=,normal,=            |
 rcdata,style,cssurl,* | interp            |  | =,=,=,=                 |
 
-rcdata,script,*,*     | ilit:"</script"   |  | closetagname,normal,=,= |
+# `</script` ends the element from EVERY JS sub-position below, including from
+# inside a string literal -- the HTML tokenizer does not know JS exists. This
+# row must therefore stay ABOVE the per-position `any` rows that follow, and it
+# clears the JS position on the way out.
+rcdata,script,*,*     | ilit:"</script"   |  | closetagname,normal,normal,none |
 rcdata,style,*,*      | ilit:"</style"    |  | closetagname,normal,=,= |
 rcdata,textarea,*,*   | ilit:"</textarea" |  | closetagname,normal,=,= |
 rcdata,title,*,*      | ilit:"</title"    |  | closetagname,normal,=,= |
+
+# JS inside a <script> BODY -----------------------------------------------
+# The subsidiary automaton the paper calls for, expressed in the flat context
+# tuple: `attr` carries the JS position, and `delim` -- free here, since a
+# script body has no HTML attribute around it -- carries the quote that opened
+# the current string literal.
+#
+# WHY THIS EXISTS. Every script context used to select the JS STRING escaper,
+# which is correct only between quotes. In expression position it escaped
+# characters that were not delimiting anything and left alone the ones that
+# matter, so `<script>var x = ${p}</script>` rendered `alert(document.cookie)`
+# verbatim as code, while honest arithmetic came out as a syntax error. Wrong
+# in both directions, from one root cause. See
+# specs/progress/2026-08-20-h-sigil-js-and-url-attr-xss.md.
+#
+# THE INVARIANT the rest of this block is arranged to keep:
+#
+#     the walk must never land at `jsstring` when the hole is really in
+#     expression position.
+#
+# That direction is the dangerous one -- it is the bug above. The reverse costs
+# an over-strict escaper or a compile error, which is loud and harmless. So
+# every construct that can hide a stray quote is tracked: a comment, a template
+# literal, and a regex literal. Each would otherwise leave the quote count off
+# by one and hand the NEXT hole the string escaper while it sat in open code.
+#
+# A hole is ACCEPTED in expression position and inside a quote-delimited string
+# literal. Comments, regex literals and template literals reject: a comment
+# hides the value until it does not, a regex literal ends at an unescaped `/`
+# that no escaper here escapes, and a template literal reads a dollar-brace as
+# a substitution -- arbitrary code -- and a backtick as its terminator, neither
+# of which the JS string escaper touches.
+
+# -- expression position; the state a script body opens in --
+# `//` and `/*` must precede the bare `/`, and the bare `/` is deliberately
+# greedy: division is read as the start of a regex literal. See the diagnostic.
+rcdata,script,normal,*        | lit:"//"          |  | =,=,jscomment,=         |
+rcdata,script,normal,*        | lit:"/*"          |  | =,=,jscomment,=         |
+rcdata,script,normal,*        | lit:"/"           |  | =,=,jsregex,=           |
+rcdata,script,normal,*        | lit:"'"           |  | =,=,jsstring,single     |
+rcdata,script,normal,*        | lit:"\""          |  | =,=,jsstring,double     |
+rcdata,script,normal,*        | lit:"`"           |  | =,=,jstemplate,=        |
+rcdata,script,normal,*        | interp            |  | =,=,=,=                 |
+rcdata,script,normal,*        | any               |  | =,=,=,=                 |
+
+# -- string literal; `delim` remembers which quote opened it --
+# The two-character escape rows come first, so a backslash-quote cannot close
+# the string. `cls+` then swallows any remaining RUN of backslashes: an odd run
+# followed by a quote makes the walk leave the string one escape early, which
+# is the over-strict direction and therefore safe.
+rcdata,script,jsstring,*      | lit:"\\'"         |  | =,=,=,=                 |
+rcdata,script,jsstring,*      | lit:"\\\""        |  | =,=,=,=                 |
+rcdata,script,jsstring,*      | cls+:[\\]         |  | =,=,=,=                 |
+rcdata,script,jsstring,single | lit:"'"           |  | =,=,normal,none         |
+rcdata,script,jsstring,double | lit:"\""          |  | =,=,normal,none         |
+rcdata,script,jsstring,*      | interp            |  | =,=,=,=                 |
+rcdata,script,jsstring,*      | any               |  | =,=,=,=                 |
+
+# -- comment; one class for both forms, carrying both terminators --
+# Conflating `//` with `/* */` can only end a comment EARLY, which returns to
+# expression position -- the safe direction.
+rcdata,script,jscomment,*     | lit:"\n"          |  | =,=,normal,=            |
+rcdata,script,jscomment,*     | lit:"*/"          |  | =,=,normal,=            |
+rcdata,script,jscomment,*     | interp            |  | =,=,=,=                 | Cannot interpolate inside a JavaScript comment. The value is dead text until a newline or an unbalanced */ moves it into live code, so a hole here is always a mistake -- move it into the code the comment describes.
+rcdata,script,jscomment,*     | any               |  | =,=,=,=                 |
+
+# -- regular-expression literal --
+rcdata,script,jsregex,*       | cls+:[\\]         |  | =,=,=,=                 |
+rcdata,script,jsregex,*       | lit:"/"           |  | =,=,normal,=            |
+rcdata,script,jsregex,*       | interp            |  | =,=,=,=                 | Cannot interpolate inside a JavaScript regular-expression literal: an unescaped / in the value would end the literal and everything after it would be parsed as code, and no escaping prevents that. If this / was meant as division, the table cannot tell the two apart and deliberately assumes the regex -- move the arithmetic out of the template.
+rcdata,script,jsregex,*       | any               |  | =,=,=,=                 |
+
+# -- template literal --
+rcdata,script,jstemplate,*    | cls+:[\\]         |  | =,=,=,=                 |
+rcdata,script,jstemplate,*    | lit:"`"           |  | =,=,normal,=            |
+rcdata,script,jstemplate,*    | interp            |  | =,=,=,=                 | Cannot interpolate inside a JavaScript template literal: a backtick would close it and a dollar-brace would open a substitution, which is arbitrary code, and the JS string escaper escapes neither. Use a single- or double-quoted JS string instead.
+rcdata,script,jstemplate,*    | any               |  | =,=,=,=                 |
+
 rcdata,*,*,*          | interp            |  | =,=,=,=                 |
 rcdata,*,*,*          | any               |  | =,=,=,=                 |
 

--- a/specs/todos/2026-08-06-ctxesc-no-subsidiary-automata.md
+++ b/specs/todos/2026-08-06-ctxesc-no-subsidiary-automata.md
@@ -1,12 +1,46 @@
 # `~H` has no subsidiary automata — nested languages are handled coarsely
 
 **Filed:** 2026-08-06
-**Priority:** P3 — a correctness/usability defect, not a known vulnerability
+**Priority:** ~~P3 — a correctness/usability defect, not a known vulnerability~~
+**Re-rated 2026-08-20: the JS half of this divergence WAS a vulnerability.**
+See `specs/progress/2026-08-20-h-sigil-js-and-url-attr-xss.md`.
 
-The contextual escaping in `specs/plans/2026-08-05-contextual-autoescaping.md`
-matches the paper (Samuel et al., arXiv:2605.16561v1) on transition tables, the
-context tuple, substitutions, terminal validity and diagnostics. It **diverges
-on one element**: subsidiary automata.
+## Status
+
+- **CSS `url()` — DONE.** `cssurl` / `EscCssUrl` landed; the two symptoms in
+  "The cost, measured" below no longer reproduce.
+- **JS — DONE, and it was exploitable.** Fixed 2026-08-20. A hole in a
+  `<script>` body or an `on*` handler got the JS *string* escaper regardless of
+  whether it sat inside a string literal, so `<script>var x = ${p}</script>`
+  rendered `alert(document.cookie)` as executable code. The table now tracks JS
+  string literals, comments, regex literals and template literals, and
+  expression position has its own escaper.
+- **URL — still flat**, and still not known to be exploitable; see below.
+
+## What this file got wrong, which is the part worth keeping
+
+The technical analysis was right. The **risk assessment** was not, and the way
+it was wrong is reusable:
+
+> the P3 rating reasoned through URL and CSS only, and concluded "not currently
+> reachable" / "not exploitable as it stands". It never analysed JS — the one
+> nested language where the same divergence *was* exploitable.
+
+The flattening was a deliberate, documented trade-off, and the trade-off is
+still defensible for URL. The defect was scoping the risk to the two languages
+that had been looked at and rating the whole divergence from them. A divergence
+from a security design is only as safe as its **worst** instance, and the
+instance nobody examined is not evidence of safety.
+
+It also left the deciding question open, and then did not come back to it:
+
+> "The full paper design ... is only worth it if a nested language appears whose
+> *position* matters in ways the flat model cannot express. The `url(` case does
+> not need it."
+
+JS was that language. Position was the entire difference between "inside a
+string literal, where escaping the delimiters is exactly right" and "in open
+code, where there are no delimiters and escaping them accomplishes nothing".
 
 ## What the paper does
 
@@ -20,60 +54,41 @@ tracked alongside the context value.
 
 ## What we do instead
 
-The nested language is flattened into the `attr` field of the 4-tuple
-(`url` / `urlmid` / `style` / `stylevalue` / `script`), and the escaper does that
-language's work in one shot. There is no separate automaton object and no codec.
+The nested language is flattened into the `attr` field of the 4-tuple, and the
+escaper does that language's work in one shot. There is no separate automaton
+object and no codec. The JS fix went further than the earlier ones — it uses
+`attr` for the JS position AND `delim` for the open string literal's quote — but
+it is still a flat encoding of a sub-automaton, not a nested one.
 
-Two positions instead of a real automaton: `url` → `urlmid` on the first literal
-character, and `style` → `stylevalue` on a `:`. A real URL automaton would track
-scheme / authority / path / query / fragment; a real CSS one would track far
-more than declaration-vs-value.
+| Nested language | Sub-positions | Escapers |
+|---|---|---|
+| URL | `url` → `urlmid` | `EscUrlWhole`, `EscUrlComponent` |
+| CSS | `style` → `stylevalue` → `cssurl` | `EscCssDecl`, `EscCssValue`, `EscCssUrl` |
+| JS | `script` ⇄ `jsstring`, plus `jscomment` / `jsregex` / `jstemplate` | `EscJsExpr`, `EscJsString` |
 
-## The cost, measured
+## What is left
 
-The codec's absence turns out **not** to be exploitable, because the attribute
-escaper escapes `&` after the URL check, so an entity cannot be decoded a second
-time:
+**URL.** A real URL automaton would track scheme / authority / path / query /
+fragment; we have two positions. The codec's absence is still not exploitable,
+because the attribute escaper escapes `&` after the URL check, so an entity
+cannot be decoded a second time:
 
 ```
 href="${'javascript&#58;alert(1)'}"  ->  href="javascript&amp;#58;alert(1)"
 ```
 
-The coarseness does bite for a URL nested inside CSS:
+Note that this reasoning is exactly the shape that failed for JS: it argues from
+the cases examined. It is recorded here as an argument, not as a clearance.
 
-```
-style="background:url(${'/img/logo.png'})"
-  -> url(\2F img\2F logo.png)          slashes escaped, legitimate URL BROKEN
-
-<style>a{background:url(${'javascript:alert(1)'})}</style>
-  -> url(javascript:alert\28 1\29 )    colon SURVIVES; only the parens escaped
-```
-
-The first is a plain usability defect: a legitimate relative URL in `url()` is
-mangled.
-
-The second is not exploitable as it stands — the escaped parens leave the JS
-malformed, and current browsers do not execute `javascript:` in a CSS `url()` —
-but the colon surviving is a smell, and it is there only because a `<style>`
-body is treated as declaration position throughout, when inside `url(...)` it is
-really a URL position.
-
-**Not currently reachable.** Nothing in bastion or forgepm interpolates inside a
-CSS `url()` — checked.
-
-## Fix
-
-Give `url(` a context of its own. Minimally: add `cssurl` to the `attr` field
-with transitions `style|stylevalue --url(--> cssurl` and `cssurl --)--> back`,
-and select the URL escaper there. That is a table change plus one escaper
-mapping, and it uses machinery that already exists.
-
-The full paper design — a real subsidiary automaton with a codec — is a larger
-change and is only worth it if a nested language appears whose *position* matters
-in ways the flat model cannot express. The `url(` case does not need it.
+**A real nested automaton with codecs** is still not built, and the JS fix shows
+the flat model can be pushed further than expected before it breaks. The
+question to revisit is no longer "is the flat model expressive enough" — it is
+whether the flat model's failure mode is acceptable, and the answer for JS was
+that we could not tell until someone wrote an attack string and looked at the
+output. See the "coverage class" note in the progress file.
 
 ## Do not "fix" this by widening the CSS allowlist
 
-Adding `/` to the CSS-safe character set would repair the broken-URL symptom and
+Adding `/` to the CSS-safe character set would repair a broken-URL symptom and
 reintroduce a hole: `/` is how a CSS comment (`/*`) starts. The escaper's
 allowlist is deliberate — see `specs/security/README.md`.

--- a/stdlib/html.march
+++ b/stdlib/html.march
@@ -231,7 +231,27 @@ mod Html do
 
   doc "Attribute names whose value is a whole URL. Mirrors `[attrs]` in specs/security/html-contexts.tbl."
   pfn url_attr_names() : List(String) do
-    ["href", "src", "action", "formaction", "poster", "cite", "background"]
+    -- The last five arrived with the 2026-08-20 fix: an attribute the table
+    -- does not list falls through to the plain attribute escaper, which
+    -- entity-encodes quotes and lets `javascript:` past. `xlink:href` and
+    -- `data` were live XSS; `ping`, `manifest` and `longdesc` were unvalidated
+    -- fetches. `data` is matched EXACTLY, so `data-*` attributes are untouched.
+    ["href", "src", "action", "formaction", "poster", "cite", "background",
+     "xlink:href", "data", "ping", "manifest", "longdesc"]
+  end
+
+  doc """
+  Attribute names no escaper can serve, which `Html.tag` refuses outright.
+
+  `srcset` is a comma-separated candidate LIST, so a whole-URL scheme check
+  validates only the first entry. `srcdoc` is HTML-decoded by the browser and
+  the result parsed as a document, so the entity escaping that makes every
+  other attribute safe is undone before the markup is read. The `~H` desugar
+  rejects a hole in either at compile time; `Html.tag` can only refuse at run
+  time. Mirrors the `srcset` and `htmldoc` classes in the `.tbl`.
+  """
+  pfn refused_attr_names() : List(String) do
+    ["srcset", "srcdoc"]
   end
 
   -- Escaper ids from Context.escaper_id (lib/ctxesc/context.ml) and
@@ -294,12 +314,20 @@ mod Html do
       panic("Html.tag: refusing the event-handler attribute `" ++ k ++ "`. Its "
         ++ "value is JavaScript, and Html.tag cannot tell whether you meant "
         ++ "that — use a ~H template, where the parse context is known.")
+    else if List.member(refused_attr_names(), lk) do
+      panic("Html.tag: refusing the attribute `" ++ k ++ "`. `srcset` is a "
+        ++ "candidate LIST, so a whole-URL check would validate only its first "
+        ++ "entry; `srcdoc` is HTML-decoded and then parsed as a document, so "
+        ++ "attribute escaping is undone before the markup is read. Neither "
+        ++ "can be made safe by escaping — the ~H desugar rejects a hole in "
+        ++ "either at compile time.")
     else if name_shape_ok(k, attr_char_ok) do k
     else
       panic("Html.tag: `" ++ k ++ "` is not a valid attribute name. An "
         ++ "attribute name built from untrusted input cannot be made safe by "
         ++ "escaping — use a ~H template with a literal attribute instead.")
-    end end
+    -- One `end` per `if`, not one per chain: three `if`s, three `end`s.
+    end end end
   end
 
   doc """

--- a/test/test_ctx_escape.c
+++ b/test/test_ctx_escape.c
@@ -66,6 +66,7 @@ int main(void) {
         { MARCH_ESC_NONE,          "none" },
         { MARCH_ESC_CSS_DECL,      "css_decl" },
         { MARCH_ESC_CSS_URL,       "css_url" },
+        { MARCH_ESC_JS_EXPR,       "js_expr" },
     };
     for (int i = 0; i < MARCH_ESC__COUNT; i++) {
         checks++;
@@ -143,11 +144,58 @@ int main(void) {
     expect_absent(MARCH_ESC_JS_STRING, "</script>", "</script",
                   "js escapes a script close");
     expect_absent(MARCH_ESC_JS_STRING, "<!--", "<!--", "js escapes a comment open");
-    expect(MARCH_ESC_JS_STRING, "a\"b", "a\\\"b", "js escapes a quote");
+    /* NUMERIC, not a backslash escape: a JS string can sit inside an HTML
+       attribute (onclick="f('${x}')"), and `\"` still contains a raw `"` that
+       ends the attribute. */
+    expect(MARCH_ESC_JS_STRING, "a\"b", "a\\u0022b",
+           "js escapes a double quote numerically, so it cannot end an on* attr");
+    expect(MARCH_ESC_JS_STRING, "a'b", "a\\u0027b",
+           "js escapes a single quote numerically too");
+    expect_absent(MARCH_ESC_JS_STRING, "x\" onerror=\"alert(1)", "\"",
+                  "js string emits no raw double quote at all");
     expect(MARCH_ESC_JS_STRING, "a\\b", "a\\\\b", "js escapes a backslash");
     expect(MARCH_ESC_JS_STRING, "a\nb", "a\\nb", "js escapes a newline");
     expect(MARCH_ESC_JS_STRING, "\xe2\x80\xa8", "\\u2028", "js escapes U+2028");
     expect(MARCH_ESC_JS_STRING, "\xe2\x80\xa9", "\\u2029", "js escapes U+2029");
+
+    /* ── JS expression position ──────────────────────────────────────────
+       The escaper that did not exist until 2026-08-20, when every script
+       context got MARCH_ESC_JS_STRING instead and `<script>var x = ${p}`
+       executed p. There is no encoding that makes an arbitrary string safe as
+       bare JS code, so this one refuses to produce code at all: it wraps the
+       value in quotes of its OWN and hands back an inert string literal.
+
+       The two properties that matter, asserted separately below because they
+       fail independently:
+         1. the value cannot escape the JS literal, and
+         2. the OUTPUT contains no raw quote byte except the two delimiters,
+            so it can also sit inside a double-quoted HTML attribute. A
+            backslash-escaped quote would satisfy (1) and fail (2) -- HTML has
+            never heard of the backslash. */
+    expect(MARCH_ESC_JS_EXPR, "alert(document.cookie)",
+           "'alert(document.cookie)'",
+           "js_expr renders a payload as an inert string, not as code");
+    expect(MARCH_ESC_JS_EXPR, "", "''", "js_expr handles empty");
+    expect(MARCH_ESC_JS_EXPR, "a'b", "'a\\u0027b'",
+           "js_expr escapes its own delimiter numerically");
+    expect(MARCH_ESC_JS_EXPR, "a\"b", "'a\\u0022b'",
+           "js_expr escapes the double quote numerically too, for on* attrs");
+    expect(MARCH_ESC_JS_EXPR, "a\\b", "'a\\\\b'",
+           "js_expr escapes a backslash, so it cannot escape the delimiter");
+    expect_absent(MARCH_ESC_JS_EXPR, "');alert(1);('", "';",
+                  "js_expr: a quote-and-semicolon breakout cannot close it");
+    expect_absent(MARCH_ESC_JS_EXPR, "</script><script>alert(1)</script>",
+                  "</script", "js_expr escapes a script close");
+    expect_absent(MARCH_ESC_JS_EXPR, "x\" onerror=\"alert(1)", "\"",
+                  "js_expr emits no raw double quote: safe in an on* attribute");
+    expect(MARCH_ESC_JS_EXPR, "\xe2\x80\xa8", "'\\u2028'",
+           "js_expr escapes U+2028, which would end the JS line");
+    /* The honest-input direction of the same bug: the string escaper turned
+       arithmetic into a syntax error. It is a string now -- not arithmetic,
+       but valid JS whose value is the text the author wrote. */
+    expect(MARCH_ESC_JS_EXPR, "1 < 2 && 3 > 2",
+           "'1 \\u003c 2 \\u0026\\u0026 3 \\u003e 2'",
+           "js_expr renders honest input as valid JS rather than a syntax error");
 
     /* ── CSS ─────────────────────────────────────────────────────────────
        Two positions. A VALUE (after `:`) may not contain `:` or `;` -- either

--- a/test/test_ctxesc.ml
+++ b/test/test_ctxesc.ml
@@ -222,11 +222,50 @@ let test_url_start_vs_mid () =
   Alcotest.check escaper "component mid-value" C.EscUrlComponent
     (esc_after "<a href=\"/search?q=")
 
+(* A <script> body has TWO positions and they take different escapers.
+   This test used to assert `<script>var x = ` -> EscJsString, which is the
+   2026-08-20 vulnerability written down as an expectation: the JS STRING
+   escaper only makes a value unable to END a string literal, and at an
+   expression position there is no literal to end -- so
+   `alert(document.cookie)`, which contains not one character that escaper
+   touches, rendered as live code. The corpus at the bottom of this file
+   asserts what actually comes out. *)
 let test_script_body_is_js () =
   let c = ctx_after "<script>" in
   Alcotest.(check bool) "script element" true (c.C.element = C.ElScript);
   Alcotest.(check bool) "rcdata" true (c.C.state = C.Rcdata);
-  Alcotest.check escaper "js escaper" C.EscJsString (esc_after "<script>var x = ")
+  Alcotest.check escaper "expression position is NOT the string escaper"
+    C.EscJsExpr (esc_after "<script>var x = ");
+  Alcotest.check escaper "inside a double-quoted JS string"
+    C.EscJsString (esc_after "<script>var x = \"");
+  Alcotest.check escaper "inside a single-quoted JS string"
+    C.EscJsString (esc_after "<script>var x = 'a");
+  (* ...and the walk comes back out of the literal again. *)
+  Alcotest.check escaper "after the string closes, expression position again"
+    C.EscJsExpr (esc_after "<script>var x = \"s\"; var y = ")
+
+(* The JS position tracker exists to keep ONE invariant: the walk must never
+   land inside a string literal when the hole is really in open code. Every
+   construct below can carry a stray quote, and each would otherwise leave the
+   quote count off by one and hand the next hole the string escaper -- the
+   exact shape of the original bug, reached by a different route. *)
+let test_stray_quotes_do_not_desynchronise_the_js_tracker () =
+  let expr what src =
+    Alcotest.check escaper what C.EscJsExpr (esc_after src) in
+  expr "an apostrophe in a line comment"
+    "<script>// don't do this\nvar x = ";
+  expr "an apostrophe in a block comment"
+    "<script>/* don't do this */ var x = ";
+  expr "a quote inside a regex literal"
+    "<script>var r = /'/; var x = ";
+  expr "an apostrophe inside a template literal"
+    "<script>var s = `it's here`; var x = ";
+  expr "a quote inside a comment in an event handler"
+    "<a onclick=\"// don't\nn = ";
+  (* An escaped quote does not close the literal it sits in, so the hole after
+     it is still a string position and not expression position. *)
+  Alcotest.check escaper "an escaped quote does not end the string"
+    C.EscJsString (esc_after "<script>var x = \"a\\\"b")
 
 let test_style_body_is_css () =
   Alcotest.check escaper "css escaper" C.EscCssDecl (esc_after "<style>a{color:")
@@ -248,7 +287,15 @@ let test_unrelated_close_tag_stays_in_script () =
   Alcotest.(check bool) "still in script" true (c.C.element = C.ElScript)
 
 let test_event_handler_attr_is_js () =
-  Alcotest.check escaper "onclick is js" C.EscJsString (esc_after "<a onclick=\"")
+  (* Same two positions as a script body. The JS string delimiter is implied by
+     the HTML one: inside a double-quoted attribute a raw double quote ends the
+     ATTRIBUTE, so the only JS string it can hold is a single-quoted one. *)
+  Alcotest.check escaper "onclick at expression position"
+    C.EscJsExpr (esc_after "<a onclick=\"");
+  Alcotest.check escaper "onclick inside a JS string"
+    C.EscJsString (esc_after "<a onclick=\"f('");
+  Alcotest.check escaper "onclick back at expression position"
+    C.EscJsExpr (esc_after "<a onclick=\"f('x'); g(")
 
 let test_style_attr_is_css () =
   (* A style attribute alternates between two positions and the escapers differ:
@@ -288,14 +335,49 @@ let test_substituted_quote_is_closed () =
 let test_rejected_positions () =
   (* Positions where no escaping can make an interpolation safe. Each must
      reject, and each must say something useful -- a bare "not allowed" would
-     leave the author with nowhere to go. *)
+     leave the author with nowhere to go.
+
+     The last six landed with the 2026-08-20 fix. Rejecting is the honest
+     answer wherever an escaper would have to guarantee something it cannot:
+     `srcdoc` is HTML-decoded and then parsed as a document, so attribute
+     escaping is undone before the markup is read; `srcset` is a candidate
+     LIST, so a single-URL scheme check validates only the first entry; and the
+     three JS sub-positions each contain a character no escaper here escapes
+     (`/` ends a regex, a backtick ends a template literal and `${` opens a
+     substitution, and a comment hides the value until it stops being a
+     comment). The single-quoted handler is different again -- the escaper
+     WOULD be safe, but its own delimiters would end the attribute. *)
   List.iter
     (fun src ->
        let d = reject_after src in
        Alcotest.(check bool)
          (Printf.sprintf "rejection after %S is explained" src) true
          (String.length d > 20))
-    [ "<div "; "<"; "<!-- " ]
+    [ "<div "; "<"; "<!-- ";
+      "<iframe srcdoc=\"";
+      "<img srcset=\"";
+      "<script>// note ";
+      "<script>/* note ";
+      "<script>var r = /";
+      "<script>var s = `";
+      "<a onclick='n = " ]
+
+(* Each rejection must name the construct it is refusing, not merely refuse.
+   A message that says only "not allowed here" leaves the author guessing which
+   of the several JS positions they are in. *)
+let test_rejections_name_the_construct () =
+  List.iter
+    (fun (src, needle) ->
+       let d = reject_after src in
+       Alcotest.(check bool)
+         (Printf.sprintf "rejection after %S mentions %S (got: %s)" src needle d)
+         true (contains_sub (String.lowercase_ascii d) needle))
+    [ "<iframe srcdoc=\"",  "srcdoc";
+      "<img srcset=\"",     "srcset";
+      "<script>// note ",   "comment";
+      "<script>var r = /",  "regular-expression";
+      "<script>var s = `",  "template literal";
+      "<a onclick='n = ",   "single-quoted" ]
 
 let test_terminal_validity () =
   Alcotest.(check bool) "balanced template is a valid end state" true
@@ -313,11 +395,295 @@ let test_literal_is_emitted_unchanged_when_no_substitution () =
   let o = walk "<p>hello &amp; goodbye</p>" in
   Alcotest.(check string) "emit is verbatim" "<p>hello &amp; goodbye</p>" o.A.emit
 
+(* ── Rendered-output attack corpus ────────────────────────────────────────
+   THE COVERAGE CLASS THIS FILE WAS MISSING, and the reason the 2026-08-20
+   `~H` vulnerability shipped past a green suite.
+
+   Everything above asserts which escaper gets CHOSEN. The leaf escapers are
+   separately and adversarially tested in test/test_ctx_escape.c (~100 checks
+   with real payloads). Both layers were green while
+   `<script>var x = ${p}</script>` rendered `alert(document.cookie)` as live
+   code, because nothing anywhere put an attack string through a template and
+   looked at what came out: the escaper WAS the one the table named, and it DID
+   escape exactly what it promised to. The defect was the pairing.
+
+   So these tests render. `render` is the desugar's loop
+   (lib/desugar/desugar.ml, the third pass) reduced to one hole: walk the
+   literal before it, take the escaper the context implies, apply it, walk the
+   literal after. What it returns is what a browser would receive. *)
+
+module E = March_ctxesc.Escape
+
+type rendered = {
+  out : string;         (** the whole template as a browser would see it *)
+  hole : string;        (** just the escaped value *)
+  at : C.t;             (** the context the hole sits in *)
+  esc : C.escaper;      (** the escaper the context chose for it *)
+}
+
+let render ~before ~after value =
+  let tbl = Lazy.force table in
+  match A.consume_literal tbl C.initial before with
+  | Error (m, off) ->
+    Alcotest.failf "prefix %S failed to walk at byte %d: %s" before off m
+  | Ok pre ->
+    (match A.consume_interp tbl pre.A.ctx with
+     | Error d -> Alcotest.failf "template %S${}%S was rejected: %s" before after d
+     | Ok (esc, subst, ctx') ->
+       let hole = E.apply esc value in
+       (match A.consume_literal tbl ctx' after with
+        | Error (m, _) -> Alcotest.failf "suffix %S failed to walk: %s" after m
+        | Ok post ->
+          { out = pre.A.emit ^ subst ^ hole ^ post.A.emit; hole; at = ctx'; esc }))
+
+(* Payloads. The first block is the probe from the P0 report; the rest are the
+   styles already proven against the leaf escapers in test_ctx_escape.c, moved
+   up a layer so they are exercised through a template rather than against an
+   escaper chosen by hand. *)
+let attack_payloads =
+  [ "alert(document.cookie)";
+    "javascript:alert(1)";
+    "JaVaScRiPt:alert(1)";
+    "java\tscript:alert(1)";
+    "\001javascript:alert(1)";
+    "  javascript:alert(1)";
+    "data:text/html,<script>alert(1)</script>";
+    "</script><script>alert(1)</script>";
+    "<img src=x onerror=alert(1)>";
+    "\" onerror=\"alert(1)";
+    "' onerror='alert(1)";
+    "` onerror=alert(1) `";
+    "\xe2\x80\xa8alert(1)";                     (* U+2028: a JS line break *)
+    "\xe2\x80\xa9alert(1)";                     (* U+2029 *)
+    "');alert(1);//";
+    "\");alert(1);//";
+    "-->" ]
+
+(* Every position a hole is ALLOWED in, one per escaper and per sub-position.
+   Adding a context here immediately subjects it to every payload above. *)
+let accepting_contexts =
+  [ "element content",       "<div>",                          "</div>";
+    "textarea body",         "<textarea>",                     "</textarea>";
+    "title body",            "<title>",                        "</title>";
+    "plain attribute",       "<div class=\"",                  "\">x</div>";
+    "single-quoted attr",    "<div class='",                   "'>x</div>";
+    "unquoted attribute",    "<div class=",                    ">x</div>";
+    "start of href",         "<a href=\"",                     "\">x</a>";
+    "mid href",              "<a href=\"/s?q=",                "\">x</a>";
+    "xlink:href",            "<a xlink:href=\"",               "\">x</a>";
+    "object data",           "<object data=\"",                "\"></object>";
+    "ping",                  "<a ping=\"",                     "\">x</a>";
+    "manifest",              "<html manifest=\"",              "\"></html>";
+    "longdesc",              "<img longdesc=\"",               "\">x";
+    "style declaration",     "<div style=\"",                  "\">x</div>";
+    "style value",           "<div style=\"color:",            "\">x</div>";
+    "css url()",             "<div style=\"background:url(",   ")\">x</div>";
+    "style body",            "<style>a{color:",                "}</style>";
+    "script expression",     "<script>var x = ",               ";</script>";
+    "script JS string",      "<script>var x = \"",             "\";</script>";
+    "handler expression",    "<button onclick=\"n = ",         "\">x</button>";
+    "handler JS string",     "<button onclick=\"f('",          "')\">x</button>" ]
+
+(* INVARIANT 1 -- no escaped value ever emits a byte that could open a tag or
+   close an attribute. This holds for EVERY escaper without exception, which is
+   what makes it worth asserting as one sweep: `<`/`>` are entity-encoded,
+   percent-encoded, hex-escaped or \u-escaped depending on the language, and
+   the quote characters likewise. The JS-expression escaper is the one that
+   contributes raw quotes, and only its own two delimiters (invariant 4). *)
+let test_no_payload_emits_structural_bytes () =
+  List.iter
+    (fun (name, before, after) ->
+       List.iter
+         (fun payload ->
+            let r = render ~before ~after payload in
+            let bad c what =
+              if String.contains r.hole c then
+                Alcotest.failf
+                  "%s: payload %S emitted a raw %s\n  hole: %s\n  full: %s"
+                  name payload what r.hole r.out
+            in
+            bad '<' "left angle bracket";
+            bad '>' "right angle bracket";
+            bad '"' "double quote";
+            (* The JS-expression escaper supplies its own single quotes -- that
+               is the whole mechanism, and invariant 4 checks it separately.
+               Every other escaper must emit none at all. *)
+            if r.esc <> C.EscJsExpr then bad '\'' "single quote")
+         attack_payloads)
+    accepting_contexts
+
+(* INVARIANT 2 -- the paper's soundness property, checked on real output: an
+   interpolated value cannot move the parser out of the context the compiler
+   proved it was in. Re-walk the ESCAPED value from the context the automaton
+   predicted and require the state, element and delimiter to come back
+   unchanged. (The `attr` sub-position may legitimately advance -- `url` demotes
+   to `urlmid` after a literal byte, a CSS `:` moves declaration to value
+   position -- that is the automaton's own bookkeeping, not an escape.) *)
+let test_no_payload_moves_the_parser () =
+  List.iter
+    (fun (name, before, after) ->
+       List.iter
+         (fun payload ->
+            let r = render ~before ~after payload in
+            (* `doublesubst` means "unquoted in the SOURCE, and the automaton
+               has already emitted a quote". The hole below is output, not
+               source, so it sits in a genuinely double-quoted attribute and
+               must be re-walked as one -- otherwise a tab in the value looks
+               like the end of an unquoted attribute that no longer exists. *)
+            let start =
+              if r.at.C.delim = C.DlDoubleSubst then
+                { r.at with C.delim = C.DlDouble }
+              else r.at in
+            match A.consume_literal (Lazy.force table) start r.hole with
+            | Error (m, _) ->
+              Alcotest.failf "%s: escaped payload %S does not re-parse: %s"
+                name payload m
+            | Ok o ->
+              let same field a b =
+                if a <> b then
+                  Alcotest.failf
+                    "%s: payload %S changed the %s of its context\n  hole: %s"
+                    name payload field r.hole
+              in
+              same "state" o.A.ctx.C.state start.C.state;
+              same "element" o.A.ctx.C.element start.C.element;
+              same "delimiter" o.A.ctx.C.delim start.C.delim)
+         attack_payloads)
+    accepting_contexts
+
+(* INVARIANT 3 -- the rendered document is still well-formed. A payload that
+   left the template ending mid-tag would splice into whatever the caller
+   concatenates next, which is the composition hazard the terminal check
+   exists to stop. *)
+let test_rendered_output_is_still_well_formed () =
+  List.iter
+    (fun (name, before, after) ->
+       List.iter
+         (fun payload ->
+            let r = render ~before ~after payload in
+            match A.consume_literal (Lazy.force table) C.initial r.out with
+            | Error (m, _) ->
+              Alcotest.failf "%s: rendered output does not re-parse: %s\n  %s"
+                name m r.out
+            | Ok o ->
+              if not (A.is_valid_terminal o.A.ctx) then
+                Alcotest.failf
+                  "%s: payload %S left the document in a bad terminal state \
+                   (%s)\n  %s"
+                  name payload (C.describe o.A.ctx) r.out)
+         attack_payloads)
+    accepting_contexts
+
+(* INVARIANT 4 -- a hole at a JS EXPRESSION position is rendered as exactly one
+   string literal, so it is data and not code. This is the assertion that
+   fails against the pre-fix tree: the old escaper returned the payload with
+   no delimiters at all, so `alert(document.cookie)` was an expression. *)
+let test_js_expression_holes_are_inert_literals () =
+  let js_expr_contexts =
+    [ "script expression",  "<script>var x = ",       ";</script>";
+      "handler expression", "<button onclick=\"n = ", "\">x</button>";
+      "unquoted handler",   "<button onclick=",       ">x</button>" ] in
+  List.iter
+    (fun (name, before, after) ->
+       List.iter
+         (fun payload ->
+            let r = render ~before ~after payload in
+            let n = String.length r.hole in
+            if n < 2 || r.hole.[0] <> '\'' || r.hole.[n - 1] <> '\'' then
+              Alcotest.failf
+                "%s: payload %S was not wrapped in a JS string literal\n  %s"
+                name payload r.hole;
+            (* ...and nothing inside it can end that literal. *)
+            let body = String.sub r.hole 1 (n - 2) in
+            if String.contains body '\'' then
+              Alcotest.failf
+                "%s: payload %S left a raw quote inside the literal\n  %s"
+                name payload r.hole)
+         attack_payloads)
+    js_expr_contexts
+
+(* The rows of the P0 report, asserted as exact output. Every one of these was
+   a different string before the fix; four of them executed. Exact expectations
+   rather than "does not contain" because the useful review artifact is the
+   diff -- a regression in either direction shows up as a readable change. *)
+let test_reported_rows_render_as_expected () =
+  let row what ~before ~after value want =
+    let r = render ~before ~after value in
+    Alcotest.(check string) what want r.out
+  in
+  (* 1. was: <script>var x = alert(document.cookie);</script>  -- EXECUTED *)
+  row "script expression is a string, not a call"
+    ~before:"<script>var x = " ~after:";</script>" "alert(document.cookie)"
+    "<script>var x = 'alert(document.cookie)';</script>";
+  (* 2. was: onclick="n = alert(document.cookie)"  -- EXECUTED *)
+  row "event handler is a string, not a call"
+    ~before:"<button onclick=\"n = " ~after:"\">x</button>"
+    "alert(document.cookie)"
+    "<button onclick=\"n = 'alert(document.cookie)'\">x</button>";
+  (* 3. unchanged by the fix, and must stay that way. *)
+  row "a hole inside a JS string is still just escaped"
+    ~before:"<script>var x = \"" ~after:"\";</script>" "hello"
+    "<script>var x = \"hello\";</script>";
+  (* 4. unchanged by the fix. *)
+  row "href keeps the scheme allowlist"
+    ~before:"<a href=\"" ~after:"\">x</a>" "javascript:alert(1)"
+    "<a href=\"about:invalid#zSoyz\">x</a>";
+  (* 5-7. were: passed through verbatim -- xlink:href and data EXECUTED. *)
+  row "xlink:href is a URL attribute"
+    ~before:"<a xlink:href=\"" ~after:"\">x</a>" "javascript:alert(1)"
+    "<a xlink:href=\"about:invalid#zSoyz\">x</a>";
+  row "object data is a URL attribute"
+    ~before:"<object data=\"" ~after:"\"></object>" "javascript:alert(1)"
+    "<object data=\"about:invalid#zSoyz\"></object>";
+  row "ping is a URL attribute"
+    ~before:"<a ping=\"" ~after:"\">x</a>" "javascript:alert(1)"
+    "<a ping=\"about:invalid#zSoyz\">x</a>";
+  (* `data` must be an EXACT match: data-* attributes are not URLs and must
+     keep the ordinary attribute escaper. *)
+  row "data-* is not a URL attribute"
+    ~before:"<div data-x=\"" ~after:"\">y</div>" "javascript:alert(1)"
+    "<div data-x=\"javascript:alert(1)\">y</div>";
+  (* 9. unchanged by the fix. *)
+  row "element content is entity-encoded"
+    ~before:"<div>" ~after:"</div>" "<img src=x onerror=alert(1)>"
+    "<div>&lt;img src=x onerror=alert(1)&gt;</div>";
+  (* 10. the honest-input direction of the same defect: this used to render
+     `var y = 1 < 2 ...`, a JS syntax error. It is a string now -- not
+     arithmetic, but valid JS carrying the text the author wrote. *)
+  row "honest arithmetic renders as valid JS"
+    ~before:"<script>var y = " ~after:";</script>" "1 < 2 && 3 > 2"
+    "<script>var y = '1 \\u003c 2 \\u0026\\u0026 3 \\u003e 2';</script>"
+
+(* The eight rows of the report that must not compile at all. *)
+let test_reported_rows_that_must_not_compile () =
+  List.iter
+    (fun (what, before) ->
+       ignore (reject_after before);
+       Alcotest.(check bool) what true true)
+    [ "srcdoc is rejected rather than entity-escaped", "<iframe srcdoc=\"";
+      "srcset is rejected rather than half-validated", "<img srcset=\"" ]
+
+let corpus_tests =
+  [ Alcotest.test_case "no payload emits structural bytes" `Quick
+      test_no_payload_emits_structural_bytes;
+    Alcotest.test_case "no payload moves the parser" `Quick
+      test_no_payload_moves_the_parser;
+    Alcotest.test_case "rendered output stays well-formed" `Quick
+      test_rendered_output_is_still_well_formed;
+    Alcotest.test_case "js expression holes are inert literals" `Quick
+      test_js_expression_holes_are_inert_literals;
+    Alcotest.test_case "reported rows render as expected" `Quick
+      test_reported_rows_render_as_expected;
+    Alcotest.test_case "reported rows that must not compile" `Quick
+      test_reported_rows_that_must_not_compile ]
+
 let automaton_tests =
   [ Alcotest.test_case "pcdata" `Quick test_pcdata_stays_pcdata;
     Alcotest.test_case "enters url attr" `Quick test_enters_double_quoted_url_attr;
     Alcotest.test_case "url start vs mid" `Quick test_url_start_vs_mid;
     Alcotest.test_case "script body is js" `Quick test_script_body_is_js;
+    Alcotest.test_case "stray quotes do not desync the js tracker" `Quick
+      test_stray_quotes_do_not_desynchronise_the_js_tracker;
     Alcotest.test_case "style body is css" `Quick test_style_body_is_css;
     Alcotest.test_case "textarea body is html" `Quick test_textarea_body_is_html;
     Alcotest.test_case "close tag leaves raw text" `Quick test_close_tag_leaves_raw_text;
@@ -329,6 +695,8 @@ let automaton_tests =
     Alcotest.test_case "unquoted attr substitution" `Quick test_unquoted_attr_gets_substituted_quote;
     Alcotest.test_case "substituted quote closed" `Quick test_substituted_quote_is_closed;
     Alcotest.test_case "rejected positions" `Quick test_rejected_positions;
+    Alcotest.test_case "rejections name the construct" `Quick
+      test_rejections_name_the_construct;
     Alcotest.test_case "terminal validity" `Quick test_terminal_validity;
     Alcotest.test_case "literal emitted verbatim" `Quick test_literal_is_emitted_unchanged_when_no_substitution ]
 
@@ -362,15 +730,25 @@ let test_attr_classification_matches_html_march () =
       (Printf.sprintf "attr %S classifies as %s" name expected)
       (Some expected) (cls name)
   in
-  (* Every url attribute listed in Html.url_attr_names(). *)
+  (* Every url attribute listed in Html.url_attr_names(). The second row
+     arrived with the 2026-08-20 fix; each was falling through to `normal`,
+     which passes `javascript:` untouched. *)
   List.iter (fun n -> check n "url")
-    [ "href"; "src"; "action"; "formaction"; "poster"; "cite"; "background" ];
+    [ "href"; "src"; "action"; "formaction"; "poster"; "cite"; "background";
+      "xlink:href"; "data"; "ping"; "manifest"; "longdesc" ];
   check "style" "style";
+  (* Rejected outright -- Html.refused_attr_names(). *)
+  List.iter (fun n -> check n "srcset") [ "srcset" ];
+  List.iter (fun n -> check n "htmldoc") [ "srcdoc" ];
   (* Event handlers -- Html.tag refuses these outright rather than escaping. *)
   List.iter (fun n -> check n "script") [ "onerror"; "onclick"; "onload"; "on" ];
-  (* Everything else falls through to normal. *)
+  (* Everything else falls through to normal. `data` is matched EXACTLY, so the
+     whole `data-*` family must NOT be swept into the URL class with it -- a
+     `data*` glob there would have changed the escaper on every data attribute
+     in every template. *)
   List.iter (fun n -> check n "normal")
-    [ "class"; "id"; "data-id"; "title"; "alt"; "width" ];
+    [ "class"; "id"; "data-id"; "data-url"; "datalist"; "title"; "alt";
+      "width" ];
   (* Case-insensitivity: HTML attribute names are, and so is the classifier. *)
   check "HREF" "url";
   check "OnClick" "script"
@@ -389,6 +767,7 @@ let tests =
        Alcotest.test_case "rejects row outside section" `Quick test_rejects_row_outside_a_section;
        Alcotest.test_case "shipped table parses" `Quick test_shipped_table_parses ]);
     ("ctxesc automaton", automaton_tests);
+    ("ctxesc rendered-output attack corpus", corpus_tests);
     ("ctxesc attr classification",
      [ Alcotest.test_case "html.march copy matches the shipped table" `Quick
          test_attr_classification_matches_html_march ]) ]


### PR DESCRIPTION
**Security fix.** `~H`'s promise is compile-time *contextual* auto-escaping — a `${hole}` is made safe for the context it lands in. In three context families it was not, and the result was attacker-controlled script execution. Found during a pre-0.3.0 adversarial sweep and reproduced first-hand on **both** backends (interpreted and `--compile --opt 2` byte-identical, so this was a context-table/automaton gap, not codegen).

Full write-up: `specs/progress/2026-08-20-h-sigil-js-and-url-attr-xss.md`.

## Before / after

Probe values: `p = "alert(document.cookie)"`, `u = "javascript:alert(1)"`, `h = "<img src=x onerror=alert(1)>"`, `j = "1 < 2 && 3 > 2"`.

| # | Template | Before | After |
|---|---|---|---|
| 1 | `<script>var x = ${p};</script>` | `var x = alert(document.cookie);` **XSS** | `var x = 'alert(document.cookie)';` |
| 2 | `<button onclick="n = ${p}">` | `n = alert(document.cookie)` **XSS** | `n = 'alert(document.cookie)'` |
| 3 | `<script>var x = "${s}";</script>` | `var x = "hello";` | unchanged |
| 4 | `<a href="${u}">` | `about:invalid#zSoyz` | unchanged |
| 5 | `<a xlink:href="${u}">` | `javascript:alert(1)` **XSS (SVG)** | `about:invalid#zSoyz` |
| 6 | `<object data="${u}">` | `javascript:alert(1)` **XSS** | `about:invalid#zSoyz` |
| 7 | `<a ping="${u}">` | `javascript:alert(1)` | `about:invalid#zSoyz` |
| 8 | `<iframe srcdoc="${h}">` | `&lt;img …&gt;` — browser HTML-decodes srcdoc then parses it as a document, so it fires **XSS** | **compile error** |
| 9 | `<div>${h}</div>` | entity-encoded | unchanged |
| 10 | `<script>var y = ${j};</script>` | `1 < 2 && 3 > 2` — a JS **syntax error** | `'1 < 2 && 3 > 2'` |

## Root cause

`escaper_for` mapped **every** script context to `EscJsString`. That escaper only stops a value *ending* a string literal — but at an expression position the template never opened one, so it escaped delimiters that weren't delimiting anything and left parens, dots, identifiers and `;` untouched. One root cause, failing both ways: hostile input executed (rows 1–2), honest arithmetic broke (row 10).

There was no JS value escaper anywhere in the escaper set, so the ability to handle expression position correctly did not exist.

## The fix

JS position is now modelled in the existing flat context tuple: `attr` holds the position and, in a `<script>` body, `delim` (free there) holds the open literal's quote. New classes `jsstring`, `jscomment`, `jsregex`, `jstemplate`, plus `srcset`/`htmldoc`, around one invariant written into the `.tbl`: *the walk must never land at `jsstring` when the hole is really in expression position.* Comments, template literals and regex literals are tracked because each can hide a stray quote (`// don't`, `` `it's` ``, `/'/`) that would desync the counter and hand the next hole the string escaper in open code.

New escaper **`EscJsExpr`**: no encoding makes an arbitrary string safe as bare JS *code*, so it doesn't try — it supplies the quotes the template didn't and renders the value as an inert JS string literal, with both quote characters escaped numerically. That's what lets one escaper serve both a `<script>` body and a double-quoted `on*` attribute.

The URL-attribute table gained `xlink:href`, `data`, `ping`, `longdesc`, `manifest`. `srcdoc` and `srcset` are rejected with diagnostics.

## Deviation from the filed plan — please review this choice

The todo recommended **failing closed** (reject bare-JS holes at compile time). The implementation deliberately did not, because `Html.trust_js` exists and its only meaningful position is exactly bare-JS expression position (`test/native/h_trusted_context.march:39` is `~H"<script>${j}</script>"`), and trust is resolved *after* typechecking, so a desugar-time diagnostic cannot distinguish trusted from untrusted. Failing closed would have deleted a shipped, golden-tested feature inside a security patch. A separate escaper id solves it — `TrustedJs → [5; 9]`, golden unchanged.

**Cost, stated plainly:** an expression-position hole now renders as a *string*, not the value's JS type — `var n = ${count}` yields `'42'`, not `42`. That is a silent meaning change. Making it loud requires the typechecker to learn the `Trusted*` types; that is filed, not built.

## Fixed beyond the report

`EscJsString` emitted `\"`, which still contains a raw `"` byte — HTML does not know what a backslash is, so a JS string inside `onclick="f('${x}')"` could end the attribute. Unexploitable only because escaping `=` stopped the escapee writing `onerror=`. Now numeric, so *"an escaped hole never emits a raw quote"* holds without exception.

## Adversarial verification of the new escaper

Because `EscJsExpr` supplies its own quotes, it is new attack surface. Verified independently against the built compiler, identical on both backends:

| Payload | Rendered |
|---|---|
| `'; alert(1); //` | `''; alert(1); //'` — cannot close the literal |
| `\'; alert(1); //` | `'\\'; …'` — **backslash-desync** handled; the backslash is itself escaped |
| `</script><img src=x onerror=alert(1)>` | `'</script>…'` — required, since HTML tokenization would otherwise end the element from inside a JS string |
| `" onmouseover="alert(1)` in `onclick` | `'" onmouseover="alert(1)'` — cannot end the HTML attribute |

Seven rejections verified end-to-end: srcdoc, srcset, JS line comment, JS block comment, regex literal, template literal, single-quoted `on*` handler — each with a diagnostic naming the construct and the way out.

## Test coverage — the gap that let this ship

The leaf escapers were already adversarially tested (`test/test_ctx_escape.c`, ~90 checks with real payloads). The gap was one layer up: `test/test_ctxesc.ml` asserted only which escaper was *selected*, never the rendered output, and its whole reject corpus was three strings. **No test anywhere rendered an attack string through a template and asserted the result was inert.**

This PR adds that missing class: an attack-string × context corpus asserting rendered output (`test/test_ctxesc.ml`, +395 lines).

**Non-vacuity proved with two controls** (file-copy swaps, no `git stash`):
1. Full pre-fix source swap → new tests don't compile (total dependence, but only a type error), so:
2. Behavioural control — `html-contexts.tbl` + `automaton.ml` reverted to HEAD, everything else fixed, exercising pre-fix escaper *selection*: **9 failures**, e.g. `payload "alert(document.cookie)" was not wrapped in a JS string literal`, and `expected a rejection after "<iframe srcdoc=\""`. Restored → 37 tests / 86 checks, 0 failures.

**Honest caveat recorded in the progress file:** the three *structural* invariants (no raw `<`/`>`/`"`, parser cannot be moved, output still well-formed) stay **green against the pre-fix tree**. The original bug was semantic, not structural — the payload never moved the parser and never emitted a structural byte, it was simply admitted as code. The inert-literal property and the exact-output rows are what actually catch it.

## Verification

| Check | Result |
|---|---|
| `scripts/run-tests.sh` | exit 0, all suites passed |
| `dune build --root . @runtest` (unpiped exit code) | **0** — C escaper test and all `test/native/h_*` goldens re-ran |
| `@types-check --force` | exit 0, 303 passed / 0 failed (non-vacuous — `--force` matters here) |
| `@grammar-check --force` | exit 0, 48 passed / 0 failed |
| `scripts/check-docs.sh` | exit 0, doc-lint passed |
| `.expected` goldens changed | **none** — `Html.trust_js` still inserts verbatim |

## Whose gap was this

Ours, not the paper's. `specs/todos/2026-08-06-ctxesc-no-subsidiary-automata.md` records that the implementation matches Samuel et al. on transition tables, the context tuple, substitutions, terminal validity and diagnostics, and diverges on exactly one element: **subsidiary automata** — the mechanism that tracks nested content languages, i.e. precisely what distinguishes in-a-string-literal from expression position.

That todo was rated **P3, "not a known vulnerability"** — but its risk analysis reasoned through URL and CSS and never JS, the one nested language where the same divergence *is* exploitable. It is re-rated in this PR. It also left open the question *"is a real subsidiary automaton worth it?"*, answered here: for JS, yes.

## Known limitations (documented, not silently accepted)

- **`srcset` rejected rather than escaped** — its value is a candidate *list*, so the whole-URL escaper's contract ("this hole IS the URL") is false; it would validate the first candidate and wave the rest through. A per-candidate escaper is a new escaper, not a table edit. One table line to flip if `url` is preferred.
- **`jsregex` reads any `/` in expression position as a regex**, so division before a hole is now a compile error. Biased deliberately — the other direction is a quote desync, which is unsafe.
- **URL still has no real subsidiary automaton.** Unchanged. Noted in the re-rated todo that the "not exploitable" argument for it is the same *shape* of argument that failed for JS — recorded as an argument, not a clearance.
- **`data` is classified as a URL everywhere**, though only `<object data>` is one. Attribute classification is by name only (pre-existing, documented). Matched exactly, so `data-*` is untouched — pinned by a test.
