### PR TITLE
test(sanitize): extend the ASAN gate to SIMD / NativeArray / Bytes codegen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@
 #   doc-lint                            (standalone, ~10s)
 #   test          (ubuntu, macos)       `dune runtest`
 #   conformance   (ubuntu, macos)       @types-check, @grammar-check, @vault-scale, docs, fmt
-#   sanitize-gate (ubuntu)              golden-corpus ASAN gate
+#   sanitize-gate (ubuntu)              ASAN gate: golden corpus + curated SIMD/NativeArray
 #   ocaml-build   (ubuntu, macos) ─┬─ property-tests × 3 (per OS)
 #                  ubuntu leg only ─┼─ cross-linux-oracle
 #                                   └─ property-oracle × 8
@@ -347,6 +347,16 @@ jobs:
           eval $(opam env)
           dune fmt 2>&1 || true
 
+  # AddressSanitizer sweep, run TWICE on this runner (plain, then MARCH_TRMC=1).
+  # sanitize.sh covers two corpora: every specs/lang/golden/*.march, plus a
+  # curated by-name list of test/native/*.march SIMD / NativeArray-narrow-width /
+  # array-backed-Bytes programs — that second corpus was added 2026-08-20 because
+  # no sanitizer had ever compiled that code (the golden corpus contains zero
+  # SIMD/NativeArray programs). See the script header for why the curated list is
+  # a list and not a glob, and why those programs are not simply new goldens.
+  #
+  # Ubuntu-only: the gate no-ops on a Mac running CrowdStrike Falcon, whose
+  # syscall interception hangs ASAN's shadow-memory setup.
   sanitize-gate:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -357,7 +367,7 @@ jobs:
         timeout-minutes: 12
         uses: ./.github/actions/march-setup
 
-      - name: Golden corpus AddressSanitizer gate (RC/UAF guard)
+      - name: AddressSanitizer gate (RC/UAF guard) — golden + curated SIMD/NativeArray
         timeout-minutes: 15
         run: |
           eval $(opam env)
@@ -366,7 +376,7 @@ jobs:
           MARCH_BIN="$PWD/_build/default/bin/main.exe" \
             ./specs/lang/golden/sanitize.sh
 
-      - name: Golden corpus AddressSanitizer gate — TRMC enabled
+      - name: AddressSanitizer gate — TRMC enabled
         timeout-minutes: 15
         run: |
           eval $(opam env)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ git log is authoritative for exact commits.
 
 ### Added
 
+- **The AddressSanitizer CI gate now covers the SIMD, narrow-width `NativeArray`
+  (`f32`/`i32`/`u8`) and array-backed `Bytes` lowerings**, which no sanitizer had
+  ever compiled. `specs/lang/golden/sanitize.sh` swept only
+  `specs/lang/golden/*.march`, and that corpus contains zero SIMD/NativeArray/Bytes
+  programs, so every raw-memory path in that area sat outside the project's only
+  ASAN gate while `dune runtest` exercised it uninstrumented on both OSes. The
+  script now sweeps a second corpus: 24 curated, by-name `test/native/*.march`
+  fixtures, kept separate in the output so a failure names the corpus it came from.
+  Programs were added by name rather than moved into `specs/lang/golden/` because
+  that directory is also the cross-compile oracle corpus and has a doc-lint-pinned
+  count. The gate also now reports how many programs it actually swept and fails
+  if that number is zero — it exits 0 without running anything on a Mac with
+  CrowdStrike Falcon, so a green exit code alone was never evidence it ran.
+
 - **`Actor.send_after(pid, msg, delay_ms)` / `Actor.cancel_timer(ref)`: schedule a
   message for delayed delivery to an actor, with cancellation.** Previously an actor
   that wanted to poll, retry, time something out, or tick had to burn a green thread

--- a/specs/lang/golden/sanitize.sh
+++ b/specs/lang/golden/sanitize.sh
@@ -1,15 +1,66 @@
 #!/usr/bin/env bash
-# AddressSanitizer gate over the core-march golden corpus (see ../core-march.md §5).
-# Compiles each golden .march with MARCH_SANITIZE=1 and asserts a clean exit plus
-# no sanitizer report — the standing guard against RC/UAF regressions in the
-# RC-heavy golden programs. Exit 0 iff every golden runs clean under ASAN.
+# AddressSanitizer gate over two corpora (see ../core-march.md §5).
+# Compiles each program with MARCH_SANITIZE=1 and asserts a clean exit plus no
+# sanitizer report — the standing guard against RC/UAF regressions.
+# Exit 0 iff every program in every corpus runs clean under ASAN.
 #
 #   MARCH_BIN=/path/to/main.exe specs/lang/golden/sanitize.sh
 # (defaults MARCH_BIN to _build/default/bin/main.exe relative to the repo root)
 #
-# All 46 goldens terminate (the sibling verify.sh runs them compiled with no
-# exclusions); a 25s per-run wall-clock guard is kept as a defensive backstop so
-# a future non-terminating golden fails loudly instead of hanging the gate.
+# The two corpora, kept SEPARATE in the output so a failure names its source:
+#
+#   golden — every specs/lang/golden/*.march. The RC-heavy core-language
+#            programs; swept wholesale because the whole directory is, by
+#            construction, deterministic and terminating.
+#
+#   native — a CURATED, EXPLICITLY-NAMED subset of test/native/*.march covering
+#            the SIMD / NativeArray-narrow-width / array-backed-Bytes lowerings.
+#            These have real CI coverage via `dune runtest` on both OSes, but
+#            until 2026-08-20 no sanitizer had ever compiled them: the golden
+#            corpus contains zero SIMD/NativeArray/Bytes programs, so every
+#            raw-memory path in that area (native <4 x float> loads/stores,
+#            narrow-width i8/i16/i32 element access, Bytes' array backing) was
+#            outside the only ASAN gate the project runs.
+#
+# WHY A CURATED LIST AND NOT NEW GOLDENS
+# --------------------------------------
+# The obvious fix — drop a few SIMD programs into specs/lang/golden/ and let the
+# existing glob pick them up — has blast radius well beyond ASAN, because this
+# directory is NOT just the ASAN corpus:
+#
+#   * specs/lang/golden IS the cross-compile oracle corpus. In cross mode
+#     test/test_oracle.ml narrows its sweep to examples/ + specs/lang/golden/,
+#     so anything landing here is also cross-compiled to linux/amd64 and
+#     differentially compared against the native run. A SIMD program would drag
+#     arm64-vs-x86_64 vector codegen differences into that diff — a separate
+#     project, not a sanitizer change.
+#   * specs/lang/golden/INDEX.md pins the corpus count and scripts/check-docs.sh
+#     Check C enforces it, so an addition here reddens doc-lint until the count
+#     is updated in lockstep.
+#
+# So the SIMD/NativeArray programs stay where they are and this gate reaches out
+# to them by name. The repo already has this exact pattern: test/test_oracle.ml
+# pulls a `test_native_allowlist` of individually-named test/native/ programs
+# into its sweep for the same reason. An explicit list, NOT a glob over
+# test/native — that directory holds 165 fixtures including deliberately
+# non-terminating, panic-asserting, FFI-shim and --target js programs.
+#
+# Please do not "simplify" either corpus back into a single glob.
+#
+# TIMEOUTS. The per-program wall-clock guard is a HANG backstop, not a
+# performance budget — it exists so a non-terminating program fails loudly
+# instead of eating the job's 30-minute ceiling. Both corpora use 25s, which is
+# enormous headroom: measured 2026-08-20 under ASAN on linux/arm64, the slowest
+# curated native program runs in 0.06s and the whole sweep's cost is COMPILE
+# time, not run time. That headroom is only true because the two multi-million-
+# iteration leak probes are excluded (see below) — re-add one and this bound
+# becomes the thing that fails, so exclude heavy probes rather than raising it.
+#
+# WHAT THIS GATE DOES NOT CATCH. ASAN_OPTIONS sets detect_leaks=0 below, so this
+# is a use-after-free / out-of-bounds / UBSan gate, NOT leak coverage. Leaks in
+# this area are guarded separately by the live_allocs() probes in test/native
+# (simd_leak_probe.march, native_arr_fold_leak_probe.march), which assert an
+# exact live-object count and need no sanitizer.
 
 set -u
 here="$(cd "$(dirname "$0")" && pwd)"
@@ -27,26 +78,119 @@ if [ "$(uname -s)" = "Darwin" ] && pgrep -qf 'com\.crowdstrike\.falcon\.Agent' 2
   echo "SKIP: CrowdStrike Falcon (EndpointSecurity system extension) detected on this Mac." >&2
   echo "Falcon's syscall interception hangs ASAN's shadow-memory mmap setup on every binary," >&2
   echo "even a no-op 'printf' program — this is environmental, not a golden regression." >&2
-  echo "Run this gate on a host without Falcon (e.g. CI) instead." >&2
+  echo "Run this gate on a host without Falcon (e.g. CI, or ci/Dockerfile.ubuntu) instead." >&2
+  echo "*** 0 programs compiled, 0 run — this is a SKIP, not a pass. ***" >&2
   exit 0
 fi
 
 export ASAN_OPTIONS="detect_leaks=0:halt_on_error=1"
 export MARCH_STDLIB="${MARCH_STDLIB:-$root/stdlib}"
 
-pass=0; fail=0
-for f in "$here"/*.march; do
-  b="$(basename "$f" .march)"
-  if ! MARCH_SANITIZE=1 "$bin" --compile "$f" -o "$work/$b.bin" >"$work/$b.clog" 2>&1; then
-    echo "  [$b] COMPILE FAIL"; sed 's/^/    /' "$work/$b.clog"; fail=$((fail+1)); continue
-  fi
-  perl -e 'alarm 25; exec @ARGV' "$work/$b.bin" >"$work/$b.out" 2>"$work/$b.err"; rc=$?
-  if [ $rc -ne 0 ] || grep -qiE "AddressSanitizer|runtime error:|LeakSanitizer" "$work/$b.err"; then
-    echo "  [$b] SANITIZER FAIL (rc=$rc)"; sed 's/^/    /' "$work/$b.err"; fail=$((fail+1))
-  else
-    echo "  [$b] CLEAN"; pass=$((pass+1))
-  fi
-done
+# ── Curated test/native subset ────────────────────────────────────────────
+# Every program here is deterministic, terminating, self-contained (no
+# MARCH_LIB_PATH, no capability grant beyond what it declares itself) and exits
+# 0 — all four are required by the runner below, which treats any non-zero exit
+# as a failure. Each was confirmed to compile and run clean uninstrumented
+# before being added.
+#
+# DELIBERATELY EXCLUDED from test/native's SIMD/NativeArray/Bytes fixtures, so
+# the next person does not re-add them and get a red gate:
+#   * simd_bounds_panic, simd_lane_panic, native_arr_map2_inline_length_panic —
+#     these assert a runtime panic, i.e. a NON-ZERO exit by design. The runner
+#     below cannot express "expected to abort", and weakening it to accept
+#     non-zero exits would blind it to the crashes it exists to catch.
+#   * simd_leak_probe (~2,000,000 calls), native_arr_fold_leak_probe
+#     (2 x 4,000,000-element folds) — multi-million-iteration probes that blow
+#     the wall-clock budget under ASAN's 2-20x slowdown. They are live_allocs()
+#     LEAK probes, and detect_leaks=0 is set above, so ASAN would add nothing
+#     to what they already assert. They keep their own `dune runtest` coverage.
+#   * peak_rss — allocates a 64,000,000-element u8 array and asserts an RSS
+#     band. ASAN's shadow memory and redzones invalidate that band by
+#     construction.
+native_curated=(
+  # array-backed Bytes
+  bytes_u8_bridge
+  closure_param_shadows_import
+  # NativeArray: narrow widths, fold, map/map2, and the inline-loop lowerings
+  native_arr_fold
+  native_arr_map2
+  native_arr_map2_inline
+  native_arr_map_closure_abi
+  native_arr_map_inline_capture
+  native_arr_map_inline_float_box_reuse
+  native_arr_map_inline_reuse
+  native_arr_map_inline_unboxed
+  native_arr_map_inline_vectorize
+  native_arr_narrow
+  native_arr_narrow_inline
+  float_arr_list_boxing
+  # SIMD
+  simd_actor_msg
+  simd_fma_fuzz
+  simd_mutual_tco
+  simd_nested_closure_acc
+  simd_poly_eq
+  simd_residency
+  simd_to_string
+  simd_vector_core
+  simd_vector_escape_arg
+  simd_vector_mem
+)
 
-echo "=== golden sanitize: $pass clean, $fail failed ==="
-[ $fail -eq 0 ]
+# Resolve the curated names to paths. A name that no longer resolves is a HARD
+# ERROR, not a silent skip: a fixture rename must not quietly shrink this gate
+# to nothing while it keeps reporting green. (test/test_oracle.ml's sibling
+# allowlist filters missing entries instead — correct for a differential sweep
+# that reports per-file verdicts, wrong for a pass/fail gate.)
+native_files=()
+missing=()
+for b in "${native_curated[@]}"; do
+  p="$root/test/native/$b.march"
+  if [ -f "$p" ]; then native_files+=("$p"); else missing+=("$b"); fi
+done
+if [ ${#missing[@]} -ne 0 ]; then
+  echo "ERROR: curated test/native fixtures no longer exist: ${missing[*]}" >&2
+  echo "Update native_curated in $0 (a rename must not silently shrink this gate)." >&2
+  exit 2
+fi
+
+total_pass=0; total_fail=0; total_ran=0
+
+# sweep <label> <timeout-seconds> <file>...
+# Compiles and runs each file under ASAN. Every result line is prefixed with the
+# corpus label so a failure says which corpus it came from.
+sweep() {
+  local label="$1" tmo="$2"; shift 2
+  local pass=0 fail=0 f b tag rc
+  for f in "$@"; do
+    b="$(basename "$f" .march)"
+    tag="$label/$b"
+    if ! MARCH_SANITIZE=1 "$bin" --compile "$f" -o "$work/$label-$b.bin" \
+         >"$work/$label-$b.clog" 2>&1; then
+      echo "  [$tag] COMPILE FAIL"; sed 's/^/    /' "$work/$label-$b.clog"
+      fail=$((fail+1)); continue
+    fi
+    perl -e 'alarm shift; exec @ARGV' "$tmo" "$work/$label-$b.bin" \
+      >"$work/$label-$b.out" 2>"$work/$label-$b.err"; rc=$?
+    if [ $rc -ne 0 ] || grep -qiE "AddressSanitizer|runtime error:|LeakSanitizer" "$work/$label-$b.err"; then
+      echo "  [$tag] SANITIZER FAIL (rc=$rc)"; sed 's/^/    /' "$work/$label-$b.err"
+      fail=$((fail+1))
+    else
+      echo "  [$tag] CLEAN"; pass=$((pass+1))
+    fi
+  done
+  echo "=== $label sanitize: $pass clean, $fail failed (of $# programs) ==="
+  total_pass=$((total_pass+pass)); total_fail=$((total_fail+fail)); total_ran=$((total_ran+$#))
+}
+
+sweep golden 25 "$here"/*.march
+echo
+sweep native 25 "${native_files[@]}"
+
+# Report the program count explicitly. A green exit code alone is NOT evidence
+# this gate ran: the Darwin/Falcon branch above exits 0 having compiled nothing,
+# and a glob that matches no files would too. Judge by the count, not the code.
+echo
+echo "=== sanitize TOTAL: $total_ran programs swept — $total_pass clean, $total_fail failed ==="
+[ $total_ran -gt 0 ] || { echo "ERROR: swept 0 programs — the gate is vacuous." >&2; exit 2; }
+[ $total_fail -eq 0 ]

--- a/specs/progress/2026-08-20-asan-gate-simd-nativearray-coverage.md
+++ b/specs/progress/2026-08-20-asan-gate-simd-nativearray-coverage.md
@@ -1,0 +1,153 @@
+# The ASAN gate now covers SIMD / narrow-width `NativeArray` / array-backed `Bytes`
+
+Landed 2026-08-20. Pre-0.3.0 release hardening.
+
+## The gap
+
+`specs/lang/golden/sanitize.sh` swept exactly one corpus — `for f in "$here"/*.march`,
+i.e. the 47 programs in `specs/lang/golden/`. That corpus contains **zero**
+SIMD/NativeArray/Bytes programs:
+
+```
+$ grep -rliE 'simd|nativearray|native_arr|Bytes\.|f32|i32|u8' specs/lang/golden/*.march
+$          # no output
+```
+
+Meanwhile `test/native/` holds ~27 SIMD / NativeArray-narrow-width /
+array-backed-Bytes fixtures that `dune runtest` compiles and runs on both OSes —
+but never under a sanitizer. So every raw-memory path in that area (native
+`<4 x float>` loads/stores, narrow `i8`/`i16`/`i32` element access, `Bytes`'
+array backing) had real correctness coverage and no memory-safety coverage.
+
+## What changed
+
+`sanitize.sh` now sweeps **two** corpora, labelled separately in the output so a
+failure names the corpus it came from:
+
+```
+=== golden sanitize: 47 clean, 0 failed (of 47 programs) ===
+=== native sanitize: 24 clean, 0 failed (of 24 programs) ===
+=== sanitize TOTAL: 71 programs swept — 71 clean, 0 failed ===
+```
+
+The second corpus is a curated, explicitly-named list of 24 `test/native/*.march`
+fixtures, not a glob and not new goldens. The reasoning is written into the
+script header so it survives the next round of tidying; in short:
+
+- `specs/lang/golden` is **also** the cross-compile oracle corpus
+  (`test/test_oracle.ml` narrows to `examples/ + specs/lang/golden/` in cross
+  mode), so a SIMD program dropped in there would additionally be cross-compiled
+  to linux/amd64 and differentially diffed — dragging arm64-vs-x86_64 vector
+  codegen into an unrelated change.
+- `specs/lang/golden/INDEX.md` pins the corpus count and `scripts/check-docs.sh`
+  Check C enforces it.
+- A glob over `test/native` would pull in 165 fixtures including deliberately
+  non-terminating, panic-asserting, FFI-shim and `--target js` programs.
+
+The precedent followed is `test/test_oracle.ml`'s own `test_native_allowlist`,
+which pulls named `test/native/` programs into its sweep for the same reasons.
+
+Three further hardening changes, all aimed at the same failure mode — a gate that
+reports success without having run:
+
+1. The script prints the **program count it actually swept** and exits 2 if that
+   count is 0. A green exit code alone was never evidence: the Darwin branch
+   exits 0 having compiled nothing when CrowdStrike Falcon is present.
+2. That Darwin skip now says so out loud — `*** 0 programs compiled, 0 run —
+   this is a SKIP, not a pass. ***`.
+3. A curated name that no longer resolves to a file is a **hard error**, not a
+   silent skip, so a fixture rename cannot quietly shrink the gate to nothing.
+   (`test_oracle.ml`'s allowlist filters missing entries instead — right for a
+   sweep that prints per-file verdicts, wrong for a pass/fail gate.)
+
+## Exclusions, and why
+
+Not every SIMD/NativeArray fixture is eligible; the excluded ones are listed in
+the script with reasons so they are not re-added:
+
+- `simd_bounds_panic`, `simd_lane_panic`,
+  `native_arr_map2_inline_length_panic` — assert a runtime panic, i.e. a
+  non-zero exit **by design**. The runner treats non-zero as failure, and
+  relaxing that would blind it to the crashes it exists to catch.
+- `simd_leak_probe` (~2,000,000 calls), `native_arr_fold_leak_probe`
+  (2 × 4,000,000-element folds) — chosen for exclusion rather than raising the
+  timeout. They are `live_allocs()` **leak** probes and this gate runs with
+  `detect_leaks=0`, so ASAN adds nothing to what they already assert, while
+  their iteration counts are the one thing that could blow the wall-clock bound.
+- `peak_rss` — asserts an RSS band that ASAN's shadow memory and redzones
+  invalidate by construction.
+
+Excluding those two probes is what keeps the standard 25s per-program hang
+backstop valid for the native corpus: measured under ASAN on linux/arm64, the
+slowest curated program runs in **0.06s**. The sweep's cost is compile time, not
+run time.
+
+## Verification
+
+Local macOS runs of this gate are worthless — ASAN binaries hang under
+CrowdStrike Falcon, confirmed here down to a two-line C `printf` program built
+with plain `clang -fsanitize=address` (30s alarm, rc=142). Everything below was
+measured in a Linux container built from `ci/Dockerfile.ubuntu` (linux/arm64,
+14 CPUs), which is the environment the gate actually runs in.
+
+| measurement | wall time |
+|---|---|
+| old gate (golden only), cold cache | 119s |
+| new gate, CI phase 1 (plain), cold cache | 156s |
+| new gate, CI phase 2 (`MARCH_TRMC=1`), same tree | 153s |
+| **both CI phases** | **309s (5m09s)** |
+
+The addition costs **+37s (+31%)** on phase 1. The job's ceiling is
+`timeout-minutes: 30` with 15 minutes per step, so both phases fit with wide
+headroom even allowing for GitHub's smaller runners. Phase 2 is not meaningfully
+cheaper than phase 1, which confirms `MARCH_TRMC` is part of the CAS cache key —
+it gets its own artifacts rather than reusing phase 1's.
+
+**Red proof.** A gate that cannot fail has added nothing. A scratch copy of
+`native_arr_narrow.march` (one of the newly-covered fixtures) with a single
+index changed — `NativeArray.get_u8(a, 2)` → `get_u8(a, 64)` on a 3-element
+array — makes the sweep fail, exit 1:
+
+```
+  [native/zz_asan_red_proof] SANITIZER FAIL (rc=1)
+    ==1223==ERROR: AddressSanitizer: heap-buffer-overflow ... READ of size 1
+        #0 native_u8_arr_get
+        #1 march_main
+    0x504000000070 is located 61 bytes after 35-byte region [0x504000000010,0x504000000033)
+    allocated by thread T0 here:
+        #0 calloc
+        #1 march_alloc
+        #2 native_arr_alloc march_runtime.c
+        #3 native_u8_arr_make
+=== native sanitize: 24 clean, 1 failed (of 25 programs) ===
+=== sanitize TOTAL: 72 programs swept — 71 clean, 1 failed ===
+```
+
+The scratch fixture lived only inside the container; the repo was mounted
+read-only and never carried it.
+
+This works because `march_alloc` is a straight `calloc` per object
+(`runtime/march_runtime.c:286`), so ASAN's malloc interceptor gives every March
+heap object its own redzones. A bump/arena allocator would have made March-heap
+overruns invisible to ASAN.
+
+One caveat surfaced in the reports: ASAN prints
+`WARNING: ASan doesn't fully support makecontext/swapcontext functions and may
+produce false positives in some cases!` because the scheduler runs green threads
+on `ucontext`. No false positive was observed — the actor-bearing goldens and
+`simd_actor_msg` are all clean — but it is the first thing to check if this gate
+ever goes red on a scheduler-heavy program.
+
+## A real bug found along the way
+
+Building the red proof surfaced a genuine memory-safety hole, filed as
+`specs/todos/2026-08-20-nativearray-get-set-unchecked-oob-compiled.md`:
+**compiled `NativeArray.get_*`/`set_*` do no bounds check at all**, across all
+five element families, so safe March code can read and write arbitrary heap
+memory with an out-of-range index. The interpreter checks and panics, the stdlib
+docs promise a panic, and `Bytes.get` gets it right — only the compiled
+`NativeArray` path is unguarded.
+
+Note this is *not* something the extended sweep finds on its own: every fixture
+in the corpus indexes in range. The gate reproduces it only once a program
+actually goes out of bounds, which is exactly what the red proof does.

--- a/specs/todos/2026-08-20-nativearray-get-set-unchecked-oob-compiled.md
+++ b/specs/todos/2026-08-20-nativearray-get-set-unchecked-oob-compiled.md
@@ -1,0 +1,126 @@
+`[P0]` Compiled `NativeArray.get_*` / `set_*` do no bounds check — safe March code can read and write arbitrary heap memory
+
+Filed 2026-08-20, found while building the deliberate-out-of-bounds RED proof for
+the SIMD/NativeArray extension of the ASAN gate
+(`specs/lang/golden/sanitize.sh`). The gate extension itself is green; this bug
+is reachable only with an out-of-range index, which no fixture in the corpus
+uses, so the sweep does not surface it on its own.
+
+## The bug
+
+Every `NativeArray` element accessor in the C runtime is a raw load/store with
+no bounds check:
+
+```c
+/* runtime/march_runtime.c:7417 */
+int64_t native_int_arr_get(void *arr, int64_t i) {
+    return *(int64_t *)((char *)arr + NATIVE_ARR_HDR + i * 8);
+}
+```
+
+The compiled backend calls these directly — `lib/tir/llvm_builtins.ml:631`
+emits `declare i64 @native_int_arr_get(ptr %arr, i64 %i)` and nothing wraps it —
+so an out-of-range index is an unchecked heap access from *safe* March code.
+
+Affected (all five element families, both directions):
+
+| function | runtime/march_runtime.c |
+|---|---|
+| `native_int_arr_get` / `_set` | 7417 / 7442 |
+| `native_float_arr_get` / `_set` | 7629 / 7636 |
+| `native_f32_arr_get` / `_set` | 7950 / 7955 |
+| `native_i32_arr_get` / `_set` | via `DEF_NARROW_INT_ARR`, 7837 / 7840 (inst. 7933) |
+| `native_u8_arr_get` / `_set` | via `DEF_NARROW_INT_ARR`, 7837 / 7840 (inst. 7934) |
+
+`_set` is the worse half: its FBIP unique-ownership fast path stores straight
+into `arr + NATIVE_ARR_HDR + i * sizeof(CTYPE)`, and its copy path stores into
+the freshly allocated `new_arr` at the same unchecked offset.
+
+## This contradicts both the docs and the interpreter
+
+`stdlib/native_array.march` documents a panic on all five getters — lines 73,
+138, 206, 266, 326: *"Return the element at index [i] (0-based). Panics if out
+of bounds."*
+
+The interpreter honours that. `lib/eval/eval.ml:8196` (int) and `:8584` (u8),
+and the corresponding `_set` cases at `:8203` / `:8591`, all range-check and
+`eval_error`. So this is an interpreter-vs-compiled divergence as well as a
+memory-safety hole — and one the oracle sweep cannot see, because
+`test/test_oracle.ml` compares programs that stay in range.
+
+## Reproduction (verified 2026-08-20, arm64 Darwin, commit 92286289)
+
+```march
+mod Oob do
+  needs IO.Console
+  fn main(_cap_console : Cap(IO.Console)) : () do
+    let a = NativeArray.make_u8(4, 7)
+    println(NativeArray.get_u8(a, 0))
+    println(NativeArray.get_u8(a, 1000000))   -- 1 MB past a 4-byte payload
+    println("survived")
+  end
+end
+```
+
+Interpreted — correct:
+
+```
+7
+native_u8_arr_get: index 1000000 out of bounds (len=4)
+rc=1
+```
+
+Compiled — silent OOB read, program continues:
+
+```
+7
+0
+survived
+rc=0
+```
+
+The write side, same shape (`NativeArray.set_u8(a, 64, 255)` on a 4-element
+array — 60 bytes past the payload): interpreted panics with
+`native_u8_arr_set: index 64 out of bounds (len=4)`; compiled prints
+`OOB WRITE survived, no panic` and exits 0.
+
+For contrast, `Bytes.get` *is* checked in compiled mode — the same program
+using `Bytes.get(b, 999999)` dies with `panic: Bytes.get: index out of bounds`.
+So this is specific to the `NativeArray` family, not a blanket policy of
+unchecked indexing.
+
+## The fix, and why it should be cheap
+
+The runtime already has exactly the right helper, written for the boxed `Array`
+family with a comment that states this bug's consequence in as many words:
+
+```c
+/* runtime/march_runtime.c:7020 — Index bounds check shared by get/set.
+ * Aborts with a clear message rather than silently reading or writing
+ * adjacent heap memory. */
+static void typed_array_check_bounds(int64_t i, int64_t len) { ... }
+```
+
+`NativeArray` simply never got it. The straightforward fix is to call the same
+check (or a `native_arr_` twin of it, reading the length from offset 16) at the
+top of each `get`/`set`, and once inside the `DEF_NARROW_INT_ARR` macro to cover
+`i32`/`u8` in one edit.
+
+Open question worth deciding before implementing: whether the check belongs in
+the runtime function (simple, correct, one branch per access) or should be
+elided by codegen when the index is provably in range. `NativeArray` exists for
+tight numeric loops, so a per-element branch in `get`/`set` is a real cost —
+but note the bulk operations (`sum`, `map`, `map2`, `fold`, `to_list`) all
+iterate `0..len` internally and would need no check at all, so the hot paths are
+mostly unaffected. Correctness first: land the unconditional check, then measure
+`bench/binary_trees.march` and `bench/list_ops.march` and optimise if it shows.
+
+## Guard to add with the fix
+
+Two panic fixtures under `test/native/`, modelled on the existing
+`simd_bounds_panic.march` / `native_arr_map2_inline_length_panic.march` (which
+assert a compiled binary's stderr): one for an out-of-range `get`, one for an
+out-of-range `set`. Note these will be *excluded* from
+`specs/lang/golden/sanitize.sh`'s curated native list by the same rule the
+existing panic fixtures are — that gate asserts a zero exit — which is fine;
+their coverage is the stderr diff in `test/dune`.


### PR DESCRIPTION
## The gap

`specs/lang/golden/sanitize.sh` swept exactly one corpus — the 47 programs in `specs/lang/golden/`. That corpus contains **zero** SIMD/NativeArray/Bytes programs:

```
$ grep -rliE 'simd|nativearray|native_arr|Bytes\.|f32|i32|u8' specs/lang/golden/*.march
$          # no output
```

Meanwhile `test/native/` holds ~27 SIMD / narrow-width `NativeArray` / array-backed-`Bytes` fixtures that `dune runtest` compiles and runs on both OSes — but that no sanitizer had ever compiled. That code had correctness coverage and no memory-safety coverage.

## What changed

The gate now sweeps **two** corpora, labelled separately so a failure names its source:

```
=== golden sanitize: 47 clean, 0 failed (of 47 programs) ===
=== native sanitize: 24 clean, 0 failed (of 24 programs) ===
=== sanitize TOTAL: 71 programs swept — 71 clean, 0 failed ===
```

The 24 native fixtures are pulled in **by name**, not moved into `specs/lang/golden/`, because that directory is also the cross-compile oracle corpus (`test_oracle.ml` narrows to `examples/ + specs/lang/golden/` in cross mode, so a SIMD program would drag arm64-vs-x86_64 vector codegen into an unrelated diff) and its count is pinned by `INDEX.md` + `check-docs.sh` Check C. The precedent followed is `test_oracle.ml`'s own `test_native_allowlist`. All of that reasoning is written into the script header so it does not get "simplified" back into a glob.

Panic-asserting fixtures, the two multi-million-iteration leak probes, and `peak_rss` are excluded with reasons in-file. Excluding the probes rather than raising the timeout is deliberate: they are `live_allocs` **leak** probes and this gate runs `detect_leaks=0`, so ASAN adds nothing to what they already assert — while their iteration counts are the one thing that could blow the wall-clock bound.

Three anti-vacuity changes, all aimed at a gate that reports success without having run:

- it prints the **program count it actually swept**, and exits 2 if that is 0;
- the Darwin/CrowdStrike-Falcon branch now says `*** 0 programs compiled, 0 run — this is a SKIP, not a pass. ***`;
- a curated name that no longer resolves is a **hard error**, not a silent skip, so a fixture rename cannot quietly shrink the gate.

## Red proof

A gate that cannot fail has added nothing. A scratch copy of `native_arr_narrow.march` with one index changed — `NativeArray.get_u8(a, 2)` → `get_u8(a, 64)` on a 3-element array — makes the sweep exit 1:

```
  [native/zz_asan_red_proof] SANITIZER FAIL (rc=1)
    ==ERROR: AddressSanitizer: heap-buffer-overflow ... READ of size 1
        #0 native_u8_arr_get
        #1 march_main
    0x504000000070 is located 61 bytes after 35-byte region [0x504000000010,0x504000000033)
    allocated by thread T0 here:
        #0 calloc  #1 march_alloc  #2 native_arr_alloc  #3 native_u8_arr_make
=== native sanitize: 24 clean, 1 failed (of 25 programs) ===
=== sanitize TOTAL: 72 programs swept — 71 clean, 1 failed ===
```

This works because `march_alloc` is a straight `calloc` per object, so every March heap object gets real ASAN redzones. The scratch fixture lived only inside the container; the repo was mounted read-only.

## :rotating_light: A real bug found while building that proof

Filed as `specs/todos/2026-08-20-nativearray-get-set-unchecked-oob-compiled.md`, and worth more attention than the CI wiring:

**Compiled `NativeArray.get_*` / `set_*` do no bounds check at all**, across all five element families, both directions. `runtime/march_runtime.c:7417` is one line with no check, and codegen calls it directly — so safe March code can read and write arbitrary heap memory with an out-of-range index.

```
interpreted:  native_u8_arr_get: index 1000000 out of bounds (len=4)   rc=1
compiled:     7 / 0 / survived                                          rc=0
```

The interpreter checks and panics, the stdlib docs promise a panic (5 sites), and `Bytes.get` gets it right — only the compiled `NativeArray` path is unguarded. The runtime already has the right helper (`typed_array_check_bounds`, written for the boxed `Array` family, whose comment says it exists "rather than silently reading or writing adjacent heap memory"); `NativeArray` never got it.

Note this is **not** something the extended sweep finds on its own — every fixture in the corpus indexes in range. Not fixed here; the todo has a proposed fix and the guard tests to land with it.

## Verification

ASAN is unusable on a Falcon-managed Mac — confirmed down to a two-line C `printf` built with plain `clang -fsanitize=address` (30s alarm, rc=142). Everything below was measured in a Linux container built from `ci/Dockerfile.ubuntu`, which is the environment the gate actually runs in.

| | wall |
|---|---|
| old gate (golden only), cold cache | 119s |
| **new gate, CI phase 1** (plain), cold cache | **156s** (+37s, +31%) |
| **new gate, CI phase 2** (`MARCH_TRMC=1`), same tree | **153s** |
| **both CI phases** | **309s (5m09s)** |

Against `timeout-minutes: 30` on the job and 15 minutes per step — wide headroom. Phase 2 is not cheaper than phase 1, which confirms `MARCH_TRMC` is part of the CAS cache key. Per-program ASAN *runtime* maxes at 0.06s; the sweep's cost is compile time, not run time.

Test suites, run directly (the box was under heavy load from a concurrent session, so these were re-run clean): codegen 584, compiler 924, eval 262, stdlib 865, stdlib_march 61 — **2696 OK, 0 FAIL**. `scripts/check-docs.sh` passes; the golden count is still 47, so Check C is untouched.
