### PR TITLE
fix(runtime): NativeArray element accessors must bounds-check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ git log is authoritative for exact commits.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Compiled `NativeArray.get_*` / `set_*` now bounds-check, as the docs and the
+  interpreter always promised.** Every element accessor was a raw load/store at
+  `arr + header + i * sizeof(elem)` with no range test, so an out-of-range index
+  from ordinary safe March code read or wrote arbitrary heap memory — `set` worst
+  of all, since both its in-place fast path and its copy path stored at the
+  unchecked offset. `stdlib/native_array.march` has always documented "Panics if
+  out of bounds" and the interpreter has always honoured it, so this was also an
+  interpreter/compiled divergence, and one the differential oracle could not see
+  because it only compares programs that stay in range. All ten accessors (five
+  element widths × get/set) now panic with the interpreter's exact message. The
+  bulk map/fold paths are deliberately unguarded — they derive indices from a
+  length they just read, so they are in range by construction — which is why the
+  cost is ~1% on a pure-indexing loop and nothing measurable on bulk numeric work.
+
 ### Added
 
 - **The AddressSanitizer CI gate now covers the SIMD, narrow-width `NativeArray`

--- a/runtime/march_runtime.c
+++ b/runtime/march_runtime.c
@@ -7450,11 +7450,50 @@ void *native_int_arr_make(int64_t len, int64_t def) {
     return arr;
 }
 
+/* Index bounds check for the NativeArray element accessors.
+ *
+ * Every native_*_arr_get/_set used to be a raw load/store at
+ * `arr + NATIVE_ARR_HDR + i * sizeof(elem)` with no range test, so an
+ * out-of-range index from SAFE March code read or wrote arbitrary heap
+ * memory — `_set` worst of all, since both its FBIP in-place path and its
+ * copy path stored at the unchecked offset. stdlib/native_array.march has
+ * always documented "Panics if out of bounds" and the interpreter has always
+ * honoured it (lib/eval/eval.ml), so this was an interp/compiled divergence
+ * as well as a memory-safety hole — and one the oracle sweep could not see,
+ * because it only compares programs that stay in range.
+ *
+ * `fn` names the accessor so the message pins WHICH one tripped, and the
+ * "<fn>: index N out of bounds (len=M)" tail is byte-identical to the
+ * interpreter's wording; test/native/native_arr_bounds_panic.march asserts
+ * that substring for all ten accessors, so the two backends cannot drift.
+ * The "march: runtime error: " prefix matches the other compiled bounds
+ * panics (typed_array_check_bounds, march_simd_bounds_panic) rather than the
+ * interpreter's bare form — see simd_bounds_panic.march's note that the two
+ * backends deliberately differ in prefix only.
+ *
+ * Length lives at byte offset 16 for every native array width, which is what
+ * the per-width native_*_arr_length accessors read.
+ *
+ * Scope: the USER-FACING accessors only. The inline map/fold fast paths
+ * (llvm_emit's $mapfast$ / nmap_body clones, and the *_fold bodies here)
+ * generate their own indices from a length they just read, so they are in
+ * range by construction; checking them would add a branch per element to
+ * exactly the loops NativeArray exists to make fast. */
+static void native_arr_check_bounds(const char *fn, int64_t i, int64_t len) {
+    if (i < 0 || i >= len) {
+        fprintf(stderr,
+            "march: runtime error: %s: index %lld out of bounds (len=%lld)\n",
+            fn, (long long)i, (long long)len);
+        exit(1);
+    }
+}
+
 int64_t native_int_arr_length(void *arr) {
     return *(int64_t *)((char *)arr + 16);
 }
 
 int64_t native_int_arr_get(void *arr, int64_t i) {
+    native_arr_check_bounds("native_int_arr_get", i, native_int_arr_length(arr));
     return *(int64_t *)((char *)arr + NATIVE_ARR_HDR + i * 8);
 }
 
@@ -7480,6 +7519,7 @@ int64_t native_int_arr_get(void *arr, int64_t i) {
  * alias keeps its own). The rc == 1 gate also excludes interned/immortal
  * arrays (rc >= MARCH_RC_IMMORTAL), which are never mutated in place. */
 void *native_int_arr_set(void *arr, int64_t i, int64_t val) {
+    native_arr_check_bounds("native_int_arr_set", i, native_int_arr_length(arr));
     if (IS_HEAP_PTR(arr) && ((march_hdr *)arr)->rc == 1) {
         *(int64_t *)((char *)arr + NATIVE_ARR_HDR + i * 8) = val;
         return arr;
@@ -7669,6 +7709,7 @@ int64_t native_float_arr_length(void *arr) {
 }
 
 double native_float_arr_get(void *arr, int64_t i) {
+    native_arr_check_bounds("native_float_arr_get", i, native_float_arr_length(arr));
     double v; memcpy(&v, (char *)arr + NATIVE_ARR_HDR + i * 8, 8); return v;
 }
 
@@ -7676,6 +7717,7 @@ double native_float_arr_get(void *arr, int64_t i) {
  * ownership contract (identical: owned/consumed arg, unique-owner mutates in
  * place, shared array copies-on-write then releases our reference). */
 void *native_float_arr_set(void *arr, int64_t i, double val) {
+    native_arr_check_bounds("native_float_arr_set", i, native_float_arr_length(arr));
     if (IS_HEAP_PTR(arr) && ((march_hdr *)arr)->rc == 1) {
         memcpy((char *)arr + NATIVE_ARR_HDR + i * 8, &val, 8);
         return arr;
@@ -7878,9 +7920,11 @@ void *PREFIX##_make(int64_t len, int64_t def) {                               \
 }                                                                             \
 int64_t PREFIX##_length(void *arr) { return *(int64_t *)((char *)arr + 16); } \
 int64_t PREFIX##_get(void *arr, int64_t i) {                                  \
+    native_arr_check_bounds(#PREFIX "_get", i, PREFIX##_length(arr));         \
     return (int64_t)*(CTYPE *)((char *)arr + NATIVE_ARR_HDR + i * sizeof(CTYPE)); \
 }                                                                             \
 void *PREFIX##_set(void *arr, int64_t i, int64_t val) {                       \
+    native_arr_check_bounds(#PREFIX "_set", i, PREFIX##_length(arr));         \
     if (IS_HEAP_PTR(arr) && ((march_hdr *)arr)->rc == 1) {                    \
         *(CTYPE *)((char *)arr + NATIVE_ARR_HDR + i * sizeof(CTYPE)) = (CTYPE)val; \
         return arr;                                                           \
@@ -7993,11 +8037,13 @@ void *native_f32_arr_make(int64_t len, double def) {
 int64_t native_f32_arr_length(void *arr) { return *(int64_t *)((char *)arr + 16); }
 
 double native_f32_arr_get(void *arr, int64_t i) {
+    native_arr_check_bounds("native_f32_arr_get", i, native_f32_arr_length(arr));
     return (double)*(float *)((char *)arr + NATIVE_ARR_HDR + i * 4);
 }
 
 /* FBIP/COW contract identical to native_float_arr_set above. */
 void *native_f32_arr_set(void *arr, int64_t i, double val) {
+    native_arr_check_bounds("native_f32_arr_set", i, native_f32_arr_length(arr));
     if (IS_HEAP_PTR(arr) && ((march_hdr *)arr)->rc == 1) {
         *(float *)((char *)arr + NATIVE_ARR_HDR + i * 4) = (float)val;
         return arr;

--- a/specs/progress/2026-08-20-nativearray-get-set-unchecked-oob-compiled.md
+++ b/specs/progress/2026-08-20-nativearray-get-set-unchecked-oob-compiled.md
@@ -1,4 +1,4 @@
-`[P0]` Compiled `NativeArray.get_*` / `set_*` do no bounds check — safe March code can read and write arbitrary heap memory
+# Compiled `NativeArray.get_*` / `set_*` did no bounds check — safe March code could read and write arbitrary heap memory (FIXED 2026-08-20)
 
 Filed 2026-08-20, found while building the deliberate-out-of-bounds RED proof for
 the SIMD/NativeArray extension of the ASAN gate
@@ -124,3 +124,67 @@ out-of-range `set`. Note these will be *excluded* from
 `specs/lang/golden/sanitize.sh`'s curated native list by the same rule the
 existing panic fixtures are — that gate asserts a zero exit — which is fine;
 their coverage is the stderr diff in `test/dune`.
+
+
+---
+
+# Fixed 2026-08-20
+
+`native_arr_check_bounds(fn, i, len)` in `runtime/march_runtime.c`, called as the
+first statement of all ten accessors. `i32`/`u8` are covered by one edit inside
+`DEF_NARROW_INT_ARR` (the message stringifies `PREFIX`), so there are six edit
+sites for ten functions. For `_set` the check precedes BOTH the FBIP in-place
+path and the copy path, which is where the write-side hole was.
+
+The message is `march: runtime error: <fn>: index N out of bounds (len=M)`. The
+prefix follows the other compiled bounds panics (`typed_array_check_bounds`,
+`march_simd_bounds_panic`); the tail is byte-identical to the interpreter's
+wording in `lib/eval/eval.ml`, so the regression test pins interp/compiled
+parity as well as the check itself.
+
+## Deliberately NOT checked: the bulk paths
+
+Only the user-facing accessors are guarded. The inline map/fold fast paths
+(`llvm_emit`'s `$mapfast$` / `nmap_body` clones, and the `*_fold` bodies) derive
+their indices from a length they just read, so they are in range by
+construction, and a per-element branch there would tax exactly the loops
+NativeArray exists to make fast. Confirmed empirically: a `bench/simd_map.march`
+binary contains **zero** occurrences of the check string, i.e. the bulk path
+does not reach a guarded accessor at all.
+
+## Cost, measured (A/B, same box, interleaved)
+
+Worst case is a loop that does nothing but indexed access — 10M `set_int` plus
+10M `get_int`, `--compile --opt 2`, baseline vs fixed runtime, first-position
+warmup discarded:
+
+| | median | min |
+|---|---|---|
+| baseline | 108.0 ms | 104 ms |
+| with check | 109.5 ms | 108 ms |
+| delta | **+1.4%** | +3.8% |
+
+So ~1-4% on a pure-indexing loop, and nothing measurable on bulk numeric work.
+That is the price of not being able to read and write arbitrary heap memory from
+safe code.
+
+## Regression test
+
+`test/native/native_arr_bounds_panic.march` + the `runtest` rule in `test/dune`.
+One binary, ten selectors chosen by `System.argv()` (a panic ends the process,
+so the accessors cannot share a run); the rule drives all ten and asserts the
+exact message for each, naming the selector on failure.
+
+Non-vacuity: against the pre-fix runtime (file-copy swap, not `git stash`),
+**10/10 selectors do not panic and exit 0**, so the rule exits 1. With the fix,
+all ten panic with the parity message.
+
+Boundary behaviour verified separately: `i = len-1` works, `i = len` panics,
+`i = -1` panics.
+
+## Note on the verification run
+
+`native_signal_watch` reddened during this work and is **unrelated** — a
+pre-existing ~7% output-ordering flake, measured at 4/60 on BOTH the baseline and
+fixed runtimes when run interleaved. Filed as
+`specs/todos/2026-08-20-signal-watch-output-ordering-flake.md`.

--- a/specs/todos/2026-08-20-signal-watch-output-ordering-flake.md
+++ b/specs/todos/2026-08-20-signal-watch-output-ordering-flake.md
@@ -1,0 +1,72 @@
+# `native_signal_watch` has a ~7% output-ordering flake
+
+Filed 2026-08-20, found while verifying the NativeArray bounds-check fix
+(`specs/progress/2026-08-20-nativearray-get-set-unchecked-oob-compiled.md`),
+whose `dune runtest` run this test reddened. It is **not** related to that
+change — see the control below.
+
+## The flake
+
+`test/native/signal_watch.expected` pins:
+
+```
+before raise
+after raise
+caught usr2
+```
+
+Two different wrong outputs were observed:
+
+```
+before raise
+after raisecaught usr2          <- handler's write lands mid-line, no newline
+```
+```
+before raise
+caught usr2
+after raise                      <- handler observed BEFORE the main thread's line
+```
+
+So both the interleaving *and* the ordering of the handler's output against the
+main thread's are unpinned. The fixture raises SIGUSR2 and expects the handler's
+line to appear strictly after `after raise`, which is only true if the handler's
+delivery is deferred to a drain point that happens to fall there.
+
+## Measurement — the change under test is exonerated
+
+Both binaries built from the same tree, differing only in the runtime, then run
+INTERLEAVED (so contention is shared evenly across arms — the box was at load
+average ~8 on 14 cores at the time):
+
+| runtime | mismatched |
+|---|---|
+| baseline (no bounds check) | 4/60 |
+| with the bounds check | 4/60 |
+
+Identical. Neither binary even links the new check (`strings | grep -c
+"out of bounds (len="` is 0 for both), and `signal_watch.march` never mentions
+`NativeArray`, so the change is mechanically inert here.
+
+Worth recording the trap: an earlier, smaller sample read 0/20 baseline vs 2/20
+fixed, which looks alarming and is not significant — at a ~7% rate, 0/20 happens
+about 12% of the time by chance. A 20-run spot check cannot resolve a flake of
+this size; the interleaved 60-run pair could.
+
+## Fix
+
+Make the assertion insensitive to the delivery point, or make the delivery point
+deterministic. Either pin only that all three lines appear (order-free, as
+`native_actor_monitor_down_reason`'s rule does with per-line `grep -Eq`), or
+have the fixture drain signals at an explicit synchronisation point before
+printing `after raise` so the ordering is guaranteed rather than typical.
+
+Prefer the second if the ordering is meant to be part of the contract — an
+order-free assertion would stop pinning "the handler does not run before the
+raise returns", which may be the property the fixture exists to check. Read
+`specs/progress/2026-08-11-signal-watch-stage-b.md` (Signal.watch Stage B)
+before choosing.
+
+## Acceptance
+
+200 consecutive runs with no mismatch, on a loaded box (an idle box hides it —
+the observed rate roughly tracks contention).

--- a/test/dune
+++ b/test/dune
@@ -4430,6 +4430,48 @@ printf 'mod CsHelper do\\n\\n  fn double(x : Int) : Int do\\n    x * 2\\n  end\\
  (alias runtest)
  (action (diff native/native_arr_narrow.expected native_arr_narrow.out)))
 
+; ── NativeArray element accessors bounds-check (P0 memory safety) ────────
+; Every native_*_arr_get/_set was a raw load/store at
+; `arr + NATIVE_ARR_HDR + i * sizeof(elem)` with no range test, so safe March
+; code could read and write arbitrary heap memory -- `_set` worst, since both
+; its FBIP in-place path and its copy path stored at the unchecked offset.
+; stdlib/native_array.march documents "Panics if out of bounds" and the
+; interpreter always honoured it, so this was an interp/compiled divergence
+; too, invisible to the oracle sweep (which only compares in-range programs).
+;
+; A panic ends the process, so the ten accessors cannot share one run: the
+; fixture selects one via argv and this rule drives all ten, asserting the
+; exact message each time. That pins interp/compiled parity as well as the
+; check itself -- the "<fn>: index N out of bounds (len=M)" tail is
+; byte-identical to lib/eval/eval.ml's wording.
+(rule
+ (targets native_arr_bounds_panic)
+ (deps (file %{exe:../bin/main.exe})
+       (glob_files ../runtime/*.c) (glob_files ../runtime/*.h)
+       (file native/native_arr_bounds_panic.march)
+       (source_tree ../stdlib))
+ (action
+  (run %{exe:../bin/main.exe} --compile -o native_arr_bounds_panic
+       native/native_arr_bounds_panic.march)))
+
+(rule
+ (alias runtest)
+ (deps (file native_arr_bounds_panic))
+ (action
+  (run bash -c
+    "fail=0; \
+     for sel in int_get int_set float_get float_set f32_get f32_set i32_get i32_set u8_get u8_set; do \
+       fam=${sel%_*}; dir=${sel##*_}; \
+       out=$(./native_arr_bounds_panic \"$sel\" 2>&1); rc=$?; \
+       want=\"native_${fam}_arr_${dir}: index 1000000 out of bounds (len=4)\"; \
+       if [ $rc -eq 0 ]; then \
+         echo \"native_arr_bounds_panic[$sel]: NO PANIC (exit 0) -- an out-of-range index read or wrote out of bounds silently. Output: $out\" >&2; fail=1; \
+       elif ! printf '%s' \"$out\" | grep -qF \"$want\"; then \
+         echo \"native_arr_bounds_panic[$sel]: panicked but the message does not match the interpreter's. want substring: $want -- got: $out\" >&2; fail=1; \
+       fi; \
+     done; \
+     exit $fail")))
+
 ; Compiled/interpreted parity witness for NativeArray.fold_int/fold_float/
 ; fold_f32/fold_i32/fold_u8 (SIMD follow-ups Task 2). fold_int/fold_float
 ; previously had no compiled implementation (link error); fold_f32/fold_i32/

--- a/test/native/native_arr_bounds_panic.march
+++ b/test/native/native_arr_bounds_panic.march
@@ -1,0 +1,46 @@
+-- Compiled NativeArray element accessors must bounds-check, like the
+-- interpreter already does and like stdlib/native_array.march documents
+-- ("Panics if out of bounds", lines 73/138/206/266/326).
+--
+-- They did not: every get/set was a raw load/store at
+-- `arr + NATIVE_ARR_HDR + i * sizeof(elem)` with no range test, so safe March
+-- code could read and write arbitrary heap memory. `set` was the worse half —
+-- both its FBIP in-place path and its copy path stored at the unchecked
+-- offset. See specs/progress/2026-08-20-nativearray-get-set-unchecked-oob-compiled.md.
+--
+-- One binary, ten selectors, driven by test/dune: a panic ends the process, so
+-- each accessor needs its own run. The dune rule asserts the exact message for
+-- each, which also pins interp/compiled parity — the messages are byte-identical
+-- to eval.ml's (lib/eval/eval.ml:8201-8596).
+--
+-- Index 1000000 is far past every array here, so a missing check reads or
+-- writes ~1 MB out of bounds rather than landing in adjacent padding, which is
+-- what makes the pre-fix failure visible rather than silently benign.
+mod Main do
+  needs IO.Console
+  needs IO.Process
+
+  fn selector() : String do
+    match System.argv() do
+      Cons(_exe, Cons(w, _)) -> w
+      _ -> "missing-selector"
+    end
+  end
+
+  fn main(_cap_console : Cap(IO.Console), _cap_process : Cap(IO.Process)) : () do
+    let i = 1000000
+    match selector() do
+      "int_get"   -> println(int_to_string(NativeArray.get_int(NativeArray.make_int(4, 7), i)))
+      "int_set"   -> println(int_to_string(NativeArray.get_int(NativeArray.set_int(NativeArray.make_int(4, 7), i, 1), 0)))
+      "float_get" -> println(float_to_string(NativeArray.get_float(NativeArray.make_float(4, 7.0), i)))
+      "float_set" -> println(float_to_string(NativeArray.get_float(NativeArray.set_float(NativeArray.make_float(4, 7.0), i, 1.0), 0)))
+      "f32_get"   -> println(float_to_string(NativeArray.get_f32(NativeArray.make_f32(4, 7.0), i)))
+      "f32_set"   -> println(float_to_string(NativeArray.get_f32(NativeArray.set_f32(NativeArray.make_f32(4, 7.0), i, 1.0), 0)))
+      "i32_get"   -> println(int_to_string(NativeArray.get_i32(NativeArray.make_i32(4, 7), i)))
+      "i32_set"   -> println(int_to_string(NativeArray.get_i32(NativeArray.set_i32(NativeArray.make_i32(4, 7), i, 1), 0)))
+      "u8_get"    -> println(int_to_string(NativeArray.get_u8(NativeArray.make_u8(4, 7), i)))
+      "u8_set"    -> println(int_to_string(NativeArray.get_u8(NativeArray.set_u8(NativeArray.make_u8(4, 7), i, 1), 0)))
+      _           -> println("unknown selector")
+    end
+  end
+end


### PR DESCRIPTION
**Memory-safety fix.** Every `native_*_arr_get`/`_set` was a raw load/store at `arr + NATIVE_ARR_HDR + i * sizeof(elem)` with **no range test**, so an out-of-range index from ordinary *safe* March code read or wrote arbitrary heap memory. `_set` was the worse half: both its FBIP unique-ownership in-place path and its copy path stored at the unchecked offset.

```march
let a = NativeArray.make_u8(4, 7)
NativeArray.get_u8(a, 1000000)     -- reads 1 MB past a 4-byte payload
```

Interpreted, that panics. Compiled, it printed `0` and the program continued; the write side printed nothing and exited 0.

`stdlib/native_array.march` has always documented *"Panics if out of bounds"* (lines 73/138/206/266/326) and `lib/eval/eval.ml` has always honoured it — so this was an **interpreter/compiled divergence** as well as a memory-safety hole, and one `test/test_oracle.ml` structurally cannot see because it only compares programs that stay in range. `Bytes.get` **is** checked when compiled, so this was specific to the NativeArray family rather than a deliberate policy.

Found by the deliberate-out-of-bounds RED proof written while extending the ASAN gate to SIMD/NativeArray (#312). The gate itself is green — no fixture in the corpus uses an out-of-range index, which is exactly why this survived.

## The fix

`native_arr_check_bounds(fn, i, len)`, called as the first statement of all ten accessors. `i32`/`u8` are covered by one edit inside `DEF_NARROW_INT_ARR` (the message stringifies `PREFIX`), so **six edit sites cover ten functions**. For `_set` the check precedes *both* stores. Length is at byte offset 16 for every width, which is what the per-width `*_length` accessors already read.

Message: `march: runtime error: <fn>: index N out of bounds (len=M)`. The prefix matches the other compiled bounds panics (`typed_array_check_bounds`, `march_simd_bounds_panic`); the tail is byte-identical to the interpreter's wording, so the regression test pins **interp/compiled parity** as well as the check itself.

## Deliberately NOT checked: the bulk paths

`llvm_emit`'s inline `$mapfast$` / `nmap_body` clones and the `*_fold` bodies derive their indices from a length they just read, so they are in range by construction, and a per-element branch there would tax exactly the loops NativeArray exists to make fast.

Confirmed empirically rather than assumed: a `bench/simd_map.march` binary contains **zero** occurrences of the check string — the bulk path never reaches a guarded accessor.

## Cost (A/B on one box, interleaved, first-position warmup discarded)

Worst case is a loop doing nothing but indexed access — 10M `set_int` + 10M `get_int`, `--compile --opt 2`:

| | median | min |
|---|---|---|
| baseline | 108.0 ms | 104 ms |
| with check | 109.5 ms | 108 ms |
| **delta** | **+1.4%** | +3.8% |

Nothing measurable on bulk numeric work. That is the price of not being able to read and write arbitrary heap memory from safe code.

## Regression test

`test/native/native_arr_bounds_panic.march` + a `runtest` rule. A panic ends the process, so the ten accessors cannot share one run: the fixture picks one via `System.argv()` and the rule drives all ten, asserting the exact message and naming the selector on failure.

**Non-vacuity:** against the pre-fix runtime (file-copy swap, not `git stash`), **10/10 selectors do not panic and exit 0**, so the rule exits 1. With the fix all ten panic with the parity message.

**Boundaries** verified separately: `i = len-1` works, `i = len` panics, `i = -1` panics.

## Verification

| Check | Result |
|---|---|
| `scripts/run-tests.sh` | exit 0, all suites passed |
| `scripts/check-docs.sh` | exit 0, doc-lint passed |
| `dune runtest` | green except `native_signal_watch` (see below) |
| Local ASAN gate | **SKIPPED — 0 programs compiled, 0 run** (CrowdStrike Falcon on this host); runs for real on CI's ubuntu leg |

`native_signal_watch` reddened during verification and is **unrelated**: a pre-existing ~7% output-ordering flake, measured **4/60 on both** the baseline and fixed runtimes run interleaved. Neither binary even links the new check, and the fixture never mentions `NativeArray`. Filed as `specs/todos/2026-08-20-signal-watch-output-ordering-flake.md`, which also records the measurement trap — an earlier 20-run sample read 0/20 vs 2/20, which looks alarming and is not significant at that rate.
