### PR TITLE
docs(todo): update Signal.watch trmc-suite flake with PR #317 evidence

### DIFF
--- a/specs/todos/2026-08-21-signal-watch-capturing-handler-trmc-suite-flake.md
+++ b/specs/todos/2026-08-21-signal-watch-capturing-handler-trmc-suite-flake.md
@@ -70,6 +70,18 @@ not strong enough alone to prove a real code defect over a marginal,
 load-sensitive race (e.g. in the signal-delivery drain point relative to
 when the 25-iteration loop launches/reaps the compiled subprocess).
 
+**UPDATE (2026-08-21, later same day):** PR #317 (`fix(codegen):
+typed_array_* must box a scalar entering its erased slot`, unrelated
+`lib`/`runtime` code touching `typed_array_*` builtins, not signal
+handling) merged with `trmc-suite` **passing cleanly**, including this
+exact test. Tally is now 2 passes (main's post-merge run of #315, #317) vs
+2 failures (both of #316's runs), across three different PRs touching
+unrelated code. This is strong confirmation of genuine intermittent
+flakiness rather than a defect in any of the PRs that happened to trip it —
+closing the loop on the "is this real" question raised above. The
+`## Suggested next step` below still applies to whoever picks this up; the
+flake itself remains unfixed.
+
 ## Suggested next step
 
 Same shape as the other Signal.watch flake's fix suggestion: either make


### PR DESCRIPTION
## Summary
- Updates specs/todos/2026-08-21-signal-watch-capturing-handler-trmc-suite-flake.md (filed while landing #316) with additional evidence: PR #317 merged with `trmc-suite` passing cleanly, including the exact test that failed twice on #316's CI runs.
- Tally: 2 passes (main's post-merge run of #315, #317) vs 2 failures (both of #316's runs), across three PRs touching unrelated code — this confirms the earlier failure was genuine intermittent flakiness, not a defect introduced by #316.

Docs-only change, no code touched.

## Test plan
- N/A — documentation update only.