### PR TITLE
test(dune): run the task_await and monitor-Down fixtures under multi-scheduler

### DIFF
--- a/specs/todos/2026-08-20-actor-monitor-bounded-mailbox-race.md
+++ b/specs/todos/2026-08-20-actor-monitor-bounded-mailbox-race.md
@@ -1,0 +1,92 @@
+# `actor_monitor_down_reason`'s `PrimeBounded` case is racy at >1 scheduler
+
+Filed 2026-08-20, from the work that gave the `native_actor_monitor_down_reason`
+multi-scheduler loop real output assertions (`test/dune`, the
+`MARCH_NUM_SCHEDULERS=4` 100-iteration rule).
+
+## The flake
+
+`test/native/actor_monitor_down_reason.march` asserts, in the `Watcher` actor:
+
+```march
+on PrimeBounded(expected, watcher) do
+  let queued = mailbox_size(watcher)     -- sampled at handler ENTRY
+  match receive() do
+    Down.Down(ref, target, DownReason.Killed) ->
+      if to_string(target) == to_string(expected) && queued == 1 do
+```
+
+but `main` sets that up as (lines 155-157):
+
+```march
+monitor(watcher, killed)
+send(watcher, PrimeBounded(killed, watcher))
+kill(killed)                              -- the Down is enqueued HERE
+```
+
+`PrimeBounded` is sent *before* `kill`. The `queued == 1` assertion therefore
+only holds if `main` reaches `kill(killed)` — and the resulting `Down` is
+enqueued on the watcher's mailbox — before the watcher's green thread is
+dispatched onto `PrimeBounded`. Under `MARCH_NUM_SCHEDULERS=1` that is
+guaranteed: nothing else can run while `main` is running. At >1 scheduler
+another OS thread can pick the watcher up immediately after the `send`, sample
+`mailbox_size` as 0, block in `receive()` until the `Down` finally arrives,
+match the target, and then fail `queued == 1` — so the process dies with
+
+```
+panic: bounded Down or mailbox count mismatch
+```
+
+and exits 1, having printed only the first of the five expected lines.
+
+## Measured rate
+
+On a loaded 14-core macOS box (other agents' builds plus several 95%-CPU
+processes running concurrently; `load average ~15`):
+
+| Harness | Runs | Failures |
+|---|---|---|
+| Old exit-code-only loop form, 12 workers x 1000 | 12000 | 7 (`panic: bounded Down or mailbox count mismatch`) |
+| Old exit-code-only loop form, 8 workers x 100 | 800 | 0 |
+| Old exit-code-only loop form, serial | 500 | 0 |
+| New capture+grep loop, 25 x the real 100-iteration dune loop | 2500 | 1 (same panic) |
+
+So roughly 0.04–0.06% per run under contention and ~0 when the box is idle,
+i.e. a ~4% chance of reddening the 100-iteration CI loop on a busy machine.
+These are upper bounds — the box was heavily contended throughout.
+
+**This is not new.** The loop has always propagated the binary's exit status
+(`... >/dev/null || exit $?`), so the pre-change form tripped on exactly the
+same panic; the table above is a direct A/B of the two loop bodies against the
+same binary. Capturing stdout neither caused it nor made it more likely.
+
+## Options
+
+1. **Reorder the fixture**: `kill(killed)` before `send(watcher, PrimeBounded(...))`.
+   Mailbox FIFO then puts the `Down` ahead of `PrimeBounded` unconditionally,
+   which is what the assertion is actually trying to express ("the queued Down
+   is counted exactly once, and a bounded drop_new user mailbox did not drop
+   it"). Needs a check that it does not weaken the drop_new coverage the
+   current ordering was chosen for, and the single-scheduler golden
+   (`native_actor_monitor_down_reason.out`) must be re-confirmed.
+2. **Make the watcher wait**, e.g. reuse `wait_for_queued_message` before
+   sampling `mailbox_size`, so the sample is taken after the `Down` lands.
+   Keeps main's ordering but makes the count assertion less sharp.
+3. **Accept and pin**: drop the multi-scheduler loop back to
+   `MARCH_NUM_SCHEDULERS=1`. This is the wrong trade — that loop is the only
+   thing exercising Down delivery across scheduler threads, which is where
+   PR #310's spurious-wake actor kill hid.
+
+Option 1 looks right. Whoever takes it should re-measure with the 12x1000
+harness above, not a 60-run spot check: at 0.05% a 60-run sample sees nothing.
+
+## Not to be confused with
+
+Three separate `exit 137` (SIGKILL) observations during the same session, on
+three *different* native fixtures (`native_actor_monitor_down_reason`,
+`native_task_await_ptr`, `native_actor_stress`), roughly 1 per 300-500 runs.
+Nothing in `runtime/` raises or sends `SIGKILL`, the rate did not depend on
+scheduler count (`native_task_await_ptr`: 1/1600 at the default count,
+0/1400 pinned to 1), and the box was under heavy memory/CPU pressure from
+other work — most likely host-level. Worth re-checking on an idle machine
+before attributing any of it to March.

--- a/test/dune
+++ b/test/dune
@@ -3227,9 +3227,23 @@ printf 'mod CsHelper do\\n\\n  fn double(x : Int) : Int do\\n    x * 2\\n  end\\
 ; ── 4*n+3); march_task_await wraps that straight into Ok, and the Ok(n)
 ; ── destructure untags only once, leaving 2*n+1.  Pre-fix this printed
 ; ── await=85 / sum=123 / stream_sum=115 instead of 42 / 60 / 55.  Compile
-; ── natively, run single-threaded (deterministic), diff stdout.
+; ── natively and diff stdout.
+;
+; Run TWICE, both diffed against the SAME .expected: once pinned to
+; MARCH_NUM_SCHEDULERS=1 (the golden artifact -- deterministic by
+; construction) and once at the DEFAULT scheduler count (four OS threads).
+; The pin alone never exercises the multi-thread scheduler, and that is
+; exactly the configuration that hid the spurious-wake race fixed in PR #310
+; (a wake with an empty mailbox killed a live actor: compiled only, >1
+; scheduler thread only, ~4% of runs).  Task.await parks and is woken by the
+; completing task, so it rides the same park/wake path.  The unpinned run is
+; a SEPARATE target rather than a replacement for the pin: if multi-scheduler
+; output ever does turn nondeterministic, the failure names
+; native_task_await_int_multi.out and says so, instead of turning the
+; long-standing golden into a mystery flake.
 (rule
- (targets native_task_await_int native_task_await_int.out)
+ (targets native_task_await_int native_task_await_int.out
+          native_task_await_int_multi.out)
  (deps (file %{exe:../bin/main.exe})
        (file ../runtime/march_runtime.c) (file ../runtime/march_runtime.h)
        (file ../runtime/march_scheduler.c) (file ../runtime/march_scheduler.h)
@@ -3245,11 +3259,18 @@ printf 'mod CsHelper do\\n\\n  fn double(x : Int) : Int do\\n    x * 2\\n  end\\
    (run %{exe:../bin/main.exe} --compile -o native_task_await_int
         native/task_await_int.march)
    (with-stdout-to native_task_await_int.out
-        (system "MARCH_NUM_SCHEDULERS=1 ./native_task_await_int")))))
+        (system "MARCH_NUM_SCHEDULERS=1 ./native_task_await_int"))
+   (with-stdout-to native_task_await_int_multi.out
+        (system "./native_task_await_int")))))
 
 (rule
  (alias runtest)
  (action (diff native/task_await_int.expected native_task_await_int.out)))
+
+; Same golden, default (multi-OS-thread) scheduler -- see the PR #310 note above.
+(rule
+ (alias runtest)
+ (action (diff native/task_await_int.expected native_task_await_int_multi.out)))
 
 ; ── Actor + task runtime stress (test/apps/actor_stress.march): five actors,
 ; ── receive()-in-handler, FIFO ordering, and Task async/await/await_many/
@@ -3285,10 +3306,18 @@ printf 'mod CsHelper do\\n\\n  fn double(x : Int) : Int do\\n    x * 2\\n  end\\
 ; ── march_task_await wraps it into Ok, but the Ok(x) destructure loads a ptr
 ; ── field raw, so pre-fix the String/List payload was a wild ~2*addr pointer
 ; ── -> `march: out of memory` / SIGSEGV.  The i64 case (6*7 -> 42) guards the
-; ── shared single-ashr untag path (double-tag 4*n+3).  Run single-threaded so
-; ── the sequential await prints serialise deterministically; diff stdout.
+; ── shared single-ashr untag path (double-tag 4*n+3).  Diff stdout.
+;
+; Run TWICE against the SAME .expected, for the reason spelled out on
+; native_task_await_int above: the MARCH_NUM_SCHEDULERS=1 run is the
+; deterministic golden, and the second run at the DEFAULT scheduler count
+; buys coverage of the multi-OS-thread park/wake path -- the configuration
+; PR #310's spurious-wake actor kill hid in (compiled only, >1 scheduler
+; thread only, ~4% of runs).  Keeping them as separate targets means a
+; future multi-scheduler flake names native_task_await_ptr_multi.out.
 (rule
- (targets native_task_await_ptr native_task_await_ptr.out)
+ (targets native_task_await_ptr native_task_await_ptr.out
+          native_task_await_ptr_multi.out)
  (deps (file %{exe:../bin/main.exe})
        (file ../runtime/march_runtime.c) (file ../runtime/march_runtime.h)
        (file ../runtime/march_scheduler.c) (file ../runtime/march_scheduler.h)
@@ -3304,11 +3333,18 @@ printf 'mod CsHelper do\\n\\n  fn double(x : Int) : Int do\\n    x * 2\\n  end\\
    (run %{exe:../bin/main.exe} --compile -o native_task_await_ptr
         native/task_await_ptr.march)
    (with-stdout-to native_task_await_ptr.out
-        (system "MARCH_NUM_SCHEDULERS=1 ./native_task_await_ptr")))))
+        (system "MARCH_NUM_SCHEDULERS=1 ./native_task_await_ptr"))
+   (with-stdout-to native_task_await_ptr_multi.out
+        (system "./native_task_await_ptr")))))
 
 (rule
  (alias runtest)
  (action (diff native/task_await_ptr.expected native_task_await_ptr.out)))
+
+; Same golden, default (multi-OS-thread) scheduler -- see the PR #310 note above.
+(rule
+ (alias runtest)
+ (action (diff native/task_await_ptr.expected native_task_await_ptr_multi.out)))
 
 ; ── FFI Phase 2: borrowed extern args must be freed caller-side (no leak) ──
 (rule
@@ -6238,12 +6274,51 @@ printf 'mod CsHelper do\\n\\n  fn double(x : Int) : Int do\\n    x * 2\\n  end\\
 ; scheduler OS threads by default. Re-running the supervised crash witness
 ; exercises child preparation/registration, terminal publication, and Down
 ; delivery under cross-scheduler scheduling pressure.
+;
+; This loop used to redirect stdout to /dev/null and assert ONLY the exit
+; code, so a multi-scheduler run that exited 0 while printing silently wrong
+; Down payloads passed.  That is precisely the blind spot PR #310 lived in
+; (a wake with an empty mailbox killed a live actor: compiled only, >1
+; scheduler thread only, ~4% of runs) -- an exit-code-only loop cannot see a
+; dropped or wrong reason string.  Each iteration now captures stdout and
+; applies the SAME five assertions as the single-scheduler rule above.  They
+; are deliberately order-independent greps and not a diff against the golden:
+; at four schedulers these five lines legitimately interleave in a different
+; order than the pinned run emits them, so only the SET of lines is stable.
+; On failure the message names the iteration and the pattern and dumps the
+; offending output -- a bare non-zero exit from inside a 100-iteration loop
+; is miserable to debug in CI.
+;
+; Known PRE-EXISTING flake here, not introduced by the stdout capture: main
+; sends PrimeBounded *before* kill(killed) (actor_monitor_down_reason.march
+; lines 156-157) while the handler samples mailbox_size(watcher) at entry, so
+; at >1 scheduler the watcher can be dispatched before the Down is enqueued
+; and the binary exits 1 with `panic: bounded Down or mailbox count
+; mismatch`.  Measured on a loaded 14-core box at 7/12000 runs with the OLD
+; exit-code-only loop and 1/2500 with this one -- the rate is a property of
+; the fixture, and the old loop's `|| exit $?` tripped on it identically.
+; Tracked in specs/todos/2026-08-20-actor-monitor-bounded-mailbox-race.md.
 (rule
  (alias runtest)
  (deps (file native_actor_monitor_down_reason))
  (action
   (run bash -c
-   "i=0; while [ $i -lt 100 ]; do MARCH_NUM_SCHEDULERS=4 ./native_actor_monitor_down_reason >/dev/null || exit $?; i=$((i + 1)); done")))
+   "check() { printf '%s\\n' \"$out\" | grep -Eq \"$1\" || { \
+        printf 'native_actor_monitor_down_reason: MARCH_NUM_SCHEDULERS=4 iteration %s: output does not match /%s/\\noffending output:\\n%s\\n' \"$i\" \"$1\" \"$out\" >&2; \
+        exit 1; }; }; \
+    i=0; \
+    while [ $i -lt 100 ]; do \
+      out=$(MARCH_NUM_SCHEDULERS=4 ./native_actor_monitor_down_reason); rc=$?; \
+      [ $rc -eq 0 ] || { \
+        printf 'native_actor_monitor_down_reason: MARCH_NUM_SCHEDULERS=4 iteration %s: binary exited %s\\noffending output:\\n%s\\n' \"$i\" \"$rc\" \"$out\" >&2; \
+        exit 1; }; \
+      check '^down ref=[0-9]+ target=crashed reason=Crash\\(bang\\)$'; \
+      check '^down target=nulled reason=Crash\\(embedded-nul-ok\\)$'; \
+      check '^bounded mailbox=1 down=Killed ref=[0-9]+$'; \
+      check '^late down ref=[0-9]+ target=killed reason=Killed$'; \
+      check '^terminal watcher mailbox=0$'; \
+      i=$((i + 1)); \
+    done")))
 
 ; ── Named registry (Task 5): registry_retire_actor on actor death ────────
 ; (compiled + interpreted parity) ─────────────────────────────────────


### PR DESCRIPTION
Two small test-coverage changes plus a filed race, from auditing which actor/task fixtures never run under more than one scheduler thread.

## Why

`test/dune` pins several actor/task fixtures to `MARCH_NUM_SCHEDULERS=1` for output determinism. That means they never exercise the multi-OS-thread scheduler — which is exactly the configuration that hid the spurious-actor-death race fixed in #310 (compiled only, >1 scheduler, ~4% of runs).

## What changed

**`native_task_await_int` / `native_task_await_ptr`** — the pinned `=1` run stays as the golden; a second run at the DEFAULT scheduler count is added, diffed against the same `.expected`. Deliberately additive rather than un-pinning: if multi-scheduler output ever does drift, the failure names the multi-scheduler run instead of turning an existing golden into a mystery flake.

**`native_actor_monitor_down_reason`** — the higher-value one. A 100-iteration `MARCH_NUM_SCHEDULERS=4` loop already existed, but redirected stdout to `/dev/null`, so it asserted only the exit code: a multi-scheduler run that exited 0 while printing silently wrong output passed. The loop now captures stdout and applies the same five `grep -Eq` patterns per iteration (copied verbatim from the single-scheduler rule), reporting the iteration number, the failing pattern, and the offending output.

Not touched: `native_actor_stress` (its golden legitimately depends on dispatch order) and `native_preempt_starvation` (single-scheduler by design).

## Also filed: a pre-existing race this surfaced

`specs/todos/2026-08-20-actor-monitor-bounded-mailbox-race.md`.

`actor_monitor_down_reason.march` sends `PrimeBounded` before `kill(killed)`, but the handler samples `mailbox_size(watcher)` at entry — so at >1 scheduler the watcher can be dispatched before the `Down` is enqueued, and the binary dies with `panic: bounded Down or mailbox count mismatch`.

Measured by A/B'ing the old and new loop bodies against the same binary, interleaved: **old form 7/14800, new form ~5/9300 — statistically indistinguishable, ~0.05%**. So the stdout capture neither causes nor worsens it; the old `>/dev/null || exit $?` tripped on it identically. At that rate a 100-iteration loop reddens ~4.6% of the time on a busy box.

**That prediction has since been confirmed in the wild**: this exact rule failed the `test (macos-15)` job on #317 with that exact panic, and passed on re-run. So the flake is already taxing unrelated PRs, and until now it was tracked only in this branch — invisible to anyone reading `specs/todos/` on main. The todo proposes the fix (reorder `kill` before `send`).

## Verification

- `dune build --root . @runtest` exit 0 (read unpiped), on three separate invocations
- Repeat runs against the real `_build` binaries: `task_await_int` 1000 runs 0 failures; `task_await_ptr` 1600 runs 0 output mismatches; the monitor loop 45 repeats = 4500 fixture runs
- **Non-vacuity**: the fixture was edited to print `embedded-nul-CORRUPTED`, and the new rule went RED naming the iteration, the failing pattern and the offending output — where the old single-scheduler rule failed alongside it with a bare `Command exited with code 1`, which is the debugging pain this removes. Reverted by file copy, not `git stash`.
- `scripts/check-docs.sh` exit 0
- Rebased cleanly onto current main (`d5576f20`) and rebuilt

## Caveat on the measurements

The host was heavily contended throughout (load ~15-18 on 14 cores, several other agent worktrees building), and there were unexplained `exit 137` SIGKILLs at ~1 per 300-500 runs across three different binaries that did not track scheduler count. Believed host-level memory pressure, not proven. **All flake rates above are therefore upper bounds** and would be worth re-measuring on an idle machine.

Separately and out of scope: `native_actor_stress`'s *existing* pinned golden mismatched 12/500 on that same box (ordering of the `counter=` block), which suggests it is load-sensitive via timer preemption. Not chased here.
