### PR TITLE
fix(runtime): tcp_connect reported succeeded connections as EISCONN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ git log is authoritative for exact commits.
 
 ### Fixed
 
+- **`tcp_connect` reported a connection that had succeeded as
+  "Socket is already connected".** An interrupted `connect()` was retried on the
+  same fd (`do { connect } while (errno == EINTR)`), but POSIX completes an
+  interrupted `connect()` asynchronously in the kernel — the retry reports the
+  in-flight attempt as `EALREADY`/`EISCONN` instead of redoing it, so a
+  successful connection surfaced as `Err`. It read as a concurrency bug even
+  though the function holds no shared state: preemption delivers `SIGUSR1` to
+  every scheduler thread each millisecond, so a process making one outbound
+  request almost never took a signal inside `connect()` while a process making
+  several took them constantly — a single HTTPS client worked, four concurrent
+  ones failed immediately. `connect()` is now issued once, with `EINTR` (and
+  `EINPROGRESS`) recovered by waiting for writability and reading `SO_ERROR`.
+  The `EINTR` retries on `recv`/`send`/`writev` are correct and unchanged.
+
 - **`typed_array_*` returned corrupt values for scalar elements when compiled.**
   The family threads a genuinely generic `'a` through a uniform erased slot, so a
   scalar element has to arrive boxed (an `Int` tagged, a `Float` boxed) — but

--- a/runtime/march_http.c
+++ b/runtime/march_http.c
@@ -35,6 +35,7 @@
 #include <sys/uio.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <poll.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <arpa/inet.h>
@@ -621,9 +622,50 @@ void *march_tcp_connect(void *host_ptr, int64_t port) {
         *(void **)((char *)r + 16) = s;
         return r;
     }
-    int crc;
-    do { crc = connect(fd, res->ai_addr, res->ai_addrlen); }
-    while (crc < 0 && errno == EINTR);   /* preemption signal — retry */
+    /* connect() is the one blocking call here that must NOT simply be
+     * re-issued on EINTR.  Unlike recv()/send(), an interrupted connect()
+     * leaves the handshake running in the KERNEL: POSIX says the connection
+     * is established asynchronously, and a second connect() on the same fd
+     * then reports the state of that in-flight attempt — EALREADY while it
+     * is still going, EISCONN once it has landed — rather than starting a
+     * new one.  The old `do { connect } while (errno == EINTR)` loop
+     * therefore turned a connection that had actually SUCCEEDED into a hard
+     * failure: "tcp_connect: Socket is already connected".
+     *
+     * That made it a concurrency bug even though this function holds no
+     * shared state.  march_block_preempt() below masks SIGUSR1, but the mask
+     * is per-OS-thread while green threads multiplex over those threads, so
+     * it does not reliably hold — and preemption fires every
+     * MARCH_QUANTUM_US (1ms) per scheduler thread.  A process running one
+     * green thread almost never takes a signal inside connect(); a process
+     * running several concurrent outbound requests takes them constantly.
+     * Symptom: a single HTTPS client worked, four concurrent ones failed
+     * immediately, each reporting EISCONN.
+     *
+     * The correct recovery from EINTR (and from EINPROGRESS, should the fd
+     * ever arrive non-blocking) is to wait for the socket to become
+     * writable and read the true outcome out of SO_ERROR. */
+    int crc = connect(fd, res->ai_addr, res->ai_addrlen);
+    if (crc < 0 && (errno == EINTR || errno == EINPROGRESS)) {
+        struct pollfd pfd;
+        pfd.fd     = fd;
+        pfd.events = POLLOUT;
+        int prc;
+        /* poll() may itself be interrupted; retrying IT is safe and correct. */
+        do { prc = poll(&pfd, 1, -1); } while (prc < 0 && errno == EINTR);
+        if (prc > 0) {
+            int       so_err = 0;
+            socklen_t so_len = sizeof(so_err);
+            if (getsockopt(fd, SOL_SOCKET, SO_ERROR, &so_err, &so_len) == 0) {
+                if (so_err == 0) { crc = 0; }
+                else             { crc = -1; errno = so_err; }
+            }
+        }
+    } else if (crc < 0 && errno == EISCONN) {
+        /* Belt and braces: an EISCONN here means the handshake we asked for
+         * completed, which is success, not failure. */
+        crc = 0;
+    }
     if (crc < 0) {
         int saved_errno = errno;
         march_unblock_preempt(&saved);

--- a/specs/progress/2026-08-21-tcp-connect-eintr-retry-eisconn.md
+++ b/specs/progress/2026-08-21-tcp-connect-eintr-retry-eisconn.md
@@ -1,0 +1,100 @@
+# `tcp_connect` reported EISCONN for connections that had actually succeeded
+
+Landed 2026-08-21. Found in a March application (Envoy) that drives several
+concurrent outbound HTTPS requests from one process: four sessions started at
+the same moment, three failed immediately with
+
+```
+DeepInfra TCP connection failed: tcp_connect: Socket is already connected
+```
+
+while the same code with a single session in flight worked every time.
+
+## Root cause — retrying `connect()` after `EINTR`
+
+`march_tcp_connect` (`runtime/march_http.c`) recovered from an interrupted
+`connect()` the same way it recovers from an interrupted `recv()`/`send()`:
+
+```c
+int crc;
+do { crc = connect(fd, res->ai_addr, res->ai_addrlen); }
+while (crc < 0 && errno == EINTR);   /* preemption signal — retry */
+```
+
+That is correct for `recv()`/`send()` and wrong for `connect()`. POSIX says an
+interrupted `connect()` completes **asynchronously in the kernel**: the
+handshake keeps running, and a second `connect()` on the same fd reports the
+state of that in-flight attempt — `EALREADY` while it is still going,
+`EISCONN` once it has landed — instead of starting a new one.
+
+So the loop took a connection that had **succeeded** and turned it into a hard
+error. The `EISCONN` branch then `close()`d the fd and returned
+`Err("tcp_connect: Socket is already connected")`.
+
+## Why it looked like a concurrency bug
+
+`march_tcp_connect` holds no shared state — fresh `socket()`, local `fd`, no
+statics — so the usual suspects (per-process socket state, a shared TLS
+context, non-zeroed `march_alloc` headers) were all ruled out by inspection.
+What concurrency actually changes is **signal pressure**:
+
+* The preemption daemon sends `SIGUSR1` to every active scheduler thread every
+  `MARCH_QUANTUM_US` (1ms).
+* A process running one green thread is mostly idle and almost never takes a
+  signal inside the microseconds `connect()` is on the stack.
+* A process running several concurrent outbound requests takes them constantly.
+
+`march_block_preempt()` is supposed to mask `SIGUSR1` across
+`getaddrinfo()`/`connect()`, and it does run — but instrumentation showed the
+mask does not reliably hold (see "Loose end" below), and `EINTR` was observed
+even on iterations where `SIGUSR1` *was* masked. The retry has to be correct
+regardless of which signal fires, so that is what was fixed.
+
+## Evidence
+
+Instrumenting the loop and issuing two concurrent requests reproduced it
+directly:
+
+```
+[MCHDBG] enter fd=199 thr=0x1f8db9d80 usr1_blocked=0
+[MCHDBG] try=1 fd=199 rc=-1 errno=4  (Interrupted system call)
+[MCHDBG] try=2 fd=199 rc=-1 errno=56 (Socket is already connected)
+```
+
+## The fix
+
+Issue `connect()` once. On `EINTR` (and on `EINPROGRESS`, should the fd ever
+arrive non-blocking) wait for the socket to become writable and read the true
+outcome out of `SO_ERROR`, which is the standard recovery. A bare `EISCONN`
+is also now treated as success rather than failure.
+
+Verified against the reporting application: 24 sessions started concurrently,
+0 failures, all completing with real provider responses. Before the fix, 4
+concurrent sessions failed reliably.
+
+## No automated regression test — deliberately
+
+A deterministic C test was written and then dropped. Reproducing the bug needs
+a signal to land inside `connect()`; a loopback `connect()` completes in
+microseconds, so the signal storm has to be dense (~50µs). At that density the
+storm also lands inside `getaddrinfo()`, which `march_http.c` already documents
+as not async-signal-safe on macOS — the test wedged the resolver and hung
+before its first iteration. Making `connect()` slow enough to widen the window
+(dialling a non-routable address) removes the completion that the assertion
+depends on.
+
+A test that can hang CI is worse than no test, so the behaviour is recorded
+here instead. If this is worth automating later, a Linux-only test using a
+`SOCK_STREAM` peer with a deliberately stalled `accept()` plus `AI_NUMERICHOST`
+(to keep `getaddrinfo()` out of the signal path) is the most promising shape.
+
+## Loose end — `march_block_preempt()` does not reliably hold
+
+The probe above recorded `usr1_blocked=0` on threads that had just called
+`march_block_preempt()`. The mask is per-OS-thread (`pthread_sigmask`) while
+green threads multiplex over those threads, so a mask set by one green thread
+is not scoped to it — and `swapcontext` carries a signal mask of its own. This
+did not need to be resolved to fix the `EINTR` handling, and the other
+`EINTR`-retrying call sites in `march_http.c` (`recv`/`send`/`writev`) are
+correct as written, but the masking itself is not currently trustworthy and is
+worth a separate look.


### PR DESCRIPTION
## The bug

`march_tcp_connect` recovered from an interrupted `connect()` the same way it recovers from an interrupted `recv()`/`send()`:

```c
int crc;
do { crc = connect(fd, res->ai_addr, res->ai_addrlen); }
while (crc < 0 && errno == EINTR);   /* preemption signal — retry */
```

That is correct for `recv()`/`send()` and wrong for `connect()`. POSIX completes an interrupted `connect()` **asynchronously in the kernel** — the handshake keeps running, and a second `connect()` on the same fd reports the state of that in-flight attempt (`EALREADY` while going, `EISCONN` once landed) instead of starting a new one.

So the loop took a connection that had **succeeded**, closed its fd, and returned:

```
Err("tcp_connect: Socket is already connected")
```

## Why it looked like a concurrency bug

`march_tcp_connect` holds no shared state — fresh `socket()`, local `fd`, no statics — so the usual suspects (per-process socket state, a shared TLS context, non-zeroed `march_alloc` headers) were all ruled out by inspection. What concurrency actually changes is **signal pressure**: the preemption daemon sends `SIGUSR1` to every active scheduler thread every `MARCH_QUANTUM_US` (1ms). A process running one green thread almost never takes a signal in the microseconds `connect()` is on the stack; a process running several concurrent outbound requests takes them constantly.

Found in a March application driving concurrent HTTPS requests from one process: one session worked every time, four started together failed immediately, each reporting EISCONN.

## Evidence

Instrumenting the loop and issuing concurrent requests reproduced it directly:

```
[MCHDBG] enter fd=199 thr=0x1f8db9d80 usr1_blocked=0
[MCHDBG] try=1 fd=199 rc=-1 errno=4  (Interrupted system call)
[MCHDBG] try=2 fd=199 rc=-1 errno=56 (Socket is already connected)
```

## The fix

Issue `connect()` once. On `EINTR` (and `EINPROGRESS`, should the fd ever arrive non-blocking) wait for the socket to become writable and read the true outcome out of `SO_ERROR` — the standard recovery. A bare `EISCONN` is treated as success. The `EINTR` retries on `recv`/`send`/`writev` are correct as written and are **unchanged**.

## Verification

- Reporting application: **24 concurrent sessions, 0 failures**, all completing with real responses. Before the fix, 4 concurrent failed reliably.
- `scripts/run-tests.sh`: **all suites passed** (2704 assertions).
- `scripts/check-docs.sh`: passes.

## No automated regression test — deliberately

A C regression test was written (following the `test_scheduler.c` dune precedent), linked against the real `march_tcp_connect`, and then dropped. Hitting the bug needs a signal inside `connect()`; a loopback `connect()` completes in microseconds, so the storm has to be ~50µs dense. At that density it also lands inside `getaddrinfo()`, which `march_http.c` already documents as not async-signal-safe on macOS — the test wedged the resolver and hung before its first iteration (a control run with the storm disabled completed fine). Widening the window by dialling a non-routable address removes the completion the assertion depends on.

A test that can hang CI seemed worse than none. The reproduction is recorded in `specs/progress/` instead, along with the most promising shape if it is worth automating later (Linux-only, `AI_NUMERICHOST` to keep the resolver out of the signal path). Happy to add it Linux-gated if preferred.

## Loose end (documented, not fixed here)

The probe recorded `usr1_blocked=0` on threads that had just called `march_block_preempt()`. That mask is per-OS-thread (`pthread_sigmask`) while green threads multiplex over those threads, so it is not scoped to the green thread that set it — and `swapcontext` carries a mask of its own. `EINTR` was observed even on iterations where `SIGUSR1` *was* masked, so the retry had to be correct regardless; but the masking itself is not currently trustworthy and is worth a separate look. Written up in the progress file.