### PR TITLE
fix(runtime,stdlib): an expired TLS read deadline is its own fact

### DIFF
--- a/runtime/march_http.c
+++ b/runtime/march_http.c
@@ -86,7 +86,9 @@ int  base64_encode(const uint8_t *in, size_t len, char *out, size_t out_sz);
  * which matches it exactly to build Socket.RecvTimeout.  Changing the spelling
  * here without changing it there degrades every timeout back into a generic
  * RecvFailed — silently.  test_socket_timeout.ml asserts on it for that reason. */
+#ifndef MARCH_RECV_TIMEOUT_MSG
 #define MARCH_RECV_TIMEOUT_MSG "recv: timed out"
+#endif
 
 /* Milliseconds on CLOCK_MONOTONIC, for deadlines spanning several syscalls. */
 static int64_t march_now_ms(void) {

--- a/runtime/march_http.h
+++ b/runtime/march_http.h
@@ -9,6 +9,16 @@
  * Translation units that need HTTP builtins should include march_http.h directly.
  */
 #pragma once
+
+/* The one spelling of "a read deadline expired", shared by march_http.c (plain
+ * recv) and march_tls.c (SSL_read over an SO_RCVTIMEO fd).  stdlib/socket.march
+ * and stdlib/tls.march both match it exactly to build their timeout variants;
+ * changing it here without changing them degrades every timeout into a generic
+ * failure, silently.  test_socket_timeout.ml asserts on it for that reason. */
+#ifndef MARCH_RECV_TIMEOUT_MSG
+#define MARCH_RECV_TIMEOUT_MSG "recv: timed out"
+#endif
+
 #include "march_runtime.h"
 #include <stdint.h>
 

--- a/runtime/march_tls.c
+++ b/runtime/march_tls.c
@@ -21,7 +21,9 @@
 #include "march_tls.h"
 #include "march_runtime.h"
 #include "march_preempt.h"
+#include "march_http.h"   /* MARCH_RECV_TIMEOUT_MSG — one spelling of an expired deadline */
 
+#include <errno.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #include <openssl/x509.h>
@@ -365,7 +367,13 @@ void *march_tls_read(int64_t ssl_handle, int64_t max_bytes) {
      * forever.  See march_preempt.h. */
     sigset_t saved;
     march_block_preempt(&saved);
+    errno = 0;
     int n = SSL_read(ssl, buf, (int)cap);
+    /* Captured HERE, before march_unblock_preempt(), ERR_get_error() or any
+     * other call can overwrite it: the errno is the only thing distinguishing
+     * an expired SO_RCVTIMEO from a connection reset, and both arrive as
+     * SSL_ERROR_SYSCALL. */
+    int read_errno = errno;
     march_unblock_preempt(&saved);
     if (n > 0) {
         void *s = march_string_lit(buf, (int64_t)n);
@@ -379,6 +387,20 @@ void *march_tls_read(int64_t ssl_handle, int64_t max_bytes) {
         /* Clean shutdown */
         void *s = march_string_lit("", 0);
         return make_ok_str(s);
+    }
+    /* An SO_RCVTIMEO set on the fd before the handshake reaches this read (that
+     * is the whole reason set_recv_timeout exists).  OpenSSL reports its expiry
+     * as SSL_ERROR_WANT_READ on a BLOCKING socket — measured, not assumed: with
+     * the mapping removed, a peer that completed a handshake and then went
+     * silent produced "SSL_read error 2".  SSL_ERROR_SYSCALL with EAGAIN is the
+     * other shape the same event can take, so both are matched, and both are
+     * qualified by errno because SSL_ERROR_SYSCALL is equally what a connection
+     * reset looks like.  A caller that cannot tell a silent peer from a broken
+     * one cannot say why a stream ended, so an expired deadline gets the same
+     * sentinel the plain-recv path already uses. */
+    if ((err == SSL_ERROR_SYSCALL || err == SSL_ERROR_WANT_READ) &&
+        (read_errno == EAGAIN || read_errno == EWOULDBLOCK || read_errno == ETIMEDOUT)) {
+        return make_err(MARCH_RECV_TIMEOUT_MSG);
     }
     char errbuf[256];
     unsigned long e = ERR_get_error();

--- a/stdlib/tls.march
+++ b/stdlib/tls.march
@@ -41,6 +41,12 @@ mod Tls do
     | TlsReadError(String)
     | TlsWriteError(String)
     | TlsContextError(String)
+    -- A read deadline expired with the peer still silent.  Distinct from
+    -- TlsReadError because only one of the two says anything about the peer:
+    -- OpenSSL reports both an expired SO_RCVTIMEO and a connection reset as
+    -- SSL_ERROR_SYSCALL, and a caller that cannot tell them apart cannot say
+    -- why a stream ended.
+    | TlsReadTimeout
 
   -- TlsConfig: configuration for creating a TLS context
   --
@@ -222,12 +228,19 @@ mod Tls do
   handshake bounds the handshake too.  A deadline that fires part-way through
   a TLS record leaves the session unusable, so treat an expired read as
   "close the connection", not as something to retry.
+
+  When that deadline expires this returns Err(TlsReadTimeout), which is a
+  different fact from Err(TlsReadError(...)) -- the peer was silent, rather
+  than the connection failing.  Both still mean close it.
   """
   fn read(conn, max_bytes) do
     match conn do
     TlsConn(h) ->
       match tls_read(h, max_bytes) do
-      Err(msg) -> Err(TlsReadError(msg))
+      -- "recv: timed out" is the runtime's one spelling of an expired
+      -- deadline (MARCH_RECV_TIMEOUT_MSG), matched exactly here the way
+      -- Socket.recv_timeout matches it.
+      Err(msg) -> if msg == "recv: timed out" do Err(TlsReadTimeout) else Err(TlsReadError(msg)) end
       Ok(data) -> Ok(data)
       end
     end
@@ -342,6 +355,8 @@ mod Tls do
   "TLS certificate error: invalid CN"
   >>> Tls.error_to_string(TlsReadError("EOF"))
   "TLS read error: EOF"
+  >>> Tls.error_to_string(TlsReadTimeout)
+  "TLS read timed out"
   >>> Tls.error_to_string(TlsWriteError("broken pipe"))
   "TLS write error: broken pipe"
   >>> Tls.error_to_string(TlsContextError("bad cert"))
@@ -352,6 +367,7 @@ mod Tls do
     TlsHandshakeFailed(msg) -> "TLS handshake failed: " ++ msg
     TlsCertError(msg)       -> "TLS certificate error: " ++ msg
     TlsReadError(msg)       -> "TLS read error: " ++ msg
+    TlsReadTimeout          -> "TLS read timed out"
     TlsWriteError(msg)      -> "TLS write error: " ++ msg
     TlsContextError(msg)    -> "TLS context error: " ++ msg
     end

--- a/test/test_socket_timeout.ml
+++ b/test/test_socket_timeout.ml
@@ -77,6 +77,79 @@ let silent_peer () =
   in
   (port, fun () -> try Unix.close s with Unix.Unix_error _ -> ())
 
+
+(** A real TLS peer that completes a handshake and then says nothing.
+
+    The plain [silent_peer] cannot test this: it never speaks TLS, so the
+    client's handshake fails and [Tls.read] is never reached.  Proving that an
+    ESTABLISHED session bounds its reads needs a server that finishes the
+    handshake and then goes quiet, which is exactly what `openssl s_server
+    -quiet` does when the client sends nothing.
+
+    Returns None when openssl, or a cert we can generate with it, is
+    unavailable — the same skip policy the handshake probe uses. *)
+let silent_tls_peer () =
+  let dir = Filename.concat (Filename.get_temp_dir_name ())
+              (Printf.sprintf "march-tlsto-%d" (Unix.getpid ())) in
+  (try Unix.mkdir dir 0o700 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let cert = Filename.concat dir "cert.pem" and key = Filename.concat dir "key.pem" in
+  let gen =
+    Printf.sprintf
+      "openssl req -x509 -newkey rsa:2048 -nodes -keyout %s -out %s -days 1        -subj /CN=127.0.0.1 >/dev/null 2>&1" (Filename.quote key) (Filename.quote cert)
+  in
+  if Sys.command gen <> 0 then None
+  else begin
+    (* Pick a free port by binding and releasing it: s_server takes a port
+       rather than an inherited descriptor. *)
+    let probe = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+    Unix.setsockopt probe Unix.SO_REUSEADDR true;
+    Unix.bind probe (Unix.ADDR_INET (Unix.inet_addr_loopback, 0));
+    let port = match Unix.getsockname probe with
+      | Unix.ADDR_INET (_, p) -> p
+      | _ -> 0 in
+    Unix.close probe;
+    if port = 0 then None
+    else begin
+      (* -naccept 2, and not 1: the readiness check below consumes one accept,
+         and the probe itself needs the other.  Restarting the server instead
+         raced against the port's TIME_WAIT and the client arrived to a closed
+         listener. *)
+      let cmd = Printf.sprintf
+        "openssl s_server -quiet -naccept 2 -cert %s -key %s -accept %d \
+         >/dev/null 2>&1" (Filename.quote cert) (Filename.quote key) port in
+      (* stdin must stay OPEN and empty.  Redirecting from /dev/null gives
+         s_server an immediate EOF, and it answers that by shutting the TLS
+         session down cleanly — which SSL_read reports as Ok("") rather than as
+         a deadline expiring, so the probe measured a close instead of a
+         silence.  A pipe nobody writes to is the silence we want. *)
+      let stdin_r, stdin_w = Unix.pipe () in
+      let pid = Unix.create_process "/bin/sh" [| "/bin/sh"; "-c"; cmd |]
+                  stdin_r Unix.stdout Unix.stderr in
+      Unix.close stdin_r;
+      let stop () =
+        (try Unix.close stdin_w with Unix.Unix_error _ -> ());
+        (try Unix.kill pid Sys.sigkill with Unix.Unix_error _ -> ());
+        (try ignore (Unix.waitpid [] pid) with Unix.Unix_error _ -> ());
+        List.iter (fun f -> try Sys.remove f with Sys_error _ -> ()) [cert; key];
+        (try Unix.rmdir dir with Unix.Unix_error _ -> ())
+      in
+      (* Wait for the listener rather than sleeping a guessed amount: a probe
+         that connects before s_server binds fails for the wrong reason, which
+         is exactly how this helper failed when it guessed. *)
+      let rec wait_bound n =
+        if n = 0 then false
+        else
+          let c = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+          match Unix.connect c (Unix.ADDR_INET (Unix.inet_addr_loopback, port)) with
+          | () -> Unix.close c; true
+          | exception Unix.Unix_error _ ->
+            (try Unix.close c with Unix.Unix_error _ -> ());
+            Thread.delay 0.1; wait_bound (n - 1)
+      in
+      if not (wait_bound 50) then (stop (); None) else Some (port, stop)
+    end
+  end
+
 (** A peer that accepts and immediately writes [payload].  This is the
     non-vacuity control: it must still be read successfully. *)
 let talking_peer payload =
@@ -248,6 +321,59 @@ mod TlsTimeoutProbe do
 end
 |}
 
+
+(* A session that HANDSHAKES and then waits.  The handshake probe above proves
+   the fd deadline reaches SSL_connect; this one proves it reaches SSL_read,
+   and — the point of the variant — that an expired deadline is reported as
+   its own fact rather than as a generic read error.  OpenSSL surfaces both an
+   expired SO_RCVTIMEO and a connection reset as SSL_ERROR_SYSCALL, so without
+   the errno check they are the same string. *)
+let tls_read_probe_src =
+  {|
+mod TlsReadTimeoutProbe do
+
+  needs IO.NetConnect
+  needs IO.NetConnect.TLS
+  needs IO.Process
+  needs IO.Console
+
+  pfn port_from_env(name) do
+    match string_to_int(String.trim(Env.get(name, "0"))) do
+    Some(p) -> p
+    None    -> 0
+    end
+  end
+
+  fn main(_c1 : Cap(IO.NetConnect), _c2 : Cap(IO.NetConnect.TLS),
+          _c3 : Cap(IO.Process), _c4 : Cap(IO.Console)) do
+    let port = port_from_env("MARCH_TEST_TLS_PORT")
+    match Socket.connect("127.0.0.1", port) do
+    Err(e) -> println("E FAIL connect " ++ Socket.error_message(e))
+    Ok(fd) ->
+      match Socket.set_recv_timeout(fd, 500) do
+      Err(e) -> println("E FAIL setopt " ++ Socket.error_message(e))
+      Ok(_) ->
+        match Tls.client_ctx(TlsConfig("", "", "", ["http/1.1"], Tls12, false)) do
+        Err(_) -> println("E FAIL ctx")
+        Ok(ctx) ->
+          match Tls.connect(fd, ctx, "127.0.0.1") do
+          Err(e) -> println("E FAIL handshake " ++ Tls.error_to_string(e))
+          Ok(conn) ->
+            match Tls.read(conn, 4096) do
+            Err(TlsReadTimeout) -> println("E OK TlsReadTimeout")
+            Err(e)              -> println("E FAIL " ++ Tls.error_to_string(e))
+            Ok(_)               -> println("E FAIL read-returned-data")
+            end
+          end
+        end
+      end
+      Socket.close(fd)
+    end
+  end
+
+end
+|}
+
 (* ── Harness ───────────────────────────────────────────────────────────── *)
 
 let read_file path =
@@ -394,9 +520,45 @@ let test_tls_read_deadline () =
             true
             (contains out "C OK bounded"))
 
+
+let test_tls_read_timeout_variant () =
+  match silent_tls_peer () with
+  | None ->
+    Printf.printf
+      "  [skip] TLS read-timeout probe: no openssl s_server to hold a session open\n"
+  | Some (port, close_tls) ->
+    Fun.protect
+      ~finally:(fun () -> close_tls ())
+      (fun () ->
+        match
+          compile_and_run ~slug:"tls_read_timeout" ~src:tls_read_probe_src
+            ~timeout_secs:30. ~env:[ Printf.sprintf "MARCH_TEST_TLS_PORT=%d" port ]
+        with
+        | None -> ()
+        | Some (out, elapsed) ->
+          Alcotest.(check bool)
+            (Printf.sprintf
+               "an established TLS session bounds its reads (took %.1fs)" elapsed)
+            true (elapsed < 10.);
+          if contains out "E FAIL ctx" || contains out "E FAIL connect" then
+            Printf.printf
+              "  [skip] TLS read-timeout probe: no usable OpenSSL TLS context (out: %s)\n"
+              (String.trim out)
+          else
+            (* The variant, not merely the bound: TlsReadError would also mean
+               the read stopped, and would say nothing about the peer. *)
+            Alcotest.(check bool)
+              (Printf.sprintf
+                 "a silent peer after a completed handshake yields \
+                  TlsReadTimeout (got: %s)" (String.trim out))
+              true
+              (contains out "E OK TlsReadTimeout"))
+
 let suites =
   [ ( "socket_timeout",
       [ Alcotest.test_case "socket read deadlines (compiled)" `Slow
           test_socket_read_deadlines;
+        Alcotest.test_case "tls read timeout is its own variant (compiled)" `Slow
+          test_tls_read_timeout_variant;
         Alcotest.test_case "TLS read deadline via SO_RCVTIMEO (compiled)" `Slow
           test_tls_read_deadline ] ) ]


### PR DESCRIPTION
## What #325 left open

#325 made TLS read deadlines real by routing them through `SO_RCVTIMEO` on the fd — correctly, since that is the only mechanism that reaches a read made through OpenSSL, and setting it before the handshake bounds the handshake too.

It left no way to tell that one had fired. `march_tls_read` reported an expired deadline as `"SSL_read error 2"`, and a connection reset arrives as `SSL_ERROR_SYSCALL` — so a caller could bound a read but could not distinguish **the peer went silent** from **the connection broke**. Only one of those says anything about the peer, and only one is worth reporting to a person as such.

## The change

- `march_tls_read` captures `errno` immediately after `SSL_read`, before `march_unblock_preempt()` or `ERR_get_error()` can overwrite it, and maps an expired deadline to `MARCH_RECV_TIMEOUT_MSG`.
- That sentinel moves from a private `#define` in `march_http.c` into `march_http.h`, so the plain-recv path and the TLS path share one definition rather than two spellings that can drift apart.
- `Tls.read` matches it and returns `Err(TlsReadTimeout)` — a new variant, mirroring `Socket.recv_timeout`'s existing `Err(RecvTimeout(ms))`.

## Two things measured, not assumed

Both would have shipped silently wrong:

1. **On a blocking socket, OpenSSL reports the expiry as `SSL_ERROR_WANT_READ`, not `SSL_ERROR_SYSCALL`.** I wrote the `SYSCALL` case first. Removing the mapping and re-running the probe produced `SSL_read error 2` — `WANT_READ`. Both shapes are matched now, and both are qualified by `errno`, because `SSL_ERROR_SYSCALL` is equally what a reset looks like.

2. **The test server's stdin must stay open.** Redirecting `openssl s_server` from `/dev/null` gives it an immediate EOF, which it answers by shutting the TLS session down cleanly. `SSL_read` then returns `Ok("")` and the probe measures a close rather than a silence.

## Test

`test_socket_timeout.ml` gains a probe against a **real** TLS peer: `openssl s_server` completes a handshake and then says nothing, and the March client asserts `Err(TlsReadTimeout)` within its deadline (~1.2s).

`silent_peer` cannot cover this — it never speaks TLS, so the handshake fails and `Tls.read` is never reached. The existing TLS probe proves the deadline reaches `SSL_connect`; this one proves it reaches `SSL_read`.

Non-vacuous by construction: with the mapping removed, the same peer yields `TLS read error: SSL_read error 2` and the assertion fails. It skips **loudly** when no usable OpenSSL is present, following the policy already stated in the file.

## Verification

- `scripts/run-tests.sh` — all suites passed.
- `scripts/check-docs.sh` — passes.
- Downstream: envoy's suite is green (416 tests) against a toolchain built from this branch, with its stream client reworked onto #325's `set_recv_timeout` API.

## Why it matters downstream

envoy bounds a model stream with these deadlines and renders the reason to a person: *"nothing arrived for 60s after 1.2kB"* versus *"the connection failed"*. Without the variant, both are the same string, and "the turn failed" is not something anyone can act on.

## Note on the other branches

Three local branches (`claude/socket-tls-read-timeouts`, `claude/fix-erased-int-field-untag`, `claude/read-timeouts-on-pinned-base`) carry an earlier, parallel design — `tcp_recv_timeout` and `tls_read_timeout` builtins returning `Ok(None)`, built before #325 merged. This PR completes what #325 chose instead, so those are superseded and can be dropped. Their write-up does document one thing worth keeping: after a TLS 1.3 handshake the socket is readable while holding no application data (session tickets), so *poll-then-blocking-`SSL_read`* is not a valid way to build a deadline. The `SO_RCVTIMEO` route #325 took is not affected by that.