### PR TITLE
ci(release): fail the build when an archive has no binaries in it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,12 @@ jobs:
             -v ${{ github.workspace }}:/work
             -w /work
           run: |
+            # set -e is load-bearing: without it this block's exit status is
+            # that of its LAST command, which is `cp LICENSE ... || true` and
+            # therefore always 0. Every v0.2.0 and v0.3.0 linux-aarch64 archive
+            # shipped with an EMPTY bin/ because the build (or the cp that
+            # follows it) failed here and the job still reported success.
+            set -euo pipefail
             apk add --no-cache bash opam ocaml build-base git llvm19-dev llvm19 brotli-dev brotli-libs
             # Build blake3 from source (portable C only — no x86 SIMD on aarch64)
             git clone --depth 1 https://github.com/BLAKE3-team/BLAKE3.git /tmp/blake3
@@ -165,6 +171,33 @@ jobs:
           cp LICENSE _dist/ 2>/dev/null || true
 
       # --- Package ---
+
+      # A release archive's whole purpose is to deliver these two binaries, and
+      # until now nothing checked that it did. The linux-aarch64 leg shipped an
+      # empty bin/ in BOTH v0.2.0 (504 KB) and v0.3.0 (692 KB) -- stdlib and
+      # runtime sources present, no compiler -- while the job reported success
+      # and the published checksums verified. A correctly-hashed, correctly-
+      # uploaded, useless artifact is the failure mode this guards.
+      #
+      # Runs BEFORE `strip`, because strip's `|| true` was the second place the
+      # absence was swallowed.
+      - name: Verify the build produced both binaries
+        run: |
+          set -euo pipefail
+          fail=0
+          for b in march forge; do
+            p="_dist/bin/$b"
+            if [ ! -f "$p" ]; then
+              echo "::error::${{ matrix.platform }}: $p is MISSING — the build did not produce it, or the copy into _dist failed. Refusing to publish an archive with no compiler in it." >&2
+              fail=1
+            elif [ ! -s "$p" ]; then
+              echo "::error::${{ matrix.platform }}: $p exists but is EMPTY (0 bytes)." >&2
+              fail=1
+            else
+              echo "  $p: $(wc -c < "$p") bytes"
+            fi
+          done
+          exit $fail
 
       - name: Strip binary
         run: |

--- a/specs/github_release_builds.md
+++ b/specs/github_release_builds.md
@@ -4,12 +4,20 @@ This spec defines how March compiler binaries are built, packaged, and published
 
 ## Build Matrix
 
+> **Stale-doc note (2026-08-23):** this document described a FOUR-platform
+> matrix including `macos-13` / `darwin-x86_64` long after that leg was removed
+> in `d083eb65` ("drop darwin-x86_64 — macOS-13 runners no longer available").
+> The row is gone below, but the YAML quoted further down this file is still
+> illustrative rather than current — `.github/workflows/build.yml` is the
+> source of truth for what actually builds. Intel macOS has no prebuilt;
+> `install.sh` detects it and points at building from source.
+
+
 All builds target OCaml 5.3.0 and produce native binaries for four platforms:
 
 | OS    | Architecture | Runner              | Platform string  | Linking    |
 |-------|-------------|---------------------|------------------|------------|
 | macOS | Apple Silicon | `macos-14`          | `darwin-arm64`   | dynamic    |
-| macOS | Intel        | `macos-13`          | `darwin-x86_64`  | dynamic    |
 | Linux | x86-64       | `ubuntu-22.04`      | `linux-x86_64`   | static (musl) |
 | Linux | AArch64      | `ubuntu-22.04` + QEMU | `linux-aarch64`  | static (musl) |
 

--- a/specs/todos/2026-08-23-linux-aarch64-release-archive-has-no-binaries.md
+++ b/specs/todos/2026-08-23-linux-aarch64-release-archive-has-no-binaries.md
@@ -1,0 +1,73 @@
+`[P1]` # Every linux-aarch64 release archive ships with an empty `bin/`
+
+Found 2026-08-23 while checking the v0.3.0 release assets, after noticing the
+aarch64 archive was 692 KB against 11 MB for linux-x86_64.
+
+## The defect
+
+`march-v0.3.0-linux-aarch64.tar.gz` contains the 116 stdlib modules and the
+bundled C runtime sources, and **no compiler**:
+
+```
+march-v0.3.0-linux-aarch64/bin/            <- empty directory
+march-v0.3.0-linux-x86_64/bin/
+march-v0.3.0-linux-x86_64/bin/march        <- present
+march-v0.3.0-linux-x86_64/bin/forge        <- present
+```
+
+Both `bin/march` and `bin/forge` are absent. Anyone installing March on ARM
+Linux gets a package with nothing to run.
+
+**Not a 0.3.0 regression.** v0.2.0's aarch64 archive has the identical defect
+(504 KB, zero binaries), so ARM Linux has never had a working release artifact.
+It shipped a month ago and nobody noticed — which is the more useful finding
+than the bug itself.
+
+## Why nothing caught it
+
+Three independent maskings, all now fixed in `.github/workflows/build.yml`:
+
+1. **The Alpine container block had no `set -e`.** A `run:` block's exit status
+   is that of its LAST command, which was `cp LICENSE _dist/ 2>/dev/null || true`
+   — always 0. So a failure in `dune build` or in
+   `cp _build/default/bin/main.exe _dist/bin/march` left the job green.
+2. **`strip _dist/bin/march || true`** swallowed the absence a second time.
+3. **Nothing verified the archive payload** before `tar czf`.
+
+The checksums file is worth calling out: it verified correctly the whole time.
+`sha256` proves the bytes arrived intact, not that they are the bytes anyone
+wanted — a correctly-hashed empty archive passes every check the pipeline had.
+
+## What is fixed vs what remains
+
+Fixed here: the failure is now loud. `set -euo pipefail` in the container block,
+plus a "Verify the build produced both binaries" step that runs before `strip`
+and fails the job with a `::error::` naming the platform if either binary is
+missing or zero-length.
+
+**Still open: WHY the aarch64 build produces no binaries.** The copy commands
+are present and correct in the workflow, and `mkdir -p _dist/bin` clearly
+succeeded (the empty directory is in the archive), and `cp stdlib/*.march`
+succeeded (those files are present) — so `cp` works and the failure is specific
+to `_build/default/bin/main.exe` not existing. That points at
+`dune build --force bin/main.exe forge/bin/main.exe` failing inside the Alpine
+container, most likely a missing or mismatched dependency (the leg installs
+`llvm19-dev`, builds blake3 from source, and creates its own global opam switch
+— none of it shared with the native legs' cached `_opam`).
+
+It cannot be diagnosed from here without an arm64 runner: the leg builds under
+QEMU inside `alpine:3.21`, and the real error was never surfaced. With `set -e`
+in place, the next release run will fail at the true error instead of
+publishing an empty archive — that log is the next step.
+
+## Acceptance
+
+A `linux-aarch64` archive whose `bin/march` and `bin/forge` are present,
+non-empty, and executable; and a deliberately broken build leg fails the job
+rather than publishing.
+
+## Note on the currently-published assets
+
+v0.3.0 and v0.2.0 both carry the broken aarch64 asset. The guard prevents
+recurrence but does not repair what is already published — that needs the
+underlying build fixed and the asset replaced.


### PR DESCRIPTION
**Every `linux-aarch64` release archive ever published contains an empty `bin/`.**

```
march-v0.3.0-linux-aarch64/bin/            <- empty directory
march-v0.3.0-linux-x86_64/bin/
march-v0.3.0-linux-x86_64/bin/march        <- present
march-v0.3.0-linux-x86_64/bin/forge        <- present
```

692 KB (v0.3.0) and 504 KB (v0.2.0) against 11 MB for `linux-x86_64`. The stdlib and bundled C runtime sources are there; neither `bin/march` nor `bin/forge` is. Anyone installing March on ARM Linux gets a package with nothing to run.

**Not a 0.3.0 regression** — it has never worked, and it shipped a month ago unnoticed. Found by pulling on a size discrepancy in the published v0.3.0 assets.

## Three independent maskings, all fixed here

1. **The Alpine container `run:` block had no `set -e`.** A block's exit status is that of its LAST command, which was `cp LICENSE _dist/ 2>/dev/null || true` — always 0. So a failure in `dune build` or in the binary `cp` left the job **green**. Now `set -euo pipefail`.
2. **`strip _dist/bin/march || true`** swallowed the absence a second time.
3. **Nothing verified the payload** before `tar czf`.

The new **"Verify the build produced both binaries"** step runs *before* `strip` (that `|| true` being masking #2) and fails with a `::error::` naming the platform if either binary is missing or zero-length.

## The checksums verified the whole time

Worth stating plainly, because it is why this was invisible: `march-v0.3.0-checksums.txt` matches the aarch64 archive exactly. `sha256` proves the bytes arrived intact, not that they are the bytes anyone wanted. A correctly-hashed, correctly-uploaded, empty archive passed every check the pipeline had.

## Guard verified, not assumed

Run against three `_dist` shapes before committing:

| shape | result |
|---|---|
| the **exact** v0.3.0 aarch64 layout (empty `bin/`) | exit 1, both errors emitted |
| zero-byte binaries | exit 1 |
| healthy x86_64 layout | exit 0 |

## Still open

`specs/todos/2026-08-23-linux-aarch64-release-archive-has-no-binaries.md` — **why** the aarch64 build produces no binaries.

The copies are present and correct in the workflow; `mkdir -p _dist/bin` plainly succeeded (the empty directory is in the archive) and `cp stdlib/*.march` succeeded, so `cp` works and the failure is specific to `_build/default/bin/main.exe` not existing — i.e. the in-container `dune build` failing. Most likely a dependency mismatch: that leg installs `llvm19-dev`, builds blake3 from source, and creates its own global opam switch, none of it shared with the native legs' cached `_opam`.

It cannot be diagnosed from a dev machine — the leg builds under QEMU inside `alpine:3.21` and the real error was never surfaced. **With `set -e` in place the next release run fails at that error instead of publishing an empty archive, and that log is the next step.**

## Also

Corrects `specs/github_release_builds.md`, which still documented a four-platform matrix including `macos-13` / `darwin-x86_64` — dropped in `d083eb65` when GitHub retired those runners. `install.sh:51` already handles Intel macOS with a clear build-from-source message, so only the doc was wrong.

## Note on already-published assets

v0.3.0 and v0.2.0 both carry the broken aarch64 asset. This guard prevents recurrence; it does not repair what is already published. That needs the underlying build fixed and the asset replaced.