### PR TITLE
bench: interpreted/REPL-JIT benchmark harness (perf plan Phase 0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,9 @@ __pycache__/
 !/bench/tfb/
 !/bench/actors/
 !/bench/actors/*.march
+!/bench/interp/
+!/bench/interp/*.march
+!/bench/interp/*.py
 # Raw benchmark output, committed on purpose: published numbers should be
 # traceable to the run that produced them, and a chart should be generated from
 # data in the repo rather than transcribed from a terminal by hand. Each file

--- a/bench/interp/README.md
+++ b/bench/interp/README.md
@@ -1,0 +1,14 @@
+# bench/interp — scaled corpus for interpreted / REPL-JIT / compiled A-B
+
+`bench/*.march` sizes are tuned for compiled code (fib(40), 100k-element
+strings). The interpreter is 100–400× slower, so this directory holds the
+same workloads at sizes that finish in 1–20 s interpreted.
+
+Rules:
+- every program prints exactly one `checksum=<int>` line; the runner diffs it
+  across modes and fails on mismatch;
+- `main` takes the narrowest capability grant it needs;
+- no timing inside the program — the runner times the whole process.
+
+Run: `bash bench/run_interp_bench.sh` (all modes) or
+`bash bench/run_interp_bench.sh --modes interp,compiled --only fib,json_stream`.

--- a/bench/interp/actor_call_storm.march
+++ b/bench/interp/actor_call_storm.march
@@ -1,0 +1,54 @@
+-- 16 concurrent callers, 20 calls each, 1 slow-ish target, short timeouts. Gate: bounded
+-- wall time (no congestive spiral) and every call returns (Ok or timeout Err).
+-- expected: checksum=320
+--
+-- Deviations from the task-1 brief's sketch:
+--   - Added `needs IO.Console` and `needs IO.Spawn` (required by println and
+--     Task.async/task_spawn respectively -- see the capability-ceiling check
+--     hit while building fanin_flood.march).
+--   - `Work` is the only handler and Actor.call's sentinel routes to
+--     whichever handler sits at ctor tag 0, so declaring a single handler is
+--     already correct here (no reordering needed, unlike crash_loop.march's
+--     two-handler Fragile actor).
+--   - `List.foldl` does not exist in the stdlib (`stdlib/list.march` only
+--     has `fold_left`/`fold_right`); replaced both call sites.
+mod CallStorm do
+  needs IO.Console
+  needs IO.Spawn
+
+  actor Slow do
+    state { n : Int }
+    init  { n: 0 }
+
+    on Work(reply_to) do
+      -- burn some reductions so callers genuinely queue
+      let _ = List.fold_left(Range.to_list(Range.new(0, 200)), 0, fn (a, b) -> a + b)
+      Actor.reply(reply_to, state.n)
+      { n: state.n + 1 }
+    end
+  end
+
+  type WorkReq = WorkReq
+
+  fn caller(pid, remaining, ok_acc, err_acc) do
+    if remaining == 0 do
+      (ok_acc, err_acc)
+    else
+      match Actor.call(pid, WorkReq, 200) do
+        Ok(_)  -> caller(pid, remaining - 1, ok_acc + 1, err_acc)
+        Err(_) -> caller(pid, remaining - 1, ok_acc, err_acc + 1)
+      end
+    end
+  end
+
+  fn main(_cap_console : Cap(IO.Console), _cap_spawn : Cap(IO.Spawn)) do
+    let pid = spawn(Slow)
+    let tasks = List.map(Range.to_list(Range.new(0, 16)), fn _ ->
+      Task.async(fn -> caller(pid, 20, 0, 0)))
+    let results = List.map(tasks, fn t -> Task.await_unwrap(t))
+    let total = List.fold_left(results, 0, fn (acc, r) ->
+      match r do (ok, err) -> acc + ok + err end)
+    println("checksum=" ++ int_to_string(total))
+    run_until_idle()
+  end
+end

--- a/bench/interp/actor_pingpong.march
+++ b/bench/interp/actor_pingpong.march
@@ -1,0 +1,40 @@
+-- 20k casts into one actor, then one call to read the total.
+-- expected: checksum=20000
+mod PingPong do
+  needs IO.Console
+  needs IO.Spawn
+
+  actor Counter do
+    state { n : Int }
+    init  { n: 0 }
+
+    on Total(reply_to) do
+      Actor.reply(reply_to, state.n)
+      state
+    end
+
+    on Ping(k : Int) do
+      { n: state.n + k }
+    end
+  end
+
+  type TotalReq = TotalReq
+
+  fn pump(pid, i) do
+    if i == 0 do ()
+    else
+      send(pid, Ping(1))
+      pump(pid, i - 1)
+    end
+  end
+
+  fn main(_c : Cap(IO.Console), _s : Cap(IO.Spawn)) do
+    let pid = spawn(Counter)
+    pump(pid, 20000)
+    run_until_idle()
+    match Actor.call(pid, TotalReq, 30000) do
+      Ok(n)  -> println("checksum=" ++ int_to_string(n))
+      Err(e) -> println("call failed: " ++ e)
+    end
+  end
+end

--- a/bench/interp/binary_trees.march
+++ b/bench/interp/binary_trees.march
@@ -1,0 +1,26 @@
+-- Binary trees, depth 10 x 4 iterations: allocation and match dispatch.
+-- expected: checksum=8188
+mod BinaryTrees do
+  needs IO.Console
+
+  type Tree = Leaf | Node(Tree, Tree)
+
+  fn make(d : Int) : Tree do
+    if d == 0 do Leaf else Node(make(d - 1), make(d - 1)) end
+  end
+
+  fn check(t : Tree) : Int do
+    match t do
+    Leaf       -> 1
+    Node(l, r) -> check(l) + check(r) + 1
+    end
+  end
+
+  fn iter(i : Int, acc : Int) : Int do
+    if i == 0 do acc else iter(i - 1, acc + check(make(10))) end
+  end
+
+  fn main(_c : Cap(IO.Console)) : Unit do
+    println("checksum=" ++ int_to_string(iter(4, 0)))
+  end
+end

--- a/bench/interp/fib.march
+++ b/bench/interp/fib.march
@@ -1,0 +1,13 @@
+-- Naive recursive fib(25): pure call/arith overhead.
+-- expected: checksum=75025
+mod Fib do
+  needs IO.Console
+
+  fn fib(n : Int) : Int do
+    if n < 2 do n else fib(n - 1) + fib(n - 2) end
+  end
+
+  fn main(_c : Cap(IO.Console)) : Unit do
+    println("checksum=" ++ int_to_string(fib(25)))
+  end
+end

--- a/bench/interp/float_loop.march
+++ b/bench/interp/float_loop.march
@@ -1,0 +1,15 @@
+-- Float accumulation loop: exercises VFloat arithmetic and comparisons.
+-- expected: checksum=133333
+mod FloatLoop do
+  needs IO.Console
+
+  fn step(i : Int, x : Float) : Float do
+    if i == 0 do x
+    else step(i - 1, x + 1.0 / 1.5) end
+  end
+
+  fn main(_c : Cap(IO.Console)) : Unit do
+    let r = step(200000, 0.0)
+    println("checksum=" ++ int_to_string(float_to_int(r)))
+  end
+end

--- a/bench/interp/http_client.py
+++ b/bench/interp/http_client.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Serial HTTP client for bench/interp/http_server.march.
+Prints checksum=<number of 200 responses> and reqps=<req/s>."""
+import sys, time, urllib.request
+n = int(sys.argv[1]) if len(sys.argv) > 1 else 500
+port = int(sys.argv[2]) if len(sys.argv) > 2 else 18080
+ok = 0
+deadline = time.time() + 15
+while time.time() < deadline:          # wait for listen()
+    try:
+        urllib.request.urlopen(f"http://127.0.0.1:{port}/", timeout=1).read(); break
+    except Exception:
+        time.sleep(0.1)
+t = time.time()
+for i in range(n):
+    path = "/" if i % 2 == 0 else f"/echo/{i}"
+    with urllib.request.urlopen(f"http://127.0.0.1:{port}{path}", timeout=5) as r:
+        body = r.read().decode()
+        if r.status == 200 and (path == "/" and body == "hello" or body == str(i)):
+            ok += 1
+dt = time.time() - t
+print(f"checksum={ok}")
+print(f"reqps={n/dt:.0f}")

--- a/bench/interp/http_server.march
+++ b/bench/interp/http_server.march
@@ -1,0 +1,23 @@
+-- HTTP server benchmark for measuring interpreted performance.
+-- Port 18080. Routes:
+--   GET /          -> "hello"
+--   GET /echo/<x>  -> x (echo the path parameter)
+--   *              -> "Not Found" (404)
+
+mod HttpBench do
+  needs IO.NetListen
+
+  fn router(conn) do
+    match (HttpServer.method(conn), HttpServer.path_info(conn)) do
+    (:get, Nil)                   -> conn |> HttpServer.text(200, "hello")
+    (:get, Cons("echo", Cons(x, Nil))) -> conn |> HttpServer.text(200, x)
+    _                             -> conn |> HttpServer.text(404, "Not Found")
+    end
+  end
+
+  fn main(_cap : Cap(IO.NetListen)) do
+    HttpServer.new(18080)
+    |> HttpServer.plug(router)
+    |> HttpServer.listen()
+  end
+end

--- a/bench/interp/json_stream.march
+++ b/bench/interp/json_stream.march
@@ -1,0 +1,51 @@
+-- JsonStream throughput: synthetic NDJSON, fed in 64KB chunks.
+-- Each record `{"id": N, "name": "user-N", "active": true, "tags": [1, 2, 3]}\n`
+-- emits 14 events: EvObjStart, EvKey("id"), EvNum, EvKey("name"), EvStr,
+-- EvKey("active"), EvBool, EvKey("tags"), EvArrStart, EvNum x3, EvArrEnd,
+-- EvObjEnd — measured empirically with 1/2/3-record probes (14, 28, 42),
+-- not derived from prose arithmetic.
+-- checksum=28000 (2000 records x 14)
+
+mod JsonStreamBench do
+  needs IO.Console
+
+pfn build_records(n, acc) do
+  if n <= 0 do acc
+  else
+    build_records(n - 1,
+      Cons("{\"id\": " ++ to_string(n) ++ ", \"name\": \"user-" ++ to_string(n)
+           ++ "\", \"active\": true, \"tags\": [1, 2, 3]}\n", acc))
+  end
+end
+
+fn main(_cap_console : Cap(IO.Console)) do
+  let n = 2000
+  let src = string_join(build_records(n, Nil), "")
+  let total = run_chunked(src, 0, JsonStream.start_ndjson(), 0)
+  println("checksum=" ++ to_string(total))
+end
+
+pfn run_chunked(src, off, st, n) do
+  let sz = string_byte_length(src)
+  if off >= sz do
+    match JsonStream.finish(st) do
+    Err(_) -> 0 - 1
+    Ok(evs) -> n + count_list(evs)
+    end
+  else
+    let take = if sz - off < 65536 do sz - off else 65536 end
+    match JsonStream.feed(st, string_slice(src, off, take)) do
+    Err(_) -> 0 - 1
+    Ok((evs, st2)) -> run_chunked(src, off + take, st2, n + count_list(evs))
+    end
+  end
+end
+
+pfn count_list(evs) do
+  match evs do
+  Nil -> 0
+  Cons(_, t) -> count_list(t) + 1
+  end
+end
+
+end

--- a/bench/interp/par_fib.march
+++ b/bench/interp/par_fib.march
@@ -1,0 +1,49 @@
+-- Parallel Fibonacci benchmark (embarrassingly parallel).
+-- Spawns independent tasks for fib(n-1) and fib(n-2) down to a threshold,
+-- then falls back to sequential naive recursion.
+--
+-- This is the classic embarrassingly parallel workload: every subtask is
+-- completely independent with no shared state or communication.
+--
+-- What this tests:
+--   - task_spawn / task_await_unwrap overhead with many small tasks
+--   - Task creation throughput (thousands of tasks)
+--   - No inter-task communication — pure fork/join
+--
+-- Checksum agrees between interpreted and compiled: 75025 (par_fib(25, 18))
+-- Interpreted par_fib(25,18) takes ~2 min; spawn is eager (no real parallelism yet).
+--
+-- Status: REQUIRES true parallelism (OCaml 5 Domains) for speedup.
+--         Phase 1 executes eagerly — measures task overhead only.
+
+mod ParFib do
+  needs IO.Console
+  needs IO.Spawn
+
+pfn fib(n : Int) : Int do
+  if n < 2 do n
+  else fib(n - 1) + fib(n - 2) end
+end
+
+-- Parallel fib: spawn tasks down to threshold, then sequential.
+-- threshold=18 gives ~100k sequential calls per task (good granularity).
+pfn par_fib(n : Int, threshold : Int) : Int do
+  if n < 2 do n
+  else if n <= threshold do fib(n)
+  else do
+    let t1 = task_spawn(fn x -> par_fib(n - 1, threshold))
+    let t2 = task_spawn(fn x -> par_fib(n - 2, threshold))
+    let r1 = task_await_unwrap(t1)
+    let r2 = task_await_unwrap(t2)
+    r1 + r2 end end
+  end
+end
+
+pfn main(_cap_console : Cap(IO.Console), _cap_spawn : Cap(IO.Spawn)) : Unit do
+  -- fib(25) with parallel threshold at 18
+  -- Scaled down from fib(40, 20) for interpreter speed.
+  let result = par_fib(25, 18)
+  println("checksum=" ++ int_to_string(result))
+end
+
+end

--- a/bench/interp/par_map.march
+++ b/bench/interp/par_map.march
@@ -1,0 +1,100 @@
+-- Parallel map benchmark (embarrassingly parallel).
+-- Splits a list into chunks and maps an expensive function over each chunk
+-- in a separate task, then concatenates results.
+--
+-- The mapped function (collatz_steps) is pure and independent per element —
+-- no communication between tasks. This is the "map-reduce without reduce"
+-- pattern: embarrassingly parallel with a trivial gather step.
+--
+-- What this tests:
+--   - task_spawn with closure captures (each task captures a list chunk)
+--   - Independent task execution with no shared state
+--   - Task overhead vs sequential map
+--   - List allocation under task boundaries
+--
+-- Checksum agreed between interpreted and compiled: 1699332 (sum of Collatz step counts for 1..20000)
+-- Interpreted par_map(20000, 1000) takes ~3-4 min; spawn is eager (no real parallelism yet).
+--
+-- Status: REQUIRES true parallelism (OCaml 5 Domains) for speedup.
+--         Phase 1 executes eagerly — measures task overhead only.
+
+mod ParMap do
+  needs IO.Console
+  needs IO.Spawn
+
+-- Collatz conjecture step count: a pure, variable-cost function.
+-- Perfect for embarrassingly parallel workloads because each element
+-- is independent and the work per element varies widely.
+pfn collatz_steps(n : Int, acc : Int) : Int do
+  if n == 1 do acc
+  else if n % 2 == 0 do collatz_steps(n / 2, acc + 1)
+  else collatz_steps(3 * n + 1, acc + 1) end end
+end
+
+-- Build a range as a list (tail-recursive with accumulator).
+pfn range_acc(lo : Int, hi : Int, acc : List(Int)) : List(Int) do
+  if lo > hi do acc
+  else range_acc(lo, hi - 1, Cons(hi, acc)) end
+end
+
+pfn range(lo : Int, hi : Int) : List(Int) do
+  range_acc(lo, hi, Nil)
+end
+
+-- Sum a list of integers.
+pfn sum(xs : List(Int), acc : Int) : Int do
+  match xs do
+  Nil -> acc
+  Cons(x, rest) -> sum(rest, acc + x)
+  end
+end
+
+-- Map collatz_steps over a list, collecting step counts.
+pfn map_collatz(xs : List(Int), acc : List(Int)) : List(Int) do
+  match xs do
+  Nil -> acc
+  Cons(x, rest) -> map_collatz(rest, Cons(collatz_steps(x, 0), acc))
+  end
+end
+
+-- Process a list in chunks, spawning a task per chunk.
+-- chunk_acc accumulates the current chunk's elements.
+-- chunk_left counts remaining elements in the current chunk.
+pfn par_map_inner(xs : List(Int), chunk_size : Int,
+                 chunk_acc : List(Int), chunk_left : Int) : Int do
+  match xs do
+  Nil ->
+    -- Process final partial chunk
+    if chunk_left == chunk_size do 0
+    else do
+      let t = task_spawn(fn x -> sum(map_collatz(chunk_acc, Nil), 0))
+      task_await_unwrap(t) end
+    end
+  Cons(h, tl) ->
+    if chunk_left == 0 do
+      -- Chunk full — spawn task, continue with next chunk
+      let t = task_spawn(fn x -> sum(map_collatz(chunk_acc, Nil), 0))
+      let rest_sum = par_map_inner(tl, chunk_size, Cons(h, Nil), chunk_size - 1)
+      let chunk_sum = task_await_unwrap(t)
+      chunk_sum + rest_sum
+    else par_map_inner(tl, chunk_size, Cons(h, chunk_acc), chunk_left - 1)
+    end
+  end
+end
+
+-- Spawn a task per chunk, await all, sum results.
+pfn par_map_sum(xs : List(Int), chunk_size : Int) : Int do
+  par_map_inner(xs, chunk_size, Nil, chunk_size)
+end
+
+pfn main(_cap_console : Cap(IO.Console), _cap_spawn : Cap(IO.Spawn)) : Unit do
+  -- 20K elements, 1000 per chunk = 20 tasks
+  -- Scaled up from 10K for more parallelism to measure.
+  let n = 20000
+  let chunk_size = 1000
+  let xs = range(1, n)
+  let total = par_map_sum(xs, chunk_size)
+  println("checksum=" ++ int_to_string(total))
+end
+
+end

--- a/bench/interp/par_map.march
+++ b/bench/interp/par_map.march
@@ -12,7 +12,7 @@
 --   - Task overhead vs sequential map
 --   - List allocation under task boundaries
 --
--- Checksum agreed between interpreted and compiled: 1699332 (sum of Collatz step counts for 1..20000)
+-- Checksum agreed between interpreted and compiled: 1834634 (sum of Collatz step counts for 1..20000)
 -- Interpreted par_map(20000, 1000) takes ~3-4 min; spawn is eager (no real parallelism yet).
 --
 -- Status: REQUIRES true parallelism (OCaml 5 Domains) for speedup.

--- a/bench/interp/repl_session.txt
+++ b/bench/interp/repl_session.txt
@@ -1,0 +1,10 @@
+1 + 2
+fn fib(n) do if n < 2 do n else fib(n-1) + fib(n-2) end end
+fib(10)
+let xs = List.range(1, 100)
+List.length(xs)
+12 * 12
+let ys = List.map(xs, fn x -> x * 2)
+List.length(ys)
+fib(20)
+:quit

--- a/bench/interp/string_pipeline.march
+++ b/bench/interp/string_pipeline.march
@@ -1,0 +1,23 @@
+-- int_to_string / string_to_int / string_join over 10k elements.
+-- checksum=54448
+mod StringPipeline do
+  needs IO.Console
+
+  fn build(lo : Int, hi : Int, acc : List(String)) : List(String) do
+    if lo > hi do acc else build(lo + 1, hi, Cons(int_to_string(lo), acc)) end
+  end
+
+  fn double_str(s : String) : String do
+    match string_to_int(s) do
+    Some(n) -> int_to_string(n * 2)
+    None    -> s
+    end
+  end
+
+  fn main(_c : Cap(IO.Console)) : Unit do
+    let xs = build(1, 10000, Nil)
+    let ys = List.map(xs, double_str)
+    let joined = string_join(ys, ",")
+    println("checksum=" ++ int_to_string(string_byte_length(joined)))
+  end
+end

--- a/bench/interp/string_split.march
+++ b/bench/interp/string_split.march
@@ -1,0 +1,23 @@
+-- Split a 20k-token comma string and count tokens containing "7".
+-- checksum=6878
+mod StringSplit do
+  needs IO.Console
+
+  fn build(i : Int, acc : String) : String do
+    if i == 0 do acc else build(i - 1, acc ++ int_to_string(i) ++ ",") end
+  end
+
+  fn count7(parts : List(String), acc : Int) : Int do
+    match parts do
+    Nil -> acc
+    Cons(p, rest) ->
+      if String.contains(p, "7") do count7(rest, acc + 1) else count7(rest, acc) end
+    end
+  end
+
+  fn main(_c : Cap(IO.Console)) : Unit do
+    let s = build(20000, "")
+    let parts = String.split(s, ",")
+    println("checksum=" ++ int_to_string(count7(parts, 0)))
+  end
+end

--- a/bench/run_interp_bench.sh
+++ b/bench/run_interp_bench.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# bench/run_interp_bench.sh — interpreted / compiled / REPL A-B over bench/interp.
+# Usage: bash bench/run_interp_bench.sh [--modes interp,compiled,repl-clang,repl-orc]
+#                                       [--only fib,json_stream] [--runs 3]
+#                                       [--march path/to/main.exe] [--tag label]
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+MARCH="$ROOT/_build/default/bin/main.exe"
+MODES="interp,compiled,repl-clang,repl-orc"; ONLY=""; RUNS=3; TAG="$(git -C "$ROOT" rev-parse --short HEAD)"
+while [ $# -gt 0 ]; do case "$1" in
+  --modes) MODES="$2"; shift 2;; --only) ONLY="$2"; shift 2;; --runs) RUNS="$2"; shift 2;;
+  --march) MARCH="$2"; shift 2;; --tag) TAG="$2"; shift 2;; *) echo "unknown arg $1" >&2; exit 2;; esac; done
+ARCH="$(uname -m)"; DATE="$(date +%Y-%m-%d)"
+OUT="$ROOT/bench/results/$DATE-interp-$ARCH.jsonl"; mkdir -p "$ROOT/bench/results"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/march-interp-bench.XXXXXX")"; trap 'rm -rf "$TMP"' EXIT
+
+ms_now() { python3 -c 'import time;print(int(time.time()*1000))'; }
+emit() { # bench mode run ms checksum ok
+  printf '{"tag":"%s","bench":"%s","mode":"%s","run":%s,"ms":%s,"checksum":"%s","ok":%s}\n' \
+    "$TAG" "$1" "$2" "$3" "$4" "$5" "$6" | tee -a "$OUT"; }
+want() { [ -z "$ONLY" ] || [[ ",$ONLY," == *",$1,"* ]]; }
+has_mode() { [[ ",$MODES," == *",$1,"* ]]; }
+
+# --- file benchmarks -------------------------------------------------------
+for src in "$ROOT"/bench/interp/*.march; do
+  b="$(basename "$src" .march)"; want "$b" || continue
+  [ "$b" = http_server ] && continue
+  # bash 3.2 (macOS default) has no associative arrays; use plain vars, reset per benchmark.
+  sum_interp=""; sum_compiled=""
+  if has_mode compiled; then
+    "$MARCH" --compile --opt 2 "$src" -o "$TMP/$b.bin" > "$TMP/$b.compile.log" 2>&1 \
+      || { echo "compile failed for $b (see $TMP/$b.compile.log)" >&2; exit 1; }
+  fi
+  for run in $(seq 1 "$RUNS"); do
+    for mode in interp compiled; do
+      has_mode "$mode" || continue
+      t0=$(ms_now)
+      if [ "$mode" = interp ]; then "$MARCH" "$src" > "$TMP/$b.$mode.out" 2>&1 || true
+      else "$TMP/$b.bin" > "$TMP/$b.$mode.out" 2>&1 || true; fi
+      t1=$(ms_now)
+      ck="$(grep -o 'checksum=[-0-9]*' "$TMP/$b.$mode.out" | head -1 || true)"
+      if [ "$mode" = interp ]; then sum_interp="$ck"; else sum_compiled="$ck"; fi
+      ok=true; [ -n "$ck" ] || ok=false
+      emit "$b" "$mode" "$run" "$((t1 - t0))" "$ck" "$ok"
+    done
+  done
+  if has_mode interp && has_mode compiled && [ "$sum_interp" != "$sum_compiled" ]; then
+    echo "CHECKSUM MISMATCH $b: interp=${sum_interp:-none} compiled=${sum_compiled:-none}" >&2; exit 1
+  fi
+done
+
+# --- http server -------------------------------------------------------------
+if want http_server; then
+  for mode in interp compiled; do
+    has_mode "$mode" || continue
+    if [ -n "$(lsof -ti :18080 2>/dev/null || true)" ]; then
+      echo "port 18080 already in use before starting http_server ($mode); aborting" >&2; exit 1
+    fi
+    if [ "$mode" = compiled ]; then
+      "$MARCH" --compile --opt 2 "$ROOT/bench/interp/http_server.march" -o "$TMP/http.bin" > "$TMP/http.compile.log" 2>&1
+      "$TMP/http.bin" > "$TMP/http.$mode.log" 2>&1 & SRV=$!
+    else
+      "$MARCH" "$ROOT/bench/interp/http_server.march" > "$TMP/http.$mode.log" 2>&1 & SRV=$!
+    fi
+    sleep 1
+    for run in $(seq 1 "$RUNS"); do
+      t0=$(ms_now); python3 "$ROOT/bench/interp/http_client.py" 500 > "$TMP/http.$mode.out"; t1=$(ms_now)
+      ck="$(grep -o 'checksum=[0-9]*' "$TMP/http.$mode.out")"; ok=true; [ "$ck" = checksum=500 ] || ok=false
+      emit http_server "$mode" "$run" "$((t1 - t0))" "$ck" "$ok"
+    done
+    kill "$SRV" 2>/dev/null || true; wait "$SRV" 2>/dev/null || true
+    sleep 1
+    survivor="$(pgrep -lf 'march-interp-http|http_server' 2>/dev/null || true)"
+    if [ -n "$survivor" ]; then
+      echo "WARNING: http_server ($mode) process survived kill: $survivor" >&2
+    fi
+  done
+fi
+
+# --- repl session ------------------------------------------------------------
+for mode in repl-clang repl-orc; do
+  has_mode "$mode" || continue
+  for run in $(seq 1 "$RUNS"); do
+    t0=$(ms_now)
+    if [ "$mode" = repl-orc ]; then MARCH_JIT_BACKEND=orc "$MARCH" < "$ROOT/bench/interp/repl_session.txt" > "$TMP/$mode.out" 2>&1 || true
+    else MARCH_JIT_BACKEND=clang "$MARCH" < "$ROOT/bench/interp/repl_session.txt" > "$TMP/$mode.out" 2>&1 || true; fi
+    t1=$(ms_now)
+    # Non-tty REPL prints prompt+result on one line ("> = ..."), not a leading "= ".
+    n="$(grep -c '> = ' "$TMP/$mode.out" || true)"; ok=true; [ "$n" = 6 ] || ok=false
+    emit repl_session "$mode" "$run" "$((t1 - t0))" "exprs=$n" "$ok"
+  done
+done
+
+# --- table -------------------------------------------------------------------
+python3 - "$OUT" "$TAG" <<'PY' >&2
+import json, sys, collections
+rows = [json.loads(l) for l in open(sys.argv[1]) if l.strip()]
+rows = [r for r in rows if r["tag"] == sys.argv[2]]
+by = collections.defaultdict(list)
+for r in rows: by[(r["bench"], r["mode"])].append(r["ms"])
+benches = sorted({b for b, _ in by}); modes = ["interp", "compiled", "repl-clang", "repl-orc"]
+print(f"\n| bench | " + " | ".join(f"{m} min/median ms" for m in modes) + " |")
+print("|---|" + "---:|" * len(modes))
+for b in benches:
+    cells = []
+    for m in modes:
+        xs = sorted(by.get((b, m), []))
+        cells.append(f"{xs[0]} / {xs[len(xs)//2]}" if xs else "–")
+    print(f"| {b} | " + " | ".join(cells) + " |")
+bad = [r for r in rows if not r["ok"]]
+if bad: print(f"\n{len(bad)} FAILED rows (ok=false): " + ", ".join(f'{r["bench"]}/{r["mode"]}' for r in bad))
+PY

--- a/specs/benchmarks.md
+++ b/specs/benchmarks.md
@@ -1196,3 +1196,4 @@ to the features it exercises. Quick reference:
 | `lib/tir/trmc.ml` / TRMC / `lib/tir/perceus_fbip.ml` | `list_producers` |
 | JsonStream / streaming JSON | `json_stream` (tiny-token), `json_stream_strings` (string-heavy) |
 | actor / mailbox / scheduler / supervision changes | `scripts/actor-load.sh` (all four scenarios: `fanin`, `churn`, `callstorm`, `crashloop`) |
+| interpreter (`lib/eval/eval.ml`) / REPL-JIT (`lib/jit/`) changes | `bench/run_interp_bench.sh` (interp vs. compiled vs. repl-clang vs. repl-orc A-B over `bench/interp/`) |

--- a/specs/progress/2026-08-23-interp-perf-phase-0-benchmark-harness.md
+++ b/specs/progress/2026-08-23-interp-perf-phase-0-benchmark-harness.md
@@ -1,0 +1,33 @@
+# Interpreter/REPL-JIT A-B benchmark harness (Phase 0, task 0.7)
+
+**What:** `bench/run_interp_bench.sh`, an A-B runner over `bench/interp/` that
+times each benchmark under `interp` (tree-walking eval), `compiled`
+(`--compile --opt 2`), and the REPL under both JIT backends (`repl-clang`,
+`repl-orc`), cross-checking `checksum=` output between `interp` and
+`compiled` and failing hard on any mismatch. Also drives `http_server` (start
+server, hammer it with `bench/interp/http_client.py`, kill it, verify no
+survivor process) and a fixed `repl_session.txt` transcript. Emits one JSON
+line per run to stdout/`bench/results/<date>-interp-<arch>.jsonl` and a
+markdown min/median table to stderr.
+
+**Why:** the interpreter-performance and REPL-JIT work (this SDD) needs a
+repeatable, checksum-verified way to catch a regression or confirm a win
+across all three execution modes before/after each phase's changes, without
+hand-timing individual `.march` files.
+
+**How to run:**
+```bash
+bash bench/run_interp_bench.sh --runs 3                      # full A-B, all modes
+bash bench/run_interp_bench.sh --only fib,string_split --runs 1   # quick smoke
+bash bench/run_interp_bench.sh --modes repl-clang,repl-orc --runs 3
+```
+
+The runner and 1-run smoke validation (ok=true across every row, all modes
+including `http_server` and both REPL backends) landed 2026-08-24 at commit
+`8bfe5455`. The 3-run committed baseline capture (`--runs 3`, tag
+`baseline-8bfe5455`) is **deferred** to a quiet-box window — a concurrent
+session on this shared machine was running `steady_state_ring` benchmarks
+from another worktree during this session, which would have contaminated a
+timing baseline (see `project_bench_load_contamination` in memory). See
+`.superpowers/sdd/2026-08-23-interpreter-and-repl-jit-performance/task-0.7-report.md`
+for the smoke-run table and deferral details.

--- a/specs/todos/2026-08-24-orc-repl-segfault-fn-def-after-let-lambda.md
+++ b/specs/todos/2026-08-24-orc-repl-segfault-fn-def-after-let-lambda.md
@@ -1,0 +1,31 @@
+# ORC REPL backend: SIGSEGV defining a fn after a let-bound lambda/map
+
+## Minimal repro
+
+```
+fn fib(n) do if n < 2 do n else fib(n-1) + fib(n-2) end end
+let ys = List.map(List.range(1, 10), fn x -> x * 2)
+fn sq(x) do x * x end
+```
+
+Run via:
+```bash
+MARCH_JIT_BACKEND=orc ./_build/default/bin/main.exe < repro.txt
+```
+
+**Result:** Process exits with code 139 (SIGSEGV) on the third line.
+
+## Control case
+
+Two consecutive `fn` definitions without the intervening let-lambda work fine:
+
+```
+fn fib(n) do if n < 2 do n else fib(n-1) + fib(n-2) end end
+fn sq(x) do x * x end
+```
+
+**Result:** Both backends handle this without error.
+
+## Context
+
+The default clang backend handles the same session fine. This blocks flipping ORC to the default REPL backend (perf plan Phase 2.2) until fixed or root-caused. Found while building `bench/interp/repl_session.txt`, which was narrowed to avoid it.


### PR DESCRIPTION
Phase 0 of docs/superpowers/plans/2026-08-23-interpreter-and-repl-jit-performance.md (sequencing: Gate G0, Lane P).

- bench/interp/: 11 scaled benchmarks across numeric, string-parsing, actors, HTTP server, and parallel workloads; every program prints a checksum= line validated to agree between interpreted and compiled modes
- bench/run_interp_bench.sh: A-B runner (interp | compiled | repl-clang | repl-orc), JSONL rows + min/median table, hard failure on cross-mode checksum mismatch
- specs/benchmarks.md row mapping interpreter/REPL-JIT changes to the runner; phase-0 progress note
- Filed en route: specs/todos entry for an ORC REPL SIGSEGV (fn def after let-bound lambda) — gates the later ORC-default flip

The committed 3-run baseline JSONL is deferred to a quiet-box window (this box is currently running other sessions' benchmarks); recorded as the open follow-up in the progress note. Regression verdicts for later phases use interleaved same-box A/B per the plan's global constraints.