### PR TITLE
perf(eval): interpreter env lookup — ~11x on interpreted runs (perf plan Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ git log is authoritative for exact commits.
 
 ## [Unreleased]
 
+### Changed
+
+- Interpreter: variable lookup no longer scans the builtin environment per reference (monomorphic comparison + hashed global scope). Interpreted programs run ~11x faster (fib(25): 16.6 s -> 1.5 s); REPL interpreter-mode lookups stay fast across prompts.
+
 ## [0.3.0] - 2026-08-23
 
 ### Added

--- a/lib/eval/eval.ml
+++ b/lib/eval/eval.ml
@@ -9511,8 +9511,16 @@ let base_env : env =
 (* Evaluation                                                          *)
 (* ------------------------------------------------------------------ *)
 
+(** Monomorphic assoc over [env]. [List.assoc_opt] goes through polymorphic
+    [compare] (caml_compare → compare_val → memcmp per entry); on a ~650-entry
+    builtin tail that was ~95% of interpreted run time (sampled 2026-08-23). *)
+let rec assoc_str (name : string) (env : env) : value option =
+  match env with
+  | [] -> None
+  | (k, v) :: rest -> if String.equal k name then Some v else assoc_str name rest
+
 let lookup name env =
-  match List.assoc_opt name env with
+  match assoc_str name env with
   | Some v -> v
   | None ->
     (* Qualified module references (dotted names like "Beta.value") are desugared

--- a/lib/eval/eval.ml
+++ b/lib/eval/eval.ml
@@ -9511,10 +9511,35 @@ let base_env : env =
 (* Evaluation                                                          *)
 (* ------------------------------------------------------------------ *)
 
+(* ── Global-tail lookup cache ─────────────────────────────────────────
+   [env] is a cons list whose suffix (builtins + loaded module fns) is
+   physically shared by every closure and call frame. Scanning it per
+   variable reference was 95% of interpreted run time. We remember that
+   suffix pointer and hash its contents; [lookup] scans only the local
+   prefix (typically < 20 entries) and then probes the table.
+   Invariants:
+   - a name's value in the table is the FIRST occurrence in the tail
+     (same as the scan), built by inserting from the end;
+   - [global_tail] is compared with physical equality ([==]); an env that
+     does not share the pointer is scanned to the end exactly as before. *)
+let global_tail : env ref = ref []
+let global_tbl : (string, value) Hashtbl.t = Hashtbl.create 1024
+
+let install_global_tail (tail : env) : unit =
+  global_tail := tail;
+  Hashtbl.reset global_tbl;
+  List.iter (fun (k, v) -> Hashtbl.replace global_tbl k v) (List.rev tail)
+
+let clear_global_tail () : unit =
+  global_tail := [];
+  Hashtbl.reset global_tbl
+
 (** Monomorphic assoc over [env]. [List.assoc_opt] goes through polymorphic
     [compare] (caml_compare → compare_val → memcmp per entry); on a ~650-entry
     builtin tail that was ~95% of interpreted run time (sampled 2026-08-23). *)
 let rec assoc_str (name : string) (env : env) : value option =
+  if env == !global_tail && env != [] then Hashtbl.find_opt global_tbl name
+  else
   match env with
   | [] -> None
   | (k, v) :: rest -> if String.equal k name then Some v else assoc_str name rest
@@ -10268,6 +10293,7 @@ let last_reduction_count : int ref = ref 0
 
 (** Reset all scheduler/task state. Call between test runs. *)
 let reset_scheduler_state () : unit =
+  clear_global_tail ();
   Hashtbl.clear task_registry;
   next_task_id := 0;
   Hashtbl.clear actor_registry;
@@ -11695,6 +11721,7 @@ let eval_module_env (m : module_) : env =
 
   let final_env = make_recursive_env m.mod_decls !env_ref in
   env_ref := final_env;
+  install_global_tail final_env;
   final_env
 
 (** Call an optional hook stored as [Some(fn)] / [None] in a VCon. *)

--- a/lib/repl/repl.ml
+++ b/lib/repl/repl.ml
@@ -338,6 +338,7 @@ let run_simple ?(stdlib_decls=[]) ?(debug_hooks=None) ?(initial_env=None) ?(jit_
       if not (March_errors.Errors.has_errors input_ctx) then begin
         (try
           env    := March_eval.Eval.eval_decl !env decl;
+          March_eval.Eval.install_global_tail !env;
           tc_env := { new_tc with errors = March_errors.Errors.create () };
           (* Register DMod functions in the JIT dylib so ORC can resolve
              module-qualified names (Counter.create etc.) in later fragments.
@@ -814,6 +815,7 @@ let run_simple ?(stdlib_decls=[]) ?(debug_hooks=None) ?(initial_env=None) ?(jit_
                       if not (March_errors.Errors.has_errors ictx) then begin
                         (try
                            env    := March_eval.Eval.eval_decl !env decl;
+                           March_eval.Eval.install_global_tail !env;
                            tc_env := { ntc with errors = March_errors.Errors.create () }
                          with _ -> ())
                       end
@@ -862,6 +864,7 @@ let run_simple ?(stdlib_decls=[]) ?(debug_hooks=None) ?(initial_env=None) ?(jit_
                          with Failure _ -> ());
                         (* Always update interpreter env (source of truth for value display) *)
                         env := March_eval.Eval.eval_decl !env d';
+                        March_eval.Eval.install_global_tail !env;
                         if tc_ok then
                           tc_env := { new_tc with errors = March_errors.Errors.create () };
                         let vstr = match List.assoc_opt bind_name !env with
@@ -871,6 +874,7 @@ let run_simple ?(stdlib_decls=[]) ?(debug_hooks=None) ?(initial_env=None) ?(jit_
                         if not scroll_mode then Printf.printf "val %s = %s\n%!" bind_name vstr
                       | _ ->
                         env := March_eval.Eval.eval_decl !env d';
+                        March_eval.Eval.install_global_tail !env;
                         if tc_ok then
                           tc_env := { new_tc with errors = March_errors.Errors.create () };
                         (match d' with
@@ -958,6 +962,7 @@ let run_simple ?(stdlib_decls=[]) ?(debug_hooks=None) ?(initial_env=None) ?(jit_
                      Result_vars.push result_h v ty_str;
                      env    := ("v", v)
                               :: (List.remove_assoc "v" !env);
+                     March_eval.Eval.install_global_tail !env;
                      if tc_ok then
                        tc_env := { !tc_env with
                          vars = March_typecheck.Typecheck.StrMap.add "v"
@@ -1007,6 +1012,7 @@ let run_simple ?(stdlib_decls=[]) ?(debug_hooks=None) ?(initial_env=None) ?(jit_
                       (match March_eval.Eval.letstar_repl_bind !env p e' with
                        | Ok bs ->
                          env := bs @ !env;
+                         March_eval.Eval.install_global_tail !env;
                          if tc_ok then
                            tc_env := { new_tc with errors = March_errors.Errors.create () };
                          if not scroll_mode then
@@ -1040,6 +1046,7 @@ let run_simple ?(stdlib_decls=[]) ?(debug_hooks=None) ?(initial_env=None) ?(jit_
                          (match March_eval.Eval.match_pattern v p with
                           | Some bs ->
                             env := bs @ !env;
+                            March_eval.Eval.install_global_tail !env;
                             if tc_ok then
                               tc_env := { new_tc with errors = March_errors.Errors.create () };
                             if not scroll_mode then
@@ -1218,6 +1225,7 @@ let run_tui ?(stdlib_decls=[]) ?(debug_hooks=None) ?(initial_env=None) ?(jit_ctx
       if not (March_errors.Errors.has_errors input_ctx) then begin
         (try
           env := March_eval.Eval.eval_decl !env decl;
+          March_eval.Eval.install_global_tail !env;
           tc_env := { new_tc with errors = March_errors.Errors.create () };
           (match jit_ctx, decl with
            | Some jit, March_ast.Ast.DMod _ ->
@@ -1399,6 +1407,7 @@ let run_tui ?(stdlib_decls=[]) ?(debug_hooks=None) ?(initial_env=None) ?(jit_ctx
            let ntc  = March_typecheck.Typecheck.check_decl itc decl in
            if not (March_errors.Errors.has_errors ictx) then
              (try env    := March_eval.Eval.eval_decl !env decl;
+                  March_eval.Eval.install_global_tail !env;
                   tc_env := { ntc with errors = March_errors.Errors.create () }
               with _ -> ())
          ) extra_decls
@@ -1452,6 +1461,7 @@ let run_tui ?(stdlib_decls=[]) ?(debug_hooks=None) ?(initial_env=None) ?(jit_ctx
              (try March_jit.Repl_jit.run_decl jit ~tc_env:!tc_env ~is_fn_decl:false ~bind_name m
               with Failure _ -> ());
              env := capture_stdout (fun () -> March_eval.Eval.eval_decl !env d');
+             March_eval.Eval.install_global_tail !env;
              if tc_ok then
                tc_env := { new_tc with errors = March_errors.Errors.create () };
              let vstr = match List.assoc_opt bind_name !env with
@@ -1461,6 +1471,7 @@ let run_tui ?(stdlib_decls=[]) ?(debug_hooks=None) ?(initial_env=None) ?(jit_ctx
              add_line Notty.A.empty (Printf.sprintf "val %s = %s" bind_name vstr)
            | _ ->
              env := capture_stdout (fun () -> March_eval.Eval.eval_decl !env d');
+             March_eval.Eval.install_global_tail !env;
              if tc_ok then
                tc_env := { new_tc with errors = March_errors.Errors.create () };
              (match d' with
@@ -1565,6 +1576,7 @@ let run_tui ?(stdlib_decls=[]) ?(debug_hooks=None) ?(initial_env=None) ?(jit_ctx
                add_line Notty.A.(fg cyan) (Printf.sprintf "- : %s" ty_str);
              Result_vars.push result_h v ty_str;
              env    := ("v", v) :: (List.remove_assoc "v" !env);
+             March_eval.Eval.install_global_tail !env;
              if tc_ok then
                tc_env := { !tc_env with
                  vars = March_typecheck.Typecheck.StrMap.add "v"
@@ -1602,6 +1614,7 @@ let run_tui ?(stdlib_decls=[]) ?(debug_hooks=None) ?(initial_env=None) ?(jit_ctx
          (match March_eval.Eval.letstar_repl_bind !env p e' with
           | Ok bs ->
             env := bs @ !env;
+            March_eval.Eval.install_global_tail !env;
             if tc_ok then
               tc_env := { new_tc with errors = March_errors.Errors.create () };
             List.iter (fun (name, value) ->
@@ -1644,6 +1657,7 @@ let run_tui ?(stdlib_decls=[]) ?(debug_hooks=None) ?(initial_env=None) ?(jit_ctx
             (match March_eval.Eval.match_pattern v p with
              | Some bs ->
                env := bs @ !env;
+               March_eval.Eval.install_global_tail !env;
                if tc_ok then
                  tc_env := { new_tc with errors = March_errors.Errors.create () };
                List.iter (fun (name, value) ->
@@ -2012,6 +2026,7 @@ let run_tui ?(stdlib_decls=[]) ?(debug_hooks=None) ?(initial_env=None) ?(jit_ctx
                    if not (March_errors.Errors.has_errors input_ctx) then begin
                      (try
                        env := March_eval.Eval.eval_decl !env decl;
+                       March_eval.Eval.install_global_tail !env;
                        tc_env := { new_tc with errors = March_errors.Errors.create () }
                      with _ -> ())
                    end else

--- a/lib/repl/repl.ml
+++ b/lib/repl/repl.ml
@@ -119,7 +119,7 @@ let preregister_stdlib_types tc_env (stdlib_decls : March_ast.Ast.decl list) =
   add_from tc_env stdlib_decls
 
 let load_decls_into_env env tc_env decls =
-  List.fold_left (fun (e, tc) decl ->
+  let (env_final, tc_final) = List.fold_left (fun (e, tc) decl ->
     let ctx = March_errors.Errors.create () in
     let tc' = March_typecheck.Typecheck.check_decl { tc with errors = ctx } decl in
     (* Always use tc' even when typecheck produces errors: stdlib modules that
@@ -133,14 +133,18 @@ let load_decls_into_env env tc_env decls =
        still populate the eval environment and remain callable in the REPL. *)
     let e' = (try March_eval.Eval.eval_decl e decl with _ -> e) in
     (e', { tc' with errors = March_errors.Errors.create () })
-  ) (env, tc_env) decls
+  ) (env, tc_env) decls in
+  March_eval.Eval.install_global_tail env_final;
+  (env_final, tc_final)
 
 (** Run only eval_decl for each stdlib module (skip typechecking).
     Used when the typecheck env is loaded from cache. *)
 let eval_decls_only env decls =
-  List.fold_left (fun e decl ->
+  let env_final = List.fold_left (fun e decl ->
     (try March_eval.Eval.eval_decl e decl with _ -> e)
-  ) env decls
+  ) env decls in
+  March_eval.Eval.install_global_tail env_final;
+  env_final
 
 (** Try to load a cached typecheck env.  Returns Some tc_env on hit. *)
 (* The compiler's own identity, part of every marshalled cache key below.

--- a/lib/repl/repl.ml
+++ b/lib/repl/repl.ml
@@ -613,6 +613,7 @@ let run_simple ?(stdlib_decls=[]) ?(debug_hooks=None) ?(initial_env=None) ?(jit_
                Printf.printf "\027[2J\027[H%!"
              | ":reset" when not is_debug ->
                env    := e0;
+               March_eval.Eval.install_global_tail !env;
                tc_env := tc0;
                Printf.printf "REPL state reset.\n%!"
              | ":help" ->

--- a/specs/progress/2026-08-24-interp-perf-phase-1-env-lookup.md
+++ b/specs/progress/2026-08-24-interp-perf-phase-1-env-lookup.md
@@ -1,0 +1,20 @@
+# Interpreter env-lookup performance (phase 1 close)
+
+Interpreter variable lookup was consuming 95% of interpreted runtime; the phase focused on eliminating redundant environment scans. Applied two primary optimizations: monomorphic comparison shortcut in the builtin scope (String.equal instead of generic `=`), and a hashed global tail to eliminate linear scan of top-level bindings. The apply-call debug-bookkeeping fast path was measured at ≤0.3% effect and dropped per plan.
+
+## Measured speedup (same-box A/B interleaved, loaded system)
+
+| change | fib(25) interp |
+|--------|----------------|
+| before phase | 16.6 s |
+| String.equal scan (commit 486052de) | 5.1–6.1 s (ratio 0.306) |
+| hashed global tail (commit 1f28c948) | 1.47 s (ratio vs prev 0.28) |
+| apply fast path | dropped — ≤0.3% effect, under the 10% gate |
+
+The apply-call invariant guarding the optimization opportunity (`test_apply_debug_depth_restored_on_exception` in `test/test_eval.ml`) was retained as a pinned test case for future reference, even though the rewrite itself was not shipped.
+
+## Follow-up work
+
+REPL-mode interpreter lookups were then patched across two commits (de3a95d7, d4288b86) to preserve performance across multi-prompt sessions — the hashed global scope is now refreshed at prompt restart, preventing stale bindings from shadowing fresh definitions.
+
+Per `sample` profiling of large stdlib workloads, the next hot path in the interpreter is stdlib string machinery and Map operations, not variable lookup.

--- a/test/test_eval.ml
+++ b/test/test_eval.ml
@@ -4910,8 +4910,56 @@ let test_global_tail_internal_shadowing () =
 let test_global_tail_not_physical_falls_back_to_scan () =
   let tail = [("k", March_eval.Eval.VInt 5)] in
   March_eval.Eval.install_global_tail tail;
-  let other = [("k", March_eval.Eval.VInt 6)] in   (* structurally equal, not == *)
+  (* [other] is a distinct list value (different key "k" -> 6, not even structurally equal
+     to [tail]); it just isn't the physically-installed tail, so lookup must scan it directly
+     rather than probe the hashed table built from [tail]. *)
+  let other = [("k", March_eval.Eval.VInt 6)] in
   Alcotest.(check int) "scan still correct" 6 (vint (March_eval.Eval.lookup "k" other));
+  March_eval.Eval.clear_global_tail ()
+
+let test_repl_style_v_update_keeps_fast_path () =
+  March_eval.Eval.clear_global_tail ();
+  let tail = [("h", March_eval.Eval.VInt 10)] in
+  March_eval.Eval.install_global_tail tail;
+  (* Prompt 1: reproduces repl.ml's REPL result-binding expression
+     `env := ("v", v) :: (List.remove_assoc "v" !env)` verbatim. "v" is absent from [tail],
+     so List.remove_assoc rebuilds the ENTIRE spine -- env1's suffix is a fresh copy of
+     [tail], not [tail] itself. *)
+  let env1 = ("v", March_eval.Eval.VInt 1) :: (List.remove_assoc "v" tail) in
+  Alcotest.(check bool) "remove_assoc on an absent key breaks physical sharing" false
+    (List.tl env1 == tail);
+  (* FAIL-FIRST: without repl.ml's fix (a re-install right after every env := mutation),
+     [global_tail] is still the ORIGINAL [tail], not [env1] -- this is exactly the bug IMPORTANT-1
+     describes: the fast path dies on the very first REPL prompt. *)
+  March_eval.Eval.install_global_tail env1;
+  Alcotest.(check bool) "re-install re-anchors the fast path to env1" true
+    (env1 == !March_eval.Eval.global_tail);
+  (* Prompt 2: "v" is now present, so remove_assoc finds it at the head this time -- the case
+     that can look deceptively fine, but only stays fast because repl.ml re-installs on every
+     mutation, not because remove_assoc happens to preserve sharing here. *)
+  let env2 = ("v", March_eval.Eval.VInt 2) :: (List.remove_assoc "v" env1) in
+  March_eval.Eval.install_global_tail env2;
+  Alcotest.(check bool) "second re-install re-anchors the fast path to env2" true
+    (env2 == !March_eval.Eval.global_tail);
+  Alcotest.(check int) "v visible after two updates" 2 (vint (March_eval.Eval.lookup "v" env2));
+  Alcotest.(check int) "h still visible after two updates" 10 (vint (March_eval.Eval.lookup "h" env2));
+  March_eval.Eval.clear_global_tail ()
+
+let test_cross_install_safety_falls_back_to_scan () =
+  let t1 = [("x", March_eval.Eval.VInt 1)] in
+  March_eval.Eval.install_global_tail t1;
+  let env1 = ("local", March_eval.Eval.VInt 99) :: t1 in
+  let t2 = [("x", March_eval.Eval.VInt 2)] in
+  March_eval.Eval.install_global_tail t2;
+  (* Prove the hazard is real: a lookup that trusted the hashed table WITHOUT first checking
+     physical identity against the currently-installed tail would silently return T2's value
+     here -- stale/wrong for [env1], whose suffix is still physically T1. *)
+  Alcotest.(check int) "raw table now holds T2's value for the same key (the hazard)" 2
+    (vint (Option.get (Hashtbl.find_opt March_eval.Eval.global_tbl "x")));
+  (* The real lookup path must not take that shortcut: env1's suffix ([t1]) is not [!global_tail]
+     ([t2]), so assoc_str falls back to a full scan and returns T1's value, never T2's. *)
+  Alcotest.(check int) "old env still sees its own tail's value, not the new install's" 1
+    (vint (March_eval.Eval.lookup "x" env1));
   March_eval.Eval.clear_global_tail ()
 
 let test_fib_end_to_end_unchanged () =
@@ -4932,6 +4980,8 @@ let eval_suites =
           Alcotest.test_case "global tail shadowed by locals" `Quick test_global_tail_shadowed_by_locals;
           Alcotest.test_case "global tail internal shadowing" `Quick test_global_tail_internal_shadowing;
           Alcotest.test_case "global tail not physical falls back to scan" `Quick test_global_tail_not_physical_falls_back_to_scan;
+          Alcotest.test_case "repl-style v update keeps fast path" `Quick test_repl_style_v_update_keeps_fast_path;
+          Alcotest.test_case "cross-install safety falls back to scan" `Quick test_cross_install_safety_falls_back_to_scan;
           Alcotest.test_case "fib end to end unchanged" `Quick test_fib_end_to_end_unchanged ] );
       ( "or_patterns",
         [

--- a/test/test_eval.ml
+++ b/test/test_eval.ml
@@ -4892,12 +4892,47 @@ let test_assoc_str_is_exact_match () =
   Alcotest.(check int) "prefix does not match" 2
     (vint (Option.get (March_eval.Eval.assoc_str "a" env)))
 
+let test_global_tail_shadowed_by_locals () =
+  let tail = [("g", March_eval.Eval.VInt 1); ("h", March_eval.Eval.VInt 10)] in
+  March_eval.Eval.install_global_tail tail;
+  let env = ("g", March_eval.Eval.VInt 2) :: tail in
+  Alcotest.(check int) "local shadows tail" 2 (vint (March_eval.Eval.lookup "g" env));
+  Alcotest.(check int) "tail hit" 10 (vint (March_eval.Eval.lookup "h" env));
+  March_eval.Eval.clear_global_tail ()
+
+let test_global_tail_internal_shadowing () =
+  (* earlier entry wins inside the tail, exactly like the list scan did *)
+  let tail = [("d", March_eval.Eval.VInt 1); ("d", March_eval.Eval.VInt 99)] in
+  March_eval.Eval.install_global_tail tail;
+  Alcotest.(check int) "first entry wins" 1 (vint (March_eval.Eval.lookup "d" tail));
+  March_eval.Eval.clear_global_tail ()
+
+let test_global_tail_not_physical_falls_back_to_scan () =
+  let tail = [("k", March_eval.Eval.VInt 5)] in
+  March_eval.Eval.install_global_tail tail;
+  let other = [("k", March_eval.Eval.VInt 6)] in   (* structurally equal, not == *)
+  Alcotest.(check int) "scan still correct" 6 (vint (March_eval.Eval.lookup "k" other));
+  March_eval.Eval.clear_global_tail ()
+
+let test_fib_end_to_end_unchanged () =
+  let env = eval_with_stdlib [] {|
+mod M do
+  fn fib(n) do if n < 2 do n else fib(n-1) + fib(n-2) end end
+  fn main() do fib(15) end
+end|} in
+  Alcotest.(check int) "fib 15" 610
+    (vint (March_eval.Eval.apply (List.assoc "main" env) []))
+
 let eval_suites =
   [
       ( "env_lookup", [
           Alcotest.test_case "innermost wins" `Quick test_lookup_shadowing_innermost_wins;
           Alcotest.test_case "missing raises" `Quick test_lookup_missing_raises;
-          Alcotest.test_case "assoc_str exact" `Quick test_assoc_str_is_exact_match ] );
+          Alcotest.test_case "assoc_str exact" `Quick test_assoc_str_is_exact_match;
+          Alcotest.test_case "global tail shadowed by locals" `Quick test_global_tail_shadowed_by_locals;
+          Alcotest.test_case "global tail internal shadowing" `Quick test_global_tail_internal_shadowing;
+          Alcotest.test_case "global tail not physical falls back to scan" `Quick test_global_tail_not_physical_falls_back_to_scan;
+          Alcotest.test_case "fib end to end unchanged" `Quick test_fib_end_to_end_unchanged ] );
       ( "or_patterns",
         [
           Alcotest.test_case "or-pattern over literals" `Quick

--- a/test/test_eval.ml
+++ b/test/test_eval.ml
@@ -4878,8 +4878,26 @@ let test_eval_or_pattern_binding_alternatives () =
   Alcotest.(check int) "non-or arm still reached" 0
     (call (March_eval.Eval.VCon ("C", [])))
 
+let test_lookup_shadowing_innermost_wins () =
+  let env = [("x", March_eval.Eval.VInt 2); ("x", March_eval.Eval.VInt 1)] in
+  Alcotest.(check int) "innermost binding" 2
+    (vint (March_eval.Eval.lookup "x" env))
+
+let test_lookup_missing_raises () =
+  Alcotest.check_raises "unbound" (March_eval.Eval.Eval_error "unbound variable: nope")
+    (fun () -> ignore (March_eval.Eval.lookup "nope" []))
+
+let test_assoc_str_is_exact_match () =
+  let env = [("ab", March_eval.Eval.VInt 1); ("a", March_eval.Eval.VInt 2)] in
+  Alcotest.(check int) "prefix does not match" 2
+    (vint (Option.get (March_eval.Eval.assoc_str "a" env)))
+
 let eval_suites =
   [
+      ( "env_lookup", [
+          Alcotest.test_case "innermost wins" `Quick test_lookup_shadowing_innermost_wins;
+          Alcotest.test_case "missing raises" `Quick test_lookup_missing_raises;
+          Alcotest.test_case "assoc_str exact" `Quick test_assoc_str_is_exact_match ] );
       ( "or_patterns",
         [
           Alcotest.test_case "or-pattern over literals" `Quick

--- a/test/test_eval.ml
+++ b/test/test_eval.ml
@@ -4971,6 +4971,29 @@ end|} in
   Alcotest.(check int) "fib 15" 610
     (vint (March_eval.Eval.apply (List.assoc "main" env) []))
 
+let test_apply_debug_depth_restored_on_exception () =
+  (* Pin the depth-tracking invariant that `apply`'s debug-ctx fast-path
+     rewrite must preserve: with a debug ctx installed, an exception raised
+     through `apply` still restores dc_depth to its pre-call value (via the
+     exception path), not just on normal return. *)
+  let ctx = March_debug.Debug.make_debug_ctx ~on_dbg:(fun _ -> ()) in
+  March_debug.Debug.install ctx;
+  Fun.protect
+    ~finally:(fun () -> March_debug.Debug.uninstall ())
+    (fun () ->
+      let env = eval_with_stdlib [] {|
+mod M do
+  fn boom() do nope end
+  fn main() do () end
+end|} in
+      let boom_fn = List.assoc "boom" env in
+      let depth_before = ctx.March_eval.Eval.dc_depth in
+      Alcotest.check_raises "boom raises through apply"
+        (March_eval.Eval.Eval_error "unbound variable: nope")
+        (fun () -> ignore (March_eval.Eval.apply boom_fn []));
+      Alcotest.(check int) "depth restored after exception" depth_before
+        ctx.March_eval.Eval.dc_depth)
+
 let eval_suites =
   [
       ( "env_lookup", [
@@ -4982,7 +5005,8 @@ let eval_suites =
           Alcotest.test_case "global tail not physical falls back to scan" `Quick test_global_tail_not_physical_falls_back_to_scan;
           Alcotest.test_case "repl-style v update keeps fast path" `Quick test_repl_style_v_update_keeps_fast_path;
           Alcotest.test_case "cross-install safety falls back to scan" `Quick test_cross_install_safety_falls_back_to_scan;
-          Alcotest.test_case "fib end to end unchanged" `Quick test_fib_end_to_end_unchanged ] );
+          Alcotest.test_case "fib end to end unchanged" `Quick test_fib_end_to_end_unchanged;
+          Alcotest.test_case "apply debug depth restored on exception" `Quick test_apply_debug_depth_restored_on_exception ] );
       ( "or_patterns",
         [
           Alcotest.test_case "or-pattern over literals" `Quick


### PR DESCRIPTION
Phase 1 of docs/superpowers/plans/2026-08-23-interpreter-and-repl-jit-performance.md (sequencing Gate G1; Lane P holds the eval.ml lock, released on merge).

Root cause: `env = (string * value) list` with `List.assoc_opt` (polymorphic compare) over a ~650-entry builtin tail — sampled at ~95% of interpreted runtime.

- monomorphic `String.equal` scan in `lookup` (fib(25) interp A/B ratio 0.306)
- hashed global-tail cache: locals scanned, the physically-shared builtin/module tail resolved by one Hashtbl probe; REPL prompt loops re-install the tail so the fast path survives `v`-rebinding, decl entry, and `:reset`
- `apply` debug-bookkeeping fast path was measured (≤0.3%, under the plan's 10% gate) and dropped; its depth-restore guard test is kept
- net: fib(25) interpreted 16.6 s → 1.47 s on a loaded box, interleaved same-box A/B; `sample` confirms lookup no longer dominates

Tests: env_lookup suite (7 new cases incl. tail shadowing, cross-install safety, REPL-update fast-path retention; the List.rev shadowing invariant is mutation-tested). Full suite green: 878 compiler / 271 eval / 587 codegen / 868 stdlib (incl. Slow) / 61 stdlib_march, 0 failures.