### PR TITLE
fix(repl): give a prompt-declared type's constructors their real tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ git log is authoritative for exact commits.
 
 ## [Unreleased]
 
+### Fixed
+
+- **REPL: a constructor of a type declared at the prompt evaluated as the
+  type's FIRST variant.** With `type Color = Red | Green | Blue`, both `Green`
+  and `Blue` answered `Red` — and, because the same wrong constructor tag
+  reached pattern matching, `match Blue do Red -> 1 Green -> 2 Blue -> 3 end`
+  answered `1`. A type declared at the prompt was registered with the REPL's
+  JIT for pretty-printing only, never as an input to code generation, so every
+  constructor of it was compiled with tag 0. `MARCH_REPL_INTERP=1` was
+  unaffected.
+- **REPL: values of Option-shaped and single-constructor types printed as raw
+  words.** `Some(1)` displayed as `3`, `None` as `null`, and `Some("hi")` took
+  the REPL down; a user `type T = X(Int) | Y` showed `X(7)` as `15` and `Y` as
+  `null`. These representations are not heap cells — the value IS the payload
+  word — and the REPL's printer was reading them as though they were.
+  Constructor payloads of ordinary types now also print at their declared type
+  rather than assuming every field is a tagged scalar (`P1(7)` was showing as
+  `P1(3)`).
+
 ## [0.3.0] - 2026-08-23
 
 ### Added

--- a/lib/jit/repl_jit.ml
+++ b/lib/jit/repl_jit.ml
@@ -389,14 +389,96 @@ let rec subst_ty (bindings : (string * March_tir.Tir.ty) list) (t : March_tir.Ti
   | TRecord fs -> TRecord (List.map (fun (n, t) -> (n, subst_ty bindings t)) fs)
   | TInt | TFloat | TBool | TString | TUnit as t -> t
 
+(** Representation of the variant type [name] as codegen sees it.
+
+    The pretty-printer MUST agree with [Repr] here: an expression fragment is
+    emitted with the same type_defs, so a niche/newtype value never reaches
+    the printer as a heap cell at all — it arrives as the raw payload word
+    (e.g. `X(7)` of `type T = X(Int) | Y` is the tagged integer 15, with no
+    cell to read a tag from).  Reading such a word as a pointer prints
+    nonsense at best and faults at worst.
+
+    [repr_of_ty] reads a generic type's payload out of the TCon's type args, so
+    a NON-generic Option-shaped type (no args) comes back [Boxed]; that is what
+    [niche_repr_of_concrete] recovers, exactly as codegen's own decode sites do. *)
+let variant_repr ~type_defs (name : string) (args : March_tir.Tir.ty list)
+    : March_tir.Repr.repr =
+  let defs = Hashtbl.fold (fun _ td acc -> td :: acc) type_defs [] in
+  match March_tir.Repr.repr_of_ty defs (March_tir.Tir.TCon (name, args)) with
+  | March_tir.Repr.Boxed when args = [] ->
+    (match March_tir.Repr.niche_repr_of_concrete defs name with
+     | Some r -> r
+     | None -> March_tir.Repr.Boxed)
+  (* Abstract-arg niche path, mirroring [Llvm_case]'s [effective_repr]: a
+     niche-shaped type applied to a still-abstract argument (e.g. a bare
+     `Nothing2` whose element type never got resolved) is Boxed by
+     [repr_of_ty] — [niche_payload_ok] is false for a TVar — but codegen
+     emits Niche anyway, under the erased convention. *)
+  | March_tir.Repr.Boxed
+    when args <> []
+      && List.exists (function March_tir.Tir.TVar _ -> true | _ -> false) args
+      && March_tir.Repr.is_niche_shaped defs name ->
+    March_tir.Repr.Niche { payload = March_tir.Tir.TVar "_"; tagged = false }
+  | r -> r
+
+(** Split an Option-shaped variant's ctors into (nullary name, single name). *)
+let niche_ctor_names (ctors : (string * March_tir.Tir.ty list) list) =
+  match ctors with
+  | [ (n, []); (s, [_]) ] -> Some (n, s)
+  | [ (s, [_]); (n, []) ] -> Some (n, s)
+  | _ -> None
+
+(** A constructor payload slot is low-bit tagged exactly when the DECLARED
+    field type is erased (a TVar): those slots are `ptr`-typed, so a scalar
+    stored there is coerced to (v<<1)|1.  A field declared at a concrete
+    scalar type gets a real i64/double slot and is stored raw.  The decision
+    must be made on the declaration's own type, BEFORE substituting the
+    TCon's type args in — the substituted type is what the value means, not
+    how it is stored. *)
+let field_is_tagged (declared : March_tir.Tir.ty) =
+  match declared with March_tir.Tir.TVar _ -> true | _ -> false
+
 (** Pretty-print a March heap value given its TIR type.
     [type_defs] provides user-declared TDVariant/TDRecord lookups for
     non-builtin TCon names.  Recursion is bounded to depth 64. *)
 let rec pp_heap_value ?(depth=0) ~type_defs (ty : March_tir.Tir.ty) (ptr : nativeint) : string =
   if depth > 64 then "#<...>"
-  else if ptr = Nativeint.zero then "#<null>"
   else
   let open March_tir.Tir in
+  match ty with
+  (* Niche / newtype types are NOT heap cells: [ptr] is the raw payload word
+     (or 0 for a niche's nullary ctor), so these must be decoded before the
+     null guard and before any tag read. *)
+  | TCon (name, args) when (match Hashtbl.find_opt type_defs name with
+                            | Some (TDVariant _) -> true | _ -> false)
+                        && (match variant_repr ~type_defs name args with
+                            | March_tir.Repr.Boxed -> false | _ -> true) ->
+    let ctors = match Hashtbl.find type_defs name with
+      | TDVariant (_, cs) -> cs | _ -> [] in
+    let bindings =
+      try List.combine (collect_tvars (Hashtbl.find type_defs name)) args
+      with Invalid_argument _ -> [] in
+    (match variant_repr ~type_defs name args with
+     | March_tir.Repr.Niche { payload; tagged } ->
+       (match niche_ctor_names ctors with
+        | None -> Printf.sprintf "#<niche:%nd>" ptr
+        | Some (nullary, single) ->
+          if ptr = Nativeint.zero then nullary
+          else Printf.sprintf "%s(%s)" single
+                 (pp_word ~depth ~type_defs ~tagged (subst_ty bindings payload) ptr))
+     | March_tir.Repr.Newtype payload ->
+       (match ctors with
+        | [ (ctor, [ declared ]) ] ->
+          Printf.sprintf "%s(%s)" ctor
+            (pp_word ~depth ~type_defs ~tagged:(field_is_tagged declared)
+               (subst_ty bindings payload) ptr)
+        | _ -> Printf.sprintf "#<newtype:%nd>" ptr)
+     (* Unreachable: the guard above already excluded Boxed.  Rendered rather
+        than asserted — a printer must never take the REPL down. *)
+     | March_tir.Repr.Boxed -> Printf.sprintf "#<%s:%nd>" name ptr)
+  | _ ->
+  if ptr = Nativeint.zero then "#<null>"
+  else
   match ty with
   | TString ->
     (* march_string layout: {rc:i64, tag:i32, pad:i32, len:i64, data:char[]} *)
@@ -431,11 +513,11 @@ let rec pp_heap_value ?(depth=0) ~type_defs (ty : March_tir.Tir.ty) (ptr : nativ
             try List.combine tvars args
             with Invalid_argument _ -> []
           in
-          let payload_tys = List.map (subst_ty bindings) payload_tys in
           if payload_tys = [] then ctor_name
           else
-            let fields = List.mapi (fun i t ->
-              pp_field ~depth ~type_defs ~tagged:true t ptr i
+            let fields = List.mapi (fun i declared ->
+              pp_field ~depth ~type_defs ~tagged:(field_is_tagged declared)
+                (subst_ty bindings declared) ptr i
             ) payload_tys in
             Printf.sprintf "%s(%s)" ctor_name (String.concat ", " fields))
      | TDRecord (_, fs) ->
@@ -483,22 +565,55 @@ and pp_list ?(depth=0) ~type_defs elem_ty (ptr : nativeint) : string =
 
 and pp_field ?(depth=0) ~type_defs ~tagged (ty : March_tir.Tir.ty) (ptr : nativeint) (i : int) : string =
   let open March_tir.Tir in
-  (* When [tagged] is true the scalar slot holds (value<<1)|1 — shift right by 1.
-     When false (tuple fields) the raw int64 is the value. *)
-  let untag_i64 v = if tagged then Int64.shift_right_logical v 1 else v in
   match ty with
-  | TInt  -> Int64.to_string (untag_i64 (field_i64 ptr i))
-  | TBool -> if untag_i64 (field_i64 ptr i) = 0L then "false" else "true"
-  | TUnit -> "()"
   | TFloat ->
-    (* Floats are stored as raw double bits via bitcast — no tag bit. *)
-    let bits = field_i64 ptr i in
-    Printf.sprintf "%g" (Int64.float_of_bits bits)
+    (* Floats are stored as raw double bits via bitcast — no tag bit, and the
+       bit pattern is not a meaningful nativeint, so read the slot directly. *)
+    Printf.sprintf "%g" (Int64.float_of_bits (field_i64 ptr i))
+  | TInt | TBool | TUnit ->
+    pp_word ~depth ~type_defs ~tagged ty (Int64.to_nativeint (field_i64 ptr i))
+  | _ -> pp_word ~depth ~type_defs ~tagged ty (field_ptr ptr i)
+
+(** Render a value held in a single machine word — a constructor field just
+    read out of a cell, or the whole value of a niche/newtype type.
+    [tagged] says the word holds a low-bit-tagged scalar (value<<1)|1. *)
+and pp_word ?(depth=0) ~type_defs ~tagged (ty : March_tir.Tir.ty) (w : nativeint) : string =
+  let open March_tir.Tir in
+  let scalar () =
+    let v = Int64.of_nativeint w in
+    if tagged then Int64.shift_right_logical v 1 else v
+  in
+  match ty with
+  | TInt  -> Int64.to_string (scalar ())
+  | TBool -> if scalar () = 0L then "false" else "true"
+  | TUnit -> "()"
+  | TFloat -> Printf.sprintf "%g" (Int64.float_of_bits (Int64.of_nativeint w))
+  | TVar _ ->
+    (* Erased slot: a scalar is low-bit tagged, a heap value is an aligned
+       pointer.  Decide from the word itself — dereferencing a tagged scalar
+       as a cell would read unmapped memory. *)
+    if Nativeint.logand w 1n = 1n then
+      Int64.to_string (Int64.shift_right_logical (Int64.of_nativeint w) 1)
+    else if w = Nativeint.zero then "null"
+    else Printf.sprintf "#<tag:%d>" (heap_tag w)
   | _ ->
-    (* Pointer field: read the child pointer, then recurse *)
-    let child = field_ptr ptr i in
-    if child = Nativeint.zero then "null"
-    else pp_heap_value ~depth:(depth + 1) ~type_defs ty child
+    if w = Nativeint.zero then "null"
+    else pp_heap_value ~depth:(depth + 1) ~type_defs ty w
+
+(** True when a value of [ty] is NOT a heap pointer but the raw payload word
+    of a niche/newtype representation — the two cases where the "small word =
+    plain integer" fallback in [run_expr] would print `15` instead of `X(7)`,
+    and where a raw 0 means the nullary constructor rather than a null value. *)
+let is_raw_word_ty ~type_defs (ty : March_tir.Tir.ty) =
+  match ty with
+  | March_tir.Tir.TCon (name, args) ->
+    (match Hashtbl.find_opt type_defs name with
+     | Some (March_tir.Tir.TDVariant _) ->
+       (match variant_repr ~type_defs name args with
+        | March_tir.Repr.Boxed -> false
+        | _ -> true)
+     | _ -> false)
+  | _ -> false
 
 (* ── run_expr ──────────────────────────────────────────────────────── *)
 
@@ -515,16 +630,52 @@ let register_type_defs ctx (types : March_tir.Tir.type_def list) =
     | March_tir.Tir.TDClosure _ -> ()
   ) types
 
+let type_def_name (td : March_tir.Tir.type_def) =
+  match td with
+  | March_tir.Tir.TDVariant (n, _) | March_tir.Tir.TDRecord (n, _)
+  | March_tir.Tir.TDClosure (n, _) -> n
+
 (** Register a user type declaration from the REPL so subsequent expressions
-    can pretty-print values of that type.  DType decls otherwise never reach
-    the JIT — the REPL loop evaluates them in the tree-walking interpreter
-    and sends only DFn/DLet/ReplExpr through run_decl/run_expr. *)
+    can pretty-print values of that type AND construct them with the right
+    constructor tags.  DType decls otherwise never reach the JIT — the REPL
+    loop evaluates them in the tree-walking interpreter and sends only
+    DFn/DLet/ReplExpr through run_decl/run_expr.
+
+    Three registrations, all required:
+    - [register_type_defs] feeds [ctx.global_type_defs], which the heap
+      pretty-printer reads to turn a tag back into a constructor name.
+    - [ctx.loaded_tir_types] is passed as the [~types] of every subsequent
+      expression fragment, and codegen's [build_ctor_info] numbers constructor
+      tags from exactly that list.  Without it the fragment's [ctor_entry]
+      lookup misses and falls back to its `ce_tag = 0` default, so EVERY
+      nullary constructor is allocated with tag 0 and prints as the type's
+      first variant (`Green` and `Blue` both showing as `Red`).
+    - [ctx.stdlib_decls] is the lowering context, so [lower_module] knows
+      which type each bare constructor belongs to and emits the type-qualified
+      "Color.Green" key that [ctor_info] is keyed by.
+
+    Re-declaring a type at the prompt replaces the previous registration
+    rather than appending: [build_ctor_info] is first-wins, so a stale entry
+    would keep handing out the OLD variant numbering. *)
 let register_user_type_decl ctx (d : March_ast.Ast.decl) =
   match d with
   | March_ast.Ast.DType (_, name, params, td, _)
   | March_ast.Ast.DAlwaysLinearType (_, name, params, td, _) ->
     (match March_tir.Lower.lower_type_def name params td with
-     | Some td' -> register_type_defs ctx [td']
+     | Some td' ->
+       register_type_defs ctx [td'];
+       ctx.loaded_tir_types <-
+         List.filter (fun t -> type_def_name t <> type_def_name td')
+           ctx.loaded_tir_types
+         @ [td'];
+       ctx.stdlib_decls <-
+         List.filter (fun (d0 : March_ast.Ast.decl) ->
+           match d0 with
+           | March_ast.Ast.DType (_, n, _, _, _)
+           | March_ast.Ast.DAlwaysLinearType (_, n, _, _, _) ->
+             n.March_ast.Ast.txt <> name.March_ast.Ast.txt
+           | _ -> true) ctx.stdlib_decls
+         @ [d]
      | None -> ())
   | _ -> ()
 
@@ -663,7 +814,9 @@ let run_expr ctx ~tc_env m =
          Int64.to_string (Jit.call_void_to_int fptr)
        | Some ty ->
          let ptr = Jit.call_void_to_ptr fptr in
-         if ptr = Nativeint.zero then "null"
+         if is_raw_word_ty ~type_defs:ctx.global_type_defs ty then
+           pp_heap_value ~type_defs:ctx.global_type_defs ty ptr
+         else if ptr = Nativeint.zero then "null"
          else pp_heap_value ~type_defs:ctx.global_type_defs ty ptr
        | None ->
          (* No type information — call as ptr (safer than int for heap objects).
@@ -675,6 +828,11 @@ let run_expr ctx ~tc_env m =
            Int64.to_string raw
          else
            Printf.sprintf "#<0x%Lx>" raw)
+    | ty when is_raw_word_ty ~type_defs:ctx.global_type_defs ty ->
+      (* Niche/newtype: the returned word IS the value (0 = nullary ctor),
+         so neither the null check nor the small-integer fallback applies. *)
+      pp_heap_value ~type_defs:ctx.global_type_defs ty
+        (Jit.call_void_to_ptr fptr)
     | ty ->
       let ptr = Jit.call_void_to_ptr fptr in
       if ptr = Nativeint.zero then "null"

--- a/specs/progress/2026-08-24-repl-jit-nullary-ctor-tags.md
+++ b/specs/progress/2026-08-24-repl-jit-nullary-ctor-tags.md
@@ -1,0 +1,105 @@
+# REPL: every nullary constructor of a prompt-declared type evaluated as the type's FIRST variant (fixed 2026-08-24)
+
+```
+printf 'type Color = Red | Green | Blue\nGreen\nBlue\nRed\n:quit\n' | march
+   before:  = Red   = Red   = Red
+   after:   = Green = Blue  = Red
+```
+
+Not a display bug. The same wrong tag reached `match`, so evaluation was
+silently wrong too:
+
+```
+type Color = Red | Green | Blue
+match Blue do Red -> 1 Green -> 2 Blue -> 3 end   -- answered 1, not 3
+```
+
+Only the JIT path (the default). `MARCH_REPL_INTERP=1` was always correct,
+which is why the "repl parity" tests never saw it: `Test_helpers.repl_eval_exprs`
+drives the tree-walking interpreter directly and never touches the JIT. The
+regression test therefore drives a real `march repl` subprocess, next to
+`test_repl_renders_desugar_parse_error` which does the same for its own reason.
+
+## Root cause: a REPL-declared type never reached codegen
+
+The REPL loop evaluates a `DType` in the interpreter and hands it to the JIT
+only through `Repl_jit.register_user_type_decl`, which registered it in
+`ctx.global_type_defs` — the *pretty-printer's* table — and nowhere else.
+
+Each subsequent expression is compiled as its own LLVM module, and
+`Llvm_toplevel.build_ctor_info` numbers constructor tags from exactly the
+`~types` list handed to that fragment (`ctx.loaded_tir_types @ tir.tm_types`).
+`Color` was in neither, so the fragment's `ctor_entry` lookup missed, fell
+through the `".<ctor>"` suffix search (also empty), and returned its default:
+
+```ocaml
+{ ce_tag = 0; ce_fields = List.init n_args_fallback (fun _ -> Tir.TVar "_") }
+```
+
+Tag 0 for *every* constructor. The printer then faithfully rendered tag 0 —
+the first variant — and `emit_case` compared against the same 0 for every arm,
+so the first arm always won.
+
+`register_user_type_decl` now also appends the lowered `type_def` to
+`ctx.loaded_tir_types` (codegen's numbering input) and the AST decl to
+`ctx.stdlib_decls` (the lowering context, so a bare `Green` lowers to the
+type-qualified `Color.Green` key instead of relying on the suffix search to
+break a tie between two prompt-declared types that share a constructor name).
+A re-declaration at the prompt *replaces* both entries rather than appending:
+`build_ctor_info` is first-wins, so a stale entry would keep handing out the
+old variant numbering.
+
+## The second half: the printer assumed the fallback's representation
+
+Registering the type fixes the tag but changes what the fragment *returns*,
+and that exposed a printer that had been written against the fallback shape
+(always a heap cell, all fields low-bit tagged) rather than against `Repr`:
+
+| value | before this fix | with tags fixed, old printer | now |
+|---|---|---|---|
+| `X(7)` of `type T = X(Int) \| Y` | `X(7)` (by luck: X *is* tag 0) | `15` | `X(7)` |
+| `P1(7)` of `P0 \| P1(Int) \| P2` | `P0` | `P1(3)` | `P1(7)` |
+| `Some(1)` | `3` | `3` | `Some(1)` |
+| `Some("hi")` | REPL died | REPL died | `Some("hi")` |
+| `None` | `null` | `null` | `None` |
+
+Two independent conventions were being ignored:
+
+- **Niche / newtype types are not heap cells.** `X(7)` IS the tagged word 15
+  and `Y` IS a raw 0; there is no cell and no tag to read. The printer now
+  classifies with `Repr.repr_of_ty`, plus the same two recoveries codegen's own
+  decode sites use (`niche_repr_of_concrete` for a params-less TCon, and the
+  abstract-arg override that `Llvm_case.effective_repr` applies), and decodes
+  the word directly. `run_expr`'s "small word ⇒ print it as an integer"
+  fallback and its `ptr = 0 ⇒ null` guard are both skipped for these types —
+  they were what turned `X(7)` into `15` and `Y` into `null`.
+- **A constructor field is tagged only when its DECLARED type is erased.** A
+  field declared `TVar` gets a `ptr` slot, so a scalar stored there is coerced
+  to `(v<<1)|1`; a field declared `Int` gets a real `i64` slot and is stored
+  raw. The old code passed `~tagged:true` for every ADT field, which was right
+  only because the fallback's field types were all `TVar "_"`. Taggedness is
+  now decided on the declaration's own type, *before* the TCon's type args are
+  substituted in — the substituted type says what the value means, not how it
+  is stored.
+
+`pp_field` and the new niche/newtype paths share one `pp_word` decoder so a
+field slot and a whole niche value cannot drift apart. `pp_word` also handles
+a genuinely erased (`TVar`) word by reading the low bit instead of
+dereferencing: a tagged scalar dereferenced as a cell reads unmapped memory.
+
+## Not covered
+
+Stdlib ADT values still print as `#<tag:0>` in the JIT REPL (`Logger.Warn`,
+`Http.Post`). Same class of gap — the warm-cache startup path dlopens the
+prelude `.so` without ever lowering stdlib to TIR, so no stdlib `type_def`
+exists to hand the fragment. Filed as
+`specs/todos/2026-08-24-repl-jit-stdlib-adt-ctor-tags.md`; it needs the
+`type_def` list cached alongside the `.so`, not a printer change.
+
+## Tests
+
+`test/test_eval.ml` → "repl integration" → *JIT: nullary ctor tags of a
+REPL-declared type*. Drives `march repl` over a script covering all three
+representations (boxed nullary, boxed-with-payload, niche) plus a `match`, and
+asserts the printed forms. Verified to fail on the pre-fix `repl_jit.ml` and
+pass after.

--- a/specs/todos/2026-08-24-repl-jit-stdlib-adt-ctor-tags.md
+++ b/specs/todos/2026-08-24-repl-jit-stdlib-adt-ctor-tags.md
@@ -1,0 +1,33 @@
+# `[P3]` REPL JIT: stdlib ADT values print as `#<tag:0>`, with tag 0 for every constructor
+
+```
+$ march
+march(1)> Logger.Warn
+= #<tag:0>
+march(2)> Http.Post
+= #<tag:0>
+```
+
+`MARCH_REPL_INTERP=1` prints `Warn` / `Post`. Expect the tag to be wrong for
+`match` on these values too, exactly as it was for prompt-declared types before
+`specs/progress/2026-08-24-repl-jit-nullary-ctor-tags.md` — worth confirming
+before fixing, since a wrong constructor tag is a wrong evaluation, not just a
+wrong rendering.
+
+Same root cause as that entry, one layer further out. An expression fragment
+numbers its constructor tags from the `~types` list it is emitted with
+(`Llvm_toplevel.build_ctor_info`), and a missing type falls back to
+`ctor_entry`'s `ce_tag = 0`. `Repl_jit.precompile_stdlib`'s **cache-hit** path
+(the common one) dlopens `~/.cache/march/stdlib_prelude_*.so` and reads the
+`.names` file — it deliberately never lowers stdlib to TIR, which is the whole
+point of the cache — so no stdlib `type_def` is ever available to hand to a
+fragment, and none reaches `ctx.global_type_defs` for the printer either.
+
+Fix direction: cache the stdlib `type_def` list next to the `.so` (a third
+companion file, or extend `.names`) and load it into `ctx.loaded_tir_types` +
+`ctx.global_type_defs` on the hit path, so both codegen and the printer see the
+same numbering the `.so` was compiled with. Do NOT rebuild the list from a
+partial lowering: `build_ctor_info` is first-wins and order-sensitive, and the
+colliding-type path (`reserve_global_tag`) allocates global tags in list order,
+so a differently-ordered list would hand out tags that disagree with the
+already-compiled prelude.

--- a/test/test_eval.ml
+++ b/test/test_eval.ml
@@ -1390,6 +1390,68 @@ let test_repl_renders_desugar_parse_error () =
        try ignore (Str.search_forward re out 0); true with Not_found -> false)
   end
 
+(** Regression: nullary constructors of a REPL-declared ADT all printed as
+    the type's FIRST variant (`Green` and `Blue` both displayed as `Red`).
+
+    Root cause: the REPL's JIT compiles each expression fragment as its own
+    LLVM module whose constructor-tag table ([Llvm_toplevel.build_ctor_info])
+    is built ONLY from the type_defs handed to the fragment emitter.  A type
+    declared at the prompt is evaluated by the tree-walking interpreter and
+    was registered with the JIT for pretty-printing only
+    ([Repl_jit.register_user_type_decl] -> [global_type_defs]), never as a
+    lowering/codegen input — so the fragment's [ctor_entry] lookup missed and
+    fell back to its `ce_tag = 0` default, allocating every nullary
+    constructor with tag 0.  The printer then faithfully rendered tag 0, i.e.
+    the first variant.
+
+    Must drive the real `march repl` subprocess: the lightweight
+    [repl_eval_exprs] helper used by the "repl parity" tests never touches the
+    JIT, so it cannot reproduce this.  ([MARCH_REPL_INTERP] likewise takes the
+    interpreter path and always printed these correctly.) *)
+let test_repl_jit_nullary_ctor_tags () =
+  let exe_dir  = Filename.dirname Sys.executable_name in
+  let main_exe = Filename.concat exe_dir "../bin/main.exe" in
+  let project_root = Filename.dirname (Filename.dirname exe_dir) in
+  if not (Sys.file_exists main_exe) then ()  (* skip: no compiler binary *)
+  else begin
+    let read_cmd cmd =
+      let ic = Unix.open_process_in cmd in
+      let buf = Buffer.create 256 in
+      (try while true do Buffer.add_channel buf ic 1 done
+       with End_of_file -> ());
+      ignore (Unix.close_process_in ic);
+      Buffer.contents buf
+    in
+    let script = String.concat "\\n" [
+      "type Color = Red | Green | Blue";
+      "Green"; "Blue"; "Red";
+      (* The tag is not cosmetic: a wrong tag also picks the wrong match arm. *)
+      "match Blue do"; "  Red -> 1"; "  Green -> 2"; "  Blue -> 3"; "end";
+      (* A payload constructor past the first: the tag must be right AND the
+         payload must survive (each repr stores its fields differently). *)
+      "type Pay = P0 | P1(Int) | P2";
+      "P1(7)"; "P2";
+      (* Option-shaped: not a heap cell at all — `X(7)` IS the tagged word 15,
+         `Y` IS a raw 0. *)
+      "type Niche = X(Int) | Y";
+      "X(7)"; "Y";
+      ":quit" ] ^ "\\n" in
+    let out = read_cmd (Printf.sprintf
+      "cd %s && printf %s | %s repl 2>&1"
+      (Filename.quote project_root)
+      (Filename.quote script)
+      (Filename.quote main_exe)) in
+    let contains needle =
+      let re = Str.regexp_string needle in
+      try ignore (Str.search_forward re out 0); true with Not_found -> false
+    in
+    List.iter (fun expected ->
+      Alcotest.(check bool)
+        (Printf.sprintf "REPL prints `= %s` (got: %s)" expected (String.trim out))
+        true (contains ("= " ^ expected)))
+      ["Green"; "Blue"; "Red"; "3"; "P1(7)"; "P2"; "X(7)"; "Y"]
+  end
+
 (** Parity: same features work in interpreter mode *)
 let test_repl_parity_closures () =
   match repl_eval_exprs [
@@ -5118,6 +5180,8 @@ let eval_suites =
           Alcotest.test_case ":inspect type+value"     `Quick test_repl_inspect_type_and_value;
           Alcotest.test_case "final-review: renders desugar ParseError, not internal error"
             `Quick test_repl_renders_desugar_parse_error;
+          Alcotest.test_case "JIT: nullary ctor tags of a REPL-declared type"
+            `Quick test_repl_jit_nullary_ctor_tags;
         ] );
       ( "repl parity",
         [


### PR DESCRIPTION
Every nullary constructor of a type declared at the REPL evaluated as the type's **first** variant:

```
$ printf 'type Color = Red | Green | Blue\nGreen\nBlue\nRed\n:quit\n' | march
  before:  = Red   = Red   = Red
  after:   = Green = Blue  = Red
```

Not cosmetic — the same wrong tag reached pattern matching, so evaluation was silently wrong:

```
type Color = Red | Green | Blue
match Blue do Red -> 1 Green -> 2 Blue -> 3 end   -- answered 1, not 3
```

Only the JIT path (the default). `MARCH_REPL_INTERP=1` was always correct, which is why the "repl parity" tests never saw it — `Test_helpers.repl_eval_exprs` drives the tree-walking interpreter and never touches the JIT.

## Root cause

A `DType` typed at the prompt is evaluated by the interpreter and was handed to the JIT only through `Repl_jit.register_user_type_decl` → `ctx.global_type_defs`, i.e. the *pretty-printer's* table.

Each expression is compiled as its own LLVM module, and `Llvm_toplevel.build_ctor_info` numbers constructor tags from exactly the `~types` list that fragment is emitted with (`ctx.loaded_tir_types @ tir.tm_types`). `Color` was in neither, so the fragment's `ctor_entry` lookup missed, fell through its `".<ctor>"` suffix search (also empty), and returned its default:

```ocaml
{ ce_tag = 0; ce_fields = List.init n_args_fallback (fun _ -> Tir.TVar "_") }
```

Tag 0 for *every* constructor. The printer faithfully rendered tag 0 — the first variant — and `emit_case` compared every arm against the same 0, so the first arm always won.

`register_user_type_decl` now also appends the lowered `type_def` to `ctx.loaded_tir_types` (codegen's numbering input) and the AST decl to `ctx.stdlib_decls` (the lowering context, so a bare `Green` lowers to the type-qualified `Color.Green` key instead of relying on the suffix search to break a tie between two prompt-declared types sharing a constructor name). A re-declaration at the prompt *replaces* both entries — `build_ctor_info` is first-wins, so a stale entry would keep handing out the old numbering.

## The second half: the printer assumed the fallback's representation

Registering the type fixes the tag but changes what the fragment *returns*, and that exposed a printer written against the fallback shape (always a heap cell, all fields low-bit tagged) rather than against `Repr`:

| value | before | tags fixed, old printer | now |
|---|---|---|---|
| `X(7)` of `type T = X(Int) \| Y` | `X(7)` (by luck: X *is* tag 0) | `15` | `X(7)` |
| `P1(7)` of `P0 \| P1(Int) \| P2` | `P0` | `P1(3)` | `P1(7)` |
| `Some(1)` | `3` | `3` | `Some(1)` |
| `Some("hi")` | REPL died | REPL died | `Some("hi")` |
| `None` | `null` | `null` | `None` |

Two conventions were being ignored:

- **Niche/newtype types are not heap cells.** `X(7)` IS the tagged word 15 and `Y` IS a raw 0 — no cell, no tag to read. The printer now classifies with `Repr.repr_of_ty` plus the same two recoveries codegen's own decode sites use (`niche_repr_of_concrete` for a params-less TCon, and the abstract-arg override from `Llvm_case.effective_repr`). `run_expr`'s "small word ⇒ print as an integer" fallback and its `ptr = 0 ⇒ null` guard are skipped for these types — they were what turned `X(7)` into `15` and `Y` into `null`.
- **A field is tagged only when its DECLARED type is erased.** A `TVar` field gets a `ptr` slot, so a scalar there is coerced to `(v<<1)|1`; a field declared `Int` gets a real `i64` slot and is stored raw. Taggedness is now decided on the declaration's own type, *before* the TCon's type args are substituted in.

`pp_field` and the niche/newtype paths share one `pp_word` decoder so a field slot and a whole niche value cannot drift apart. `pp_word` handles a genuinely erased word by reading the low bit rather than dereferencing — a tagged scalar dereferenced as a cell reads unmapped memory.

## Tests

`test/test_eval.ml` → "repl integration" → *JIT: nullary ctor tags of a REPL-declared type*. Drives a real `march repl` subprocess (next to `test_repl_renders_desugar_parse_error`, which does the same for its own reason) over all three representations plus a `match`. **Verified to fail on the pre-fix `repl_jit.ml` and pass after.**

All suites run directly with exit codes checked: compiler 932, eval 263, codegen 587, stdlib 868, stdlib_march 61, snapshots 33 — all green. `scripts/check-docs.sh` passes. No benchmark run: the change is confined to the REPL JIT's registration and printing, which no compiled path touches.

## Not covered

Stdlib ADT values still print as `#<tag:0>` (`Logger.Warn`, `Http.Post`) — same class of gap one layer out: the warm-cache startup dlopens the prelude `.so` without ever lowering stdlib to TIR, so no stdlib `type_def` exists to hand a fragment. Filed as `specs/todos/2026-08-24-repl-jit-stdlib-adt-ctor-tags.md`; it needs the `type_def` list cached alongside the `.so`, not a printer change.
