### PR TITLE
fix(repl): make the stdlib typecheck cache actually save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ git log is authoritative for exact commits.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The REPL now actually caches its stdlib typecheck env.** Saving it had been
+  failing on every start since the cache was introduced — the env holds an
+  import-tracker closure that `Marshal` refuses to write, and the failure was
+  swallowed — so each REPL launch re-typechecked the whole stdlib and left a
+  zero-byte `stdlib_tcenv_*.tmp` file behind in `~/.cache/march` (1,132 of them
+  had accumulated on one machine). Start-up now hits the cache on the second and
+  later launches, a save that fails says so on stderr instead of degrading
+  silently, and both the REPL and the CLI sweep stale staging files left by
+  processes that died mid-write.
+
 ## [0.3.0] - 2026-08-23
 
 ### Added

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -652,6 +652,10 @@ let get_stdlib_tc_env ~for_js (stdlib_decls : March_ast.Ast.decl list) =
     (Printf.sprintf "stdlib_tcenv_cli%s_%s_%s.bin" js_suffix build_id short_hash) in
   let type_map : (March_ast.Ast.span, March_typecheck.Typecheck.ty) Hashtbl.t =
     Hashtbl.create 4096 in
+  (* Drop staging files left by processes that died mid-write — the REPL
+     sweeps the same shared dir on start, but a user who only ever runs the
+     CLI would otherwise never clear them. *)
+  March_repl.Repl.sweep_stale_cache_tmps cache_dir;
   let load_from_cache () =
     try
       if Sys.file_exists cache_path then begin
@@ -685,13 +689,27 @@ let get_stdlib_tc_env ~for_js (stdlib_decls : March_ast.Ast.decl list) =
        with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
       let tmp = Printf.sprintf "%s.%d.tmp" cache_path (Unix.getpid ()) in
       let oc = open_out_bin tmp in
-      Marshal.to_channel oc final_env [];
-      let tm_list = Hashtbl.fold (fun k v acc -> (k, v) :: acc)
-        final_env.March_typecheck.Typecheck.type_map [] in
-      Marshal.to_channel oc tm_list [];
-      close_out oc;
-      Sys.rename tmp cache_path
-    with _ -> ());
+      (* Same staging discipline as [March_repl.Repl.save_cached_tc_env], and
+         for the same reasons: the env is stripped of its unmarshalable
+         import-tracker closures before writing, and [Fun.protect] unlinks the
+         temp if anything raises, so a failed save cannot leave a zero-byte
+         orphan in the shared cache dir. *)
+      Fun.protect
+        ~finally:(fun () ->
+          (try close_out oc with _ -> ());
+          if Sys.file_exists tmp then (try Sys.remove tmp with _ -> ()))
+        (fun () ->
+          Marshal.to_channel oc (March_repl.Repl.marshalable_tc_env final_env) [];
+          let tm_list = Hashtbl.fold (fun k v acc -> (k, v) :: acc)
+            final_env.March_typecheck.Typecheck.type_map [] in
+          Marshal.to_channel oc tm_list [];
+          close_out oc;
+          Sys.rename tmp cache_path)
+    with e ->
+      Printf.eprintf
+        "[warn] could not save the stdlib typecheck cache (%s); stdlib will be \
+         re-typechecked on every invocation\n%!"
+        (Printexc.to_string e));
     { final_env with
       March_typecheck.Typecheck.errors = March_errors.Errors.create ();
       type_map = final_env.March_typecheck.Typecheck.type_map }

--- a/lib/repl/repl.ml
+++ b/lib/repl/repl.ml
@@ -151,9 +151,41 @@ let eval_decls_only env decls =
 let cache_build_id () =
   String.sub (Lazy.force March_cas.Cas.compiler_identity) 0 12
 
+(** Remove `<name>.<pid>.tmp` scratch files in [dir] whose owning pid is gone.
+
+    Every writer in this cache dir stages through a pid-suffixed temp and
+    renames; a writer that dies — or, as [save_cached_tc_env] did on every
+    single REPL start, raises — between the two leaves the temp behind.  Same sweep-by-liveness
+    shape as [March_jit.Repl_jit.create]'s per-pid tmp dirs.  Never raises:
+    cache upkeep must not be able to stop a REPL from starting. *)
+let sweep_stale_cache_tmps cache_dir =
+  let self = Unix.getpid () in
+  try
+    Array.iter (fun entry ->
+      if Filename.check_suffix entry ".tmp" then begin
+        (* "<name>.<pid>.tmp": ".<pid>" is the extension of the chopped name. *)
+        let ext = Filename.extension (Filename.chop_suffix entry ".tmp") in
+        let pid =
+          if ext = "" then None
+          else int_of_string_opt (String.sub ext 1 (String.length ext - 1)) in
+        match pid with
+        | Some pid when pid <> self ->
+          let alive =
+            try Unix.kill pid 0; true
+            with Unix.Unix_error (Unix.ESRCH, _, _) -> false
+               | Unix.Unix_error _ -> true (* EPERM etc: assume alive *)
+          in
+          if not alive then
+            (try Sys.remove (Filename.concat cache_dir entry) with _ -> ())
+        | _ -> ()
+      end
+    ) (Sys.readdir cache_dir)
+  with _ -> ()
+
 let load_cached_tc_env ~content_hash ~type_map =
   let home = (try Sys.getenv "HOME" with Not_found -> ".") in
   let cache_dir = Filename.concat home ".cache/march" in
+  sweep_stale_cache_tmps cache_dir;
   let short_hash = String.sub content_hash 0 16 in
   let cache_path = Filename.concat cache_dir
     ("stdlib_tcenv_" ^ cache_build_id () ^ "_" ^ short_hash ^ ".bin") in
@@ -173,6 +205,25 @@ let load_cached_tc_env ~content_hash ~type_map =
     end else None
   with _ -> None
 
+(** Drop the fields of a typecheck env that [Marshal] cannot represent.
+
+    [import_tracker]'s entries carry an [ie_matches : string -> bool] closure,
+    so marshalling an env that has ANY import entry raises
+    [Invalid_argument "output_value: functional value"] — and after a stdlib
+    fold every env has some.  That is what silently defeated this cache: the
+    save raised on every REPL start, so the REPL re-typechecked the whole
+    stdlib every time and left a zero-byte temp file behind each launch.
+
+    Dropping the tracker (and its parallel index) is sound here for the same
+    reason [Lsp.Typecheck_cache.derive] does it: both fields exist only to
+    report unused-import warnings for the decls that populated them, and
+    nothing reports those for stdlib.  Imports the user types AT the REPL are
+    registered on the live env afterwards either way. *)
+let marshalable_tc_env (tc_env : March_typecheck.Typecheck.env) =
+  { tc_env with
+    March_typecheck.Typecheck.import_tracker = ref [];
+    import_idx = March_typecheck.Typecheck.make_import_index () }
+
 (** Save the typecheck env to cache. *)
 let save_cached_tc_env ~content_hash tc_env =
   let home = (try Sys.getenv "HOME" with Not_found -> ".") in
@@ -184,17 +235,31 @@ let save_cached_tc_env ~content_hash tc_env =
     (try Unix.mkdir cache_dir 0o755
      with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
     (* Write-to-temp + rename: the cache dir is shared across concurrent
-       sessions; a reader must never see a half-written Marshal blob. *)
+       sessions; a reader must never see a half-written Marshal blob.
+       [Fun.protect] unlinks the temp on failure — without it a raising save
+       leaks one orphan per launch, which is how the failure below accumulated
+       1,132 zero-byte files before anyone read the directory. *)
     let tmp = Printf.sprintf "%s.%d.tmp" cache_path (Unix.getpid ()) in
     let oc = open_out_bin tmp in
-    Marshal.to_channel oc tc_env [];
-    (* Save type_map as association list (Hashtbl isn't stable across runs) *)
-    let tm_list = Hashtbl.fold (fun k v acc -> (k, v) :: acc)
-      tc_env.March_typecheck.Typecheck.type_map [] in
-    Marshal.to_channel oc tm_list [];
-    close_out oc;
-    Sys.rename tmp cache_path
-  with _ -> ())
+    Fun.protect
+      ~finally:(fun () ->
+        (try close_out oc with _ -> ());
+        if Sys.file_exists tmp then (try Sys.remove tmp with _ -> ()))
+      (fun () ->
+        Marshal.to_channel oc (marshalable_tc_env tc_env) [];
+        (* Save type_map as association list (Hashtbl isn't stable across runs) *)
+        let tm_list = Hashtbl.fold (fun k v acc -> (k, v) :: acc)
+          tc_env.March_typecheck.Typecheck.type_map [] in
+        Marshal.to_channel oc tm_list [];
+        close_out oc;
+        Sys.rename tmp cache_path)
+  with e ->
+    (* Loud: a silently failing cache costs a full stdlib typecheck on every
+       single REPL start, and looks like nothing at all. *)
+    Printf.eprintf
+      "[warn] could not save the stdlib typecheck cache (%s); the REPL will \
+       re-typecheck the stdlib on every start\n%!"
+      (Printexc.to_string e))
 
 (** Compute a content hash of stdlib decls using MD5 of their marshalled form.
     Stable within a binary build — changes whenever stdlib source changes. *)

--- a/lib/repl/repl.mli
+++ b/lib/repl/repl.mli
@@ -46,6 +46,16 @@ val load_decls_into_env :
   March_ast.Ast.decl list ->
   March_eval.Eval.env * March_typecheck.Typecheck.env
 
+(** Delete `<name>.<pid>.tmp` staging files in the given cache directory whose
+    owning process is no longer alive.  Never raises. *)
+val sweep_stale_cache_tmps : string -> unit
+
+(** Strip the typecheck-env fields [Marshal] cannot write (the import tracker
+    and its index, whose entries hold closures).  Callers that persist an env
+    must go through this. *)
+val marshalable_tc_env :
+  March_typecheck.Typecheck.env -> March_typecheck.Typecheck.env
+
 (** Load a cached typecheck env from disk. *)
 val load_cached_tc_env :
   content_hash:string ->

--- a/specs/progress/2026-08-24-repl-tcenv-cache-never-saved.md
+++ b/specs/progress/2026-08-24-repl-tcenv-cache-never-saved.md
@@ -1,0 +1,75 @@
+# The REPL's stdlib typecheck cache had never once been written
+
+Filed and fixed 2026-08-24. Symptom that surfaced it: `~/.cache/march` held
+1,132 zero-byte files named `stdlib_tcenv_<build>_<hash>.bin.<pid>.tmp`, the
+oldest dating to 2026-08-17 (the retention horizon of that directory, not the
+age of the bug).
+
+## What was actually happening
+
+`Repl.save_cached_tc_env` staged the marshalled env through a pid-suffixed temp
+and renamed it into place, with the whole body wrapped in `try ... with _ -> ()`.
+`Marshal.to_channel oc tc_env []` raised
+`Invalid_argument "output_value: functional value"` — **every time** — the
+handler swallowed it, and the already-created temp was never unlinked.
+
+The functional value is `Typecheck.import_entry.ie_matches : string -> bool`.
+Any env that has folded a decl carrying a `use`/`import`/alias holds such an
+entry in `import_tracker` (and in the `import_idx` that mirrors it), so a
+post-stdlib env is structurally unmarshalable. There was no version of this
+cache that worked: the `[timing] tc_env cache hit` line it prints on the load
+path had never been reachable in a real session.
+
+Three consequences, in descending order of how visible they were:
+
+1. one 0-byte orphan per REPL launch, forever;
+2. every REPL start paid the full stdlib typecheck fold (~0.7s here);
+3. the entire cache-**hit** code path was dead — it had never run outside tests.
+
+## The fix
+
+`lib/repl/repl.ml`:
+
+- **`marshalable_tc_env`** strips `import_tracker` and `import_idx` before the
+  write. Sound for the same reason `Lsp.Typecheck_cache.derive` already does
+  it: both fields exist only to drive unused-import warnings for the decls that
+  populated them, and nothing reports those for stdlib. Imports the user types
+  at the REPL register on the live env either way.
+- **`Fun.protect`** around the staged write unlinks the temp on any failure, so
+  a future unmarshalable field costs a slow start, not an orphan per launch.
+- The `with _ -> ()` became a **loud stderr warning**. A cache whose only
+  failure mode is "silently slower forever" is a cache that cannot be trusted
+  to be working, which is exactly what happened here.
+- **`sweep_stale_cache_tmps`** removes `<name>.<pid>.tmp` files in the cache dir
+  whose owning pid is gone, run from `load_cached_tc_env` (i.e. on every REPL
+  start). Same liveness-based shape as `Repl_jit.create`'s sweep of its per-pid
+  tmp dirs, and deliberately conservative: a pid that has been recycled by an
+  unrelated live process keeps its file.
+
+`bin/main.ml`'s `get_stdlib_tc_env` writes into the same directory with the same
+staging discipline, so it got the same three: sanitize, `Fun.protect`, sweep.
+Its own writes were succeeding (its `stdlib_tcenv_cli_*.bin` blobs are valid),
+but it had left five 0-byte orphans of its own from killed processes.
+
+## Verification
+
+- New `test/test_repl_cache.ml` (suite `repl_cache`, carried by
+  `run_compiler.exe`): a save of an env with a populated import tracker must
+  leave a non-empty blob that `load_cached_tc_env` reads back, and no `.tmp`;
+  and a dead-pid temp must be swept while a live-pid one survives. Both fail on
+  the pre-fix code — the first with exactly the observed orphan filename.
+- Real REPL, fresh `HOME`: first start `load_decls 0.701s`, no temp left; second
+  start `[timing] tc_env cache hit: 0.083s` + `eval_decls 0.111s`.
+- Cache-hit/cache-miss parity: a 12-line REPL script (list/enum/option/result
+  ops, a `type` decl, a user `fn`, `:type`) produces byte-identical output on
+  both paths — worth doing precisely because the hit path had never executed
+  before this change.
+- `march warm-cache` now genuinely warms this cache: `tc_env 0.799s (built +
+  cached)` on a cold `HOME`, `0.089s (cached)` on the second run. Before the
+  fix it printed "built + cached" every single time — the subcommand's whole
+  purpose, silently not happening.
+- `scripts/run-tests.sh`: all five suites green (compiler 934, eval 262,
+  codegen 587, stdlib 868, stdlib_march 61); `scripts/check-docs.sh` passes.
+- Sweep against the real `~/.cache/march`: 1132 → 6 temps in one REPL start; the
+  six survivors are pid-reuse false negatives, confirmed by `ps` (Slack, keybagd
+  and friends now hold those pids).

--- a/test/dune
+++ b/test/dune
@@ -11,7 +11,7 @@
 (library
  (name march_test_compiler)
  (wrapped false)
- (modules test_compiler test_cap_strip test_cap_symbols test_cap_markers test_cap_package test_cap_scope test_cap_ceiling test_cap_unforgeable test_cap_attrib_agreement test_cap_sandbox_profile test_cap_sandbox_runtime test_ctxesc)
+ (modules test_compiler test_repl_cache test_cap_strip test_cap_symbols test_cap_markers test_cap_package test_cap_scope test_cap_ceiling test_cap_unforgeable test_cap_attrib_agreement test_cap_sandbox_profile test_cap_sandbox_runtime test_ctxesc)
  (libraries march_test_helpers march_lexer march_parser march_ast march_desugar march_typecheck march_refinecheck march_errors march_effects march_eval march_tir march_repl march_debug march_scheduler march_cas march_caps march_ctxesc march_modules march_resolver march_forge march_lint alcotest str unix threads.posix))
 
 (library

--- a/test/test_compiler.ml
+++ b/test/test_compiler.ml
@@ -14726,6 +14726,7 @@ let compiler_suites =
   [
       sigil_interp_suite;
       csrf_suite;
+      ("repl_cache", Test_repl_cache.tests);
       ("cap_strip", Test_cap_strip.tests);
       ("cap_symbols", Test_cap_symbols.tests);
       ("cap_markers", Test_cap_markers.tests);

--- a/test/test_repl_cache.ml
+++ b/test/test_repl_cache.ml
@@ -1,0 +1,111 @@
+(** Regression tests for the REPL's stdlib typecheck-env disk cache
+    ([lib/repl/repl.ml]'s [save_cached_tc_env] / [load_cached_tc_env]).
+
+    The cache save had been failing silently on every REPL start since the
+    import tracker gained its [ie_matches : string -> bool] closure: a
+    [Marshal] of the env record raises [Invalid_argument "output_value:
+    functional value"], the `with _ -> ()` swallowed it, and the pid-suffixed
+    temp file it had already created was never unlinked — 1132 zero-byte
+    orphans in ~/.cache/march, and a full stdlib typecheck on every start. *)
+
+module Tc = March_typecheck.Typecheck
+module Repl = March_repl.Repl
+
+let with_temp_home f =
+  let dir = Filename.concat (Filename.get_temp_dir_name ())
+    (Printf.sprintf "march_repl_cache_test.%d.%d" (Unix.getpid ())
+       (Hashtbl.hash (Sys.time ()))) in
+  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  (* The cache code mkdirs ~/.cache/march but not ~/.cache, so give it the
+     parent a real home always has. *)
+  (try Unix.mkdir (Filename.concat dir ".cache") 0o755
+   with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let old_home = try Some (Sys.getenv "HOME") with Not_found -> None in
+  Unix.putenv "HOME" dir;
+  Fun.protect
+    ~finally:(fun () ->
+      (match old_home with Some h -> Unix.putenv "HOME" h | None -> ());
+      let cache = Filename.concat dir ".cache/march" in
+      (try Array.iter (fun f -> try Sys.remove (Filename.concat cache f)
+                                with _ -> ()) (Sys.readdir cache)
+       with _ -> ());
+      (try Unix.rmdir cache with _ -> ());
+      (try Unix.rmdir (Filename.concat dir ".cache") with _ -> ());
+      (try Unix.rmdir dir with _ -> ()))
+    (fun () -> f dir)
+
+let cache_files home =
+  let cache = Filename.concat home ".cache/march" in
+  try Array.to_list (Sys.readdir cache) with _ -> []
+
+let ends_with suffix s =
+  let ls = String.length s and lf = String.length suffix in
+  ls >= lf && String.sub s (ls - lf) lf = suffix
+
+(* An env whose import tracker holds a real entry — i.e. exactly what the REPL
+   hands [save_cached_tc_env] after folding stdlib through [check_decl]. The
+   entry's [ie_matches] field is the functional value that made the whole
+   record unmarshalable. *)
+let env_with_import_entry () =
+  let env = Tc.make_env (March_errors.Errors.create ()) (Hashtbl.create 16) in
+  let entry = {
+    Tc.ie_span = March_ast.Ast.dummy_span;
+    ie_desc = "unused import `List`";
+    ie_matches = (fun n -> n = "List");
+    ie_used = ref false;
+    ie_used_names = Hashtbl.create 4;
+  } in
+  env.Tc.import_tracker := [entry];
+  Tc.import_index_add_exact env.Tc.import_idx "List" entry;
+  { env with Tc.vars = Tc.StrMap.add "marker" (Tc.Mono (Tc.TCon ("Int", []))) env.Tc.vars }
+
+let test_save_writes_loadable_blob () =
+  with_temp_home (fun home ->
+    let env = env_with_import_entry () in
+    Repl.save_cached_tc_env ~content_hash:(String.make 32 'a') env;
+    let files = cache_files home in
+    let tmps = List.filter (ends_with ".tmp") files in
+    let bins = List.filter (ends_with ".bin") files in
+    Alcotest.(check (list string)) "no orphaned temp file left behind" [] tmps;
+    Alcotest.(check int) "one cache blob written" 1 (List.length bins);
+    List.iter (fun b ->
+      let path = Filename.concat (Filename.concat home ".cache/march") b in
+      Alcotest.(check bool) "blob is non-empty" true
+        ((Unix.stat path).Unix.st_size > 0)) bins;
+    (* And it must read back: a blob that only *exists* is worthless if the
+       loader rejects it, which is how a silent save failure would look from
+       the next REPL start's point of view. *)
+    let loaded =
+      Repl.load_cached_tc_env ~content_hash:(String.make 32 'a')
+        ~type_map:(Hashtbl.create 16) in
+    match loaded with
+    | None -> Alcotest.fail "cached env did not load back"
+    | Some tc ->
+      Alcotest.(check bool) "loaded env carries the saved bindings" true
+        (Tc.StrMap.mem "marker" tc.Tc.vars);
+      Alcotest.(check (list string)) "import tracker comes back empty" []
+        (List.map (fun (e : Tc.import_entry) -> e.Tc.ie_desc) !(tc.Tc.import_tracker)))
+
+let test_sweeps_stale_temp_files () =
+  with_temp_home (fun home ->
+    let cache = Filename.concat home ".cache/march" in
+    (try Unix.mkdir (Filename.concat home ".cache") 0o755 with _ -> ());
+    (try Unix.mkdir cache 0o755 with _ -> ());
+    (* A dead pid's leftover, and a live one (our own) that must survive. *)
+    let dead = Filename.concat cache "stdlib_tcenv_deadbeef_0123.bin.999999.tmp" in
+    let live = Filename.concat cache
+      (Printf.sprintf "stdlib_tcenv_deadbeef_0123.bin.%d.tmp" (Unix.getpid ())) in
+    close_out (open_out dead);
+    close_out (open_out live);
+    ignore (Repl.load_cached_tc_env ~content_hash:(String.make 32 'b')
+              ~type_map:(Hashtbl.create 4));
+    Alcotest.(check bool) "dead-pid temp swept" false (Sys.file_exists dead);
+    Alcotest.(check bool) "live-pid temp kept" true (Sys.file_exists live);
+    (try Sys.remove live with _ -> ()))
+
+let tests = [
+  Alcotest.test_case "save writes a loadable non-empty blob" `Quick
+    test_save_writes_loadable_blob;
+  Alcotest.test_case "stale pid-suffixed temps are swept" `Quick
+    test_sweeps_stale_temp_files;
+]


### PR DESCRIPTION
## The bug

`~/.cache/march` on my machine held **1,132 zero-byte** `stdlib_tcenv_<build>_<hash>.bin.<pid>.tmp` files, oldest dating to 2026-08-17. They were staging files from `Repl.save_cached_tc_env`, which stages through a pid-suffixed temp and renames.

The save had **never once succeeded**. `Typecheck.import_entry` carries `ie_matches : string -> bool`, so any env that has folded a decl with a `use`/`import`/alias — i.e. every post-stdlib env — makes `Marshal.to_channel` raise `Invalid_argument "output_value: functional value"`. The enclosing `try ... with _ -> ()` swallowed it, and the already-created temp was never unlinked.

Three consequences, in descending order of visibility:

1. one 0-byte orphan per REPL launch, forever;
2. every REPL start paid the full stdlib typecheck (~0.7s here);
3. the entire cache-**hit** path was dead code — `[timing] tc_env cache hit` had never been printed in a real session, and `march warm-cache` reported "built + cached" every single run while warming nothing.

## The fix

In `lib/repl/repl.ml`:

- **`marshalable_tc_env`** strips `import_tracker` and `import_idx` before the write. Sound for the same reason `Lsp.Typecheck_cache.derive` already does it: both fields exist only to drive unused-import warnings for the decls that populated them, and nothing reports those for stdlib. Imports typed *at* the REPL register on the live env either way.
- **`Fun.protect`** around the staged write unlinks the temp on any failure, so a future unmarshalable field costs a slow start, not an orphan per launch.
- The `with _ -> ()` is now a **loud stderr warning**. A cache whose only failure mode is "silently slower forever" is exactly how this survived.
- **`sweep_stale_cache_tmps`** removes `<name>.<pid>.tmp` files whose owning pid is gone, run on every REPL start. Same liveness-based shape as `Repl_jit.create`'s per-pid tmp-dir sweep, and deliberately conservative — a recycled pid held by an unrelated live process keeps its file.

`bin/main.ml`'s `get_stdlib_tc_env` writes into the same directory with the same staging discipline, so it gets all three. Its own writes were succeeding, but it had left five orphans from killed processes.

## Verification

- New `test/test_repl_cache.ml` (suite `repl_cache`, carried by `run_compiler.exe`): a save of an env with a populated import tracker must leave a non-empty blob that `load_cached_tc_env` reads back, and no `.tmp`; a dead-pid temp must be swept while a live-pid one survives. **Both fail on the pre-fix code** — the first with exactly the observed orphan filename.
- Real REPL, fresh `HOME`: first start `load_decls 0.701s`, no temp left; second start `[timing] tc_env cache hit: 0.083s` + `eval_decls 0.111s`.
- Hit/miss parity: a 12-line REPL script (list/enum/option/result ops, a `type` decl, a user `fn`, `:type`) gives byte-identical output on both paths — worth checking precisely because the hit path had never executed before.
- `march warm-cache`: `tc_env 0.799s (built + cached)` cold, `0.089s (cached)` on the second run.
- `scripts/run-tests.sh` all five suites green (compiler 934, eval 262, codegen 587, stdlib 868, stdlib_march 61); `scripts/check-docs.sh` passes.
- Sweep against the real `~/.cache/march`: 1132 → 6 temps in one REPL start; the six survivors are pid-reuse false negatives, confirmed by `ps`.

`specs/progress/2026-08-24-repl-tcenv-cache-never-saved.md` and a `CHANGELOG.md` entry land with the fix.
