### PR TITLE
fix(repl-jit): fn redefinition rebinds instead of being silently ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ git log is authoritative for exact commits.
 
 ## [Unreleased]
 
+### Fixed
+
+- REPL: redefining a `fn` at the prompt now takes effect under both JIT
+  backends (clang and ORC), matching interpreter mode's rebinding — the new
+  body was previously silently ignored and calls kept answering with the
+  first definition. `:reset` scroll-replay of unchanged cells still skips
+  recompilation.
+
 ### Changed
 
 - Interpreter: variable lookup no longer scans the builtin environment per reference (monomorphic comparison + hashed global scope). Interpreted programs run ~11x faster (fib(25): 16.6 s -> 1.5 s); REPL interpreter-mode lookups stay fast across prompts.

--- a/lib/jit/repl_jit.ml
+++ b/lib/jit/repl_jit.ml
@@ -44,6 +44,15 @@ type t = {
   mutable next_slot : int;
   mutable handles : Jit.dl_handle list;      (* open dl handles *)
   compiled_fns : (string, unit) Hashtbl.t;  (* fns already compiled in prior fragments *)
+  (* bind_name -> Digest of the declaration's marshaled AST, recorded when a
+     REPL-typed `fn` compiles successfully (run_decl ~is_fn_decl:true only —
+     stdlib-prelude and :load fns are compiled elsewhere and have no entry).
+     Distinguishes a :reset scroll-replay of the identical cell (same digest
+     → skip, closure slot still valid) from a genuine REDEFINITION (digest
+     differs → recompile and rebind the slot).  Each REPL input is parsed
+     from its own fresh [Lexing.from_string], so identical source text
+     yields a byte-identical marshaled AST. *)
+  fn_fingerprints : (string, string) Hashtbl.t;
   global_tir_tys : (string, March_tir.Tir.ty) Hashtbl.t;  (* bare_name -> TIR type, for display *)
   global_type_defs : (string, March_tir.Tir.type_def) Hashtbl.t;  (* type name -> TDVariant/TDRecord for display *)
   mutable stdlib_decls : March_ast.Ast.decl list;  (* cached for incremental lowering context *)
@@ -108,6 +117,7 @@ let create ~runtime_so ?(clang="clang") () =
     counter = 0; var_slots = []; next_slot = 0;
     handles = [rt_handle];
     compiled_fns = Hashtbl.create 256;
+    fn_fingerprints = Hashtbl.create 64;
     global_tir_tys = Hashtbl.create 16;
     global_type_defs = Hashtbl.create 16;
     stdlib_decls = [];
@@ -122,6 +132,9 @@ let next_id ctx =
   let n = ctx.counter in
   ctx.counter <- n + 1;
   n
+
+(* See the .mli — test-only observability for the replay skip fast path. *)
+let fragment_count ctx = ctx.counter
 
 let profile_enabled = Sys.getenv_opt "MARCH_JIT_PROFILE" <> None
 let time_phase name f =
@@ -282,6 +295,78 @@ let mark_compiled_fns ctx (fns : March_tir.Tir.fn_def list) =
   List.iter (fun (f : March_tir.Tir.fn_def) ->
     Hashtbl.replace ctx.compiled_fns f.fn_name ()
   ) fns
+
+module SS = Set.Make (String)
+
+(** Rename every reference to the top-level fn [old_name] to [new_name]
+    across a fragment's fn_defs (used when REDEFINING a REPL fn: the new
+    version must be emitted under a session-unique symbol so it can't
+    collide with the earlier fragment's definition — a hard duplicate-
+    definition error in the ORC backend's single JITDylib, and a latent
+    flat-namespace shadowing hazard under clang+dlopen).
+
+    Capture-avoiding: a locally bound [old_name] (param, let, case binder,
+    letrec) shadows the top-level fn, so references under such a binder are
+    left alone.  Both [EApp] heads (direct calls, incl. self-recursion) and
+    [AVar] atoms (the fn taken as a first-class value — emit_atom's top-fns
+    wrap path) are renamed; [ADefRef]/literals are untouched.  Runs post-
+    defun, so helper lambdas are separate fn_defs in the same list and get
+    the same treatment. *)
+let rename_top_fn_refs ~old_name ~new_name
+    (fns : March_tir.Tir.fn_def list) : March_tir.Tir.fn_def list =
+  let open March_tir.Tir in
+  let rename_var bound (v : var) =
+    if v.v_name = old_name && not (SS.mem old_name bound)
+    then { v with v_name = new_name } else v
+  in
+  let rename_atom bound = function
+    | AVar v -> AVar (rename_var bound v)
+    | (ADefRef _ | ALit _) as a -> a
+  in
+  let bind bound (v : var) = SS.add v.v_name bound in
+  let rec go bound e =
+    let ra = rename_atom bound in
+    match e with
+    | EAtom a -> EAtom (ra a)
+    | EApp (v, args) -> EApp (rename_var bound v, List.map ra args)
+    | ECallPtr (f, args) -> ECallPtr (ra f, List.map ra args)
+    | ELet (v, e1, e2) -> ELet (v, go bound e1, go (bind bound v) e2)
+    | ELetRec (lfns, e2) ->
+      (* The letrec's own names shadow throughout (bodies and continuation). *)
+      let bound' = List.fold_left (fun b (f : fn_def) ->
+        SS.add f.fn_name b) bound lfns in
+      let lfns' = List.map (fun (f : fn_def) ->
+        let fb = List.fold_left bind bound' f.fn_params in
+        { f with fn_body = go fb f.fn_body }) lfns in
+      ELetRec (lfns', go bound' e2)
+    | ECase (scrut, branches, dflt) ->
+      let branches' = List.map (fun (b : branch) ->
+        let bb = List.fold_left bind bound b.br_vars in
+        { b with br_body = go bb b.br_body }) branches in
+      ECase (ra scrut, branches', Option.map (go bound) dflt)
+    | ETuple atoms -> ETuple (List.map ra atoms)
+    | ERecord fields -> ERecord (List.map (fun (n, a) -> (n, ra a)) fields)
+    | EField (a, n) -> EField (ra a, n)
+    | EUpdate (a, fields) ->
+      EUpdate (ra a, List.map (fun (n, x) -> (n, ra x)) fields)
+    | EAlloc (ty, atoms) -> EAlloc (ty, List.map ra atoms)
+    | EStackAlloc (ty, atoms) -> EStackAlloc (ty, List.map ra atoms)
+    | EFree a -> EFree (ra a)
+    | EIncRC a -> EIncRC (ra a)
+    | EDecRC a -> EDecRC (ra a)
+    | EAtomicIncRC a -> EAtomicIncRC (ra a)
+    | EAtomicDecRC a -> EAtomicDecRC (ra a)
+    | EReuse (a, ty, atoms) -> EReuse (ra a, ty, List.map ra atoms)
+    | ESeq (e1, e2) -> ESeq (go bound e1, go bound e2)
+    | EAllocHole (tok, ty, atoms, hole) ->
+      EAllocHole (Option.map ra tok, ty, List.map ra atoms, hole)
+    | ESetField (obj, i, v) -> ESetField (ra obj, i, ra v)
+  in
+  List.map (fun (f : fn_def) ->
+    let bound = List.fold_left bind SS.empty f.fn_params in
+    { f with
+      fn_name = (if f.fn_name = old_name then new_name else f.fn_name);
+      fn_body = go bound f.fn_body }) fns
 
 (** Build the [repl_slot_info list] passed to LLVM emit functions from
     the current [ctx.var_slots] list. *)
@@ -711,15 +796,70 @@ let run_decl ctx ~tc_env ~is_fn_decl ~bind_name m =
     f.fn_name <> "main") tir.March_tir.Tir.tm_fns in
   let (user_fns, extern_fns) = partition_fns ctx all_support_fns in
   if is_fn_decl then begin
-    (* JIT context persists across :reset.  When the scroll system resends prior
-       cells, the function is already compiled and its closure slot is still valid.
-       Skip recompilation entirely — helper lambdas may have new defun UIDs but
-       the compiled closure is unchanged. *)
-    if Hashtbl.mem ctx.compiled_fns bind_name then ()
+    (* JIT context persists across :reset.  When the scroll system resends
+       prior cells, the function is already compiled and its closure slot is
+       still valid — skip recompilation entirely (helper lambdas may have new
+       defun UIDs but the compiled closure is unchanged).  A REPLAY is
+       recognized by its AST fingerprint matching the recorded one; a genuine
+       REDEFINITION (same name, different body) has a different fingerprint
+       and must recompile and rebind the closure slot, matching interpreter-
+       mode's Elixir-style rebinding.  A compiled name with NO fingerprint on
+       record was compiled outside run_decl (stdlib prelude, :load): calls to
+       those resolve as direct extern calls, not through a slot, so a
+       redefinition could never take effect — keep the historical skip. *)
+    let fingerprint = Digest.to_hex (Digest.string (Marshal.to_string m [])) in
+    let already_compiled = Hashtbl.mem ctx.compiled_fns bind_name in
+    let is_replay =
+      already_compiled &&
+      (match Hashtbl.find_opt ctx.fn_fingerprints bind_name with
+       | Some fp -> fp = fingerprint
+       | None -> true)
+    in
+    if is_replay then ()
     else begin
+    let is_redefinition = already_compiled in
+    (* partition_fns classified the freshly lowered [bind_name] as extern
+       (its OLD version is in compiled_fns); pull it back so the new body is
+       defined in this fragment rather than declared. *)
+    let (user_fns, extern_fns) =
+      if is_redefinition then
+        let (redef, ext) = List.partition
+          (fun (f : March_tir.Tir.fn_def) -> f.fn_name = bind_name)
+          extern_fns in
+        (user_fns @ redef, ext)
+      else (user_fns, extern_fns)
+    in
+    (* Emit a redefinition under a session-unique symbol: the earlier
+       fragment already defined [bind_name], and the ORC backend's single
+       JITDylib hard-errors on a duplicate definition (clang+dlopen would
+       merely shadow ambiguously in the flat namespace).  Calls resolve
+       through the closure SLOT, not the symbol, so only the slot binding
+       below needs the bare name.  [ctx.counter] is monotonic and the
+       primary emit below advances it, so successive redefinitions get
+       distinct names. *)
+    let emit_name =
+      if is_redefinition then
+        Printf.sprintf "%s$redef$%d" bind_name ctx.counter
+      else bind_name
+    in
+    let user_fns =
+      if is_redefinition then
+        rename_top_fn_refs ~old_name:bind_name ~new_name:emit_name user_fns
+      else user_fns
+    in
+    (* On redefinition, drop the OLD binding's slot from prev_slots: the
+       emitter would otherwise emit a slot-loader `define @<bind_name>()`
+       that collides with the original fragment's definition under ORC, and
+       the new body must not silently resolve its own name to the old
+       closure anyway (self-recursion was renamed to [emit_name] above). *)
+    let prev_slots =
+      List.filter (fun (si : March_tir.Llvm_emit.repl_slot_info) ->
+        not (is_redefinition && si.rs_bare = bind_name))
+        (prev_slots_of ctx)
+    in
     let primary_fn =
       match List.find_opt (fun (f : March_tir.Tir.fn_def) ->
-        f.fn_name = bind_name) user_fns with
+        f.fn_name = emit_name) user_fns with
       | Some f -> f
       | None -> List.hd user_fns
     in
@@ -745,20 +885,29 @@ let run_decl ctx ~tc_env ~is_fn_decl ~bind_name m =
     let pn = next_id ctx in
     let slot = alloc_slot ctx in
     let ir = March_tir.Llvm_emit.emit_repl_fn_with_closure_slot
-      ~n:pn ~bind_name ~dest_slot:slot ~prev_slots:(prev_slots_of ctx)
+      ~n:pn ~bind_name ~dest_slot:slot ~prev_slots
       ~extern_fns:(extern_fns @ helper_fns) ~types:(ctx.loaded_tir_types @ tir.March_tir.Tir.tm_types)
       primary_fn in
     let handle = compile_fragment ctx ir in
     mark_compiled_fns ctx [primary_fn];
+    (* Record the declaration's fingerprint only after the fragment compiled
+       and loaded — a failed compile must leave the previous state (and its
+       fingerprint) intact so the user's retry recompiles cleanly, mirroring
+       the mark_compiled_fns discipline. *)
+    Hashtbl.replace ctx.fn_fingerprints bind_name fingerprint;
     let init_name = Printf.sprintf "repl_%d_init" pn in
     let fptr = lookup_sym handle init_name in
     Jit.call_void_to_void fptr;
     (* Register the slot so future fragments can load the closure as a value.
        The type is TFn (closures are heap pointers), which causes emit_prev_slot_bridges
-       to emit inttoptr when loading the closure from the slot. *)
+       to emit inttoptr when loading the closure from the slot.  On a
+       redefinition this REBINDS the bare name to the fresh slot holding the
+       new closure — later fragments resolve calls through this binding, so
+       they pick up the new body.  (The old slot keeps the old closure alive;
+       one abandoned closure per redefinition, same shape as `let` rebinding.) *)
     ctx.var_slots <- (bind_name, slot, March_tir.Tir.TFn ([], March_tir.Tir.TUnit)) ::
       List.filter (fun (b, _, _) -> b <> bind_name) ctx.var_slots
-    end (* if user_fns <> [] *)
+    end (* not is_replay *)
   end else begin
     (* Let binding: compute value and store in a fresh slot. *)
     let main_fn = match List.find_opt (fun (f : March_tir.Tir.fn_def) ->

--- a/lib/jit/repl_jit.mli
+++ b/lib/jit/repl_jit.mli
@@ -8,6 +8,12 @@ type t
     [clang] is the clang binary path (default "clang"). *)
 val create : runtime_so:string -> ?clang:string -> unit -> t
 
+(** Number of IR fragments compiled so far in this session.  Exposed for
+    tests: it lets them assert that an identical :reset-style replay of a
+    declaration takes the skip fast path (count unchanged) rather than
+    recompiling. *)
+val fragment_count : t -> int
+
 (** Compile and execute a REPL expression.
     Returns the LLVM IR return type and a string representation of the result.
     Raises [Failure] on compile or link error. *)

--- a/specs/progress/2026-08-24-repl-jit-fn-redefinition-silently-ignored.md
+++ b/specs/progress/2026-08-24-repl-jit-fn-redefinition-silently-ignored.md
@@ -1,0 +1,104 @@
+# REPL JIT: `fn` redefinition silently ignored on both backends
+
+## Symptom
+
+```
+march(1)> fn f(x) do x + 1 end
+march(2)> fn f(x) do x + 100 end
+march(3)> f(1)
+= 2            <- should be 101
+```
+
+The second definition printed `val f = <fn>` but had no effect, on BOTH the
+clang and ORC JIT backends. Interpreter mode (`MARCH_REPL_INTERP=1`) already
+rebound correctly (`= 101`), so the JIT paths diverged from the language's
+Elixir-style rebinding semantics. Found 2026-08-24 while reviewing the ORC
+REPL segfault fix (see that fix's spec, "Follow-up noticed" — landed on the
+`claude/jit-repl-interpreted-perf-68373c` branch).
+
+## Root cause
+
+`lib/jit/repl_jit.ml` `run_decl`'s `is_fn_decl` path early-returned whenever
+`Hashtbl.mem ctx.compiled_fns bind_name` — a guard added for `:reset`
+scroll-replay (the scroll system resends prior cells verbatim; the function
+is already compiled and its closure slot still valid, so recompiling is pure
+waste). The guard could not tell a verbatim resend from a genuine
+redefinition, so a new body for an existing name never recompiled and never
+rebound the closure slot.
+
+## Semantics decision
+
+Redefinition rebinds, exactly as interpreter mode already does. The
+mechanism the JIT already uses makes this natural: cross-fragment calls to a
+REPL-defined `fn` resolve through its persistent closure SLOT
+(`march_repl_get` + indirect call at closure+16 — verified in the emitted
+fragment IR), not through the LLVM symbol, so rebinding the slot to a new
+closure redirects every later call.
+
+## Fix (lib/jit/repl_jit.ml)
+
+- New `ctx.fn_fingerprints : bind_name -> Digest(Marshal(decl AST module))`,
+  recorded only after the fragment compiles and loads (same
+  success-only discipline as `mark_compiled_fns`). Each REPL input is parsed
+  from its own fresh `Lexing.from_string`, so identical source text yields a
+  byte-identical marshaled AST.
+- `run_decl ~is_fn_decl:true` now distinguishes three cases:
+  - **Replay** (compiled + fingerprint matches): keep the skip fast path.
+  - **Redefinition** (compiled + fingerprint differs): recompile and rebind.
+  - **No fingerprint on record** (compiled by the stdlib prelude or `:load`,
+    not by `run_decl`): keep the historical skip — calls to those resolve as
+    direct extern calls, not through a slot, so a redefinition could never
+    take effect anyway.
+- A redefinition is emitted under a session-unique symbol
+  (`<name>$redef$<fragment-counter>`, via a capture-avoiding
+  `rename_top_fn_refs` over the fragment's post-defun TIR so self-recursion
+  and first-class self-references follow the rename): the earlier fragment
+  already defined `<name>`, and the ORC backend's single JITDylib
+  hard-errors on duplicate definitions (clang+dlopen would merely shadow
+  ambiguously in the flat namespace).
+- The freshly lowered `bind_name` is pulled back out of `partition_fns`'
+  extern list (its OLD version being in `compiled_fns` had classified it as
+  extern), and the old binding's slot is filtered out of `prev_slots` so the
+  emitter doesn't emit a slot-loader `define @<name>()` that would collide
+  with the original definition under ORC. This filter is what lets the fix
+  work independently of the ORC internal-linkage loader fix on the
+  `claude/jit-repl-interpreted-perf-68373c` branch; the two compose.
+- The slot registration at the end rebinds the bare name to a fresh slot
+  holding the new closure. The old slot keeps the old closure alive — one
+  abandoned closure per redefinition, the same shape as `let` rebinding.
+
+`val fragment_count : t -> int` was added to the `.mli` so tests can assert
+the replay path compiles no new fragment.
+
+## Validation
+
+- `test/test_codegen.ml` `test_repl_jit_fn_redefinition` (in-process, clang):
+  original body, redefinition (`101` not `2`), identical replay skips
+  (fragment count unchanged) and keeps the binding, self-recursive
+  redefinition reaches the new body, arity-changing redefinition works.
+  Verified red against the un-fixed compiler (`Received: "2"`).
+- `test/test_jit.ml` `repl_session` group: subprocess end-to-end sessions of
+  the real binary for the clang backend, ORC backend (`MARCH_JIT_BACKEND=orc`,
+  skips when libLLVM is absent), and interpreter mode. Subprocess so a
+  backend SIGSEGV fails one test rather than the runner, and because the
+  backend env vars are read once at module init. Both JIT sessions verified
+  red pre-fix; interpreter green pre- and post-fix.
+- Control sessions unchanged: `fn f; fn sq; sq(3); f(1)` and a redefinition
+  with an intervening stdlib let-lambda both behave on clang.
+
+## Known limitations (pre-existing, unchanged)
+
+- `fn g(x) do f(x) end` referencing a prior REPL `fn` fails on both backends
+  ("I cannot find `g`" / fragment IR collision) — the "Follow-up noticed"
+  item on the ORC-fix branch. Because later REPL-defined functions cannot
+  reference `f` at all today, there are no stale direct-call sites for a
+  redefinition to miss; if that limitation is lifted, calls lowered as
+  direct extern `f` calls inside OTHER functions would pin the version
+  compiled at their definition time and should be revisited then.
+- Redefining a stdlib/`:load`-ed function is still silently ignored (see
+  above — no slot to rebind).
+- A REPL `fn` whose body contains any lambda already fails its helpers
+  fragment's dlopen on the clang backend (`symbol not found in flat
+  namespace '_f'`) and loses the binding — reproduced on unmodified HEAD
+  with a fresh HOME, so redefinition of such functions is untestable until
+  that is fixed. Filed separately.

--- a/test/dune
+++ b/test/dune
@@ -805,7 +805,11 @@
 (test
  (name test_jit)
  (modules test_jit)
- (libraries march_jit alcotest)
+ (libraries march_jit alcotest unix)
+ ; The repl_session tests spawn the real compiler binary and need the staged
+ ; stdlib + runtime trees next to it (same dep shape as the bench_gate rule).
+ (deps (source_tree ../stdlib) (source_tree ../runtime)
+       (file %{exe:../bin/main.exe}))
  (action (setenv HOME %{project_root}/_build/jit_home (run %{test}))))
 
 (test

--- a/test/test_codegen.ml
+++ b/test/test_codegen.ml
@@ -1841,6 +1841,74 @@ let test_repl_jit_selfref_fn_no_duplicate_wrapper () =
      with exn ->
        March_jit.Repl_jit.cleanup jit; raise exn)
 
+(** Regression: redefining a REPL `fn` must take effect (Elixir-style
+    rebinding, matching interpreter mode).  run_decl's is_fn_decl path used
+    to early-return whenever [bind_name] was already in [compiled_fns] — a
+    guard meant only for :reset scroll-replay (which resends identical
+    cells) — so a genuine redefinition never recompiled or rebound the
+    closure slot and `f(1)` kept answering with the FIRST body.  The fix
+    fingerprints the declaration AST: an identical resend still takes the
+    replay fast path (asserted below via [fragment_count]), while a changed
+    body recompiles under a fresh unique symbol and rebinds the slot. *)
+let test_repl_jit_fn_redefinition () =
+  match setup_jit_runtime () with
+  | None -> ()  (* counted skip: no clang on PATH (anything else fails loudly, W2.0) *)
+  | Some runtime_so ->
+    let jit = March_jit.Repl_jit.create ~runtime_so () in
+    (try
+       let type_map = Hashtbl.create 16 in
+       let tc_env = ref (March_typecheck.Typecheck.base_env (March_errors.Errors.create ()) type_map) in
+       let run_fn_decl src =
+         match parse_repl src with
+         | March_ast.Ast.ReplDecl d ->
+           let d' = March_desugar.Desugar.desugar_decl d in
+           let bind_name = match d' with
+             | March_ast.Ast.DFn (def, _) -> def.March_ast.Ast.fn_name.txt
+             | _ -> failwith ("expected DFn for: " ^ src)
+           in
+           let s = March_ast.Ast.dummy_span in
+           let m = { March_ast.Ast.mod_name = { txt = "Repl"; span = s };
+                     mod_decls = [d'] } in
+           March_jit.Repl_jit.run_decl jit ~tc_env:!tc_env ~is_fn_decl:true ~bind_name m;
+           let new_env = March_typecheck.Typecheck.check_decl
+             { !tc_env with March_typecheck.Typecheck.errors = March_errors.Errors.create () } d' in
+           tc_env := { new_env with March_typecheck.Typecheck.errors = March_errors.Errors.create () };
+           (bind_name, m)
+         | _ -> failwith ("expected ReplDecl for: " ^ src)
+       in
+       let eval_expr src expected label =
+         match parse_repl src with
+         | March_ast.Ast.ReplExpr e ->
+           let e' = March_desugar.Desugar.desugar_expr e in
+           let m = make_jit_test_module e' in
+           let (_, result) = March_jit.Repl_jit.run_expr jit ~tc_env:!tc_env m in
+           Alcotest.(check string) label expected result
+         | _ -> failwith ("expected ReplExpr for: " ^ src)
+       in
+       ignore (run_fn_decl "fn f(x) do x + 1 end");
+       eval_expr "f(1)" "2" "original f(1) = 2";
+       (* Genuine redefinition: different body, same name. *)
+       let (bind_name, m2) = run_fn_decl "fn f(x) do x + 100 end" in
+       eval_expr "f(1)" "101" "redefined f(1) = 101 (not silently ignored)";
+       (* :reset scroll-replay resends the identical cell: must stay a
+          fast-path skip (no new fragment compiled) and keep the binding. *)
+       let frags_before = March_jit.Repl_jit.fragment_count jit in
+       March_jit.Repl_jit.run_decl jit ~tc_env:!tc_env ~is_fn_decl:true ~bind_name m2;
+       Alcotest.(check int) "identical replay compiles no new fragment"
+         frags_before (March_jit.Repl_jit.fragment_count jit);
+       eval_expr "f(1)" "101" "f(1) = 101 after identical replay";
+       (* Self-recursive redefinition: the recursive call must reach the NEW
+          body (the renamed fragment-local symbol), not the old one. *)
+       ignore (run_fn_decl
+         "fn f(n) do if n < 1 do 0 else 10 + f(n - 1) end end");
+       eval_expr "f(3)" "30" "self-recursive redefined f(3) = 30";
+       (* Arity-changing redefinition through the same closure slot. *)
+       ignore (run_fn_decl "fn f(a, b) do a + b end");
+       eval_expr "f(3, 4)" "7" "arity-changed f(3, 4) = 7";
+       March_jit.Repl_jit.cleanup jit
+     with exn ->
+       March_jit.Repl_jit.cleanup jit; raise exn)
+
 (** Regression: a top-level function referenced as a first-class VALUE (not
     called) from a plain REPL expression or `let` RHS.  emit_atom wraps such a
     reference in a @<fn>$clo_wrap trampoline whose definition is appended to
@@ -14165,6 +14233,7 @@ let codegen_suites =
         Alcotest.test_case "hof with fn and let cross-line" `Quick test_repl_jit_cross_line_hof;
         Alcotest.test_case "B11: stored closure returns untagged Int" `Quick test_repl_jit_stored_closure_returns_untagged_int;
         Alcotest.test_case "B11: self-referencing fn no duplicate clo_wrap" `Quick test_repl_jit_selfref_fn_no_duplicate_wrapper;
+        Alcotest.test_case "fn redefinition rebinds (replay still skips)" `Quick test_repl_jit_fn_redefinition;
         Alcotest.test_case "top-level fn as first-class value" `Quick test_repl_jit_topfn_first_class_value;
         Alcotest.test_case "capture-free closure materialization does not leak" `Quick test_repl_jit_capture_free_closure_no_leak;
         Alcotest.test_case "stdlib List.length via precompile" `Quick test_repl_jit_stdlib_list_length;

--- a/test/test_jit.ml
+++ b/test/test_jit.ml
@@ -7,9 +7,97 @@ let test_dlopen_libc () =
   March_jit.Jit.dlclose handle;
   Alcotest.(check pass) "dlopen/dlsym/dlclose round-trip" () ()
 
+(* ── REPL session subprocess harness ──────────────────────────────────
+   Runs the real `march` binary end-to-end with a scripted stdin session.
+   A subprocess (rather than in-process Repl_jit calls) for two reasons:
+   a backend crash (SIGSEGV) fails the one test instead of taking down the
+   whole runner, and MARCH_JIT_BACKEND / MARCH_REPL_INTERP are read once at
+   module init, so they can only differ per-PROCESS, not per-test.
+   HOME is pinned to _build/jit_home by the dune action, so the stdlib
+   precompile cache is warm after the first JIT-backed session test. *)
+
+let main_exe =
+  Filename.concat (Filename.dirname Sys.executable_name) "../bin/main.exe"
+
+let clang_available () =
+  Sys.command "clang --version >/dev/null 2>&1" = 0
+
+let contains ~needle hay =
+  let nl = String.length needle and hl = String.length hay in
+  let rec scan i = i + nl <= hl && (String.sub hay i nl = needle || scan (i + 1)) in
+  nl = 0 || scan 0
+
+(** Pipe [lines] into the REPL under [env_prefix] (e.g. "MARCH_JIT_BACKEND=orc"),
+    returning (combined stdout+stderr, exit code; signals map to 128+n). *)
+let run_repl_session ~env_prefix (lines : string list) : string * int =
+  let input = Filename.temp_file "march_repl_session" ".txt" in
+  let oc = open_out input in
+  List.iter (fun l -> output_string oc l; output_char oc '\n') lines;
+  close_out oc;
+  let cmd = Printf.sprintf "%s %s < %s 2>&1"
+      env_prefix (Filename.quote main_exe) (Filename.quote input) in
+  let ic = Unix.open_process_in cmd in
+  let buf = Buffer.create 1024 in
+  (try
+     while true do Buffer.add_channel buf ic 1 done
+   with End_of_file -> ());
+  let status = Unix.close_process_in ic in
+  (try Sys.remove input with _ -> ());
+  let code = match status with
+    | Unix.WEXITED n -> n
+    | Unix.WSIGNALED n | Unix.WSTOPPED n -> 128 + n
+  in
+  (Buffer.contents buf, code)
+
+(* ── fn redefinition sessions ────────────────────────────────────────
+   Redefining a REPL `fn` must take effect (Elixir-style rebinding, matching
+   interpreter mode).  The JIT's run_decl used to skip ANY already-compiled
+   bind_name (a guard meant only for :reset scroll-replay), silently keeping
+   the first definition: f(1) = 2 instead of 101. *)
+
+let redefinition_session =
+  [ "fn f(x) do x + 1 end";
+    "fn f(x) do x + 100 end";
+    "f(1)" ]
+
+let check_redefinition ~label (out, code) =
+  Alcotest.(check int) (label ^ ": REPL exit code") 0 code;
+  if not (contains ~needle:"= 101" out) then
+    Alcotest.failf
+      "%s: expected redefined f(1) = 101 in session output, got:\n%s"
+      label out
+
+let test_repl_session_fn_redefinition_clang () =
+  if not (clang_available ()) then ()  (* skip: no clang on PATH *)
+  else
+    check_redefinition ~label:"clang backend"
+      (run_repl_session ~env_prefix:"" redefinition_session)
+
+let test_repl_session_fn_redefinition_orc () =
+  if not (clang_available ()) then ()  (* skip: stdlib precompile needs clang *)
+  else begin
+    let (out, code) =
+      run_repl_session ~env_prefix:"MARCH_JIT_BACKEND=orc" redefinition_session in
+    (* No libLLVM on this machine: the ORC backend can't start at all. *)
+    if contains ~needle:"libLLVM not found" out then ()
+    else check_redefinition ~label:"orc backend" (out, code)
+  end
+
+let test_repl_session_fn_redefinition_interp () =
+  check_redefinition ~label:"interpreter mode"
+    (run_repl_session ~env_prefix:"MARCH_REPL_INTERP=1" redefinition_session)
+
 let () =
   Alcotest.run "march_jit" [
     "jit", [
       Alcotest.test_case "dlopen_libc" `Quick test_dlopen_libc;
-    ]
+    ];
+    "repl_session", [
+      Alcotest.test_case "fn redefinition (clang JIT)" `Slow
+        test_repl_session_fn_redefinition_clang;
+      Alcotest.test_case "fn redefinition (ORC JIT)" `Slow
+        test_repl_session_fn_redefinition_orc;
+      Alcotest.test_case "fn redefinition (interpreter)" `Quick
+        test_repl_session_fn_redefinition_interp;
+    ];
   ]

--- a/test/test_jit.ml
+++ b/test/test_jit.ml
@@ -13,11 +13,27 @@ let test_dlopen_libc () =
    a backend crash (SIGSEGV) fails the one test instead of taking down the
    whole runner, and MARCH_JIT_BACKEND / MARCH_REPL_INTERP are read once at
    module init, so they can only differ per-PROCESS, not per-test.
-   HOME is pinned to _build/jit_home by the dune action, so the stdlib
-   precompile cache is warm after the first JIT-backed session test. *)
+   The session HOME is a directory this file creates itself rather than the
+   ambient one: the REPL fatals on startup if $HOME/.cache cannot be created
+   (so it cannot inherit a HOME that does not exist — dune's action pins one
+   under _build that nothing creates), and an own directory keeps the stdlib
+   precompile / JIT .so caches out of the developer's real ~/.cache. It is
+   created once and shared by every session here, so only the first
+   JIT-backed session pays the stdlib precompile. *)
 
 let main_exe =
   Filename.concat (Filename.dirname Sys.executable_name) "../bin/main.exe"
+
+(* Per-process so concurrent test runners (dune runs suites in parallel) do
+   not share a half-written cache — the same per-pid convention repl_jit.ml
+   uses for its own artifact dir. *)
+let session_home = lazy (
+  let dir = Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "march_jit_test_home.%d" (Unix.getpid ())) in
+  List.iter
+    (fun d -> try Unix.mkdir d 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ())
+    [dir; Filename.concat dir ".cache"];
+  dir)
 
 let clang_available () =
   Sys.command "clang --version >/dev/null 2>&1" = 0
@@ -34,7 +50,8 @@ let run_repl_session ~env_prefix (lines : string list) : string * int =
   let oc = open_out input in
   List.iter (fun l -> output_string oc l; output_char oc '\n') lines;
   close_out oc;
-  let cmd = Printf.sprintf "%s %s < %s 2>&1"
+  let cmd = Printf.sprintf "HOME=%s %s %s < %s 2>&1"
+      (Filename.quote (Lazy.force session_home))
       env_prefix (Filename.quote main_exe) (Filename.quote input) in
   let ic = Unix.open_process_in cmd in
   let buf = Buffer.create 1024 in


### PR DESCRIPTION
## Problem

At the REPL, redefining a function was silently ignored on **both** JIT backends:

```
march(1)> fn f(x) do x + 1 end
march(2)> fn f(x) do x + 100 end
march(3)> f(1)
= 2            <- should be 101
```

The second definition printed `val f = <fn>` but had no effect. Interpreter mode
(`MARCH_REPL_INTERP=1`) already rebound correctly (`= 101`), so the JIT paths
diverged from the language's Elixir-style rebinding semantics.

`run_decl`'s `is_fn_decl` path early-returned whenever `bind_name` was already in
`compiled_fns` — a guard added for `:reset` scroll-replay, where the scroll system
resends prior cells verbatim and recompiling is pure waste. The guard could not
tell a verbatim resend from a genuine redefinition.

## Approach

Redefinition rebinds, matching interpreter mode. The mechanism the JIT already uses
makes this cheap: cross-fragment calls to a REPL-defined `fn` resolve through its
persistent closure **slot** (`march_repl_get` + indirect call at `closure+16` —
verified in the emitted fragment IR), not through the LLVM symbol, so rebinding the
slot redirects every later call.

- **Fingerprint** each fn declaration (`Digest` of the marshaled AST), recorded only
  after the fragment compiles and loads — the same success-only discipline as
  `mark_compiled_fns`, so a failed compile leaves state intact for a clean retry.
  Identical resend → replay fast path preserved; changed body → recompile and rebind.
- **Unique symbol** for a redefinition (`f$redef$<n>`), because the earlier fragment
  already defined `f` and ORC's single JITDylib hard-errors on duplicates (clang+dlopen
  would merely shadow ambiguously in the flat namespace). A capture-avoiding
  `rename_top_fn_refs` over the post-defun TIR makes self-recursion and first-class
  self-references follow the rename; locally bound shadows are left alone.
- **Filter the old slot** out of `prev_slots` so the fragment emits no colliding slot
  loader under ORC. This is what makes the fix independent of the unmerged ORC
  loader-linkage work on `claude/jit-repl-interpreted-perf-68373c`; the two compose.
- Names compiled **outside** `run_decl` (stdlib prelude, `:load`) keep the historical
  skip — they are called as direct externs, not through a slot, so a redefinition
  could never take effect there anyway.

## Tests

- `test/test_codegen.ml` — in-process (clang): original body, redefinition
  (`101` not `2`), identical replay compiles no new fragment and keeps the binding,
  self-recursive redefinition reaches the new body, arity-changing redefinition.
  Verified **red pre-fix** (`Received: "2"`).
- `test/test_jit.ml` — new `repl_session` group: subprocess end-to-end sessions of the
  real binary for clang, ORC (`MARCH_JIT_BACKEND=orc`, skips when libLLVM is absent),
  and interpreter mode. Subprocess because a backend SIGSEGV would otherwise take down
  the runner, and because the backend env vars are read once at module init. Both JIT
  sessions verified red pre-fix; interpreter green before and after.
- New `Repl_jit.fragment_count` exposes the replay-skip assertion to tests.

Full suite green: compiler 932, eval 272, codegen 588, stdlib 868 (incl. `Slow`),
stdlib_march 61, jit 4, snapshots 33. `scripts/check-docs.sh` passes.

## Pre-existing bugs found, not fixed here

Both reproduced on unmodified `HEAD` (68dff6e6) with a fresh `HOME`, and filed
separately:

1. A `fn` calling a previously REPL-defined `fn` (`fn g(x) do f(x) end`) fails on both
   backends — the slot loader `define @f()` collides with the `declare @f` extern in
   the same fragment. This is the "Follow-up noticed" item on the ORC-fix branch.
2. A `fn` whose body contains **any** lambda fails its helpers-fragment dlopen
   (`symbol not found in flat namespace '_f'`) and loses the binding.

Because of (1), later REPL functions cannot reference `f` at all today, so there are
no stale direct-call sites for a redefinition to miss. If that limitation is lifted,
direct extern calls inside other functions would pin the version compiled at their
definition time and should be routed through the slot instead — noted in the spec.

Details in `specs/progress/2026-08-24-repl-jit-fn-redefinition-silently-ignored.md`.
