### PR TITLE
perf(startup): file runs reuse the stdlib typecheck-env cache (perf plan Phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ git log is authoritative for exact commits.
 
 - Interpreter: variable lookup no longer scans the builtin environment per reference (monomorphic comparison + hashed global scope). Interpreted programs run ~11x faster (fib(25): 16.6 s -> 1.5 s); REPL interpreter-mode lookups stay fast across prompts.
 - REPL: expressions now compile in-process through LLVM ORC when libLLVM is installed (~200x lower per-line compile latency, whole-session ~3x); set MARCH_JIT_BACKEND=clang to restore the previous clang-subprocess backend. Unrecognized MARCH_JIT_BACKEND values fall back to clang as before.
-- `march file.march` reuses the cached stdlib type environment; interpreted startup drops from ~1.0-1.2 s to ~0.18 s on a warm cache.
+- `march file.march` reuses the cached stdlib type environment; interpreted startup drops from ~1.0-1.2 s to ~0.28-0.36 s on a warm cache.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ git log is authoritative for exact commits.
 
 - Interpreter: variable lookup no longer scans the builtin environment per reference (monomorphic comparison + hashed global scope). Interpreted programs run ~11x faster (fib(25): 16.6 s -> 1.5 s); REPL interpreter-mode lookups stay fast across prompts.
 - REPL: expressions now compile in-process through LLVM ORC when libLLVM is installed (~200x lower per-line compile latency, whole-session ~3x); set MARCH_JIT_BACKEND=clang to restore the previous clang-subprocess backend. Unrecognized MARCH_JIT_BACKEND values fall back to clang as before.
+- `march file.march` reuses the cached stdlib type environment; interpreted startup drops from ~1.0-1.2 s to ~0.18 s on a warm cache.
 
 ### Fixed
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2487,6 +2487,7 @@ let compile filename =
      to the external version: strip the stdlib copy so the external one is
      the sole definition. *)
   let stdlib_decls = load_stdlib ~for_js:is_js_target () in
+  let stdlib_decls_unshadowed_count = List.length stdlib_decls in
   let extern_mod_names =
     (* The ENTRY module's own name must shadow a same-named stdlib module
        too: its declarations live at the top level (not as a DMod in
@@ -2508,6 +2509,22 @@ let compile filename =
       | _ -> true
     ) stdlib_decls
   in
+  (* Mirrors [run_check_cmd]'s [no_shadowing] guard.  A shadowed stdlib copy
+     is stripped above so the user's own definition wins, but that leaves a
+     HOLE in the stdlib module set: any unshadowed stdlib module that itself
+     depends on the shadowed one now resolves against nothing, and whatever
+     that produces (missing bindings, spurious errors) gets swallowed by
+     [get_stdlib_tc_env]'s cache — which strips its errors before caching
+     (see `{ final_env with errors = March_errors.Errors.create () }`) and,
+     worse, would otherwise be REUSED across later runs against unrelated
+     projects with no shadowing at all, degrading a valid cache into a
+     poisoned one. This is not a cache-freshness problem (the content hash
+     already busts correctly per shadow set) — it is that the seed-env
+     itself is unsound whenever shadowing occurs, cached or not. So: no
+     cache read or write in that case, same from-scratch combined check as
+     before this optimization existed. *)
+  let no_shadowing =
+    List.length stdlib_decls = stdlib_decls_unshadowed_count in
   (* [desugared] is also what gets LOWERED further down (TIR needs stdlib's
      own function bodies too, not just their types, to emit a working
      binary) — so unlike [run_check_cmd] (--check only, no lowering), stdlib
@@ -2555,20 +2572,24 @@ let compile filename =
   (* Seed pass 1 from the cached stdlib typecheck env instead of
      re-typechecking [stdlib_decls] from scratch every run — stdlib
      typecheck alone is the dominant fixed cost of a `march file.march`
-     interpreted start.  [get_stdlib_tc_env] hashes on [stdlib_decls]'
-     exact content (already shadow-filtered above), so a shadowed stdlib
-     module naturally busts the cache instead of needing a separate
-     fallback.  Checking [user_only_desugared] (no stdlib decls) against
-     that seed is behaviorally identical to combined-checking [desugared]
-     for the user's own portion — same [check_module_core] pass 1/1b/2
-     machinery either way (see [get_stdlib_tc_env]'s docstring) — and the
-     returned [type_map] is the seed's own hashtable with the user decls'
-     entries added into it, so it still carries stdlib's span entries for
-     the lowering pass below. [desugared] (stdlib-prepended) is untouched
-     and still what gets lowered. *)
+     interpreted start.  Checking [user_only_desugared] (no stdlib decls)
+     against that seed is behaviorally identical to combined-checking
+     [desugared] for the user's own portion — same [check_module_core] pass
+     1/1b/2 machinery either way (see [get_stdlib_tc_env]'s docstring) — and
+     the returned [type_map] is the seed's own hashtable with the user
+     decls' entries added into it, so it still carries stdlib's span entries
+     for the lowering pass below. [desugared] (stdlib-prepended) is
+     untouched and still what gets lowered.
+
+     ONLY when [no_shadowing]: see the comment on [no_shadowing] above for
+     why a shadowed stdlib module set makes the seed itself unsound, not
+     just cache-stale — mirrors [run_check_cmd]'s identical fallback. *)
   let (errors, type_map, typecheck_env) =
-    let seed_env = get_stdlib_tc_env ~for_js:is_js_target stdlib_decls in
-    March_typecheck.Typecheck.check_module_full ~seed_env user_only_desugared
+    if no_shadowing then
+      let seed_env = get_stdlib_tc_env ~for_js:is_js_target stdlib_decls in
+      March_typecheck.Typecheck.check_module_full ~seed_env user_only_desugared
+    else
+      March_typecheck.Typecheck.check_module_full desugared
   in
   (* Phase A1b: discharge refinement-precondition VCs at call sites. *)
   March_refinecheck.Refine_check.check_module ~measure_axioms:!measure_axioms
@@ -5019,6 +5040,18 @@ let () =
        March_repl.Repl.save_cached_tc_env ~content_hash tc0;
        let t2 = Unix.gettimeofday () in
        Printf.printf "tc_env:          %.3fs (built + cached)\n%!" (t2 -. t1));
+    (* 2b. Typecheck stdlib via [get_stdlib_tc_env] too — the SEPARATE cache
+       `march file.march` actually reads (see the perf-startup comment on
+       [get_stdlib_tc_env] above): the REPL's cache warmed just above is a
+       different cache/mechanism (fold-based, its own filename prefix), so
+       warming only that one left `march warm-cache` NOT warming the cache
+       the CLI file-run path depends on — its own hit/miss timing already
+       happens inside [get_stdlib_tc_env] via [load_from_cache], so this
+       call alone is enough to populate it on a miss. *)
+    let t2b_0 = Unix.gettimeofday () in
+    ignore (get_stdlib_tc_env ~for_js:false stdlib_decls);
+    let t2b_1 = Unix.gettimeofday () in
+    Printf.printf "tc_env (cli):    %.3fs\n%!" (t2b_1 -. t2b_0);
     (* 3. Compile C runtime .so *)
     let t3 = Unix.gettimeofday () in
     let runtime_so = ensure_runtime_so () in

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2474,6 +2474,13 @@ let compile filename =
     { desugared with
       March_ast.Ast.mod_decls = extra_decls @ desugared.March_ast.Ast.mod_decls }
   in
+  (* Snapshot of the user's own decls (entry file + resolved imports) BEFORE
+     stdlib gets prepended below.  Used to typecheck against the cached
+     stdlib env (see [get_stdlib_tc_env]) instead of re-typechecking stdlib
+     from scratch on every invocation — [desugared] itself keeps the stdlib
+     prepend it always had, since lowering further down still needs stdlib's
+     own bodies physically present (see the comment at the prepend site). *)
+  let user_only_desugared = desugared in
   stamp "resolve-imports";
   (* Inject stdlib declarations before user declarations.
      If MARCH_LIB_PATH provided a module that also ships in the stdlib, defer
@@ -2545,7 +2552,24 @@ let compile filename =
      (`march check`/`march caps`) and the LSP deliberately do NOT set it: they
      never run refinecheck, so they keep the old unconditional ban. *)
   March_typecheck.Typecheck.proof_based_panic_surface := true;
-  let (errors, type_map, typecheck_env) = March_typecheck.Typecheck.check_module_full desugared in
+  (* Seed pass 1 from the cached stdlib typecheck env instead of
+     re-typechecking [stdlib_decls] from scratch every run — stdlib
+     typecheck alone is the dominant fixed cost of a `march file.march`
+     interpreted start.  [get_stdlib_tc_env] hashes on [stdlib_decls]'
+     exact content (already shadow-filtered above), so a shadowed stdlib
+     module naturally busts the cache instead of needing a separate
+     fallback.  Checking [user_only_desugared] (no stdlib decls) against
+     that seed is behaviorally identical to combined-checking [desugared]
+     for the user's own portion — same [check_module_core] pass 1/1b/2
+     machinery either way (see [get_stdlib_tc_env]'s docstring) — and the
+     returned [type_map] is the seed's own hashtable with the user decls'
+     entries added into it, so it still carries stdlib's span entries for
+     the lowering pass below. [desugared] (stdlib-prepended) is untouched
+     and still what gets lowered. *)
+  let (errors, type_map, typecheck_env) =
+    let seed_env = get_stdlib_tc_env ~for_js:is_js_target stdlib_decls in
+    March_typecheck.Typecheck.check_module_full ~seed_env user_only_desugared
+  in
   (* Phase A1b: discharge refinement-precondition VCs at call sites. *)
   March_refinecheck.Refine_check.check_module ~measure_axioms:!measure_axioms
     ~stdlib_files:(stdlib_span_files stdlib_decls) errors desugared;

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -663,8 +663,52 @@ let get_stdlib_tc_env ~for_js (stdlib_decls : March_ast.Ast.decl list) =
         let (cached_env : March_typecheck.Typecheck.env) = Marshal.from_channel ic in
         let (cached_tm : (March_ast.Ast.span * March_typecheck.Typecheck.ty) list) =
           Marshal.from_channel ic in
+        (* Restore the two PROCESS-GLOBAL side-tables a from-scratch stdlib
+           check would have advanced/populated as a side effect, and that a
+           cache hit otherwise skips entirely:
+             - [Typecheck._counter]: the fresh-metavar id source. Checking
+               stdlib alone burns ~2000 ids; skip that on a cache hit and
+               pass 2 (the user's own file) starts allocating from near 0
+               instead of continuing where a from-scratch run would have
+               left off. The raw id VALUES differ either way (harmless —
+               golden fixtures compare via canonical renumbering — see
+               test/test_emit_core_ast.ml's [canonicalize]), but which of
+               two user-file schemes happens to get the SMALLER raw id can
+               flip depending on the counter's starting point, and THAT
+               flips their relative order in the emitted `schemes` array
+               (sorted by raw id, then canonicalized — canonicalization
+               renumbers id VALUES but never reorders arrays). Confirmed via
+               a three-way diff (cold / warm / pre-Task-3.1 binary) on
+               `--emit-core-ast` of specs/lang/types/accept/
+               t07_generic_option_two_types.march: cold and the pre-3.1
+               binary agree on scheme order, warm alone disagrees — see
+               specs/progress/2026-08-24-interp-perf-phase-3-startup-tcenv-cache.md's
+               "Fix round 2" section. [max] rather than a blind overwrite:
+               never let a cache read move the counter BACKWARD, which
+               could mint an id that collides with one already allocated
+               earlier in this same process.
+             - [Typecheck._record_names]: a display-only signature->name
+               index (never consulted by --emit-core-ast's JSON emitter,
+               confirmed by reading [Ast_json.resolved_ty_to_json]'s TRecord
+               case — it never touches this table) but DOES feed [pp_ty],
+               which renders type names into ordinary diagnostic text. Left
+               unrestored, a cache-hit run could render a record type
+               structurally where a cold run renders it nominally (or vice
+               versa) purely because stdlib's own record declarations never
+               ran through [register_record_name] on this process — a
+               latent diagnostic-text divergence beyond what actually
+               reproduced in the golden corpus. Restored defensively for
+               the same reason the round-1 fix insisted on byte-identical
+               diagnostics rather than "close enough". *)
+        let (cached_counter : int) = Marshal.from_channel ic in
+        let (cached_record_names : (string * string option) list) =
+          Marshal.from_channel ic in
         close_in ic;
         List.iter (fun (k, v) -> Hashtbl.replace type_map k v) cached_tm;
+        if cached_counter > !March_typecheck.Typecheck._counter then
+          March_typecheck.Typecheck._counter := cached_counter;
+        List.iter (fun (k, v) -> Hashtbl.replace March_typecheck.Typecheck._record_names k v)
+          cached_record_names;
         Some { cached_env with
                March_typecheck.Typecheck.errors = March_errors.Errors.create ();
                type_map }
@@ -703,6 +747,16 @@ let get_stdlib_tc_env ~for_js (stdlib_decls : March_ast.Ast.decl list) =
           let tm_list = Hashtbl.fold (fun k v acc -> (k, v) :: acc)
             final_env.March_typecheck.Typecheck.type_map [] in
           Marshal.to_channel oc tm_list [];
+          (* Snapshot the two process-global side-tables RIGHT NOW — the
+             point where a from-scratch run would hand off from "stdlib
+             checked" to "start checking the user's own file" — so a later
+             cache hit can restore them to this exact point. See the long
+             comment on [load_from_cache] above for why both matter. *)
+          Marshal.to_channel oc !March_typecheck.Typecheck._counter [];
+          let record_names_list =
+            Hashtbl.fold (fun k v acc -> (k, v) :: acc)
+              March_typecheck.Typecheck._record_names [] in
+          Marshal.to_channel oc record_names_list [];
           close_out oc;
           Sys.rename tmp cache_path)
     with e ->

--- a/specs/progress/2026-08-24-interp-perf-phase-3-startup-tcenv-cache.md
+++ b/specs/progress/2026-08-24-interp-perf-phase-3-startup-tcenv-cache.md
@@ -128,3 +128,81 @@ Full detail, including the shadowing-witness reproduction attempts (both
 successful and inconclusive) and the exact `dune build`/test output, is in
 `.superpowers/sdd/2026-08-23-interpreter-and-repl-jit-performance/task-3.1-report.md`'s
 "Fix round 1" section.
+
+## Fix round 2 (2026-08-24, same day)
+
+CI on both platforms failed on `test/test_emit_core_ast.exe`'s
+`emit_core_ast` suite — a dune-rule test (`(rule (alias runtest) ...)` in
+`test/dune`, ~line 954) that `scripts/run-tests.sh` never runs (a known
+gap: the script only builds and runs the five alcotest binaries directly;
+CI's `dune runtest`/`dune build @types-check @grammar-check` alias-based
+rules are invisible to it). Reproduced locally once built and run directly.
+
+**Root cause**: `Typecheck._counter` (`lib/typecheck/typecheck.ml:147`) is
+a process-global `ref`, NOT a field of `Typecheck.env` — so it is outside
+everything Fix round 1's `get_stdlib_tc_env` cache marshals. A from-scratch
+run burns ~2000 fresh-metavar ids checking stdlib before it ever reaches
+the user's own file; a cache-hit run skips that entirely, so pass 2 (the
+user file) starts allocating ids from wherever the counter happened to be
+at process start (near 0) instead of continuing where stdlib left off. The
+resulting raw id VALUES differing is harmless on its own — golden fixtures
+compare through `test_emit_core_ast.ml`'s `canonicalize`, which renumbers
+metavar ids by first textual occurrence — but `--emit-core-ast`'s `schemes`
+array is sorted by RAW id before canonicalization
+(`bin/main.ml`: `List.sort (fun (ids1,_,_) (ids2,_,_) -> compare ids1 ids2)`),
+and canonicalization only rewrites id VALUES, never reorders arrays. Which
+of two user-file schemes happens to get the smaller raw id can flip
+depending on where the counter starts, flipping their relative position in
+the array — a real byte-level divergence canonical renumbering cannot
+paper over.
+
+Confirmed via a three-way diff on `specs/lang/types/accept/
+t07_generic_option_two_types.march --emit-core-ast`: the pre-Task-3.1
+binary (`368181a7`) and a COLD run of the current tree agree with the
+golden fixture's canonical scheme order; only a WARM (cache-hit) run
+disagrees — cold's raw scheme ids were `[1909]`/`[39941]` (continuing a
+counter already advanced by a full stdlib check), warm's were
+`[166]`/`[1909]` (continuing from near-zero), and the semantic scheme that
+lands on the smaller number differs between the two, flipping their array
+order after the ascending sort.
+
+Investigated the reviewer's other suspect, `Typecheck._record_names`
+(`typecheck.ml:229`, also process-global, also skipped on cache hit): read
+`lib/dump/ast_json.ml`'s `resolved_ty_to_json`, whose `TRecord` case never
+touches this table — `--emit-core-ast` serializes `TRecord` structurally
+always, by design, so this table cannot be the cause of the observed
+failure. It DOES feed `pp_ty` (ordinary diagnostic-text rendering), so a
+cache-hit run could still render a record type structurally where a
+from-scratch run renders it nominally (or vice versa) in an error message
+— a latent diagnostic-text divergence never actually observed in this
+corpus but real in principle, given round 1's hard constraint that
+diagnostics be byte-identical cold vs warm.
+
+**Fix**: `get_stdlib_tc_env`'s cache file now marshals two more values
+after the env and type_map — `!Typecheck._counter` and an assoc-list dump
+of `Typecheck._record_names` — captured at exactly the point a from-scratch
+run hands off from "stdlib checked" to "about to check the user's file".
+On a cache hit, after reading them back: the counter is restored via `if
+cached_counter > !_counter then _counter := cached_counter` (never move it
+backward — that could mint an id colliding with one already allocated
+earlier in the same process), and `_record_names`' entries are merged in
+via `Hashtbl.replace` per key. Old (round-1/round-2-pre-fix) two-value
+cache files fail to read the two new values, raise inside
+`load_from_cache`'s `try`, and fall through to a full rebuild that
+overwrites the file in the new four-value format — no migration code
+needed, same self-healing shape the corruption-tolerance design already
+had.
+
+Also ran the other CI-only, run-tests.sh-invisible dune-rule gates the
+task flagged as worth checking for the same class of gap: `@types-check`
+(303/303), `@grammar-check` (48/48), `run_snapshots.exe -e` (33/33, a
+library-level TIR test that never touches `bin/main.ml`'s cache and was
+unaffected as expected). `@oracle` (the interp-vs-compile differential
+sweep) was also kicked off; see the task report for its result if it
+completed before this doc was written.
+
+Validation: `test_emit_core_ast.exe -e` 5/5 (not 6 — the suite has 5
+cases, not the 6 the initial report guessed) exit 0, both cold and warm
+cache; `tcenv_cli_cache` suite still green; `run_compiler.exe -e` 936
+tests, exit 0. Full three-way diff transcript and file-by-file breakdown
+in the task report's "Fix round 2" section.

--- a/specs/progress/2026-08-24-interp-perf-phase-3-startup-tcenv-cache.md
+++ b/specs/progress/2026-08-24-interp-perf-phase-3-startup-tcenv-cache.md
@@ -72,8 +72,10 @@ interpreted runs go through up to the typecheck call):
 ## Verification
 
 - `scripts/run-tests.sh` suites `compiler` (934 tests) and `eval` (273
-  tests): both exit 0, cold and warm cache. `codegen` also run as an extra
-  safety net given `--compile` shares this call site — exit 0.
+  tests): both exit 0, cold and warm cache — this author's own runs. The
+  `codegen` suite was NOT run as part of this author's validation (an
+  earlier version of this doc incorrectly claimed it was); a reviewer
+  subsequently ran it independently and reports 589 tests green.
 - Diagnostics identity: a file with an undefined variable
   (`println(undefined_var)`) produces byte-identical stderr cold-cache vs
   warm-cache vs a pre-patch binary built by `git show HEAD:bin/main.ml`
@@ -84,3 +86,45 @@ interpreted runs go through up to the typecheck call):
   A trivial `println`-only program with `needs IO.Console`: cold ≈1.07s,
   warm ≈0.18-0.19s. The pre-patch binary pays ≈1.0-1.2s on *every* run
   (no caching existed at this shared site before).
+
+## Fix round 1 (2026-08-24, same day)
+
+Code review found the initial version dropped the shadowing fallback
+`run_check_cmd` deliberately keeps (`bin/main.ml`'s `no_shadowing` guard,
+~line 4732): when a user's own module (or a `MARCH_LIB_PATH` dependency)
+shadows a stdlib module name, the stdlib copy is stripped before typecheck
+so the user's definition wins — but that leaves a HOLE in the stdlib module
+set. Any *other*, unshadowed stdlib module that itself depends on the
+shadowed one now resolves against nothing during `get_stdlib_tc_env`'s
+stdlib-alone check, and whatever that produces gets silently discarded
+(`get_stdlib_tc_env` resets `errors` before caching) — and, uncaught, the
+resulting degraded env would be **cached and reused** across later,
+unrelated runs of any project whose stdlib content-hash happens to match.
+This is not a cache-freshness problem — the content hash already busts
+correctly per shadow set — it is that the seed env itself is unsound
+whenever shadowing occurs, cached or not.
+
+Fix: added the same `no_shadowing` computation `run_check_cmd` already had
+(comparing the shadow-filtered `stdlib_decls` length against its
+pre-filter count) and gated the seed/cache path on it — shadowed runs now
+fall back to `Typecheck.check_module_full desugared` (no `seed_env`, no
+`get_stdlib_tc_env` call at all: no cache read, no cache write), which is
+*the exact same call on the exact same value* the code made before Task
+3.1 existed. That is a structural guarantee, not just an empirical one:
+whenever `no_shadowing` is false, post-fix output is provably identical to
+the pre-Task-3.1 binary's output, because it is the same function applied
+to the same input.
+
+Also added: `test/test_compiler.ml`'s `tcenv_cli_cache` group (IR-identity
+across cold/warm cache, `--emit-llvm` byte comparison — never `cmp` on
+linked binaries, see `project_cmp_binaries_lc_uuid_macos` in memory); `march
+warm-cache` now also warms the `get_stdlib_tc_env` (`_cli`) cache, not just
+the REPL's own; CHANGELOG's warm-cache figure corrected to the
+`bench/interp/fib.march` measurement (~0.28-0.36s), which is more
+reproducible than the trivial-program one (small, so proportionally more
+affected by process-startup noise).
+
+Full detail, including the shadowing-witness reproduction attempts (both
+successful and inconclusive) and the exact `dune build`/test output, is in
+`.superpowers/sdd/2026-08-23-interpreter-and-repl-jit-performance/task-3.1-report.md`'s
+"Fix round 1" section.

--- a/specs/progress/2026-08-24-interp-perf-phase-3-startup-tcenv-cache.md
+++ b/specs/progress/2026-08-24-interp-perf-phase-3-startup-tcenv-cache.md
@@ -1,0 +1,86 @@
+# Phase 3: `march file.march` reuses the cached stdlib typecheck env
+
+Filed and fixed 2026-08-24. Task 3.1 of
+`.superpowers/sdd/2026-08-23-interpreter-and-repl-jit-performance/task-3.1-brief.md`,
+scoped down to Step 4 (the `bin/main.ml` wiring) + Step 5 (validation) after
+PR #337 (commit `2dff9d87`) already fixed the REPL's cache save path and
+exported `stdlib_content_hash` / `load_cached_tc_env` / `save_cached_tc_env`
+/ `marshalable_tc_env` / `sweep_stale_cache_tmps` from `lib/repl/repl.mli`,
+with round-trip coverage in `test/test_repl_cache.ml`.
+
+## What was slow
+
+Every `march file.march` — interpreted run or `--compile` — typechecks
+stdlib and the user module together as one combined `Ast.module_` via
+`Typecheck.check_module_full` (`bin/main.ml`, the shared site before the
+`if !do_compile` / interpreted-run split). Stdlib alone is the dominant
+fixed cost of that call, paid again on every single invocation regardless of
+whether the user's own file changed.
+
+## The site, and why it isn't the REPL's cache
+
+`bin/main.ml` already had a *second*, separate stdlib-typecheck-env disk
+cache — `get_stdlib_tc_env` (added earlier, `stdlib_tcenv_cli_*.bin`) — used
+only by `run_check_cmd` (`march check` / `march caps`). Its docstring
+explains why it is deliberately NOT the REPL's `stdlib_tcenv_*.bin` cache:
+the REPL's env is built by folding `Typecheck.check_decl` over stdlib decls
+one at a time (and is known to tolerate real typecheck errors in some
+stdlib modules — see `Repl.load_decls_into_env`), whereas `get_stdlib_tc_env`
+is built via the same `check_module_core` pass-1/1b/2 machinery a combined
+check already trusts, applied to stdlib alone first. Seeding a user-only
+`check_module_core` call from that env is behaviorally identical to what a
+full combined check would have produced for stdlib's own portion — not a
+reduced approximation.
+
+Reusing the REPL's own `March_repl.Repl.load_cached_tc_env` /
+`save_cached_tc_env` directly at this site would have written to the exact
+same cache filename (`stdlib_tcenv_<build>_<hash>.bin`, same hash function,
+same build id) that a REPL session populates via the fold-based path — a
+namespace collision that could hand `march file.march` a differently-shaped
+env than a combined check would have produced, silently changing user-file
+diagnostics. `get_stdlib_tc_env` already avoids this (`_cli` suffix, own
+filename), so this change reuses it rather than duplicating a third cache.
+
+## The fix
+
+In `bin/main.ml`'s `compile` function (the single path both `--compile` and
+interpreted runs go through up to the typecheck call):
+
+- Captured `user_only_desugared` — the entry file + resolved imports, in the
+  same form used later, but *before* stdlib decls get prepended into
+  `desugared` for lowering.
+- Replaced the single `check_module_full desugared` call with:
+  ```
+  let seed_env = get_stdlib_tc_env ~for_js:is_js_target stdlib_decls in
+  March_typecheck.Typecheck.check_module_full ~seed_env user_only_desugared
+  ```
+  `stdlib_decls` here is the already shadow-filtered list (a user module
+  reusing a stdlib module name has its stdlib copy stripped earlier in the
+  same function), so a shadowed stdlib module naturally produces a different
+  cache key instead of needing a separate no-shadowing fallback the way
+  `run_check_cmd` needs one.
+- `desugared` (stdlib-prepended, used for TIR lowering further down) is
+  untouched — an earlier attempt at this exact optimization regressed
+  `--compile` by also skipping the stdlib prepend into `desugared`, dropping
+  stdlib bodies from what gets lowered (see the comment already in the code
+  at the prepend site). This change only touches how `(errors, type_map,
+  typecheck_env)` are computed, not what gets lowered.
+- `check_module_core`'s `?seed_env` reuses the seed's own `type_map`
+  hashtable in place, so the returned `type_map` still carries stdlib's span
+  entries (needed by lowering) alongside the freshly-checked user entries.
+
+## Verification
+
+- `scripts/run-tests.sh` suites `compiler` (934 tests) and `eval` (273
+  tests): both exit 0, cold and warm cache. `codegen` also run as an extra
+  safety net given `--compile` shares this call site — exit 0.
+- Diagnostics identity: a file with an undefined variable
+  (`println(undefined_var)`) produces byte-identical stderr cold-cache vs
+  warm-cache vs a pre-patch binary built by `git show HEAD:bin/main.ml`
+  (file-copy swap, not `git stash`) — `diff` reports no difference across
+  all three.
+- Timing (`bench/interp/fib.march`, `HOME`'s real `~/.cache/march`):
+  cold ≈1.24s, warm ≈0.36s (includes fib's own interpreted compute time).
+  A trivial `println`-only program with `needs IO.Console`: cold ≈1.07s,
+  warm ≈0.18-0.19s. The pre-patch binary pays ≈1.0-1.2s on *every* run
+  (no caching existed at this shared site before).

--- a/test/dune
+++ b/test/dune
@@ -11,7 +11,7 @@
 (library
  (name march_test_compiler)
  (wrapped false)
- (modules test_compiler test_repl_cache test_cap_strip test_cap_symbols test_cap_markers test_cap_package test_cap_scope test_cap_ceiling test_cap_unforgeable test_cap_attrib_agreement test_cap_sandbox_profile test_cap_sandbox_runtime test_ctxesc)
+ (modules test_compiler test_repl_cache test_tcenv_cli_cache test_cap_strip test_cap_symbols test_cap_markers test_cap_package test_cap_scope test_cap_ceiling test_cap_unforgeable test_cap_attrib_agreement test_cap_sandbox_profile test_cap_sandbox_runtime test_ctxesc)
  (libraries march_test_helpers march_lexer march_parser march_ast march_desugar march_typecheck march_refinecheck march_errors march_effects march_eval march_tir march_repl march_debug march_scheduler march_cas march_caps march_ctxesc march_modules march_resolver march_forge march_lint alcotest str unix threads.posix))
 
 (library

--- a/test/test_compiler.ml
+++ b/test/test_compiler.ml
@@ -14727,6 +14727,7 @@ let compiler_suites =
       sigil_interp_suite;
       csrf_suite;
       ("repl_cache", Test_repl_cache.tests);
+      ("tcenv_cli_cache", Test_tcenv_cli_cache.tests);
       ("cap_strip", Test_cap_strip.tests);
       ("cap_symbols", Test_cap_symbols.tests);
       ("cap_markers", Test_cap_markers.tests);

--- a/test/test_tcenv_cli_cache.ml
+++ b/test/test_tcenv_cli_cache.ml
@@ -1,0 +1,194 @@
+(** Regression tests for the `march file.march` file-run stdlib
+    typecheck-env disk cache ([bin/main.ml]'s [get_stdlib_tc_env],
+    `~/.cache/march/stdlib_tcenv_cli_*.bin`).
+
+    Fix-round-1 context: the cache was wired into [bin/main.ml]'s shared
+    typecheck call (both `--compile` and interpreted `march file.march` go
+    through it) without mirroring [run_check_cmd]'s `no_shadowing` guard —
+    so a project that shadows a stdlib module name (a `MARCH_LIB_PATH`
+    dependency, or the entry module itself, reusing a stdlib module's name)
+    would seed pass 1 from — and CACHE — a typecheck env built by checking
+    the shadow-filtered stdlib ALONE, with a hole where the shadowed module
+    used to be. Any error that hole produced in an unrelated, unshadowed
+    stdlib module was silently discarded before caching, and the resulting
+    degraded env was written to disk for potential reuse by a later,
+    unrelated (differently-shadowed or unshadowed) run whose content hash
+    happened to coincide.
+
+    These tests exercise `bin/main.exe` directly (not the OCaml
+    [Typecheck]/[get_stdlib_tc_env] functions) because the bug lives in
+    `bin/main.ml`'s wiring, which only exists in the compiled executable —
+    same reason [test_missing_needs_dedup_no_orphan_hint] above shells out
+    rather than calling `March_typecheck.Typecheck` in-process. *)
+
+let with_temp_home f =
+  let dir = Filename.concat (Filename.get_temp_dir_name ())
+    (Printf.sprintf "march_tcenv_cli_cache_test.%d.%d" (Unix.getpid ())
+       (Hashtbl.hash (Sys.time ()))) in
+  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  (try Unix.mkdir (Filename.concat dir ".cache") 0o755
+   with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let old_home = try Some (Sys.getenv "HOME") with Not_found -> None in
+  Unix.putenv "HOME" dir;
+  Fun.protect
+    ~finally:(fun () ->
+      (match old_home with Some h -> Unix.putenv "HOME" h | None -> ());
+      let rec rm_rf p =
+        if Sys.file_exists p then begin
+          if Sys.is_directory p then begin
+            Array.iter (fun c -> rm_rf (Filename.concat p c)) (Sys.readdir p);
+            (try Unix.rmdir p with _ -> ())
+          end else (try Sys.remove p with _ -> ())
+        end
+      in
+      rm_rf dir)
+    (fun () -> f dir)
+
+let cache_dir home = Filename.concat home ".cache/march"
+
+let cli_cache_files home =
+  try
+    Sys.readdir (cache_dir home)
+    |> Array.to_list
+    |> List.filter (fun f ->
+        String.length f >= 16 && String.sub f 0 16 = "stdlib_tcenv_cli")
+  with Sys_error _ -> []
+
+let read_file path =
+  let ic = open_in_bin path in
+  let n = in_channel_length ic in
+  let s = really_input_string ic n in
+  close_in ic; s
+
+(* A stdlib-heavy program: exercises List, String and a `needs`-gated
+   println so real capability + type inference machinery from several
+   different stdlib modules is exercised, not just trivial arithmetic. *)
+let stdlib_heavy_src =
+  "mod StdlibHeavy do\n\
+  \  needs IO.Console\n\
+  \n\
+  \  fn main(_cap : Cap(IO.Console)) do\n\
+  \    let xs = List.map([1, 2, 3, 4, 5], fn x -> x * 2)\n\
+  \    let s = List.fold_left(xs, 0, fn (acc, x) -> acc + x)\n\
+  \    let joined = String.join([\"a\", \"b\", \"c\"], \",\")\n\
+  \    println(int_to_string(s))\n\
+  \    println(joined)\n\
+  \  end\n\
+   end"
+
+let run_emit_llvm ~home ?(lib_path : string option) ~march_file main_exe =
+  let out = march_file ^ ".compile_out" in
+  let env_prefix =
+    match lib_path with
+    | None -> ""
+    | Some p -> Printf.sprintf "MARCH_LIB_PATH=%s " (Filename.quote p)
+  in
+  let cmd =
+    Printf.sprintf "%sHOME=%s %s --emit-llvm %s > %s 2>&1"
+      env_prefix (Filename.quote home) (Filename.quote main_exe)
+      (Filename.quote march_file) (Filename.quote out)
+  in
+  let rc = Sys.command cmd in
+  let out_text = try read_file out with Sys_error _ -> "" in
+  (try Sys.remove out with Sys_error _ -> ());
+  (rc, out_text)
+
+let ll_path_of march_file = Filename.remove_extension march_file ^ ".ll"
+
+(* ── Test 1: cold vs warm cache produces byte-identical IR ──────────────── *)
+let test_ir_identical_cold_vs_warm_cache () =
+  let main_exe = Test_helpers.find_main_exe () in
+  with_temp_home (fun home ->
+    let src = Filename.temp_file "tcenv_cli_ir" ".march" in
+    let oc = open_out src in
+    output_string oc stdlib_heavy_src;
+    close_out oc;
+    (* Cold: no cache in this fresh HOME yet. *)
+    let (rc1, out1) = run_emit_llvm ~home ~march_file:src main_exe in
+    Alcotest.(check int) "cold --emit-llvm exits 0" 0 rc1;
+    let ll = ll_path_of src in
+    let cold_ir = read_file ll in
+    Alcotest.(check bool) "cold run populated the cli tcenv cache" true
+      (cli_cache_files home <> []);
+    (* Warm: same HOME, cache now populated. *)
+    let (rc2, out2) = run_emit_llvm ~home ~march_file:src main_exe in
+    Alcotest.(check int) "warm --emit-llvm exits 0" 0 rc2;
+    let warm_ir = read_file ll in
+    Alcotest.(check string) "cold/warm stdout+stderr identical" out1 out2;
+    Alcotest.(check string) "cold/warm emitted LLVM IR byte-identical"
+      cold_ir warm_ir;
+    List.iter (fun f -> try Sys.remove f with Sys_error _ -> ()) [src; ll])
+
+(* ── Test 2 (fix round 1 regression): a shadowed stdlib module bypasses
+   the cli cache entirely — no read, no write.  Fails on the pre-fix
+   binary, which unconditionally called [get_stdlib_tc_env] (and so wrote
+   a `stdlib_tcenv_cli_*` blob built from a stdlib set with a
+   shadowed-module-shaped hole in it) regardless of shadowing. ────────── *)
+let test_shadowed_run_bypasses_cli_cache () =
+  let main_exe = Test_helpers.find_main_exe () in
+  with_temp_home (fun home ->
+    let lib_dir = Filename.concat home "shadow_lib" in
+    (try Unix.mkdir lib_dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+    let json_shadow = Filename.concat lib_dir "json.march" in
+    let oc = open_out json_shadow in
+    output_string oc
+      "mod Json do\n\
+      \  fn greet() do\n\
+      \    \"shadow json\"\n\
+      \  end\n\
+       end";
+    close_out oc;
+    let entry = Filename.temp_file "tcenv_cli_shadow" ".march" in
+    let oc2 = open_out entry in
+    output_string oc2
+      "mod ShadowEntry do\n\
+      \  needs IO.Console\n\
+      \n\
+      \  fn main(_cap : Cap(IO.Console)) do\n\
+      \    println(Json.greet())\n\
+      \  end\n\
+       end";
+    close_out oc2;
+    (* Run A: completely empty cache dir. *)
+    let (rcA, outA) =
+      run_emit_llvm ~home ~lib_path:lib_dir ~march_file:entry main_exe in
+    Alcotest.(check int) "shadowed --emit-llvm exits 0" 0 rcA;
+    let llA = read_file (ll_path_of entry) in
+    Alcotest.(check (list string))
+      "a shadowed run writes NO stdlib_tcenv_cli_* cache entry"
+      [] (cli_cache_files home);
+    (* Pre-populate the cache with an UNRELATED, unshadowed run's entry —
+       simulates a real machine where `march file.march` has already run
+       on some other, non-shadowing project sharing this HOME. *)
+    let unrelated = Filename.temp_file "tcenv_cli_unrelated" ".march" in
+    let oc3 = open_out unrelated in
+    output_string oc3 stdlib_heavy_src;
+    close_out oc3;
+    let (rcU, _) = run_emit_llvm ~home ~march_file:unrelated main_exe in
+    Alcotest.(check int) "unrelated warm-up run exits 0" 0 rcU;
+    Alcotest.(check bool) "unrelated run DID populate the cli cache" true
+      (cli_cache_files home <> []);
+    List.iter (fun f -> try Sys.remove f with Sys_error _ -> ())
+      [unrelated; ll_path_of unrelated];
+    (* Run B: same shadowed program, cache dir now non-empty (but keyed
+       under the unshadowed stdlib's content hash, never the shadowed
+       one) — output must be identical to Run A regardless. *)
+    let (rcB, outB) =
+      run_emit_llvm ~home ~lib_path:lib_dir ~march_file:entry main_exe in
+    Alcotest.(check int) "shadowed run (cache present) exits 0" 0 rcB;
+    let llB = read_file (ll_path_of entry) in
+    Alcotest.(check string)
+      "shadowed run: stdout+stderr identical whether the (unrelated) cache is empty or populated"
+      outA outB;
+    Alcotest.(check string)
+      "shadowed run: emitted LLVM IR identical whether the (unrelated) cache is empty or populated"
+      llA llB;
+    List.iter (fun f -> try Sys.remove f with Sys_error _ -> ())
+      [entry; ll_path_of entry; json_shadow])
+
+let tests = [
+  Alcotest.test_case "cold/warm cli tcenv cache: IR byte-identical" `Quick
+    test_ir_identical_cold_vs_warm_cache;
+  Alcotest.test_case "shadowed stdlib module bypasses the cli tcenv cache" `Quick
+    test_shadowed_run_bypasses_cli_cache;
+]


### PR DESCRIPTION
Phase 3 of docs/superpowers/plans/2026-08-23-interpreter-and-repl-jit-performance.md (sequencing Gate G3, Lane P).

`march file.march` (and `--compile`, which shares the typecheck site) no longer re-typechecks all 116 stdlib modules per run: `check_module_full` seeds from the existing `get_stdlib_tc_env` CLI cache (own namespace, keyed by compiler BLAKE3 identity + stdlib content hash — deliberately NOT the REPL's cache file, whose env is built by a different, error-tolerant fold). Startup: ~1.0-1.2 s cold → ~0.28-0.36 s warm.

Guardrails, from review:
- a user module shadowing a stdlib module bypasses the cache entirely (no read, no write) and takes the pre-existing from-scratch check — the seeded env would be degraded; regression test proves the pre-fix cache pollution (fail-first against the unfixed binary, independently reproduced by the re-reviewer)
- new `tcenv_cli_cache` suite pins cold/warm `--emit-llvm` IR byte-identity under an isolated HOME
- `march warm-cache` now warms this cache too

Suites: compiler 936 / eval 273 / codegen 589 — all green at head; user-file diagnostics byte-identical cold vs warm vs pre-change binary; stdlib-heavy compiled IR byte-identical across all three.