### PR TITLE
test: run test_jit under scripts/run-tests.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,17 +56,23 @@ scripts/run-tests.sh -q                # quick only, skips Slow tests (~2s)
 scripts/run-tests.sh compiler eval     # subset by name
 scripts/run-tests.sh -q stdlib         # quick subset
 scripts/run-tests.sh stdlib_march      # the .march test files under test/stdlib/
+scripts/run-tests.sh test_jit          # REPL-JIT / --jit alcotest suite
 
-# Suites: compiler, eval, codegen, stdlib, stdlib_march. An unknown name is a
-# hard error listing the known suites, not a confusing dune build failure.
+# Suites: compiler, eval, codegen, stdlib, stdlib_march, test_jit. An unknown
+# name is a hard error listing the known suites, not a confusing dune build
+# failure.
 
 # 2. Direct binary invocation (no dune RPC at execution time)
-dune build test/run_compiler.exe test/run_eval.exe test/run_codegen.exe test/run_stdlib.exe test/test_stdlib_march.exe
+dune build test/run_compiler.exe test/run_eval.exe test/run_codegen.exe test/run_stdlib.exe test/test_stdlib_march.exe test/test_jit.exe
 ./_build/default/test/run_compiler.exe -e
 ./_build/default/test/run_eval.exe -e
 ./_build/default/test/run_codegen.exe -e
 ./_build/default/test/run_stdlib.exe -e
 ./_build/default/test/test_stdlib_march.exe -e
+# test_jit needs MARCH_BIN pointed at a freshly built compiler or its cases
+# silently skip (reported as passing) — scripts/run-tests.sh sets this for
+# you; direct invocation needs it explicitly:
+MARCH_BIN="$PWD/_build/default/bin/main.exe" ./_build/default/test/test_jit.exe -e
 
 # 3. Standard dune flags for one-off runs
 dune runtest --no-buffer   # real-time output (lines appear as they're written)

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -11,13 +11,26 @@
 #   scripts/run-tests.sh compiler eval   # run a subset by name
 #   scripts/run-tests.sh -q stdlib       # quick subset
 #   scripts/run-tests.sh stdlib_march    # the .march stdlib test files
+#   scripts/run-tests.sh test_jit        # the REPL-JIT / --jit alcotest suite
 #
-# Suites: compiler, eval, codegen, stdlib, stdlib_march.  The first four are
-# test/run_<name>.exe; stdlib_march is test/test_stdlib_march.exe, which runs
-# the .march test files under test/stdlib/.
+# Suites: compiler, eval, codegen, stdlib, stdlib_march, test_jit.  The first
+# four are test/run_<name>.exe; stdlib_march is test/test_stdlib_march.exe,
+# which runs the .march test files under test/stdlib/; test_jit is
+# test/test_jit.exe, which drives the REPL JIT / `march --jit` as subprocesses
+# of a freshly built bin/main.exe.
 #
 # Slow tests skipped by -q: repl_compiler_parity (JIT parity, ~5s),
-#   compiled adversarial regressions (~5s), pbkdf2 key derivation (~3s).
+#   compiled adversarial regressions (~5s), pbkdf2 key derivation (~3s), and
+#   test_jit's ORC/clang REPL-session and --jit-file cases (~5-10s).
+#
+# test_jit is NOT a plain alcotest exe: `dune runtest` normally runs it with
+# HOME and MARCH_BIN pinned (see the `(test (name test_jit) ...)` stanza in
+# test/dune) because it spawns bin/main.exe as a subprocess for REPL/--jit
+# sessions.  Running the built exe directly (as this script does for every
+# suite) skips that env, and test_jit.ml's fallback path SILENTLY SKIPS
+# (`Alcotest.(check pass)`, reported as a pass) whenever MARCH_BIN/main.exe or
+# libLLVM isn't found — so this script sets MARCH_BIN and HOME itself, below,
+# to keep the jit cases actually executing rather than vacuously skipping.
 #
 # Environment:
 #   MARCH_TEST_TIMEOUT  seconds per suite process  (default: 2400)
@@ -69,7 +82,7 @@ fi
 # never ran under this script no matter which subset argument was passed, and a
 # fully green run said nothing about it.  `dune runtest` did cover it, which is
 # exactly why the gap was easy to miss locally.
-ALL_RUNNERS=(run_compiler run_eval run_codegen run_stdlib test_stdlib_march)
+ALL_RUNNERS=(run_compiler run_eval run_codegen run_stdlib test_stdlib_march test_jit)
 QUICK_FLAG=""
 
 # Map a suite name to its executable.  Accepts the bare name ("compiler",
@@ -134,8 +147,21 @@ FAILED=0
 for runner in "${RUNNERS[@]}"; do
   echo ""
   echo "==> ${runner}"
-  if ! $TIMEOUT_CMD ./_build/default/test/${runner}.exe -e $QUICK_FLAG; then
-    FAILED=1
+  if [[ "$runner" == "test_jit" ]]; then
+    # test_jit spawns bin/main.exe as a subprocess for REPL/--jit sessions
+    # (see test/dune's `(test (name test_jit) ...)` stanza) and silently
+    # SKIPS those cases — reported as passing — if MARCH_BIN doesn't resolve
+    # to a real binary. Mirror dune's env here so the jit cases actually run
+    # instead of vacuously skipping.
+    mkdir -p "$PWD/_build/jit_home"
+    if ! HOME="$PWD/_build/jit_home" MARCH_BIN="$PWD/_build/default/bin/main.exe" \
+        $TIMEOUT_CMD ./_build/default/test/${runner}.exe -e $QUICK_FLAG; then
+      FAILED=1
+    fi
+  else
+    if ! $TIMEOUT_CMD ./_build/default/test/${runner}.exe -e $QUICK_FLAG; then
+      FAILED=1
+    fi
   fi
 done
 

--- a/specs/progress/2026-08-25-run-tests-includes-test-jit.md
+++ b/specs/progress/2026-08-25-run-tests-includes-test-jit.md
@@ -1,0 +1,56 @@
+# `scripts/run-tests.sh` now runs `test_jit`
+
+Landed 2026-08-25.
+
+## The gap
+
+`test/test_jit.exe` (19 alcotest cases covering the REPL JIT and
+`march --jit`, added 2026-08-24/25) ran under `dune runtest` — and therefore
+in CI — but was never in `scripts/run-tests.sh`'s `ALL_RUNNERS` list. Local
+agent/dev runs via `scripts/run-tests.sh` (the documented, agent-safe way to
+run tests — see `CLAUDE.md`) silently never exercised it, which is how a
+REPL-JIT regression reached CI twice in one month without a local run ever
+having a chance to catch it.
+
+## The subtlety
+
+`test_jit` is not a plain alcotest exe: `test/dune`'s `(test (name test_jit)
+...)` stanza sets `HOME` to a project-relative tmp dir and `MARCH_BIN` to the
+freshly built `bin/main.exe`, because the tests spawn the real compiler as a
+subprocess to drive REPL/`--jit` sessions. `test_jit.ml`'s `march_bin ()`
+falls back to `../bin/main.exe` (relative to dune's per-test sandbox cwd)
+when `MARCH_BIN` is unset, which does not resolve when the exe is invoked
+directly from the repo root the way `run-tests.sh` invokes every other
+runner. When the binary doesn't resolve, the affected cases don't fail —
+`check_session` calls `Alcotest.(check pass) "... (skipped: no main.exe)"`,
+which alcotest reports as `[OK]` — so a naively-added entry would have looked
+identically green whether or not the JIT cases actually ran.
+
+## The fix
+
+- Added `test_jit` to `scripts/run-tests.sh`'s `ALL_RUNNERS`.
+- In the execution loop, `test_jit` gets a special-cased invocation that sets
+  `HOME="$PWD/_build/jit_home"` (mirroring dune's own env) and
+  `MARCH_BIN="$PWD/_build/default/bin/main.exe"` (the exe the script's own
+  build phase already ensures is fresh), and `mkdir -p`s the HOME dir first.
+- Documented the suite in the script's usage header and in `CLAUDE.md`'s
+  "Suites:" line and direct-invocation examples.
+- `-q` continues to work: the JIT/ORC/clang session cases are tagged `Slow`
+  in `test_jit.ml`'s own `Alcotest.run` call (same mechanism as the other
+  suites' Slow tests), so `run-tests.sh -q test_jit` skips them and only runs
+  the two `Quick` cases.
+
+## Non-vacuity evidence
+
+- `scripts/run-tests.sh test_jit` → exit 0, "19 tests run", and the per-test
+  output log (`_build/_tests/march_jit/jit.003.output`) shows a real REPL
+  transcript (`val fib = <fn>`, `= 144`, …) rather than a skip message.
+- Control: re-running `test/test_jit.exe` directly with `MARCH_BIN` pointed
+  at a nonexistent path reproduces the vacuous-pass failure mode this fix
+  avoids — same `[OK]` alcotest summary, but the per-test log reads
+  `ASSERT orc fn-after-let-lambda (skipped: no main.exe)`. This confirms
+  `run-tests.sh`'s correct-`MARCH_BIN` run is exercising the real subprocess
+  path, not silently skipping like the naive case would.
+- `scripts/run-tests.sh -q test_jit` → exit 0, "3 tests run" (16 Slow cases
+  reported `[SKIP]` — alcotest's real Quick/Slow skip, distinct from the
+  vacuous no-`MARCH_BIN` skip above).


### PR DESCRIPTION
## Summary

`test/test_jit.exe` (19 alcotest cases covering the REPL JIT and `march --jit`, added 2026-08-24/25) runs under `dune runtest` and therefore in CI, but was missing from `scripts/run-tests.sh`'s `ALL_RUNNERS` list -- the documented, agent-safe way to run tests locally. That's how a REPL-JIT regression reached CI twice this month without a local run ever having a chance to catch it.

`test_jit` isn't a plain alcotest exe: `test/dune`'s `(test (name test_jit) ...)` stanza sets `HOME` and `MARCH_BIN` because the tests spawn the real compiler as a subprocess for REPL/`--jit` sessions. Without `MARCH_BIN` resolving to a real binary, the affected cases don't fail -- `check_session` calls `Alcotest.(check pass) "... (skipped: no main.exe)"`, which alcotest reports as `[OK]`. A naive addition to the runner list would have looked identically green whether or not the JIT cases actually ran.

- Added `test_jit` to `ALL_RUNNERS` in `scripts/run-tests.sh`.
- The execution loop special-cases `test_jit`: sets `HOME="$PWD/_build/jit_home"` (mirroring dune's own env) and `MARCH_BIN="$PWD/_build/default/bin/main.exe"` (the exe the script's build phase already ensures is fresh), `mkdir -p`s the HOME dir first.
- `-q` continues to skip the `Slow`-tagged JIT/ORC/clang session cases via the existing mechanism.
- Documented the suite in the script's usage header and in `CLAUDE.md`'s "Suites:" line and direct-invocation examples.
- Added `specs/progress/2026-08-25-run-tests-includes-test-jit.md` recording the gap and fix, per repo convention. No CHANGELOG entry -- internal tooling, no user-visible behavior change.

## Non-vacuity evidence

- `scripts/run-tests.sh test_jit` -> exit 0, "19 tests run", all cases `[OK]`, and the per-test log (`_build/_tests/march_jit/jit.003.output`) shows a real REPL transcript rather than a skip message.
- **Control:** running `test/test_jit.exe` directly with `MARCH_BIN` pointed at a nonexistent path reproduces the vacuous-pass failure mode this fix avoids: alcotest still prints `[OK]`/"Test Successful" (19 tests, exit 0), but the per-test logs read `ASSERT orc fn-after-let-lambda (skipped: no main.exe)` for all 6 subprocess-driven `jit.*` cases. This is the exact contrast that proves the fix's `MARCH_BIN`/`HOME` wiring is load-bearing, not decorative.
- `scripts/run-tests.sh -q test_jit` -> exit 0, "3 tests run" (16 `Slow` cases correctly `[SKIP]`, distinct from the vacuous no-`MARCH_BIN` skip above).
- `scripts/run-tests.sh` (full, unfiltered) -> exit 0, all suites including all 19 `test_jit` cases passing.

## Test plan

- [x] `dune build --root . bin/main.exe test/test_jit.exe`
- [x] `scripts/run-tests.sh test_jit` -- exit 0, jit cases actually run
- [x] Non-vacuity control with bogus `MARCH_BIN` -- confirms skip messages appear, restored afterward
- [x] `scripts/run-tests.sh -q` -- exit 0, Slow jit cases skipped
- [x] `scripts/run-tests.sh` (full) -- exit 0