### PR TITLE
specs: decide decomposition targets from measurement, not stale sizes

### DIFF
--- a/specs/2026-08-25-file-decomposition-analysis.md
+++ b/specs/2026-08-25-file-decomposition-analysis.md
@@ -1,0 +1,149 @@
+# Which compiler files to decompose, and in what order
+
+**Date:** 2026-08-25
+**Feeds:** `specs/plans/2026-08-19-compiler-file-decomposition.md`
+**Supersedes:** the file-size column of `specs/features/compiler-pipeline.md`'s
+Implementation Status Summary, which was stale by 3–7× and has been removed in
+favour of this document.
+
+## Why this exists
+
+The decomposition plan picked its targets in August 2026 from sizes that were
+already wrong, and `compiler-pipeline.md` carried a *different* set of wrong
+sizes (it claimed `typecheck.ml` was 2,006 lines in one table and ~7,700 in a
+section header; it is 14,958). Neither document ranked by how often anyone
+actually has to work in these files. This is a measurement pass, so target
+selection rests on numbers that were true when written and are cheap to
+re-derive.
+
+## Method
+
+Three axes, measured 2026-08-25 at `1e5bafcf`:
+
+- **Size** — total lines. Proxy for how much you must hold in context.
+- **Concentration** — lines in the file's single largest top-level definition,
+  as a share of the file. A 1,000-line function is unworkable regardless of its
+  file's size.
+- **Churn** — commits touching the file in the last six months. This is the one
+  the earlier passes omitted, and it is the one that decides payoff:
+  decomposing a file nobody edits buys nothing.
+
+Reproduce with `git log --oneline --since="6 months ago" -- <file> | wc -l` and
+the line/concentration scan in the appendix.
+
+A fourth, qualitative axis matters for *risk*, not priority: whether the large
+definition is **logic** or a **data table**. `eval.ml`'s `base_env` (5,290
+lines) and `llvm_builtins.ml`'s `builtins` (893) are tables — long, simple, and
+nearly free to move. `emit_expr`, `check_call`, `infer_expr` and `compile` are
+logic, where extraction can change behaviour.
+
+## The measurements
+
+| File | Lines | Largest definition | Conc. | Commits/6mo | Pain score |
+|---|---:|---|---:|---:|---:|
+| `lib/typecheck/typecheck.ml` | 14,958 | `infer_expr` 1,500 | 10% | **387** | **5,789** |
+| `lib/eval/eval.ml` | 12,265 | `base_env` 5,290 *(table)* | 43% | 262 | 3,214 |
+| `bin/main.ml` | 5,403 | `compile` 2,510 | 46% | **337** | 1,820 |
+| `lib/tir/llvm_emit.ml` | 5,720 | `emit_expr` 4,319 | **76%** | 299 | 1,710 |
+| `lsp/lib/analysis.ml` | 8,133 | `ast_code_actions` 1,089 | 13% | 129 | 1,049 |
+| `lib/refinecheck/refine_check.ml` | 7,417 | `check_call` 1,361 | 18% | 82 | 608 |
+| `lib/tir/lower.ml` | 2,001 | `lower_module` 896 | 45% | 134 | 268 |
+| `lib/desugar/desugar.ml` | 3,321 | `derive_impl` 942 | 28% | 76 | 252 |
+| `lib/repl/repl.ml` | 2,290 | `run_tui` 1,109 | 48% | 71 | 163 |
+| `lib/tir/perceus.ml` | 1,998 | `insert_rc_expr` 856 | 43% | 66 | 132 |
+| `lib/tir/llvm_builtins.ml` | 1,851 | `builtins` 893 *(table)* | 48% | 54 | 100 |
+| `lsp/lib/server.ml` | 1,557 | `semantic_tokens_data` 1,313 | **84%** | 33 | 51 |
+| `lib/tir/mono.ml` | 1,327 | `rewrite_calls` 675 | 51% | 34 | 45 |
+| `lib/tir/llvm_toplevel.ml` | 1,521 | `emit_module` 787 | 52% | 24 | 36 |
+| `lib/tir/llvm_case.ml` | 1,093 | `emit_case` 1,040 | **95%** | 11 | 12 |
+
+Pain score is `commits × KLoC` — a crude "how much oversized code does someone
+have to navigate per unit of work". It is a sorting aid, not a target.
+
+## Findings
+
+**1. The plan's priority order is close to inverted at the top.**
+`typecheck.ml` scores highest by a factor of nearly two over the next file, and
+it is the plan's *most downscoped* phase (Phase 6, "cold data only" — extract
+`builtin_cap_table` and stop). It is simultaneously the largest file in the
+compiler and the most frequently edited, at 387 commits in six months. That
+combination is the definition of the problem this project exists to solve.
+
+The reason for the downscoping is real: at 10% concentration there is no single
+clean seam, and type inference is mutually recursive, so the extraction is
+genuinely harder than `eval.ml`'s. But "hard" is an argument about sequencing
+and technique, not about value. Phase 6 should be re-scoped from "cold data
+only" to a real plan, and it should not be last.
+
+**2. Concentration without churn is not worth fixing.** `llvm_case.ml` is 95%
+one function — the worst ratio in the tree — and would top any concentration-
+ranked list. It changed 11 times in six months. Nobody is suffering there.
+Ranking by concentration alone, as the earlier pass effectively did, promotes
+cold code and hides `typecheck.ml`, whose diffuse 10% conceals the highest
+actual cost in the repository.
+
+**3. Three sizeable, actively-edited files are absent from the plan entirely.**
+
+| File | Lines | Commits/6mo | Note |
+|---|---:|---:|---|
+| `lib/tir/lower.ml` | 2,001 | 134 | more churn than `refine_check.ml`, which gets a whole phase |
+| `lib/desugar/desugar.ml` | 3,321 | 76 | fourth-largest `lib/` file |
+| `lib/tir/perceus.ml` | 1,998 | 66 | 43% in `insert_rc_expr`; RC bugs are historically expensive here |
+
+**4. Only 2 of 31 files over 800 lines have an `.mli`** — `repl.ml` and
+`repl_jit.ml`. Everything else exports its entire contents. This is both a
+cause of the growth and the cheapest partial remedy available: an interface file
+declares a boundary, makes accidental coupling a compile error, and shrinks the
+surface a reader must consider, without moving a single line of code. Several
+targets below would get most of the benefit of decomposition from an `.mli`
+alone, at a fraction of the risk. The decomposition plan does not mention `.mli`
+files except for `refine_check.mli` in its Phase 3.
+
+**5. `bin/main.ml` deserves re-examination.** Phase 5 declines to split it, on
+the grounds that "linear driver code is the friendliest shape to work in". At
+337 commits in six months — second-highest in the tree — and a 2,510-line
+`compile` function, that argument is worth re-testing against the evidence. This
+session alone hit three separate defects inside that function.
+
+## Recommended order
+
+Ranked by payoff, with the plan's current sequencing noted:
+
+| # | Target | Approach | vs. plan today |
+|---|---|---|---|
+| 1 | `typecheck.ml` | Re-scope Phase 6 into a real decomposition. Start with an `.mli` and the cold tables, then peel off self-contained checkers (exhaustiveness, capability/`needs`, linearity) which are not part of the inference recursion. | **Promote** from last/downscoped |
+| 2 | `eval.ml` | As planned: `base_env` is a table, so Phase 1 is high-value and low-risk. Keep the interpreter-perf control the plan now carries. | Unchanged (Phase 1) |
+| 3 | `llvm_emit.ml` | As planned: 76% concentration in `emit_expr` with a natural split by construct. | Unchanged (Phase 2) |
+| 4 | `bin/main.ml` | Re-open the "do not split" decision for `compile` specifically. | **Re-examine** Phase 5 |
+| 5 | `lower.ml`, `desugar.ml`, `perceus.ml` | Add as a phase. Each has one dominant function and a clear seam. | **Add** — currently absent |
+| 6 | `analysis.ml`, `refine_check.ml` | As planned. | Unchanged (Phases 3–4) |
+| — | `llvm_case.ml`, `llvm_toplevel.ml`, `server.ml`, `mono.ml` | Leave. Cold enough that the churn does not justify the risk. | Not in plan; correctly so |
+
+**Do first, independent of all of the above:** add `.mli` files to the
+highest-churn targets (`typecheck.ml`, `llvm_emit.ml`, `lower.ml`,
+`desugar.ml`). It is the only item here that buys a real boundary without
+moving code, and it makes every later extraction safer by making the current
+surface explicit.
+
+## Appendix — re-deriving the table
+
+```bash
+# size + concentration + .mli presence, for every file over 800 lines
+python3 - <<'PY'
+import os,re
+for root,dirs,files in os.walk('.'):
+    if any(s in root for s in ('_build','.git','.superpowers','.march')): continue
+    if not root.startswith(('./lib','./bin','./lsp','./forge')): continue
+    for f in files:
+        if not f.endswith(('.ml','.mll','.mly')): continue
+        p=os.path.join(root,f); lines=open(p,errors='ignore').read().split('\n')
+        if len(lines)<800: continue
+        starts=[i for i,l in enumerate(lines) if re.match(r'^(let|and|type|module|external)\s',l)]
+        big=max((b-a,lines[a][:46]) for a,b in zip(starts,starts[1:]+[len(lines)]))
+        print(f"{len(lines):6} {big[0]:6} {100*big[0]//len(lines):3}% "
+              f"{'mli' if os.path.exists(p[:-3]+'.mli') else '---'}  {p}  {big[1]}")
+PY
+
+# churn
+git log --oneline --since="6 months ago" -- <file> | wc -l
+```

--- a/specs/features/compiler-pipeline.md
+++ b/specs/features/compiler-pipeline.md
@@ -1,7 +1,9 @@
 # March Language Compiler Pipeline
 
-**Document Date**: March 22, 2026
-**Total Lines Analyzed**: ~18,500 (across 30+ source files)
+**Document Date**: March 22, 2026 (body); execution modes and status table revised 2026-08-25
+**Scope**: the compiler pipeline, stage by stage. Deliberately no file sizes —
+see `specs/2026-08-25-file-decomposition-analysis.md` for current, re-derivable
+measurements.
 
 **Implementation:** `lib/` directory — `typecheck/`, `tir/`, `jit/`, `repl/`, `cas/`, `debug/`, `scheduler/`
 
@@ -14,11 +16,11 @@ The March compiler transforms source code through a series of passes, from surfa
 ```
 Source Code
     ↓
-[Lexer] (lib/lexer/lexer.mll:1-183)
+[Lexer] (lib/lexer/lexer.mll)
     ↓
-[Parser] (lib/parser/parser.mly:1-688)
+[Parser] (lib/parser/parser.mly)
     ↓
-[Desugaring] (lib/desugar/desugar.ml:1-263)
+[Desugaring] (lib/desugar/desugar.ml)
     ↓
 [Type Checking] (lib/typecheck/typecheck.ml — Typecheck.check_module / check_module_full)
     ↓
@@ -77,7 +79,7 @@ Source Code
 
 ## 1. Lexical Analysis
 
-**File**: `lib/lexer/lexer.mll` (183 lines, OCamllex)
+**File**: `lib/lexer/lexer.mll`
 **Status**: Complete
 
 ### Key Features
@@ -102,7 +104,7 @@ Source Code
 
 ## 2. Parsing
 
-**File**: `lib/parser/parser.mly` (688 lines, Menhir)
+**File**: `lib/parser/parser.mly`
 **Status**: Complete
 
 ### Key Features
@@ -137,7 +139,7 @@ end
 
 ## 3. Desugaring Pass
 
-**File**: `lib/desugar/desugar.ml` (263 lines)
+**File**: `lib/desugar/desugar.ml`
 **Status**: Complete
 
 ### Transformations
@@ -201,7 +203,7 @@ end
 
 ## 4. Type Checking
 
-**File**: `lib/typecheck/typecheck.ml` (~7700 lines)
+**File**: `lib/typecheck/typecheck.ml`
 **Status**: Complete, heavily featured
 
 Entry points: `Typecheck.check_module` and `check_module_full` (the latter also returns the typecheck env). Capability/`needs` enforcement is embedded here via `check_module_needs`. Pattern-match exhaustiveness (`check_exhaustiveness`/`find_missing_mc`) and redundancy (`check_redundant_arms`) checks run during declaration checking. Type-level naturals are reduced by `normalize_tnat`. Immediately after typecheck, `bin/main.ml` runs `Refine_check.check_module` for refinement-type verification.
@@ -264,7 +266,7 @@ Hashtbl mapping expression span → inferred type. Used by lowering to produce c
 
 ## 5. Lowering to TIR
 
-**File**: `lib/tir/lower.ml` (1122 lines)
+**File**: `lib/tir/lower.ml`
 **Status**: Complete
 
 ### Target Intermediate Representation
@@ -312,7 +314,7 @@ Hashtbl mapping expression span → inferred type. Used by lowering to produce c
 
 ## 6. TIR Types and Structures
 
-**File**: `lib/tir/tir.ml` (107 lines)
+**File**: `lib/tir/tir.ml`
 **Status**: Complete
 
 ### ANF-Based IR
@@ -361,7 +363,7 @@ type expr = EAtom of atom
 
 ## 7. Monomorphization Pass
 
-**File**: `lib/tir/mono.ml` (314 lines)
+**File**: `lib/tir/mono.ml`
 **Status**: Complete
 
 ### Purpose
@@ -395,7 +397,7 @@ Eliminates all `TVar` type variables by specializing polymorphic functions at ca
 
 ## 8. Defunctionalization Pass
 
-**File**: `lib/tir/defun.ml` (336 lines)
+**File**: `lib/tir/defun.ml`
 **Status**: Complete
 
 ### Purpose
@@ -507,7 +509,7 @@ Insert reference-counting instructions (EIncRC, EDecRC) and linear/affine cleanu
 
 ## 11. Inlining Pass
 
-**File**: `lib/tir/inline.ml` (179 lines)
+**File**: `lib/tir/inline.ml`
 **Status**: Complete
 
 ### Heuristics
@@ -540,7 +542,7 @@ Insert reference-counting instructions (EIncRC, EDecRC) and linear/affine cleanu
 
 ## 12. Constant Folding Pass
 
-**File**: `lib/tir/fold.ml` (91 lines)
+**File**: `lib/tir/fold.ml`
 **Status**: Complete
 
 ### Operations Folded
@@ -561,7 +563,7 @@ Insert reference-counting instructions (EIncRC, EDecRC) and linear/affine cleanu
 
 ## 13. Simplification Pass
 
-**File**: `lib/tir/simplify.ml` (107 lines)
+**File**: `lib/tir/simplify.ml`
 **Status**: Complete
 
 ### Simplifications
@@ -581,7 +583,7 @@ Insert reference-counting instructions (EIncRC, EDecRC) and linear/affine cleanu
 
 ## 14. Dead Code Elimination Pass
 
-**File**: `lib/tir/dce.ml` (130 lines)
+**File**: `lib/tir/dce.ml`
 **Status**: Complete
 
 ### Two Phases
@@ -604,7 +606,7 @@ Insert reference-counting instructions (EIncRC, EDecRC) and linear/affine cleanu
 
 ## 15. Optimization Coordinator
 
-**File**: `lib/tir/opt.ml` (19 lines)
+**File**: `lib/tir/opt.ml`
 **Status**: Complete
 
 ### Fixed-Point Loop
@@ -627,7 +629,7 @@ let run (m : Tir.tir_module) : Tir.tir_module =
 
 ## 16. LLVM IR Emission
 
-**File**: `lib/tir/llvm_emit.ml` (1659 lines)
+**File**: `lib/tir/llvm_emit.ml`
 **Status**: Substantially complete
 
 ### Object Layout
@@ -688,23 +690,34 @@ Allocation size = 16 + arity × 8 bytes.
 
 ---
 
-## 17. Code Generation Stub
+## 17. `lib/codegen` — a vestigial shim, not the code generator
 
-**File**: `lib/codegen/codegen.ml` (10 lines)
-**Status**: Placeholder
+**File**: `lib/codegen/codegen.ml`
+**Status**: Empty placeholder. **Code generation itself is implemented and shipping** — it simply does not live here.
+
+This module is a leftover:
 
 ```ocaml
 let compile _module_ = ()  (* TODO: Implement *)
 ```
 
-Currently a stub. Full code generation (linking, assembly) not yet implemented.
+An earlier revision of this document read that literally and reported "full code
+generation (linking, assembly) not yet implemented", which is false and badly
+misleading: March emits LLVM IR and links native binaries today. The real path
+is `lib/tir/llvm_emit.ml` (+ the `llvm_*` family) for IR, and `bin/main.ml` for
+the clang invocation that assembles and links it. See §16 and §18.
+
+The shim is retained only because the `march_codegen` library name is still
+referenced by the build; nothing calls into it.
 
 ---
 
 ## 18. Main CLI Entry Point
 
-**File**: `bin/main.ml` (5,390 lines as of 2026-08-25; an earlier revision of this
-document said 334, which was stale by more than an order of magnitude)
+**File**: `bin/main.ml` — one of the largest and most-edited files in the tree.
+An earlier revision claimed 334 lines, understating it by more than an order of
+magnitude; a figure added on 2026-08-25 to correct that went stale within a day.
+Sizes now live only in `specs/2026-08-25-file-decomposition-analysis.md`.
 **Status**: Complete
 
 ### Key Functions
@@ -804,7 +817,7 @@ Capabilities **are** enforced. `lib/effects/effects.ml` is a thin wrapper whose 
 
 ## 20. Purity Analysis
 
-**File**: `lib/tir/purity.ml` (25 lines)
+**File**: `lib/tir/purity.ml`
 **Status**: Complete
 
 ### Definition
@@ -823,7 +836,7 @@ Used by inlining pass to decide which functions are safe to inline.
 
 ## 21. Pretty Printing
 
-**File**: `lib/tir/pp.ml` (98 lines)
+**File**: `lib/tir/pp.ml`
 **Status**: Complete
 
 Renders TIR expressions and types as readable text for debugging (`--dump-tir`).
@@ -888,40 +901,51 @@ Renders TIR expressions and types as readable text for debugging (`--dump-tir`).
 
 ## Implementation Status Summary
 
-| Pass | File | Lines | Status |
-|------|------|-------|--------|
-| Lexer | `lib/lexer/lexer.mll` | 183 | ✓ Complete |
-| Parser | `lib/parser/parser.mly` | 688 | ✓ Complete |
-| AST | `lib/ast/ast.ml` | 306 | ✓ Complete |
-| Desugaring | `lib/desugar/desugar.ml` | 263 | ✓ Complete |
-| Type Checking | `lib/typecheck/typecheck.ml` | 2006 | ✓ Complete |
-| Lowering to TIR | `lib/tir/lower.ml` | 1122 | ✓ Complete |
-| TIR Types | `lib/tir/tir.ml` | 107 | ✓ Complete |
-| Monomorphization | `lib/tir/mono.ml` | 314 | ✓ Complete |
-| Defunctionalization | `lib/tir/defun.ml` | 336 | ✓ Complete |
-| Perceus RC | `lib/tir/perceus.ml` | — | ✓ Complete (runs before Escape) |
-| Escape Analysis | `lib/tir/escape.ml` | — | ✓ Complete (runs after Perceus) |
-| Fusion | `lib/tir/fusion.ml` | — | ✓ Complete |
-| Known-call | `lib/tir/known_call.ml` | — | ✓ Complete |
-| Beta-ADT | `lib/tir/beta_adt.ml` | — | ✓ Complete |
-| Join points | `lib/tir/join_points.ml` | — | ✓ Complete |
-| Refinement check | `lib/refinecheck/refine_check.ml` | ~1069 | ✓ Complete (post-typecheck) |
-| Division safety | `lib/refinecheck/division_safety.ml` | ~307 | ✓ Complete (`cap no_panic`: proves divisors ≠ 0 via Z3) |
-| No-alloc check | `lib/refinecheck/no_alloc.ml` | ~87 | ✓ Complete (`cap no_alloc`: bans heap-allocating exprs) |
-| Capability inference | `lib/refinecheck/cap_infer.ml` | ~120 | ✓ Complete (emits `needs` hint at call sites missing cap decl) |
-| Return refinement inference | `lib/refinecheck/return_infer.ml` | ~238 | ✓ Complete (Z3 sign-candidate probing for return type hints) |
-| Inlining | `lib/tir/inline.ml` | 179 | ✓ Complete |
-| Constant Folding | `lib/tir/fold.ml` | 91 | ✓ Complete |
-| Simplification | `lib/tir/simplify.ml` | 107 | ✓ Complete |
-| DCE | `lib/tir/dce.ml` | 130 | ✓ Complete |
-| Optimization Loop | `lib/tir/opt.ml` | 19 | ✓ Complete |
-| LLVM Emission | `lib/tir/llvm_emit.ml` | 1659 | ✓ Substantial (constructor collision & arity mismatch fixed) |
-| Code Generation | `lib/codegen/codegen.ml` | 10 | ⚠ Stub |
-| Effects System | `lib/effects/effects.ml` | — | ✓ Enforced (delegates to `Typecheck.check_module_needs`) |
-| Purity Analysis | `lib/tir/purity.ml` | 25 | ✓ Complete |
-| Pretty Printing | `lib/tir/pp.ml` | 98 | ✓ Complete |
-| Main CLI | `bin/main.ml` | 334 | ✓ Complete |
-| Tests | `test/test_compiler.ml`, `test_eval.ml`, `test_codegen.ml`, `test_stdlib_suite.ml` | — | ✓ Comprehensive |
+> **File sizes deliberately removed (2026-08-25).** This table used to carry a
+> `Lines` column. Every figure in it had drifted — `typecheck.ml` was listed at
+> 2,006 lines against an actual 14,958, and the document contradicted itself
+> (§4 said ~7,700 for the same file). Because this is the table a reader
+> consults when asking "what is too big to work in?", a stale answer here is
+> worse than no answer. Current, re-derivable measurements — size, largest
+> definition, concentration and churn — live in
+> `specs/2026-08-25-file-decomposition-analysis.md`, which is the single source
+> of truth for file sizes and feeds
+> `specs/plans/2026-08-19-compiler-file-decomposition.md`.
+
+| Pass | File | Status |
+|------|------|--------|
+| Lexer | `lib/lexer/lexer.mll` | ✓ Complete |
+| Parser | `lib/parser/parser.mly` | ✓ Complete |
+| AST | `lib/ast/ast.ml` | ✓ Complete |
+| Desugaring | `lib/desugar/desugar.ml` | ✓ Complete |
+| Type Checking | `lib/typecheck/typecheck.ml` | ✓ Complete |
+| Lowering to TIR | `lib/tir/lower.ml` | ✓ Complete |
+| TIR Types | `lib/tir/tir.ml` | ✓ Complete |
+| Monomorphization | `lib/tir/mono.ml` | ✓ Complete |
+| Defunctionalization | `lib/tir/defun.ml` | ✓ Complete |
+| Perceus RC | `lib/tir/perceus.ml` | ✓ Complete (runs before Escape) |
+| Escape Analysis | `lib/tir/escape.ml` | ✓ Complete (runs after Perceus) |
+| Fusion | `lib/tir/fusion.ml` | ✓ Complete |
+| Known-call | `lib/tir/known_call.ml` | ✓ Complete |
+| Beta-ADT | `lib/tir/beta_adt.ml` | ✓ Complete |
+| Join points | `lib/tir/join_points.ml` | ✓ Complete |
+| Refinement check | `lib/refinecheck/refine_check.ml` | ✓ Complete (post-typecheck) |
+| Division safety | `lib/refinecheck/division_safety.ml` | ✓ Complete (`cap no_panic`: proves divisors ≠ 0 via Z3) |
+| No-alloc check | `lib/refinecheck/no_alloc.ml` | ✓ Complete (`cap no_alloc`: bans heap-allocating exprs) |
+| Capability inference | `lib/refinecheck/cap_infer.ml` | ✓ Complete (emits `needs` hint at call sites missing cap decl) |
+| Return refinement inference | `lib/refinecheck/return_infer.ml` | ✓ Complete (Z3 sign-candidate probing for return type hints) |
+| Inlining | `lib/tir/inline.ml` | ✓ Complete |
+| Constant Folding | `lib/tir/fold.ml` | ✓ Complete |
+| Simplification | `lib/tir/simplify.ml` | ✓ Complete |
+| DCE | `lib/tir/dce.ml` | ✓ Complete |
+| Optimization Loop | `lib/tir/opt.ml` | ✓ Complete |
+| LLVM Emission | `lib/tir/llvm_emit.ml` | ✓ Substantial (constructor collision & arity mismatch fixed) |
+| Code Generation | `lib/codegen/codegen.ml` | ⚠ Stub |
+| Effects System | `lib/effects/effects.ml` | ✓ Enforced (delegates to `Typecheck.check_module_needs`) |
+| Purity Analysis | `lib/tir/purity.ml` | ✓ Complete |
+| Pretty Printing | `lib/tir/pp.ml` | ✓ Complete |
+| Main CLI | `bin/main.ml` | ✓ Complete |
+| Tests | `test/test_compiler.ml`, `test_eval.ml`, `test_codegen.ml`, `test_stdlib_suite.ml` | ✓ Comprehensive |
 
 ---
 

--- a/specs/plans/2026-08-19-compiler-file-decomposition.md
+++ b/specs/plans/2026-08-19-compiler-file-decomposition.md
@@ -10,6 +10,48 @@
 
 ---
 
+## Target selection revised 2026-08-25 — read with the analysis
+
+**`specs/2026-08-25-file-decomposition-analysis.md` supersedes this plan's choice
+of targets and their order.** This plan picked its six files in August from sizes
+that were already stale, and ranked them without measuring how often anyone edits
+them. The analysis measures three axes — size, concentration (share of the file in
+its single largest definition) and **churn** (commits per six months) — and churn
+changes the answer materially. Four conclusions bear directly on the phases below:
+
+1. **`typecheck.ml` is the highest-payoff target, not the lowest.** It is the
+   largest file in the compiler (14,958 lines) *and* the most edited (387 commits
+   in six months, more than `bin/main.ml` or `llvm_emit.ml`). Phase 6 currently
+   downscopes it to "cold data only". The downscoping rationale is real — at 10%
+   concentration there is no single clean seam, and inference is mutually
+   recursive — but that is an argument about technique and sequencing, not value.
+   Phase 6 needs a real plan and should not be last.
+2. **Concentration without churn is not worth fixing.** `llvm_case.ml` is 95% one
+   function, the worst ratio in the tree, and changed 11 times in six months.
+   Ranking by concentration promotes cold code; it is the reason `typecheck.ml`'s
+   diffuse but expensive bulk was ranked below files nobody edits.
+3. **Three actively-edited files are missing from this plan entirely:**
+   `lib/tir/lower.ml` (2,001 lines, 134 commits — more churn than
+   `refine_check.ml`, which gets a whole phase), `lib/desugar/desugar.ml` (3,321,
+   76) and `lib/tir/perceus.ml` (1,998, 66). Each has one dominant function and a
+   clear seam. They warrant a phase.
+4. **Only 2 of 31 files over 800 lines have an `.mli`.** Adding interface files to
+   the highest-churn targets is the cheapest real boundary available — it makes
+   accidental coupling a compile error and shrinks the surface a reader must hold,
+   without moving a line. Do it *before* the corresponding extraction; it makes
+   the extraction safer by declaring what the current surface actually is.
+
+Also worth re-testing: Phase 5 declines to split `bin/main.ml` because "linear
+driver code is the friendliest shape to work in". At 337 commits in six months and
+a 2,510-line `compile`, that judgement deserves evidence — three separate defects
+were found inside that one function during the perf project.
+
+File sizes are no longer recorded in `specs/features/compiler-pipeline.md`; its
+status table carried figures stale by 3–7× and now points at the analysis, which
+is the single source of truth and carries the commands to re-derive every number.
+
+---
+
 ## Re-anchored 2026-08-25 (at `8d2b22fb`, merged onto `origin/main` `7f91ea5d`)
 
 **Read this before executing any task below.** This plan was drafted on 2026-08-19 against


### PR DESCRIPTION
Three documents disagreed about how big the compiler's files are, and the decomposition plan picked its targets from the wrong set.

**New:** `specs/2026-08-25-file-decomposition-analysis.md` — measures size, concentration (share of a file in its single largest definition) and **churn** (commits/6mo) across every file over 800 lines, with the commands to re-derive all of it.

Churn is the axis the earlier passes omitted, and it changes the answer:
- `typecheck.ml` is both the **largest** file (14,958) and the **most edited** (387 commits/6mo) — and is the plan's *most downscoped* phase. It should not be last.
- `llvm_case.ml` is **95%** one function, the worst concentration in the tree — and changed **11** times in six months. Ranking by concentration promotes cold code.
- `lower.ml` (134 commits), `desugar.ml` (76) and `perceus.ml` (66) are absent from the plan entirely.
- Only **2 of 31** files over 800 lines have an `.mli`. That is both a cause of the growth and the cheapest real boundary available — no code moves.

**`specs/features/compiler-pipeline.md`** now records no file sizes at all. Its status table had a `Lines` column stale by 3–7×, and the document contradicted itself (`typecheck.ml` at 2,006 in the table, ~7,700 in §4). That is the table someone consults to ask "what is too big to work in?", so a stale answer is worse than none. It points at the analysis instead. A figure I added yesterday to correct one of these went stale within a day, which is the argument for one source of truth in miniature.

Also fixed there: **§17 claimed "full code generation (linking, assembly) not yet implemented"** — reading a 10-line vestigial shim literally, while March emits LLVM IR and links native binaries today. A newcomer would conclude the compiler cannot produce executables.

**`specs/plans/2026-08-19-compiler-file-decomposition.md`** gains a "Target selection revised" section pointing at the analysis. I deliberately did not restructure its phases — that is a judgement for whoever executes it, made with the measurements in hand.

Docs-only; `check-docs.sh` passes.