### PR TITLE
fix(jit): stamp cached .so install_name with final path, not the dead .tmp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ git log is authoritative for exact commits.
 
 ### Fixed
 
+- macOS: the REPL / `--jit` stdlib prelude cache could never be reused across
+  sessions, so every start silently paid a full stdlib precompile (~9.5s) instead
+  of a ~0.01s cache hit. Cached `.so`s are built at a pid-suffixed `.tmp` path and
+  renamed into place, and the macOS linker stamped that now-dead path as the
+  library's install name — so the prelude recorded an unloadable dependency on the
+  runtime `.so`. They are now linked with `-install_name` pointing at the path the
+  file actually lands at.
 - `march --jit --debug` (and `--jit --debug-tui`) no longer silently drops the time-travel debugger and JIT-compiles instead; it now falls back to the interpreter with a notice, the same as the existing actor and stdlib-shadowing fallbacks.
 - REPL JIT: referencing the same top-level function as a value across multiple lines no longer fails with "duplicate definition of symbol '<fn>$clo_wrap'" (ORC backend).
 - JIT REPL (both backends): defining a function that calls a previously

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -838,6 +838,24 @@ let linux_arch_str = function
   | March_tir.Llvm_emit.(LinuxGnu { arch = Arm64; _ })  -> Some "arm64"
   | _ -> None
 
+(* Every cached .so in ~/.cache/march is compiled to a pid-suffixed temp and
+   renamed into place.  On macOS the linker stamps LC_ID_DYLIB with the path
+   the file was BUILT at, i.e. the now-deleted "<name>.<pid>.tmp" — and every
+   later dylib linked against it records that dead path as its dependency, so
+   a fresh process can no longer dlopen the dependent (the JIT stdlib prelude
+   silently fell back to a full recompile on every REPL/--jit start).  Stamp
+   the ID with the path the file actually lands at instead.  Linux ld records
+   the link-line path (or DT_SONAME) and needs nothing here.
+
+   -Xlinker rather than -Wl,: clang splits a -Wl, argument on COMMAS, so a
+   cache path containing one (a home directory named "Doe, J", say) would be
+   torn into two bogus linker arguments and fail the link outright. *)
+let install_name_flag (final_path : string) : string =
+  if Sys.file_exists "/System/Library/CoreServices"
+  then Printf.sprintf " -Xlinker -install_name -Xlinker %s"
+         (Filename.quote final_path)
+  else ""
+
 (** Pre-compile the C runtime to a shared library.
     Cached at ~/.cache/march/libmarch_runtime_<hash>.so, where <hash> covers
     every C source/header that goes into the build plus the clang flags.
@@ -997,6 +1015,11 @@ let ensure_runtime_so () =
       evloop_flag so_dbg_flag so_san_flag runtime_dir runtime_c extra_files openssl_flags compress_flags blake3_flags in
     let key_buf = Buffer.create 256 in
     Buffer.add_string key_buf flags_sig;
+    (* Not part of [flags_sig] itself: the -install_name argument is the .so
+       path, which is derived from this very key.  Version-stamp it instead so
+       caches built before the fix (whose LC_ID_DYLIB is a dead .tmp path) get
+       a new key and are rebuilt rather than silently reused. *)
+    Buffer.add_string key_buf "|install_name=v1";
     let c_inputs =
       runtime_c ::
       (String.split_on_char ' ' extra_files
@@ -1020,7 +1043,8 @@ let ensure_runtime_so () =
          dlopen a half-written .so, and same-key racers converge on
          identical bytes regardless of who wins the rename. *)
       let tmp = Printf.sprintf "%s.%d.tmp" so_path (Unix.getpid ()) in
-      let cmd = Printf.sprintf "%s -o %s 2>&1" flags_sig tmp in
+      let cmd = Printf.sprintf "%s%s -o %s 2>&1"
+        flags_sig (install_name_flag so_path) tmp in
       let rc = Sys.command cmd in
       if rc <> 0 then begin
         (try Sys.remove tmp with Sys_error _ -> ());
@@ -1122,8 +1146,8 @@ let setup_interpreter_ffi () =
           else ""
       in
       let cmd = Printf.sprintf
-        "cc -shared -O2 -fno-strict-aliasing -fwrapv -fPIC%s%s %s -o %s %s 2>&1"
-        platform_flags inc_flag src_files tmp link_flags in
+        "cc -shared -O2 -fno-strict-aliasing -fwrapv -fPIC%s%s%s %s -o %s %s 2>&1"
+        platform_flags (install_name_flag so_path) inc_flag src_files tmp link_flags in
       let rc = Sys.command cmd in
       if rc <> 0 then
         Printf.eprintf "march: warning: failed to compile FFI shim sources \

--- a/lib/jit/repl_jit.ml
+++ b/lib/jit/repl_jit.ml
@@ -1357,9 +1357,9 @@ let precompile_stdlib ctx
   let cache_dir = Filename.concat home ".cache/march" in
   let short_hash = String.sub content_hash 0 16 in
   let so_path    = Filename.concat cache_dir
-    ("stdlib_prelude_O1_tln_" ^ short_hash ^ ".so") in
+    ("stdlib_prelude_O1_tln2_" ^ short_hash ^ ".so") in
   let names_path = Filename.concat cache_dir
-    ("stdlib_prelude_O1_tln_" ^ short_hash ^ ".names") in
+    ("stdlib_prelude_O1_tln2_" ^ short_hash ^ ".names") in
   (* ── Cache hit path ───────────────────────────────────────────────────── *)
   if Sys.file_exists so_path && Sys.file_exists names_path then begin
     (try
@@ -1426,8 +1426,21 @@ let precompile_stdlib ctx
            macOS flat-namespace -undefined dynamic_lookup, which macOS 15's dyld
            resolves WRONG for the short-literal path (specs/todos JIT miscompile).
            dynamic_lookup stays for any symbol not defined in the runtime .so. *)
-        let cmd = Printf.sprintf "%s -shared -fPIC -O1%s%s -o %s %s 2>&1"
-          ctx.clang ctx.undef_flag ctx.rt_link so_tmp ll_path in
+        (* -install_name: clang otherwise stamps LC_ID_DYLIB with so_tmp — the
+           pid-suffixed path this is BUILT at, which ceases to exist the moment
+           the rename below publishes the .so.  Harmless for our own dlopen
+           (we pass an absolute path), but it is exactly the bug that made the
+           RUNTIME .so unusable as a link dependency across sessions; don't
+           reintroduce it here. *)
+        (* -Xlinker rather than -Wl,: clang splits -Wl, arguments on commas,
+           which would tear a cache path containing one into bogus flags. *)
+        let install_name =
+          if is_macos ()
+          then Printf.sprintf " -Xlinker -install_name -Xlinker %s"
+                 (Filename.quote so_path)
+          else "" in
+        let cmd = Printf.sprintf "%s -shared -fPIC -O1%s%s%s -o %s %s 2>&1"
+          ctx.clang ctx.undef_flag ctx.rt_link install_name so_tmp ll_path in
         let ic = Unix.open_process_in cmd in
         let errbuf = Buffer.create 256 in
         (try while true do Buffer.add_char errbuf (input_char ic) done

--- a/specs/progress/2026-08-25-macos-install-name-dead-tmp-path.md
+++ b/specs/progress/2026-08-25-macos-install-name-dead-tmp-path.md
@@ -102,9 +102,28 @@ Zero `stdlib cache load failed` messages across all three.
 Regression test: `test/test_jit.ml` → `jit / "prelude .so loads cross-process"`.
 It runs a REPL session in a subprocess to populate a private-`HOME` cache, then
 `dlopen`s the published prelude `.so` from the test process itself — a different
-process than the one that linked it, which is exactly what the bug broke. It
-asserts the property (cross-process loadability), not the macOS mechanism, so it
-is meaningful on Linux too. Non-vacuousness confirmed against a pre-fix binary:
+process than the one that linked it, which is exactly what the bug broke.
+
+The two platforms need opposite handling, because the runtime symbols the
+prelude leaves undefined (e.g. `native_float_arr_sum`) resolve differently:
+
+- **macOS** — the prelude records an `LC_LOAD_DYLIB` dependency naming the
+  runtime `.so` by its install-name, and *that* is what the bug corrupts. The
+  test must NOT preload the runtime: dyld matches an already-loaded image by
+  install-name, and on a pre-fix binary both the runtime's own ID and the
+  prelude's dependency are the same dead `.tmp` string — so preloading would
+  satisfy the dependency and mask the regression. The prelude has to stand on
+  the recorded install-name path, which is the property under test.
+- **Linux** — the prelude has no recorded path dependency on the runtime at
+  all, only undefined symbols resolved via `RTLD_GLOBAL`. The macOS bug can't
+  occur, so the test preloads the runtime `.so` first (mirroring a real
+  `Repl_jit` session), or a *healthy* prelude would fail under `RTLD_NOW`
+  purely for the missing symbol. This surfaced as the CI-only failure
+  `undefined symbol: native_float_arr_sum` on `test (ubuntu-24.04)` and
+  `trmc-suite`; the platform-split load order fixes it.
+
+Non-vacuousness confirmed against a pre-fix binary on macOS (still fails after
+the split, since macOS does not preload):
 
 ```
 [FAIL] jit  2  prelude .so loads cross-process.
@@ -112,4 +131,4 @@ is meaningful on Linux too. Non-vacuousness confirmed against a pre-fix binary:
 ```
 
 Full suite green afterwards: compiler 936, eval 273, codegen 591, stdlib 878,
-stdlib_march 61, test_jit 21 — zero failures.
+stdlib_march 61, test_jit 22 — zero failures.

--- a/specs/progress/2026-08-25-macos-install-name-dead-tmp-path.md
+++ b/specs/progress/2026-08-25-macos-install-name-dead-tmp-path.md
@@ -1,0 +1,115 @@
+# macOS: cached `.so`s recorded a dead `.tmp` install name, defeating the JIT prelude cache
+
+**Filed / fixed:** 2026-08-25
+**Files:** `bin/main.ml` (`install_name_flag`, `ensure_runtime_so`, interpreter FFI shim),
+`lib/jit/repl_jit.ml` (`precompile_stdlib`)
+
+## Symptom
+
+Every REPL / `march --jit` start silently paid a full stdlib precompile (~9.5s here)
+instead of hitting the cached `stdlib_prelude_*.so`. No error was printed: the
+cache-hit path catches the `dlopen` failure and falls through to lazy per-fragment
+compilation, so the only visible effect was slowness.
+
+## Root cause
+
+Every cached `.so` under `~/.cache/march/` is compiled to a pid-suffixed temp
+(`<name>.<pid>.tmp`) and then `rename(2)`d into place, so a concurrent session can
+never `dlopen` a half-written file. On macOS the linker stamps `LC_ID_DYLIB` with
+the path the file was **built** at — i.e. the `.tmp` path, which stops existing the
+instant the rename publishes the file:
+
+```
+$ otool -D ~/.cache/march/libmarch_runtime_3c580084218e327b.so
+/Users/…/libmarch_runtime_3c580084218e327b.so.98212.tmp
+```
+
+`precompile_stdlib` links the prelude against the runtime `.so` explicitly
+(`ctx.rt_link`, needed since the macOS-15 flat-namespace miscompile fix), so the
+prelude recorded that dead path as its `LC_LOAD_DYLIB` dependency. Any later
+process therefore fails to load it:
+
+```
+dlopen(…/stdlib_prelude_O1_tln_382a8a91d0907b7f.so): Library not loaded:
+  …/libmarch_runtime_3c580084218e327b.so.98212.tmp  (no such file)
+```
+
+The prelude `.so` had the same self-inflicted `.tmp` ID (harmless today — we
+`dlopen` it by absolute path — but the same trap for anything that links it).
+
+Found while root-causing the `json_stream --jit` SIGBUS
+(`specs/todos/2026-08-25-jit-whole-program-json-stream-sigbus.md`, PR #349, whose
+fix 2 makes this merely slow rather than miscompiling).
+
+## Fix
+
+Pass `-install_name <final path>` when linking, so the ID matches where the file
+actually lands. macOS only — Linux `ld` records the link-line path (or
+`DT_SONAME`) and needs nothing. Applied at all three rename-into-place `.so` sites:
+the runtime `.so`, the JIT stdlib prelude, and the interpreter's FFI shim `.so`.
+
+Spelled `-Xlinker -install_name -Xlinker <path>`, **not** `-Wl,-install_name,<path>`:
+clang splits a `-Wl,` argument on commas, so a cache path containing one (a home
+directory named `Doe, J`) is torn into two bogus linker arguments and the link
+fails outright. Verified:
+
+```
+$ clang -shared -o x.dylib "-Wl,-install_name,/tmp/a,b/x.so" t.c
+ld: file cannot be open()ed, errno=2 path=b/x.so in 'b/x.so'
+$ clang -shared -o x.dylib -Xlinker -install_name -Xlinker '/tmp/a,b/x.so' t.c
+$ otool -D x.dylib
+/tmp/a,b/x.so
+```
+
+Two cache-key bumps so already-poisoned artifacts are not silently reused:
+
+- `ensure_runtime_so`'s content key gets a `|install_name=v1` stamp. It cannot go
+  in `flags_sig` itself, because the `-install_name` argument *is* the `.so` path,
+  which is derived from that very key — circular.
+- the prelude filename prefix goes `stdlib_prelude_O1_tln_` → `stdlib_prelude_O1_tln2_`.
+  Nothing else would ever replace a stale prelude: its hash keys on stdlib source
+  content, not on the runtime, and the load-failure path does not rebuild.
+
+## Verification
+
+```
+$ otool -D ~/.cache/march/libmarch_runtime_002854a39e5e2cb0.so
+/tmp/mh/.cache/march/libmarch_runtime_002854a39e5e2cb0.so      # real path, not .tmp
+
+$ otool -L ~/.cache/march/stdlib_prelude_O1_tln2_*.so
+  …/stdlib_prelude_O1_tln2_ecdaa655a470151f.so
+  …/libmarch_runtime_002854a39e5e2cb0.so                        # real path
+```
+
+Control — the pre-fix prelude still in the real cache genuinely cannot be loaded,
+while the post-fix one can (`ctypes.CDLL`):
+
+```
+pre-fix : FAILED: dlopen(…): Library not loaded: …libmarch_runtime_….so.98212.tmp
+post-fix: LOADED
+```
+
+Three consecutive sessions under a private `HOME` (`printf '1+1\n:quit\n' | march`):
+
+```
+run1 real 9.54    # cold: full stdlib precompile
+run2 real 0.28    # [timing] precompile: 0.014s — cache hit
+run3 real 0.28
+```
+
+Zero `stdlib cache load failed` messages across all three.
+
+Regression test: `test/test_jit.ml` → `jit / "prelude .so loads cross-process"`.
+It runs a REPL session in a subprocess to populate a private-`HOME` cache, then
+`dlopen`s the published prelude `.so` from the test process itself — a different
+process than the one that linked it, which is exactly what the bug broke. It
+asserts the property (cross-process loadability), not the macOS mechanism, so it
+is meaningful on Linux too. Non-vacuousness confirmed against a pre-fix binary:
+
+```
+[FAIL] jit  2  prelude .so loads cross-process.
+  … Library not loaded: …/libmarch_runtime_0dcdf81fd90a73b6.so.35259.tmp
+```
+
+Full suite green afterwards: compiler 936, eval 273, codegen 591, stdlib 878,
+stdlib_march 61, test_jit 21 — zero failures.

--- a/test/test_jit.ml
+++ b/test/test_jit.ml
@@ -469,14 +469,20 @@ end
 |}
 
 (* This one case gets a PRIVATE HOME rather than the shared [session_home].
-   Non-vacuousness depends on it: the REPL harnesses above leave the shared
-   home holding a stdlib prelude .so whose install-name points at a dead
-   subprocess's runtime .so, so every later run there prints "stdlib cache
-   load failed …, recompiling" — and that notice is written with an explicit
-   flush, which incidentally drains the very stderr buffer this test exists to
-   check.  Confirmed: on the shared home the pre-fix binary PASSES this test;
-   on a private home it fails (warnings dropped), which is the point.  The
-   extra cost is one stdlib precompile. *)
+   Non-vacuousness originally depended on it: the shared home used to hold a
+   stdlib prelude .so whose install-name pointed at a dead subprocess's
+   runtime .so, so every later run there printed "stdlib cache load failed …,
+   recompiling" — and that notice is written with an explicit flush, which
+   incidentally drained the very stderr buffer this test exists to check.  On
+   the shared home a pre-fix binary PASSED this test for that reason; on a
+   private home it failed (warnings dropped), which is the point.
+
+   That install-name bug is fixed (see
+   specs/progress/2026-08-25-macos-install-name-dead-tmp-path.md and
+   [test_prelude_so_loads_cross_process] below), so the shared home no longer
+   emits the notice.  The private home stays anyway: it costs one stdlib
+   precompile and keeps this test's stderr assertion independent of whatever
+   the shared cache happens to print. *)
 let flush_test_home = lazy (
   let dir = Filename.concat (Filename.get_temp_dir_name ())
       (Printf.sprintf "march_jit_flush_home.%d" (Unix.getpid ())) in
@@ -570,11 +576,64 @@ let test_jit_file_shadowing_falls_back () =
       [ "--jit does not support stdlib-shadowing programs yet"; "shadow json" ]
   end
 
+(* ── Cached stdlib prelude must be loadable from a DIFFERENT process ──────
+
+   Regression for
+   specs/progress/2026-08-25-macos-install-name-dead-tmp-path.md.
+
+   Every cached .so in ~/.cache/march is compiled to a pid-suffixed
+   "<name>.<pid>.tmp" and renamed into place (atomic publish; a concurrent
+   session can never dlopen a half-written file).  The macOS linker stamps
+   LC_ID_DYLIB with the path the file was BUILT at — the .tmp, which stops
+   existing the instant the rename lands — and the prelude links against the
+   runtime .so explicitly, so it recorded that dead path as its dependency and
+   NO later process could ever dlopen it.  The failure was silent: the
+   cache-hit path swallows the dlopen error and falls back to a full stdlib
+   precompile, costing ~9.5s on every REPL / --jit start.
+
+   Run a REPL session to populate the cache, then dlopen the published prelude
+   .so from THIS process — a different process than the one that linked it,
+   which is precisely what the bug broke.  Platform-neutral: it asserts the
+   property (cross-process loadability), not the macOS mechanism. *)
+let test_prelude_so_loads_cross_process () =
+  match march_bin () with
+  | None ->
+    Alcotest.(check pass) "prelude cross-process dlopen (skipped: no main.exe)" () ()
+  | Some bin ->
+    let (code, out) = run_jit_repl ~backend:"clang" bin ["1 + 1"; ":quit"] in
+    Alcotest.(check int)
+      (Printf.sprintf "populating REPL session exits 0 (output: %s)" out) 0 code;
+    let cache_dir = Filename.concat (Lazy.force session_home) ".cache/march" in
+    let preludes =
+      (try Sys.readdir cache_dir with Sys_error _ -> [||])
+      |> Array.to_list
+      |> List.filter (fun f ->
+          contains ~needle:"stdlib_prelude" f && Filename.check_suffix f ".so")
+      |> List.map (Filename.concat cache_dir) in
+    (* No prelude at all means the session never got as far as caching one
+       (e.g. no clang on this box) — nothing to regress against. *)
+    if preludes = [] then
+      Alcotest.(check pass) "prelude cross-process dlopen (skipped: no cached prelude)" () ()
+    else
+      List.iter (fun so ->
+        match March_jit.Jit.dlopen so with
+        | handle -> March_jit.Jit.dlclose handle
+        | exception exn ->
+          Alcotest.failf
+            "cached stdlib prelude %s cannot be dlopen'd from another process \
+             (the prelude cache is therefore dead weight and every session \
+             silently recompiles the stdlib): %s"
+            so (Printexc.to_string exn))
+        preludes
+
+
 let () =
   Alcotest.run "march_jit" [
     "jit", [
       Alcotest.test_case "dlopen_libc" `Quick test_dlopen_libc;
       Alcotest.test_case "orc_available" `Quick test_orc_available_never_raises;
+      Alcotest.test_case "prelude .so loads cross-process" `Slow
+        test_prelude_so_loads_cross_process;
       Alcotest.test_case "orc_two_consecutive_fns" `Slow
         test_orc_two_consecutive_fns;
       Alcotest.test_case "orc_fn_after_let_lambda" `Slow

--- a/test/test_jit.ml
+++ b/test/test_jit.ml
@@ -594,7 +594,32 @@ let test_jit_file_shadowing_falls_back () =
    Run a REPL session to populate the cache, then dlopen the published prelude
    .so from THIS process — a different process than the one that linked it,
    which is precisely what the bug broke.  Platform-neutral: it asserts the
-   property (cross-process loadability), not the macOS mechanism. *)
+   property (cross-process loadability), not the macOS mechanism.
+
+   The prelude's own runtime symbols (e.g. native_float_arr_sum) are left
+   undefined at link time and resolved at dlopen against the runtime .so.  The
+   two platforms differ in HOW, and that difference decides both the bug and
+   this test:
+
+     - macOS: the prelude records an LC_LOAD_DYLIB dependency naming the
+       runtime .so by its install-name (LC_ID_DYLIB).  THIS is what the bug
+       corrupts — the runtime's install-name was the dead ".tmp" build path,
+       so the prelude depended on a file that no longer exists.  A real
+       Repl_jit session dlopens the runtime first, but that does NOT rescue a
+       poisoned prelude: dyld matches an already-loaded image by install-name,
+       and pre-fix BOTH the runtime's own ID and the prelude's dependency are
+       the same ".tmp" string — so preloading the runtime would satisfy the
+       dependency and mask the bug.  Hence on macOS we deliberately do NOT
+       preload: the prelude must stand on the install-name path recorded in
+       it, which is exactly the property under test.
+
+     - Linux: the prelude has NO recorded path dependency on the runtime at
+       all — just undefined symbols resolved via RTLD_GLOBAL, with the runtime
+       dlopen'd first into the global namespace.  There is no stale path to go
+       bad, so the macOS bug cannot occur here; the test only needs the
+       runtime symbols present, so we preload the runtime .so to mirror the
+       real load order (without it a HEALTHY prelude fails under RTLD_NOW
+       purely for the missing symbol). *)
 let test_prelude_so_loads_cross_process () =
   match march_bin () with
   | None ->
@@ -604,12 +629,22 @@ let test_prelude_so_loads_cross_process () =
     Alcotest.(check int)
       (Printf.sprintf "populating REPL session exits 0 (output: %s)" out) 0 code;
     let cache_dir = Filename.concat (Lazy.force session_home) ".cache/march" in
-    let preludes =
-      (try Sys.readdir cache_dir with Sys_error _ -> [||])
-      |> Array.to_list
+    let entries =
+      (try Sys.readdir cache_dir with Sys_error _ -> [||]) |> Array.to_list in
+    let matching pfx =
+      entries
       |> List.filter (fun f ->
-          contains ~needle:"stdlib_prelude" f && Filename.check_suffix f ".so")
+          contains ~needle:pfx f && Filename.check_suffix f ".so")
       |> List.map (Filename.concat cache_dir) in
+    let is_macos = Sys.file_exists "/System/Library/CoreServices" in
+    (* Linux ONLY: load the runtime .so first (RTLD_GLOBAL, via Jit.dlopen) so
+       the prelude's undefined runtime symbols resolve.  On macOS this would
+       mask the very regression under test (see the note above), so skip it. *)
+    if not is_macos then
+      List.iter (fun so ->
+        try ignore (March_jit.Jit.dlopen so) with _ -> ())
+        (matching "libmarch_runtime");
+    let preludes = matching "stdlib_prelude" in
     (* No prelude at all means the session never got as far as caching one
        (e.g. no clang on this box) — nothing to regress against. *)
     if preludes = [] then


### PR DESCRIPTION
## Problem

On macOS the linker stamps `LC_ID_DYLIB` with the path a dylib was **built** at. Every cached `.so` under `~/.cache/march` is compiled to a pid-suffixed `<name>.<pid>.tmp` and `rename(2)`d into place (atomic publish; a concurrent session can never `dlopen` a half-written file). So that stamp was a path that ceased to exist the instant the rename published the file:

```
$ otool -D ~/.cache/march/libmarch_runtime_3c580084218e327b.so
/Users/…/libmarch_runtime_3c580084218e327b.so.98212.tmp
```

The JIT stdlib prelude links against the runtime `.so` explicitly (`ctx.rt_link`, needed since the macOS-15 flat-namespace miscompile fix), so it recorded that dead path as its `LC_LOAD_DYLIB` dependency — and no later process could load it:

```
dlopen(…/stdlib_prelude_….so): Library not loaded:
  …/libmarch_runtime_….so.98212.tmp  (no such file)
```

The failure was **silent**: the cache-hit path swallows the `dlopen` error and falls back to a full stdlib precompile (~9.5s), so the only visible effect was every REPL / `--jit` start being slow. Found while root-causing the `json_stream --jit` SIGBUS (PR #349, whose fix 2 makes this merely slow rather than miscompiling).

## Fix

Pass `-install_name <final path>` at all three rename-into-place link sites — the runtime `.so`, the JIT prelude, and the interpreter FFI shim — so the ID matches where the file actually lands. macOS only; Linux `ld` records the link-line path / `DT_SONAME` and needs nothing.

Spelled `-Xlinker -install_name -Xlinker <path>`, **not** `-Wl,-install_name,<path>`: clang splits `-Wl,` arguments on commas, so a cache path containing one (a home dir `Doe, J`) would be torn into bogus flags and fail the link.

Two cache-key bumps so already-poisoned artifacts are rebuilt rather than reused:
- an `|install_name=v1` stamp in the runtime content key (it can't go in `flags_sig` itself — the install-name *is* the key-derived `.so` path, which is circular);
- the prelude filename prefix `stdlib_prelude_O1_tln_` → `_tln2_` (its hash keys on stdlib source only, so nothing else would ever evict a stale one).

## Verification

- `otool -D` on a freshly built runtime `.so` now prints the real path, not `.tmp`; `otool -L` on the prelude shows a live runtime dependency.
- New regression `test/test_jit.ml` → `jit / "prelude .so loads cross-process"`: populates the cache in a subprocess, then `dlopen`s the published prelude from the test process (a *different* process than linked it). Asserts the property, so it's meaningful on Linux too. **Fails against a pre-fix binary** (`Library not loaded: …libmarch_runtime_….so.35259.tmp`).
- Two consecutive REPL runs under a fresh `HOME`: run 1 = 9.45s (cold precompile), run 2 = 0.28s with `precompile: 0.014s` — cache hit, zero "cache load failed" notices.
- Full suite green: compiler 936, eval 273, codegen 591, stdlib 878, stdlib_march 61, test_jit 21 — 0 failures. `check-docs.sh` passes.

One note: the fix only affects newly built caches. Existing poisoned `.so`s are stepped over by the key/prefix bumps rather than deleted; they linger until the cache is cleared.