### PR TITLE
Add .mli files to the four highest-churn compiler modules (73% of their surface was accidental)

### DIFF
--- a/lib/desugar/desugar.mli
+++ b/lib/desugar/desugar.mli
@@ -1,0 +1,55 @@
+(** Desugaring: the AST-to-AST pass between parsing and typechecking.
+
+    It lowers surface conveniences onto the core AST — pipes, multi-head
+    function definitions into a single [EMatch] clause, [let?] propagation,
+    string/HTML interpolation, [derive]/[satisfy] expansion, interface default
+    methods, and module-reference qualification.  Everything it emits is
+    ordinary AST; nothing downstream needs to know a desugaring happened.
+
+    The exported surface below is deliberately small.  The bulk of this module
+    is single-purpose helpers for one of those expansions; if you need one from
+    outside, widen this file on purpose rather than by reflex. *)
+
+module Err = March_errors.Errors
+
+(** {1 Entry point} *)
+
+val desugar_module :
+  ?errors:Err.ctx ->
+  ?is_entry:bool -> March_ast.Ast.module_ -> March_ast.Ast.module_
+
+(** {1 Sub-entry points}
+
+    Used by consumers that hold something smaller than a module: the REPL and
+    LSP desugar a bare expression, and the driver re-runs individual stages. *)
+
+val desugar_expr : March_ast.Ast.expr -> March_ast.Ast.expr
+val desugar_ty : March_ast.Ast.ty -> March_ast.Ast.ty
+val desugar_decl : March_ast.Ast.decl -> March_ast.Ast.decl
+
+val inject_defaults :
+  (string * March_ast.Ast.interface_def) list ->
+  March_ast.Ast.decl -> March_ast.Ast.decl
+
+(** {1 Module qualification} *)
+
+val make_qualifier :
+  string ->
+  string list -> string list -> March_ast.Ast.expr -> March_ast.Ast.expr
+
+val qualify_module_refs :
+  ?entry_prefix:string -> March_ast.Ast.decl list -> March_ast.Ast.decl list
+
+val collect_direct_names :
+  externs:bool -> March_ast.Ast.decl list -> string list
+
+(** {1 Misc. helpers with outside callers} *)
+
+(** Normalises a refinement predicate's qualifier chain; used by refinecheck. *)
+val flatten_pred_quals : March_ast.Ast.expr -> March_ast.Ast.expr
+
+(** Rewrites spans to fresh synthetic ones, so derived/injected code cannot be
+    mistaken for user source by diagnostics. *)
+val respan_ty : March_ast.Ast.ty -> March_ast.Ast.ty
+
+val check_main_signature : Err.ctx -> March_ast.Ast.decl list -> unit

--- a/lib/tir/llvm_emit.mli
+++ b/lib/tir/llvm_emit.mli
@@ -1,0 +1,192 @@
+(** LLVM IR emission: the core expression emitter plus the public backend API.
+
+    See [llvm_emit.ml]'s module doc for the pass itself and for the Wave-3
+    split into [Llvm_ctx] / [Llvm_builtins] / [Llvm_eq] / [Llvm_data] /
+    [Llvm_case] / [Llvm_calls] / [Llvm_tco] / [Llvm_toplevel] / [Llvm_repl].
+
+    That split left this file re-exporting most of those modules' surfaces
+    bare, for API stability. In practice only the values below are reached from
+    outside [march_tir]; the rest stays available to in-library callers under
+    its defining module's own name ([Llvm_ctx.fresh], [Llvm_data.emit_load_field],
+    [Llvm_builtins.is_int_arith], …), which is where new code should reach for
+    it. [emit_expr] itself has no external caller: the sibling emitters that
+    need it receive it as a labelled [~emit_expr] callback threaded from here. *)
+
+(** {1 Targets} *)
+
+type arch = Llvm_toplevel.arch = X86_64 | Arm64
+
+type target_config =
+  Llvm_toplevel.target_config =
+    Native
+  | LinuxGnu of { arch : arch; glibc_min : string; }
+  | Wasm64Wasi
+  | Wasm32Wasi
+  | Wasm32Unknown
+  | Js
+
+val is_wasm_target : target_config -> bool
+val target_triple : target_config -> string
+val target_is_linux : target_config -> bool
+
+(** Cross-compilation target string for the bundled zig cc, when one applies. *)
+val zig_target : target_config -> string option
+
+(** {1 Whole-module emission} *)
+
+val emit_module :
+  ?fast_math:bool ->
+  ?pmap_threshold:int ->
+  ?target:target_config ->
+  ?hot_reload:Hot_reload.config option ->
+  ?impl_hashes:(string, string) Hashtbl.t ->
+  ?remote_impl_hashes:(string, string) Hashtbl.t ->
+  ?remote_sig_hashes:(string, string) Hashtbl.t ->
+  ?emit_main:bool ->
+  ?cap_attrib:(String.t * string) list ->
+  ?cap_decls:(string * string) list -> Tir.tir_module -> string
+
+val emit_preamble : ?target:target_config -> ?repl:bool -> Buffer.t -> unit
+
+(** Symbol name an [extern] declaration links against. *)
+val mangle_extern : string -> string
+
+(** {1 REPL / JIT fragment emission}
+
+    Driven by [lib/jit/repl_jit.ml], which compiles one entry at a time into a
+    fresh module linked against the slots the session has already defined. *)
+
+type session_wraps =
+  Llvm_ctx.session_wraps = {
+  sw_defined : (string, unit) Hashtbl.t;
+  sw_pending : (string, unit) Hashtbl.t;
+}
+
+type repl_slot_info =
+  Llvm_repl.repl_slot_info = {
+  rs_bare : string;
+  rs_slot : int;
+  rs_ty : Tir.ty;
+}
+
+val emit_repl_expr :
+  ?fast_math:bool ->
+  n:int ->
+  ret_ty:Tir.ty ->
+  prev_slots:repl_slot_info list ->
+  fns:Tir.fn_def list ->
+  ?extern_fns:Tir.fn_def list ->
+  ?store_as_slot:int option ->
+  ?session_wraps:session_wraps ->
+  types:Tir.type_def list -> Tir.expr -> string
+
+val emit_repl_decl :
+  ?fast_math:bool ->
+  n:int ->
+  name:string ->
+  val_ty:Tir.ty ->
+  dest_slot:int ->
+  prev_slots:repl_slot_info list ->
+  fns:Tir.fn_def list ->
+  ?extern_fns:Tir.fn_def list ->
+  ?session_wraps:session_wraps ->
+  types:Tir.type_def list -> Tir.expr -> string
+
+val emit_repl_fn_with_closure_slot :
+  ?fast_math:bool ->
+  n:int ->
+  bind_name:string ->
+  dest_slot:int ->
+  prev_slots:repl_slot_info list ->
+  ?helper_fns:Tir.fn_def list ->
+  ?extern_fns:Tir.fn_def list ->
+  ?session_wraps:session_wraps ->
+  types:Tir.type_def list -> Tir.fn_def -> string
+
+val emit_fns_fragment :
+  types:Tir.type_def list ->
+  fns:Tir.fn_def list ->
+  ?extern_fns:Tir.fn_def list ->
+  ?session_wraps:session_wraps ->
+  repl:bool -> unit -> string
+
+(** {1 Re-exports kept only to stay compilable}
+
+    The 33 values below are re-export bindings left over from the Wave-3 split
+    ([let emit_fn = Llvm_toplevel.emit_fn], and so on). None has a caller —
+    not inside this file, not elsewhere in [march_tir], not outside it —
+    because every in-library user already names the defining module directly.
+    Hiding them turns each into an unused-value error under the project's
+    warnings-as-errors, so they are declared here with this note rather than
+    deleted; removing the [let] lines and these [val]s together is a separate,
+    equally safe follow-up. Do not read this block as public API. *)
+
+(** Hiding this type makes [s_kind] an unused-field error; the type itself has
+    no caller outside this module. *)
+type simd_ty = {
+  s_vec : string;
+  s_kind : int;
+  s_lanes : int;
+  s_elem : string;
+  s_boundary_float : bool;
+  s_arr_prefix : string;
+}
+
+(** Likewise an unused-type-declaration error if hidden. *)
+type repl_globals = Llvm_repl.repl_globals
+
+val alloc_size : int -> int
+val apply_ty_subst : (string * Tir.ty) list -> Tir.ty -> Tir.ty
+val build_ctor_info : Llvm_ctx.ctx -> Tir.tir_module -> unit
+val emit_atom_val : Llvm_ctx.ctx -> Tir.atom -> string
+val emit_fn : Llvm_ctx.ctx -> Tir.fn_def -> unit
+val emit_load_tag : Llvm_ctx.ctx -> string -> string
+val emit_main_wrapper : Buffer.t -> unit
+val emit_prev_global_bridges : Llvm_ctx.ctx -> (string * string) list -> unit
+val emit_prev_slot_bridges : Llvm_ctx.ctx -> repl_slot_info list -> unit
+val emit_reduction_check : Llvm_ctx.ctx -> unit
+
+val emit_repl_fn :
+  ?fast_math:bool ->
+  n:int ->
+  prev_slots:repl_slot_info list ->
+  ?extern_fns:Tir.fn_def list ->
+  types:Tir.type_def list -> Tir.fn_def -> string
+
+val emit_repl_globals_decl : Buffer.t -> (string * string) list -> unit
+val emit_slot_loader_fns : Llvm_ctx.ctx -> repl_slot_info list -> unit
+val emit_store_to_slot : Llvm_ctx.ctx -> int -> string -> Tir.ty -> unit
+
+val emit_untag_known_scalar :
+  Llvm_ctx.ctx -> raw:string -> unt:string -> string -> string
+
+val ensure_shape_globals : Llvm_ctx.ctx -> string -> string * string
+val field_load_llty : Tir.ty -> string
+val fn_declare_str : Tir.fn_def -> string
+val fnv1a_64 : string -> int64
+val is_wasm32 : target_config -> bool
+val llvm_escape_string : string -> string
+
+val llvm_param_ty :
+  ?type_defs:Tir.type_def list ->
+  ?collision_set:(string, string list) Hashtbl.t -> Tir.ty -> string
+
+val llvm_ty_of_tir : Tir.ty -> string
+
+val make_ctx :
+  ?fast_math:bool ->
+  ?pmap_threshold:int ->
+  ?repl:bool ->
+  ?hot_reload:Hot_reload.config option ->
+  ?hr_names:Hot_reload.Name_table.t ->
+  ?type_defs:Tir.type_def list -> unit -> Llvm_ctx.ctx
+
+val ok_payload_ty : Tir.ty -> Tir.ty
+val repr_audit_report : unit -> unit
+val resolve_ctor_fields : Llvm_ctx.ctx -> Tir.ty -> string -> int -> Tir.ty list
+val shape_desc : (string * Tir.ty) list -> string
+val simd_kind_of_vec : string -> int
+val target_arch : target_config -> arch option
+val target_int_ty : target_config -> string
+val target_ptr_size : target_config -> int
+val target_ptr_ty : target_config -> string

--- a/lib/tir/lower.mli
+++ b/lib/tir/lower.mli
@@ -1,0 +1,95 @@
+(** AST → TIR lowering: orchestrator and public entry points.
+
+    See [lower.ml]'s module doc for the full description of the pass and of the
+    Wave-3 split into [Lower_state] / [Lower_types] / [Lower_match] /
+    [Lower_decls] / [Lower_actor] / [Lower_tests].
+
+    Historically this file re-exported nearly all of those five modules'
+    surfaces bare, so external callers could keep writing [Lower.x]. In
+    practice only the handful of values below are used from outside; the rest
+    of the re-export block stays available to in-library callers under its
+    defining module's own name ([Lower_state.fresh_name], [Lower_types.unknown_ty],
+    [Lower_decls.lower_fn_def], …), which is where new code should reach for it.
+    Anything genuinely needed from outside should be added here deliberately. *)
+
+module Ast = March_ast.Ast
+module Typecheck = March_typecheck.Typecheck
+
+(** Re-exported from [Lower_state] with its definition visible, so callers can
+    build and pattern-match an env without naming [Lower_state]. *)
+type env = Lower_state.env = {
+  type_map : (Ast.span, Typecheck.ty) Hashtbl.t option;
+  current_module_aliases : (string, string) Hashtbl.t;
+  mod_prefix : string;
+  collision_set : (string, string list) Hashtbl.t;
+}
+
+val empty_env : env
+
+(** {1 Entry point} *)
+
+val lower_module :
+  ?type_map:(Ast.span, Typecheck.ty) Hashtbl.t ->
+  ?stdlib_context:Ast.decl list ->
+  ?test_mode:bool ->
+  ?hot_reload:bool -> Ast.module_ -> Tir.tir_module
+
+(** {1 Piecewise lowering}
+
+    The REPL JIT and the eval/JS pipelines lower fragments rather than whole
+    modules, and need the type converters and the prelude ADTs directly. *)
+
+val lower_ty : Ast.ty -> Tir.ty
+val convert_ty : Typecheck.ty -> Tir.ty
+
+val lower_type_def :
+  Ast.name -> Ast.name list -> Ast.type_def -> Tir.type_def option
+
+(** The compiler's always-injected prelude ADTs (Option/Result/List). *)
+val builtin_type_defs : Tir.type_def list
+
+val collect_type_names :
+  prefix:string -> Tir.type_def list -> Ast.decl list -> Tir.type_def list
+
+(** Interface-method dispatch table, consulted after lowering by [Mono] and by
+    the JIT/JS drivers. *)
+val get_iface_methods : unit -> (string, (string * string) list) Hashtbl.t
+
+(** {1 Cross-run state}
+
+    Lowering keeps module-level tables; a driver that lowers more than once in
+    a process (REPL, test harness, snapshot runner) must be able to reset and
+    to reach the accumulated definitions. *)
+
+val reset_counter : unit -> unit
+val _fns_ref : Tir.fn_def list ref ref
+val _types_ref : Tir.type_def list ref ref
+val _lowered_modules : (string, unit) Hashtbl.t ref
+
+(** Forward reference to the lazy stdlib-module loader, installed by this
+    module at load time. *)
+val _ensure_module_lowered : (env -> string -> unit) ref
+
+(** Alias-resolution state. [test/test_codegen.ml] drives these directly to
+    reproduce the cross-module qualified-alias hijack (see that test's comment);
+    a caller that resets them must reset all three together. *)
+
+val _fn_param_types : (string, Tir.ty) Hashtbl.t
+val _use_aliases : (string, string) Hashtbl.t ref
+val _module_aliases : (string, string) Hashtbl.t ref
+val with_current_module_fns : string list -> (unit -> 'a) -> 'a
+val resolve_use_alias : env -> string -> string
+
+(** {1 Re-exports kept only to stay compilable}
+
+    These three have no caller anywhere — inside this module, elsewhere in
+    [march_tir], or outside it. They are re-export bindings of
+    [Lower_state]/[Lower_decls] values, and hiding them turns them into
+    unused-value errors under the project's warnings-as-errors. Declaring them
+    keeps this change to "add a file, touch no code"; deleting the three
+    [let] lines in [lower.ml] and these three [val]s together is a separate,
+    equally safe follow-up. *)
+
+val nonexhaustive_panic : unit -> Tir.expr
+val lower_fn_def : Lower_state.env -> Ast.fn_def -> Tir.fn_def
+val rename_tir_vars : string -> string list -> Tir.fn_def -> Tir.fn_def

--- a/lib/typecheck/typecheck.mli
+++ b/lib/typecheck/typecheck.mli
@@ -1,0 +1,327 @@
+(** Bidirectional Hindley-Milner type inference, plus the checks layered on
+    top of it: linearity, exhaustiveness, capabilities and effect ceilings,
+    session-type projection, panic/pure/deterministic surfaces, and tail-call
+    enforcement.
+
+    The type language ([ty], [scheme], [env] and friends) is the module's real
+    contract — TIR lowering, the LSP, the REPL and the search index all read
+    it — so it stays fully visible here, along with the [check_module*] family
+    the drivers call and the pretty-printers everything shares.
+
+    Inference itself is deliberately closed. [unify], [instantiate_ctor],
+    [infer_pattern], [check_exhaustiveness], the capability walkers and the
+    several hundred helpers behind them are not exported: they are mutually
+    recursive, they read and write module-level state, and calling one from
+    outside a [check_module] run would see that state half-built. Reach for
+    [check_module_with_env] or one of its siblings instead, and if something
+    here really must become public, widen this file on purpose. *)
+
+module Ast = March_ast.Ast
+module Err = March_errors.Errors
+module StringSet :
+  sig
+    type elt = String.t
+    type t = Set.Make(String).t
+    val empty : t
+    val add : elt -> t -> t
+    val singleton : elt -> t
+    val remove : elt -> t -> t
+    val union : t -> t -> t
+    val inter : t -> t -> t
+    val disjoint : t -> t -> bool
+    val diff : t -> t -> t
+    val cardinal : t -> int
+    val elements : t -> elt list
+    val min_elt : t -> elt
+    val min_elt_opt : t -> elt option
+    val max_elt : t -> elt
+    val max_elt_opt : t -> elt option
+    val choose : t -> elt
+    val choose_opt : t -> elt option
+    val find : elt -> t -> elt
+    val find_opt : elt -> t -> elt option
+    val find_first : (elt -> bool) -> t -> elt
+    val find_first_opt : (elt -> bool) -> t -> elt option
+    val find_last : (elt -> bool) -> t -> elt
+    val find_last_opt : (elt -> bool) -> t -> elt option
+    val iter : (elt -> unit) -> t -> unit
+    val fold : (elt -> 'acc -> 'acc) -> t -> 'acc -> 'acc
+    val map : (elt -> elt) -> t -> t
+    val filter : (elt -> bool) -> t -> t
+    val filter_map : (elt -> elt option) -> t -> t
+    val partition : (elt -> bool) -> t -> t * t
+    val split : elt -> t -> t * bool * t
+    val is_empty : t -> bool
+    val mem : elt -> t -> bool
+    val equal : t -> t -> bool
+    val compare : t -> t -> int
+    val subset : t -> t -> bool
+    val for_all : (elt -> bool) -> t -> bool
+    val exists : (elt -> bool) -> t -> bool
+    val to_list : t -> elt list
+    val of_list : elt list -> t
+    val to_seq_from : elt -> t -> elt Seq.t
+    val to_seq : t -> elt Seq.t
+    val to_rev_seq : t -> elt Seq.t
+    val add_seq : elt Seq.t -> t -> t
+    val of_seq : elt Seq.t -> t
+  end
+type reason =
+    RAnnotation of Ast.span
+  | RFnReturn of string * Ast.span
+  | RFnArg of Ast.span * int
+  | RMatchArm of Ast.span
+  | RLetBind of Ast.span
+  | RBuiltin of string
+  | RBecause of reason * string
+type ty =
+    TCon of string * ty list
+  | TVar of tvar ref
+  | TArrow of ty * ty
+  | TTuple of ty list
+  | TRecord of (string * ty) list
+  | TLin of Ast.linearity * ty
+  | TNat of int
+  | TNatOp of Ast.nat_op * ty * ty
+  | TChan of session_ty ref
+  | TError
+  | TRefine of ty * string * Ast.expr
+and session_ty =
+    SSend of ty * session_ty
+  | SRecv of ty * session_ty
+  | SChoose of (string * session_ty) list
+  | SOffer of (string * session_ty) list
+  | SEnd
+  | SRec of string * session_ty
+  | SVar of string
+  | SError
+  | SMSend of string * ty * session_ty
+  | SMRecv of string * ty * session_ty
+and tvar = Unbound of int * int | Link of ty
+type constraint_ =
+    CNum of ty
+  | COrd of ty
+  | CInterface of string * ty
+  | CADTBound of string * ty
+  | CTNatBound of ty
+type scheme = Mono of ty | Poly of int list * constraint_ list * ty
+val _counter : int ref
+val fresh_var : int -> ty
+val repr : ty -> ty
+val _record_names : (string, string option) Hashtbl.t
+val pp_ty : ?parens:bool -> ty -> string
+val pp_ty_pretty : ?indent:int -> ?width:int -> ty -> string
+val pp_session_ty : session_ty -> string
+type message_part =
+    MPText of string
+  | MPCode of string
+  | MPType of ty
+  | MPBreak
+  | MPBullet of message_part list
+type lin_entry = {
+  le_name : string;
+  le_lin : Ast.linearity;
+  le_used : bool ref;
+  le_first_use : Ast.span option ref;
+}
+type ctor_info = {
+  ci_type : string;
+  ci_params : string list;
+  ci_arg_tys : Ast.ty list;
+  ci_vis : Ast.visibility;
+  ci_module : string;
+  ci_is_actor_msg : bool;
+}
+type import_entry = {
+  ie_span : Ast.span;
+  ie_desc : string;
+  ie_matches : string -> bool;
+  ie_used : bool ref;
+  ie_used_names : (string, unit) Hashtbl.t;
+}
+type import_index = {
+  ie_exact_index : (string, import_entry list) Hashtbl.t;
+  ie_prefix_index : (string, import_entry list) Hashtbl.t;
+}
+val make_import_index : unit -> import_index
+val import_index_add_exact : import_index -> string -> import_entry -> unit
+type proto_info = {
+  pi_def : Ast.protocol_def;
+  pi_projections : (string * session_ty) list;
+  pi_span : Ast.span;
+}
+module StrMap :
+  sig
+    type key = String.t
+    type 'a t = 'a Map.Make(String).t
+    val empty : 'a t
+    val add : key -> 'a -> 'a t -> 'a t
+    val add_to_list : key -> 'a -> 'a list t -> 'a list t
+    val update : key -> ('a option -> 'a option) -> 'a t -> 'a t
+    val singleton : key -> 'a -> 'a t
+    val remove : key -> 'a t -> 'a t
+    val merge :
+      (key -> 'a option -> 'b option -> 'c option) -> 'a t -> 'b t -> 'c t
+    val union : (key -> 'a -> 'a -> 'a option) -> 'a t -> 'a t -> 'a t
+    val cardinal : 'a t -> int
+    val bindings : 'a t -> (key * 'a) list
+    val min_binding : 'a t -> key * 'a
+    val min_binding_opt : 'a t -> (key * 'a) option
+    val max_binding : 'a t -> key * 'a
+    val max_binding_opt : 'a t -> (key * 'a) option
+    val choose : 'a t -> key * 'a
+    val choose_opt : 'a t -> (key * 'a) option
+    val find : key -> 'a t -> 'a
+    val find_opt : key -> 'a t -> 'a option
+    val find_first : (key -> bool) -> 'a t -> key * 'a
+    val find_first_opt : (key -> bool) -> 'a t -> (key * 'a) option
+    val find_last : (key -> bool) -> 'a t -> key * 'a
+    val find_last_opt : (key -> bool) -> 'a t -> (key * 'a) option
+    val iter : (key -> 'a -> unit) -> 'a t -> unit
+    val fold : (key -> 'a -> 'acc -> 'acc) -> 'a t -> 'acc -> 'acc
+    val map : ('a -> 'b) -> 'a t -> 'b t
+    val mapi : (key -> 'a -> 'b) -> 'a t -> 'b t
+    val filter : (key -> 'a -> bool) -> 'a t -> 'a t
+    val filter_map : (key -> 'a -> 'b option) -> 'a t -> 'b t
+    val partition : (key -> 'a -> bool) -> 'a t -> 'a t * 'a t
+    val split : key -> 'a t -> 'a t * 'a option * 'a t
+    val is_empty : 'a t -> bool
+    val mem : key -> 'a t -> bool
+    val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+    val compare : ('a -> 'a -> int) -> 'a t -> 'a t -> int
+    val for_all : (key -> 'a -> bool) -> 'a t -> bool
+    val exists : (key -> 'a -> bool) -> 'a t -> bool
+    val to_list : 'a t -> (key * 'a) list
+    val of_list : (key * 'a) list -> 'a t
+    val to_seq : 'a t -> (key * 'a) Seq.t
+    val to_rev_seq : 'a t -> (key * 'a) Seq.t
+    val to_seq_from : key -> 'a t -> (key * 'a) Seq.t
+    val add_seq : (key * 'a) Seq.t -> 'a t -> 'a t
+    val of_seq : (key * 'a) Seq.t -> 'a t
+  end
+type ref_record = {
+  callee : string;
+  caller : string;
+  ref_kind : [ `Call | `Ctor | `TypeRef ];
+  ref_file : string;
+  ref_line : int;
+}
+type env = {
+  vars : scheme StrMap.t;
+  types : int StrMap.t;
+  ctors : ctor_info list StrMap.t;
+  records : (string list * (string * Ast.ty) list) StrMap.t;
+  level : int;
+  lin : lin_entry list;
+  errors : Err.ctx;
+  pending_constraints : constraint_ list ref;
+  type_map : (Ast.span, ty) Hashtbl.t;
+  refs : ref_record list ref;
+  current_decl : string ref;
+  scheme_witnesses : (int list, constraint_ list * ty) Hashtbl.t;
+  inst_witnesses : (Ast.span, int list * ty list) Hashtbl.t;
+  interfaces : Ast.interface_def StrMap.t;
+  sigs : (string * Ast.sig_def) list;
+  mod_needs : string list;
+  mod_need_scopes : (string * string option) list;
+  module_caps : (string * string list) list;
+  protocols : proto_info StrMap.t;
+  impls : (ty * Ast.span * string option) list StrMap.t;
+  import_tracker : import_entry list ref;
+  import_idx : import_index;
+  local_fns : unit StrMap.t;
+  fn_arities : (int * Ast.span) StrMap.t;
+  qual_fn_names : unit StrMap.t;
+  plain_let_names : StringSet.t;
+  proof_caps : (string * string) list;
+  always_linear_types : string list;
+  current_module : string;
+  root_cap_allowed : bool;
+  cur_fn_public : bool;
+  cap_qual_prefix : string;
+  enclosing_package : string;
+  no_panic_mod : bool;
+  no_panic_modules : string list;
+  nonexhaustive_match_spans : Ast.span list ref;
+  cap_producer_ivars : (int, Ast.span) Hashtbl.t;
+  cap_narrow_factory_fns : (string, Ast.span) Hashtbl.t;
+  mint_cap_sites : (Ast.span * ty * bool * string) list ref;
+  cap_narrow_sites : (Ast.span * ty) list ref;
+  json_cap_sites : (Ast.span * ty * string) list ref;
+  pure_mod : bool;
+  no_extern_mod : bool;
+  deterministic_mod : bool;
+  cap_closures : (string, string list) Hashtbl.t;
+  own_cap_closures : (string, string list) Hashtbl.t;
+  body_cap_closures : (string, string list) Hashtbl.t;
+  stdlib_fns : (string, unit) Hashtbl.t;
+  ceiling_extra_roots : (string, unit) Hashtbl.t;
+  fn_refs : (string, string list) Hashtbl.t;
+  fn_row_bodies : (string, (string list * Ast.expr) list) Hashtbl.t;
+  fn_grant_points : (string, string list * Ast.span) Hashtbl.t;
+  local_mods : string list StrMap.t;
+  offer_conts : (session_ty ref * (string * session_ty) list) list ref;
+  offer_labels :
+    (string * (session_ty ref * (string * session_ty) list)) list;
+  offer_unrefined : session_ty ref list ref;
+}
+val make_env : Err.ctx -> (Ast.span, ty) Hashtbl.t -> env
+val lookup_ctor : StrMap.key -> env -> ctor_info option
+val add_ctor :
+  string -> ctor_info -> ctor_info list StrMap.t -> ctor_info list StrMap.t
+val instantiate : ?use_span:Ast.span -> int -> env -> scheme -> ty
+val stdlib_source_files : string list ref
+val cap_strict_ceiling : bool ref
+val builtin_cap_table : (string * string) list
+val locally_declared_names_of : Ast.decl list -> (string, unit) Hashtbl.t
+val builtin_interface_bindings : (string * scheme) list
+val prelude_collision_builtin_names : string list
+val prelude_collision_iface_arities : (string * int) list
+val base_env : Err.ctx -> (Ast.span, ty) Hashtbl.t -> env
+val session_ty_equal : session_ty -> session_ty -> bool
+val normalize_tnat : ty -> ty
+val record_use : string -> March_ast.Ast.span -> env -> unit
+val bind_vars_with_linearity : (string * scheme) list -> env -> env
+val span_of_expr : Ast.expr -> Ast.span
+type spat =
+    SPWild
+  | SPCon of string * spat list
+  | SPLit of Ast.literal
+  | SPTup of spat list
+  | SPRec of (string * spat) list
+val unfold_srec : session_ty -> session_ty
+val infer_expr : env -> Ast.expr -> ty
+val fn_transitive_capability_closures_tbl :
+  env -> (string, string list) Hashtbl.t
+val check_module_needs :
+  env -> Ast.name -> cap_qname_prefix:string -> Ast.decl list -> unit
+val fn_capability_closures : env -> (string * string list) list
+val declared_cap_scopes : env -> (string * string option) list
+val fn_own_capability_closures : env -> (string * string list) list
+val fn_transitive_capability_closures : env -> (string * string list) list
+val subst_svar : string -> session_ty -> session_ty -> session_ty
+val dual_session_ty : session_ty -> session_ty
+val panic_surface_contracted : StringSet.t
+val proof_based_panic_surface : bool ref
+val panic_surface_suggestion : string -> string
+val check_no_panic_module : Err.ctx -> env -> Ast.decl list -> unit
+val check_decl : env -> Ast.decl -> env
+val render_cap_chain : string list -> string
+val check_module_core :
+  ?errors:Err.ctx ->
+  ?seed_env:env -> Ast.module_ -> Err.ctx * (Ast.span, ty) Hashtbl.t * env
+val check_module :
+  ?errors:Err.ctx -> Ast.module_ -> Err.ctx * (Ast.span, ty) Hashtbl.t
+val check_module_with_refs :
+  ?errors:Err.ctx ->
+  Ast.module_ -> Err.ctx * (Ast.span, ty) Hashtbl.t * ref_record list
+val check_module_with_env :
+  env -> Ast.module_ -> Err.ctx * (Ast.span, ty) Hashtbl.t
+val check_module_with_env_full :
+  env -> Ast.module_ -> Err.ctx * (Ast.span, ty) Hashtbl.t * env
+val check_module_full :
+  ?errors:Err.ctx ->
+  ?seed_env:env -> Ast.module_ -> Err.ctx * (Ast.span, ty) Hashtbl.t * env
+val check_letq_repl : env -> Ast.pattern -> Ast.expr -> env
+val check_letstar_repl : env -> Ast.pattern -> Ast.expr -> env
+

--- a/specs/progress/2026-08-25-mli-interfaces-top-churn-files.md
+++ b/specs/progress/2026-08-25-mli-interfaces-top-churn-files.md
@@ -1,0 +1,72 @@
+# `.mli` files for the four highest-churn compiler modules
+
+Landed 2026-08-25.
+
+Implements Finding 4 of
+[`specs/2026-08-25-file-decomposition-analysis.md`](../2026-08-25-file-decomposition-analysis.md):
+only 2 of 31 files over 800 lines had an interface, which is both why they grow
+unchecked and the cheapest available remedy. Four now do.
+
+## What landed
+
+One `.mli` per file, one commit each, no `.ml` line moved and no call site
+adjusted. Where a value had a caller anywhere — including a test — it was
+exposed and the interface says so; nothing was hidden by editing a consumer.
+
+| File | Inferred vals | Curated vals | Internal |
+|---|---:|---:|---:|
+| `lib/desugar/desugar.ml` | 69 | 11 | 84% |
+| `lib/tir/lower.ml` | 41 | 21 | 49% |
+| `lib/tir/llvm_emit.ml` | 114 | 44 | 61% |
+| `lib/typecheck/typecheck.ml` | 243 | 50 | 79% |
+| **total** | **467** | **126** | **73%** |
+
+"Inferred vals" is the maximal interface `ocamlfind ocamlc -i` prints — what
+each module exported before this change. Roughly three quarters of the compiler
+surface in its four most-edited files was accidental.
+
+## Method
+
+For each file: generate the maximal interface, then keep a value only if a
+sweep of `bin/ lib/ lsp/ forge/ test/ js/` finds it referenced from outside the
+module — qualified (`Desugar.x`), through a module alias (`Tc.x`, `TC.x`,
+`T.x`), or bare inside a `let open`. Doc-comment mentions were discarded by
+hand; alias and `let open` uses are the two the first sweep missed, and both
+turned into build errors that named the missing value exactly, so `dune build
+@check` was the real oracle.
+
+## What the numbers hide
+
+`lower.ml`'s 49% is the weakest result and the most informative. The Wave-3
+split turned it into a re-export hub — `let lower_ty = Lower_types.lower_ty` and
+some forty siblings — kept bare "so external callers keep working". Most of
+those callers don't exist. But hiding a re-export nothing calls makes it an
+unused-value error under warnings-as-errors, so three had to be declared anyway
+with a comment saying they are not API. `llvm_emit.ml` has the same problem
+thirty-three times over: its real public surface is 11 values, not 44. Deleting
+those dead `let` re-exports (and their `val`s) is an obvious, separately safe
+follow-up.
+
+`llvm_emit.emit_expr` — the 4,319-line function the file exists for, 76% of it
+by line count — has no external caller at all. The sibling emitters that need it
+receive it as a labelled `~emit_expr` callback threaded from inside.
+
+## Verification
+
+`scripts/ir-oracle.sh` ran once as a baseline and four times as a check, one
+per file: **IR IDENTICAL across 240 programs** every time, never anything else.
+Adding an interface must not change emitted code, and it did not.
+
+Also per file: `dune build @check` (no new errors beyond the 19 pre-existing
+missing-dev-dependency ones in `forge/test/` and `js/`), `dune build
+bin/main.exe`, and `scripts/run-tests.sh`. The `lower.mli` run had one
+`run_codegen` fixture killed by SIGKILL (exit 137) — another session's process
+sweep on this shared box, not a regression; it passes on rerun.
+
+## Follow-ups
+
+- Delete the dead re-export `let`s in `lower.ml` (3) and `llvm_emit.ml` (33)
+  together with their `val`s.
+- The remaining oversized files in the analysis table have no interface either;
+  `eval.ml`, `bin/main.ml` and `lsp/lib/analysis.ml` are the next candidates by
+  the same cheap method.


### PR DESCRIPTION
Implements Finding 4 of `specs/2026-08-25-file-decomposition-analysis.md`:
only 2 of 31 files over 800 lines had an `.mli`, which is both why they grow
unchecked and the cheapest available remedy. Four of them now do — the four
highest-churn compiler modules, one commit each so any single file can be
dropped without losing the others.

**No `.ml` line was moved and no call site was adjusted.** Where a value had a
caller anywhere — including a test — it was exposed, and the interface says so.

## Surface reduction

| File | Lines | Commits/6mo | Inferred vals | Curated vals | Internal |
|---|---:|---:|---:|---:|---:|
| `lib/desugar/desugar.ml` | 3,321 | 76 | 69 | 11 | **84%** |
| `lib/tir/lower.ml` | 2,001 | 134 | 41 | 21 | **49%** |
| `lib/tir/llvm_emit.ml` | 5,720 | 299 | 114 | 44 | **61%** |
| `lib/typecheck/typecheck.ml` | 14,958 | 387 | 243 | 50 | **79%** |
| **total** | | | **467** | **126** | **73%** |

"Inferred vals" is what `ocamlfind ocamlc -i` prints — what each module
exported before this change. Roughly three quarters of the exported surface of
the compiler's four most-edited files was accidental.

## What the table hides

`lower.ml`'s 49% is the weakest number and the most informative. The Wave-3
split turned it into a re-export hub (`let lower_ty = Lower_types.lower_ty`, and
some forty siblings) kept bare "so external callers keep working" — but most of
those callers do not exist. Hiding a re-export nothing calls makes it an
unused-value **error** under warnings-as-errors, so three had to be declared
anyway, in a block that says in as many words that they are not API.
`llvm_emit.ml` has the same problem 33 times over: its real public surface is
**11** values, not 44. Deleting those dead `let`s together with their `val`s is
an obvious follow-up, and equally safe — but it edits code, so it is not in
this PR.

`llvm_emit.emit_expr` — the 4,319-line function the file exists for, 76% of it
by line count — has no external caller at all. The sibling emitters that need
it receive it as a labelled `~emit_expr` callback threaded from inside.

For `typecheck.ml` the whole type language stays visible (`ty`, `scheme`, `env`
and friends are the module's real contract, read by TIR lowering, the LSP, the
REPL and the search index); only values were hidden.

## Method, and the two things grep alone got wrong

Generate the maximal interface, then keep a value only if a sweep of `bin/ lib/
lsp/ forge/ test/ js/` finds it used from outside the module. Two reference
forms the first sweep missed, both of which surfaced as build errors naming the
exact missing value:

- **module aliases** — `Tc.`, `TC.`, `T.` in `lint/`, `dump/`, `search/`, `lsp/`
- **`let open`** — `test_codegen.ml` opens `March_tir.Lower` and drives its
  alias-resolution state directly; `repl.ml` and `test_stdlib_suite.ml` open
  `March_typecheck.Typecheck`

So `dune build @check`, which type-checks `test/` and `lsp/` as well, is the
real oracle for this kind of change, not grep. That `test_codegen.ml` reaches
into `_fn_param_types` / `_use_aliases` / `_module_aliases` was the one genuine
surprise: lowering's alias-resolution state is public API by virtue of a test.

## Verification

`scripts/ir-oracle.sh` — the oracle that landed for exactly this purpose — ran
once as a baseline and **four times as a check, one per file: IR IDENTICAL
across 240 programs every time**, never anything else. Adding an interface must
not change emitted code, and it did not.

Per file, also: `dune build @check` (no new errors beyond the 19 pre-existing
missing-dev-dependency ones under `forge/test/` and `js/`), `dune build
bin/main.exe`, and `scripts/run-tests.sh`. `scripts/check-docs.sh` passes.

Two of the four `run-tests.sh` runs had a single `run_codegen` fixture fail
with `Killed: 9` / `EXIT:137` — SIGKILL from another session's process sweep on
this shared box, in one case after the fixture had already printed the correct
output. Both pass on rerun of that suite; the other four suites and the other
two full runs were green.
