### PR TITLE
refine_check.ml Phase 3: a diagnostic oracle, 23 § headers, check_call's 13 params → 8, and a 198→17 .mli

### DIFF
--- a/lib/refinecheck/refine_check.ml
+++ b/lib/refinecheck/refine_check.ml
@@ -14,10 +14,44 @@
    a complex expression) is conservatively SKIPPED — no false positives.
    Scope: direct (named) calls only, no path sensitivity. *)
 
+(* Table of contents — the § markers below are greppable:
+     grep -n '§' lib/refinecheck/refine_check.ml
+
+     §1  Refined parameters and base-type classification
+     §2  SMT sorts: strings, scalars, measures, well-sortedness
+     §3  Predicate scope and parameter substitution
+     §4  Function signatures, measures, and stdlib-provided names
+     §5  ADT and record sorts: registry and SMT preamble builders
+     §6  AST traversal helpers and measure gating
+     §7  Reflection: March expressions into SMT terms
+     §8  Rendering: predicates, models, counterexamples
+     §9  Scope — the refined bindings in scope
+     §10 The other fact channels: path, launder, recenv, cbenv
+     §11 Signature extraction and definition collection
+     §12 Name resolution: module paths, aliases, call targets
+     §13 Reflecting actual arguments: fields, records, scalars
+     §14 Verdict state and withdrawal diagnostics
+     §15 check_call — precondition checking at a call site
+     §16 Postcondition checking
+     §17 Postconditions by induction
+     §18 Function-level postcondition entry points and gating
+     §19 The visit traversal
+     §20 Refinement-placement warnings
+     §21 The declaration walk
+     §22 Registration and stdlib-shape validation
+     §23 Entry point: check_module
+
+   §15 is `check_call`, 1,361 lines and the single largest thing here;
+   §16-§18 are its postcondition counterpart. *)
+
 module A = March_ast.Ast
 module Smt = March_refine.Smt
 module Refine = March_refine.Refine
 module Err = March_errors.Errors
+
+(* =================================================================
+   §1  Refined parameters and base-type classification
+   ================================================================= *)
 
 (* A refined parameter: position, predicate binder, predicate expression, and
    the SMT sort of its base type when that base is NOT `Int`:
@@ -52,6 +86,10 @@ let is_bool_base : A.ty -> bool = function
 let is_float_base : A.ty -> bool = function
   | A.TyCon ({ A.txt = "Float"; _ }, []) -> true
   | _ -> false
+
+(* =================================================================
+   §2  SMT sorts: strings, scalars, measures, well-sortedness
+   ================================================================= *)
 
 (* ── The String encoding ───────────────────────────────────────────────────
    `String` is modelled as an UNINTERPRETED SORT and `len` as an uninterpreted
@@ -323,6 +361,10 @@ let rec formula_wellsorted (sort_of : string -> Smt.sort option) (t : Smt.term) 
   | Smt.App _ | Smt.IntLit _ | Smt.FloatLit _ | Smt.Add _ | Smt.Sub _
   | Smt.MulLit _ | Smt.Mul _ | Smt.Neg _ -> false
 
+(* =================================================================
+   §3  Predicate scope and parameter substitution
+   ================================================================= *)
+
 (* How a return refinement's predicate relates to the callee's parameters.
 
    [Closed]      — mentions only the refinement binder; usable as-is (Tier 0).
@@ -399,6 +441,10 @@ let rec subst_params (env : (string * A.expr) list) (e : A.expr) : A.expr =
   | A.EField (r, n, sp) -> A.EField (go r, n, sp)
   | A.EAnnot (inner, t, sp) -> A.EAnnot (go inner, t, sp)
   | _ -> e
+
+(* =================================================================
+   §4  Function signatures, measures, and stdlib-provided names
+   ================================================================= *)
 
 (* A function's signature: parameter names by position, its refined params, and
    its declared return refinement (binder + predicate) when the return type is
@@ -641,6 +687,10 @@ let measure_body_nonneg (self : string) (known : string list) (body : A.expr) : 
     | _ -> false (* variables, subtraction, arbitrary calls: unknown sign *)
   in
   go body
+
+(* =================================================================
+   §5  ADT and record sorts: registry and SMT preamble builders
+   ================================================================= *)
 
 (* ── Measure axioms (M-a): datatype model + recursion-equation preamble ───── *)
 (* ctor name -> field sorts as the measure sees them (recursive self -> SData adt,
@@ -1229,6 +1279,10 @@ let record_vc_preamble () : string =
   | m, "" -> m
   | m, t -> m ^ "\n" ^ t
 
+(* =================================================================
+   §6  AST traversal helpers and measure gating
+   ================================================================= *)
+
 (* ── M-b: the @[measure] soundness gate ─────────────────────────────────────
    `@[measure]` is a promise that the function is a TOTAL, TERMINATING, PURE
    mathematical function.  The axiom encoding trusts that promise: axiomatising a
@@ -1372,6 +1426,10 @@ let measure_gate_errors (fd : A.fn_def) : string list =
     fd.A.fn_clauses;
   List.rev !errs
 
+(* =================================================================
+   §7  Reflection: March expressions into SMT terms
+   ================================================================= *)
+
 (* ── Translate the decidable predicate fragment to an SMT term ────────────── *)
 (* [resolve_var] maps a scalar variable to its SMT term; [resolve_measure]
    maps a (measure-name, argument-name) to its measure term.  None => outside
@@ -1491,6 +1549,10 @@ let rec smt_of ~resolve_var ~resolve_measure ?(resolve_field = fun _ _ -> None)
      | _, A.ELit (A.LitInt k, _) -> Option.map (fun x -> Smt.MulLit (k, x)) (r a)
      | _ -> None)
   | _ -> None
+
+(* =================================================================
+   §8  Rendering: predicates, models, counterexamples
+   ================================================================= *)
 
 (* User-facing infix rendering of a predicate (best-effort). *)
 let rec pred_str (e : A.expr) : string =
@@ -1627,6 +1689,10 @@ let cx_block (model : (string * string) list) : string =
     String.concat "\n    " (List.map render_model_entry model)
 
 let model_of = function Refine.Refuted m -> m | _ -> []
+
+(* =================================================================
+   §9  Scope — the refined bindings in scope
+   ================================================================= *)
 
 (* ── Scope of refined locals/params: name -> (binder, predicate) ─────────── *)
 type scope = (string * (string * A.expr * string option)) list
@@ -1965,6 +2031,10 @@ let arm_excludes_tag (br : A.branch) : string option =
 let path_shadow (path : (A.expr * bool) list) (names : string list) : (A.expr * bool) list =
   if names = [] then path else List.filter (fun (c, _) -> not (expr_mentions names c)) path
 
+(* =================================================================
+   §10 The other fact channels: path, launder, recenv, cbenv
+   ================================================================= *)
+
 (* ── Laundered guards: name -> the application it was let-bound to ─────────
    [visit] records, per program point, which local names are ONE `let` away
    from a direct application: `let n = List.length(ys)` records
@@ -2195,6 +2265,10 @@ let scope_add_binding
      | _ -> sc)
   | _ -> sc
 
+(* =================================================================
+   §11 Signature extraction and definition collection
+   ================================================================= *)
+
 (* ── Collect signatures, keyed by bare + qualified name ──────────────────── *)
 let param_name_of : A.fn_param -> string = function
   | A.FPNamed p | A.FPDefault (p, _) -> p.A.param_name.A.txt
@@ -2376,6 +2450,10 @@ let strip_param_refinements (fd : A.fn_def) : A.fn_def =
       List.map
         (fun (c : A.fn_clause) -> { c with A.fc_params = List.map fp c.A.fc_params })
         fd.A.fn_clauses }
+
+(* =================================================================
+   §12 Name resolution: module paths, aliases, call targets
+   ================================================================= *)
 
 (* ── Use/alias-aware call resolution ───────────────────────────────────────
    Resolve a call name the way the typechecker does: a bare name binds to the
@@ -2581,6 +2659,10 @@ let postcond_of (ctx : rctx) (defs : (string, fn_sig option) Hashtbl.t) (fname :
           else None)
      | _ -> None)
   | _ -> None
+
+(* =================================================================
+   §13 Reflecting actual arguments: fields, records, scalars
+   ================================================================= *)
 
 (* Fresh-name counter for SMT constants standing in for a call's return value.
    Monotonic per compilation; freshness is all that is required. *)
@@ -2897,6 +2979,10 @@ let sort_of_ctor (ctor : string) : string option =
   with
   | [ s ] -> Some s
   | _ -> None
+
+(* =================================================================
+   §14 Verdict state and withdrawal diagnostics
+   ================================================================= *)
 
 (* ── `cap verified`: a skipped obligation becomes an error ───────────────── *)
 (* March's default stance is DEFINITE FAILURE ONLY — an obligation the checker
@@ -3367,6 +3453,10 @@ let arg_span (fallback : A.span) : A.expr -> A.span = function
   | A.EAtom (_, _, sp) -> sp
   | A.EVar name -> name.A.span
   | _ -> fallback
+
+(* =================================================================
+   §15 check_call — precondition checking at a call site
+   ================================================================= *)
 
 let check_call ~root errctx ~span ~(callee : string) ?(subject = Argument)
     ?(verdict_out : Obligation.verdict option ref option) ~(lets : launder)
@@ -4721,6 +4811,10 @@ let check_call ~root errctx ~span ~(callee : string) ?(subject = Argument)
                  labels; notes = []; code = None; fix = None }
            | _ -> note (Obligation.Skipped Obligation.Solver_undecided))))
 
+(* =================================================================
+   §16 Postcondition checking
+   ================================================================= *)
+
 (* ── Postconditions: a function's return value must satisfy its return
    refinement.  We check each *tail* expression (a return position) under the
    path/scope reaching it, with the same definite-failure soundness stance. ── *)
@@ -5135,6 +5229,10 @@ let check_post ~root errctx ~span ?(record_sort : string option = None)
           else note (Obligation.Skipped Obligation.Solver_undecided);
           false))
 
+(* =================================================================
+   §17 Postconditions by induction
+   ================================================================= *)
+
 (* ══ Tier 2: structural induction over a recursive function ═════════════════
 
    A RELATIONAL postcondition on a recursive function — `fn insert(t, x) :
@@ -5531,6 +5629,10 @@ let check_post_induction ~root ?(record = true) (fd : A.fn_def) : bool =
       | _ -> false))
   | _ -> false
 
+(* =================================================================
+   §18 Function-level postcondition entry points and gating
+   ================================================================= *)
+
 (* Check every return-position tail of every clause of [fd] against its declared
    return refinement.  Returns true iff ALL of them positively verified (a
    function with no clauses, or a clause with no reachable tail, counts as NOT
@@ -5621,6 +5723,10 @@ let gate_unverified_posts ~root errctx (defs : (string, fn_sig option) Hashtbl.t
       decls
   in
   go "" decls
+
+(* =================================================================
+   §19 The visit traversal
+   ================================================================= *)
 
 (* ── An annotated `let`'s refinement is an OBLIGATION, not a promise ───────
 
@@ -6033,6 +6139,10 @@ let rec visit ~root errctx defs (ctx : rctx) (path : (A.expr * bool) list)
   | A.EDbg (Some e, _) -> go e
   | A.ELit _ | A.EVar _ | A.EHole _ | A.EResultRef _ | A.EDbg (None, _) -> ()
 
+(* =================================================================
+   §20 Refinement-placement warnings
+   ================================================================= *)
+
 (* Render a dotted MODULE path (`List.length`, `M.N.f`, …) back to a string, or
    [None] for anything else.  Mirrors [desugar_expr]'s [flatten_module_path]
    (`lib/desugar/desugar.ml`) exactly, which is the ground truth for what the
@@ -6419,6 +6529,10 @@ let rec warn_predicate_decls (errctx : Err.ctx) ~(strict : bool) (decls : A.decl
       | A.DUse _ | A.DAlias _ -> ())
     decls
 
+(* =================================================================
+   §21 The declaration walk
+   ================================================================= *)
+
 (* [assume_params:false] walks the body with the parameter refinements erased,
    so none of them can discharge anything.  Used for an `impl` method whose
    contract [collect_all_defs] could not adopt unambiguously: with no caller
@@ -6582,6 +6696,10 @@ and visit_decl ~root errctx defs (ctx : rctx) (d : A.decl) : unit =
   | A.DSatisfy _             (* likewise desugared into DImpl *)
   | A.DUse _                 (* import: read into [ctx.uses] above *)
   | A.DAlias _ -> ()         (* alias: read into [ctx.aliases] above *)
+
+(* =================================================================
+   §22 Registration and stdlib-shape validation
+   ================================================================= *)
 
 (** Register ADT/record sorts for a list of declarations without running the full
     VC pass.  Called by [--check-migration] mode to prime the type tables before
@@ -7273,6 +7391,10 @@ let bare_builtin_undefined ?(mod_name = "") (name : string) (decls : A.decl list
   in
   go decls;
   (not !taken, !cause)
+
+(* =================================================================
+   §23 Entry point: check_module
+   ================================================================= *)
 
 (* [measure_axioms] (default true) gates the whole measure-axiom machinery —
    datatype modelling, recursion-equation axioms, AND the M-b soundness gate (the

--- a/lib/refinecheck/refine_check.ml
+++ b/lib/refinecheck/refine_check.ml
@@ -3458,11 +3458,54 @@ let arg_span (fallback : A.span) : A.expr -> A.span = function
    §15 check_call — precondition checking at a call site
    ================================================================= *)
 
-let check_call ~root errctx ~span ~(callee : string) ?(subject = Argument)
-    ?(verdict_out : Obligation.verdict option ref option) ~(lets : launder)
-    ~(postcond : string -> A.expr list -> (string * A.expr * string option) option)
-    (sg : fn_sig) (args : A.expr list)
-    (path : (A.expr * bool) list) (rp : rparam) (sc : scope) (re : recenv) : unit =
+(* The environment [check_call] discharges an obligation IN, as opposed to the
+   obligation itself.  Every field is threaded unchanged through the whole of
+   [visit]'s walk of one call node, so bundling them stops a twelve-parameter
+   signature from having to be re-read at each of the three call sites — and
+   gives each thread a place to say what it is, which is the documentation
+   this function has never had.
+
+   The four things that differ per obligation stay explicit parameters:
+   [~span] / [~callee] (which call), [sg] / [args] (its signature and actuals)
+   and [rp] (which refined parameter of it), plus [?subject] / [?verdict_out],
+   which only the `let`-annotation caller sets. *)
+type call_ctx = {
+  root : string;
+      (* Project root — passed to [Refine.discharge] so the SMT bridge can
+         place its scratch files and resolve solver configuration. *)
+  errctx : Err.ctx;
+      (* Diagnostic sink.  [check_call] is a REPORTING site: every exit path
+         records an outcome through [note], and violations are emitted here. *)
+  postcond :
+    string -> A.expr list -> (string * A.expr * string option) option;
+      (* Return refinement of a callee, by name and actuals — how a nested
+         call's postcondition becomes a premise for this one.  Always
+         [postcond_of ctx defs] at every call site; it is a parameter rather
+         than a direct call because [rctx]/[defs] are not in scope here. *)
+  path : (A.expr * bool) list;
+      (* Path facts: the guards (and their polarity) reaching this call site.
+         One of the two fact channels — see the shadowing discipline note in
+         §10: a name rebound in between must retire from BOTH this and
+         [sc], or a stale fact proves a goal about a different value. *)
+  lets : launder;
+      (* Laundering `let`s: bindings whose RHS lets a guard about one name be
+         re-attributed to another.  Retires on rebinding of either the key or
+         any name its RHS mentions. *)
+  sc : scope;
+      (* The other fact channel: refined locals and parameters in scope, name
+         -> (binder, predicate, sort). *)
+  re : recenv;
+      (* Record-typed variables in scope, name -> SMT sort name, so a
+         predicate's `v.field` projections can be resolved through that
+         sort's selectors. *)
+}
+
+let check_call (cx : call_ctx) ~span ~(callee : string) ?(subject = Argument)
+    ?(verdict_out : Obligation.verdict option ref option)
+    (sg : fn_sig) (args : A.expr list) (rp : rparam) : unit =
+  (* Destructured to the names the body has always used: this is a signature
+     change, not a rewrite of 1,361 lines. *)
+  let { root; errctx; postcond; path; lets; sc; re } = cx in
   let subject_noun = match subject with Argument -> "argument" | Bound_expr -> "bound expression" in
   let obligation_noun =
     match subject with Argument -> "precondition" | Bound_expr -> "type annotation"
@@ -5798,14 +5841,23 @@ let check_let_annotation ~root errctx defs (ctx : rctx) (path : (A.expr * bool) 
       }
     in
     let out = ref None in
-    check_call ~root errctx ~span:n.A.span
+    (* Every fact channel is shadowed by the names this binding introduces —
+       see [call_ctx]'s note: all of them, or none. *)
+    let cx =
+      { root
+      ; errctx
+      ; postcond = postcond_of ctx defs
+      ; path = path_shadow path names
+      ; lets = launder_shadow lets names
+      ; sc = scope_shadow sc names
+      ; re = recenv_shadow re names
+      }
+    in
+    check_call cx ~span:n.A.span
       ~callee:(Printf.sprintf "let %s" name)
-      ~subject:Bound_expr ~verdict_out:out ~lets:(launder_shadow lets names)
-      ~postcond:(postcond_of ctx defs) sg
+      ~subject:Bound_expr ~verdict_out:out sg
       [ b.A.bind_expr ]
-      (path_shadow path names)
-      { idx = 0; binder; pred; sort }
-      (scope_shadow sc names) (recenv_shadow re names);
+      { idx = 0; binder; pred; sort };
     Some (!out = Some Obligation.Proved)
   | _ -> None
 
@@ -5819,24 +5871,16 @@ let rec visit ~root errctx defs (ctx : rctx) (path : (A.expr * bool) list)
   | A.EApp (A.EVar { A.txt = fname; _ }, args, sp) ->
     (match resolve_call ctx defs fname with
      | Some (Some sg) ->
-       let postcond = postcond_of ctx defs in
-       List.iter
-         (fun rp ->
-           check_call ~root errctx ~span:sp ~callee:fname ~lets ~postcond sg args path rp
-             sc re)
-         sg.refined
+       let cx = { root; errctx; postcond = postcond_of ctx defs; path; lets; sc; re } in
+       List.iter (fun rp -> check_call cx ~span:sp ~callee:fname sg args rp) sg.refined
      | _ ->
        (* Not a resolvable NAMED callee: fall back to the callee env — a call
           made through a refined function-typed parameter, or through a local
           alias of a named function (see [cbenv]). *)
        (match List.assoc_opt fname cb with
         | Some sg ->
-          let postcond = postcond_of ctx defs in
-          List.iter
-            (fun rp ->
-              check_call ~root errctx ~span:sp ~callee:fname ~lets ~postcond sg args path
-                rp sc re)
-            sg.refined
+          let cx = { root; errctx; postcond = postcond_of ctx defs; path; lets; sc; re } in
+          List.iter (fun rp -> check_call cx ~span:sp ~callee:fname sg args rp) sg.refined
         | None -> ()));
     List.iter go args
   | A.EApp (f, args, _) -> go f; List.iter go args

--- a/lib/refinecheck/refine_check.mli
+++ b/lib/refinecheck/refine_check.mli
@@ -1,0 +1,193 @@
+(** Refinement checking — the post-typecheck pass that discharges refinement
+    obligations through the Z3 bridge.
+
+    {1 What this interface is}
+
+    The implementation has {b 198} top-level values. Seventeen of them have a
+    caller outside this module; the rest are the checker's internals and are
+    now hidden. See the module docstring and the §-numbered table of contents
+    in [refine_check.ml] for the internal structure.
+
+    Everything here was kept because a sweep of [bin/ lib/ lsp/ forge/ test/
+    js/] found it referenced from outside — qualified ([Refine_check.x]) or
+    through the [RC.]/[Rc.] aliases in [precond_infer], [postcond_infer] and
+    [bin/main.ml]. Mentions inside doc comments were discarded by hand. If you
+    need something that is not here, expose it deliberately rather than
+    reaching around the interface.
+
+    {1 The one entry point}
+
+    [check_module] is what the driver calls: 52 of the qualified references in
+    the tree are to it. Everything else exists because two later passes
+    ([precond_infer], [postcond_infer], [division_safety]) and the migration
+    checker re-use pieces of the machinery it sets up — several of them
+    {i require} [check_module] to have run first, because the registration
+    globals they read are populated by it. *)
+
+module A = March_ast.Ast
+module Smt = March_refine.Smt
+module Err = March_errors.Errors
+
+(** {1 Types crossing the boundary} *)
+
+(** A refined parameter: position, predicate binder, predicate expression, and
+    the SMT sort of its base type when that base is not [Int] (a [String], a
+    registered ADT, or a 1-constructor record; [None] for plain [Int]). *)
+type rparam = {
+  idx : int;
+  binder : string;
+  pred : A.expr;
+  sort : string option;
+}
+
+(** How a return refinement's predicate relates to the callee's parameters:
+    [Closed] mentions only the binder and is usable as-is; [Relational] also
+    mentions the named parameters and needs their actuals substituted;
+    [Unusable] cannot be reflected. *)
+type pred_scope = Closed | Relational of string list | Unusable
+
+(** A function's refinement-relevant signature: parameter names, which of them
+    are strings, their scalar SMT sorts, the refined ones, and the return
+    refinement with its sort. *)
+type fn_sig = {
+  param_names : string list;
+  param_str : bool list;
+  param_scalar : Smt.sort list;
+  refined : rparam list;
+  ret : (string * A.expr) option;
+  ret_sort : string option;
+}
+
+(** Resolution context for a call: the current module path, its aliases, its
+    [use] selectors, and the locally bound names that shadow them. *)
+type rctx = {
+  modpath : string;
+  aliases : (string * string) list;
+  uses : (string * A.use_selector * string) list;
+  locals : string list;
+}
+
+(** The empty context — module path [""], nothing aliased, used or shadowed. *)
+val rctx0 : rctx
+
+(** {1 Entry point} *)
+
+(** Check one module: register its types and measures, walk every declaration,
+    and report violated preconditions, postconditions and division-safety
+    obligations through the error context.
+
+    [?root] is the project root handed to the SMT bridge (default
+    [Sys.getcwd ()]). [?measure_axioms] enables the measure-axiom preamble
+    (default [true]). [?stdlib_files] names the files that ARE the standard
+    library, which decides whether a competing [List.length] is the stdlib's
+    own; omitting it is safe (the answer becomes "no file is") but disables
+    nothing. *)
+val check_module :
+  ?root:string ->
+  ?measure_axioms:bool ->
+  ?stdlib_files:string list ->
+  Err.ctx ->
+  A.module_ ->
+  unit
+
+(** {1 Signature extraction and resolution}
+
+    Used by [precond_infer] / [postcond_infer] to answer "what would the
+    checker make of this function?" without paying for a full
+    [check_module]. *)
+
+(** The refinement signature of a function definition. *)
+val sig_of_fn : A.fn_def -> fn_sig
+
+(** Every definition in a declaration list, by name; [None] where a name is
+    defined more than once ambiguously. *)
+val collect_all_defs : A.decl list -> (string, fn_sig option) Hashtbl.t
+
+(** The signature a refined function-typed {i parameter} presents to calls made
+    through it, or [None] when it has none. *)
+val entry_of_sig : fn_sig -> fn_sig option
+
+(** How a predicate relates to a parameter list — see {!pred_scope}. *)
+val classify_pred : string -> string list -> A.expr -> pred_scope
+
+(** Whether a name is one of the operators a refinement predicate may apply. *)
+val known_predicate_fn : string -> bool
+
+(** The [impl] methods whose contracts [collect_all_defs] can adopt
+    unambiguously. *)
+val adoptable_impl_methods : A.decl list -> string list
+
+(** The same function with every parameter refinement erased — used where a
+    contract must not be assumed because no caller was obliged to establish
+    it. *)
+val strip_param_refinements : A.fn_def -> A.fn_def
+
+(** {1 Shadowing helpers}
+
+    Exposed for [division_safety], which threads the same fact channels: a
+    name rebound in between must retire from every channel, or a stale fact
+    proves a goal about a different value. *)
+
+(** Retire path facts mentioning any of the given rebound names. *)
+val path_shadow : (A.expr * bool) list -> string list -> (A.expr * bool) list
+
+(** Every name a pattern binds. *)
+val pat_binders : A.pattern -> string list
+
+(** {1 Traversal and postconditions}
+
+    These require [check_module]'s registration globals to be populated, i.e.
+    they are not standalone entry points. *)
+
+(** Walk a declaration list, checking every call site in it. *)
+val visit_decls :
+  root:string ->
+  Err.ctx ->
+  (string, fn_sig option) Hashtbl.t ->
+  rctx ->
+  A.decl list ->
+  unit
+
+(** Check one function's postcondition and report it. *)
+val check_fn_post : root:string -> Err.ctx -> A.fn_def -> unit
+
+(** The same check as a verdict. [?emit:false] answers "would this
+    postcondition verify?" without emitting a diagnostic or double-counting
+    the obligation. *)
+val check_fn_post_verdict :
+  root:string -> Err.ctx -> ?emit:bool -> A.fn_def -> bool
+
+(** Drop the postconditions that did not verify, so no later obligation may
+    rest on an unproven premise. *)
+val gate_unverified_posts :
+  root:string ->
+  Err.ctx ->
+  (string, fn_sig option) Hashtbl.t ->
+  A.decl list ->
+  unit
+
+(** {1 Priming the type tables}
+
+    Called by [--check-migration], which runs [check_fn_post] against a
+    synthesised signature and so must register the sorts itself. *)
+
+val register_adt_names : A.decl list -> unit
+val register_field_sorts : A.decl list -> unit
+
+(** {1 Not API — declared only because they are dead}
+
+    These three have no caller anywhere: not in this module, not outside it.
+    Hiding them would make each an [unused-value-declaration] error under
+    warnings-as-errors, so they are declared here with this note instead. They
+    are candidates for deletion, not for use.
+
+    [register_types_for_check] is the interesting one: its own docstring says
+    [--check-migration] calls it, and [--check-migration] does not — it calls
+    {!register_adt_names} and {!register_field_sorts} directly (see
+    [bin/main.ml]'s [Rc] block), so the table-clearing that only this function
+    does never happens. That is a behavioural question, not an interface one;
+    it is recorded in this phase's progress note rather than changed here. *)
+
+val smt_sort_of_marker : string option -> Smt.sort
+val register_types_for_check : A.decl list -> unit
+val expr_binds_name : string -> A.expr -> bool

--- a/scripts/refine-oracle.sh
+++ b/scripts/refine-oracle.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Refinement-diagnostic oracle — proves a refine_check refactor changed no
+# diagnostic.
+#
+# `lib/refinecheck/refine_check.ml` affects DIAGNOSTICS, not emitted code, so
+# scripts/ir-oracle.sh proves exactly nothing about it: a checker that stopped
+# checking emits byte-identical IR.  This script is the counterpart oracle —
+# it runs `--check --refine-report` over the whole March corpus and pins every
+# line of output.
+#
+# Two caches produce vacuous green if left warm:
+#   .march/cas/artifacts-v2  -> a compile-path CAS hit short-circuits before
+#                               --refine-report can print anything
+#   .march/cas/vc            -> verification conditions are reused, so a
+#                               checker that stopped checking still "proves"
+# Both are cleared ONCE here, before the sweep — never between fixtures (the
+# within-run warming is part of the recorded behaviour and is identical in the
+# baseline and the check run, which walk the corpus in the same order).
+#
+#   scripts/refine-oracle.sh baseline /tmp/refine-base-<slug>   # record
+#   scripts/refine-oracle.sh check    /tmp/refine-base-<slug>   # compare
+#
+# Suffix <slug> with your worktree name: /tmp is shared across every march
+# worktree on this box, and a collided baseline presents as an inexplicable
+# diagnostic diff — precisely the failure this oracle exists to rule out.
+#
+# A THIRD shared cache bites here and is not in .march/: ~/.cache/march holds
+# the Marshal'd stdlib AST and typecheck env (bin/main.ml's stdlib_decls /
+# get_stdlib_tc_env), keyed by stdlib content + compiler build id and shared by
+# every worktree on the box.  The marshalled spans carry the ABSOLUTE paths of
+# whichever worktree populated it, so stdlib diagnostics print another agent's
+# directory and the diff moves without anyone touching the checker — measured
+# 2026-08-26, 14 phantom `stdlib_prelude` lines.  The sweep therefore runs
+# under a private HOME inside <dir>, and paths are normalised below as well.
+#
+# Runtime is ~6 minutes over ~300 z3-backed fixtures.  Let it finish; a
+# half-run baseline is worse than none.
+#
+# See specs/plans/2026-08-19-compiler-file-decomposition.md (Phase 3, Task 3.1).
+set -uo pipefail
+
+# NB: the ${x:?msg} message must contain no `}` — bash ends the expansion at
+# the first one, so a "{baseline|check}" in the message silently appends the
+# tail of it to the variable's value.  (Both this plan's draft AND the
+# ir-oracle draft had exactly that bug: MODE came out as "baseline <dir>}" and
+# every invocation died with "unknown mode" before touching a fixture.)
+USAGE='usage: refine-oracle.sh baseline|check <dir>'
+MODE="${1:?$USAGE}"
+DIR="${2:?$USAGE}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+EXE="$ROOT/_build/default/bin/main.exe"
+OUT="$DIR/refine.txt"
+
+[ -x "$EXE" ] || { echo "FATAL: $EXE not built. Run: dune build --root . bin/main.exe"; exit 2; }
+
+rm -rf "$ROOT/.march/cas/artifacts-v2" "$ROOT/.march/cas/vc"
+mkdir -p "$DIR"
+# Private HOME: ~/.cache/march is shared across worktrees (see the note above).
+# Wiped per run so the stdlib blobs are always written by THIS worktree.
+rm -rf "$DIR/home"
+mkdir -p "$DIR/home"
+export HOME="$DIR/home"
+: > "$DIR/run.tmp"
+
+n=0
+for f in "$ROOT"/test/native/*.march "$ROOT"/stdlib/*.march; do
+  [ -e "$f" ] || continue
+  # Namespace by parent dir: basenames can collide across the two corpora.
+  tag="$(basename "$(dirname "$f")")_$(basename "$f" .march)"
+  # Normalise absolute paths so the manifest is machine- and worktree-
+  # independent, then tag every line so a fixture that stops emitting shows up
+  # as its lines disappearing rather than as a silent shift.
+  # The second sed collapses any directory prefix on a stdlib path: the
+  # compiler reaches prelude.march as either the staged `_build/default/bin/
+  # ../stdlib/…` copy or the source tree, and which spelling appears is not a
+  # property of the checker.
+  "$EXE" --check --refine-report "$f" 2>&1 \
+    | sed "s|$ROOT/||g" \
+    | sed -E 's#[A-Za-z0-9_./-]*stdlib/#stdlib/#g' \
+    | sed "s|^|$tag: |" >> "$DIR/run.tmp"
+  n=$((n+1))
+done
+
+# Sorting makes the manifest insensitive to nothing that matters (every line
+# carries its fixture tag) and immune to interleaving.
+sort "$DIR/run.tmp" > "$DIR/run.sorted"
+lines=$(wc -l < "$DIR/run.sorted" | tr -d ' ')
+echo "fixtures=$n report_lines=$lines"
+
+if [ "$n" -lt 100 ] || [ "$lines" -lt 50 ]; then
+  echo "FATAL: $n fixtures / $lines report lines — the refinement checker is"
+  echo "not being exercised (warm cache? stale build? wrong exe?).  Refusing"
+  echo "to record a vacuous baseline."
+  exit 2
+fi
+
+case "$MODE" in
+  baseline)
+    cp "$DIR/run.sorted" "$OUT"
+    echo "baseline recorded: $OUT ($lines lines over $n fixtures)"
+    ;;
+  check)
+    [ -f "$OUT" ] || { echo "FATAL: no baseline at $OUT"; exit 2; }
+    if diff -u "$OUT" "$DIR/run.sorted" > "$DIR/refine.diff"; then
+      echo "REFINEMENT DIAGNOSTICS IDENTICAL ($lines lines over $n fixtures)"
+      exit 0
+    else
+      echo "DIAGNOSTICS CHANGED — $(grep -c '^[+-][^+-]' "$DIR/refine.diff") differing lines:"
+      head -40 "$DIR/refine.diff"
+      echo "(full diff: $DIR/refine.diff)"
+      exit 1
+    fi
+    ;;
+  *) echo "unknown mode: $MODE"; exit 2 ;;
+esac

--- a/specs/plans/2026-08-19-compiler-file-decomposition.md
+++ b/specs/plans/2026-08-19-compiler-file-decomposition.md
@@ -1352,6 +1352,26 @@ git add lib/tir/llvm_emit_arith.ml lib/tir/llvm_emit_task.ml lib/tir/llvm_emit_r
 
 ## Phase 3 — `refine_check.ml`: navigation and the 12-parameter flood
 
+**LANDED 2026-08-26** on `claude/refine-check-phase3` — see
+[`specs/progress/2026-08-26-refine-check-decomposition-phase3.md`](../progress/2026-08-26-refine-check-decomposition-phase3.md).
+Four commits: the oracle, 23 § headers + a TOC (comments only, 122 insertions /
+0 deletions), `check_call`'s 13 parameters down to 8 behind a documented
+`call_ctx`, and a `.mli` cutting 198 inferred vals to 17.
+
+Three corrections to what is written below:
+
+1. **The inline draft of `scripts/refine-oracle.sh` could never have run** — it
+   repeated the `${x:?…}` bug fixed in `ir-oracle.sh` on 2026-08-25. Task 3.1
+   Step 1 now points at the committed script instead. **[corrected 2026-08-26]**
+2. **A third cache makes the oracle vacuous or flaky, and it is not under
+   `.march/`:** `~/.cache/march`'s Marshal'd stdlib typecheck env is shared
+   across worktrees and its spans carry the populating worktree's absolute
+   paths. The sweep runs under a private `HOME`. **[corrected 2026-08-26]**
+3. **Task 3.3's field list is wrong in both directions.** `rp` varies per
+   iteration at both `visit` sites and is therefore a parameter, not context;
+   `path` is threaded and shadowed exactly like `lets`/`sc`/`re` and belongs in
+   the record with them. **[corrected 2026-08-26]**
+
 **[verified 2026-08-25]** — `refine_check.ml` is untouched by the perf project: still 7,416 lines, `check_call` still at `:3371–4731` (1,361 lines), still three call sites at `:5695` / `:5719` / `:5731`. Every number in this phase re-measured correct.
 
 7,416 lines with **zero section headers** — the only file in this set with no navigational structure at all. `check_call` is 1,361 lines behind a twelve-parameter signature. It has **three** call sites, all inside the `visit` traversal (`refine_check.ml:5695`, `:5719`, `:5731`), so the parameter bundle can be changed with a bounded blast radius — but all three must be read, not one.
@@ -1430,7 +1450,7 @@ git add scripts/refine-oracle.sh && git commit -m "test: add refinement-diagnost
 
 **Files:** Modify `lib/refinecheck/refine_check.ml`
 
-- [ ] **Step 1: Identify natural boundaries**
+- [x] **Step 1: Identify natural boundaries**
 
 ```bash
 grep -n '^let [a-z_]*' lib/refinecheck/refine_check.ml | head -60
@@ -1438,7 +1458,7 @@ grep -n '^let [a-z_]*' lib/refinecheck/refine_check.ml | head -60
 
 Group the 197 top-level definitions into ~12 sections by concern (SMT sort management, path/scope fact channels, record sorts, precondition checking, postcondition checking, induction, capability walks, the `visit` traversal, entry points).
 
-- [ ] **Step 2: Insert numbered headers in the same style as `typecheck.ml`**
+- [x] **Step 2: Insert numbered headers in the same style as `typecheck.ml`**
 
 ```ocaml
 (* =================================================================
@@ -1446,9 +1466,9 @@ Group the 197 top-level definitions into ~12 sections by concern (SMT sort manag
    ================================================================= *)
 ```
 
-- [ ] **Step 3: Add a table of contents below the module docstring**
+- [x] **Step 3: Add a table of contents below the module docstring**
 
-- [ ] **Step 4: Verify comments-only and commit**
+- [x] **Step 4: Verify comments-only and commit**
 
 ```bash
 dune build --root . bin/main.exe 2>&1 | tail -3 && scripts/refine-oracle.sh check /tmp/refine-base-$SLUG; echo "exit=$?"
@@ -1462,7 +1482,7 @@ git add lib/refinecheck/refine_check.ml && git commit -m "docs(refinecheck): add
 **Interfaces:**
 - Produces: `type call_ctx = { root : …; errctx : …; lets : launder; postcond : string -> A.expr list -> (string * A.expr * string option) option; rp : rparam; sc : scope; re : recenv }` — the seven parameters that are *constant across the whole traversal*. The four that vary per call (`~span`, `~callee`, `sg`, `args`, `path`) stay as explicit parameters.
 
-- [ ] **Step 1: Read the current signature and classify each parameter**
+- [x] **Step 1: Read the current signature and classify each parameter**
 
 ```bash
 S=$(grep -n '^let check_call ' lib/refinecheck/refine_check.ml | cut -d: -f1)
@@ -1473,15 +1493,15 @@ Current: `~root errctx ~span ~(callee : string) ?(subject = Argument) ?(verdict_
 
 Classify by tracing **all three call sites** — `refine_check.ml:5695`, `:5719`, `:5731`, all inside the `visit` traversal: a parameter passed unchanged at every site on every iteration is *context*; one that varies at **any** site is a *parameter*. Do not guess, and do not stop after the first site — an argument constant at one can vary at another.
 
-- [ ] **Step 2: Define the record next to `check_call`, with a docstring per field**
+- [x] **Step 2: Define the record next to `check_call`, with a docstring per field**
 
 Each field's comment says what it is and why it is threaded — this is the documentation that does not exist today and is the main reason the function is hard to edit.
 
-- [ ] **Step 3: Change the signature and all three call sites**
+- [x] **Step 3: Change the signature and all three call sites**
 
 Build the record once, where `visit` binds the traversal-constant values, and pass it at `:5695`, `:5719`, and `:5731`.
 
-- [ ] **Step 4: Verify diagnostics are unchanged**
+- [x] **Step 4: Verify diagnostics are unchanged**
 
 ```bash
 dune build --root . bin/main.exe 2>&1 | tail -5 && scripts/refine-oracle.sh check /tmp/refine-base-$SLUG; echo "refine_exit=$?"
@@ -1490,7 +1510,7 @@ scripts/run-tests.sh compiler; echo "suite_exit=$?"
 
 Expected: both exit 0. A diagnostic-text change here would also break the CI-only `@types-check` alias, which asserts on exact message text.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add lib/refinecheck/refine_check.ml && git commit -m "refactor(refinecheck): bundle check_call's traversal-constant params into a record"
@@ -1500,17 +1520,17 @@ git add lib/refinecheck/refine_check.ml && git commit -m "refactor(refinecheck):
 
 **Files:** Create `lib/refinecheck/refine_check.mli`; modify `lib/refinecheck/dune` if needed (`.mli` files do not need a `(modules …)` entry — the `.ml` already has one).
 
-- [ ] **Step 1: Find the actual public surface**
+- [x] **Step 1: Find the actual public surface**
 
 ```bash
 grep -rhoE '\bRefine_check\.[a-z_][a-zA-Z0-9_]*' --include='*.ml' . | sort | uniq -c | sort -rn
 ```
 
-- [ ] **Step 2: Write an `.mli` exporting only those names**
+- [x] **Step 2: Write an `.mli` exporting only those names**
 
 Do not export all 197 definitions. If the externally-used set is small (likely under 10), the `.mli` is the single most valuable artifact in this phase: it turns "197 top-level lets" into a readable API.
 
-- [ ] **Step 3: Build, verify, commit**
+- [x] **Step 3: Build, verify, commit**
 
 ```bash
 dune build --root . bin/main.exe 2>&1 | tail -5 && scripts/refine-oracle.sh check /tmp/refine-base-$SLUG && scripts/run-tests.sh compiler; echo "exit=$?"

--- a/specs/plans/2026-08-19-compiler-file-decomposition.md
+++ b/specs/plans/2026-08-19-compiler-file-decomposition.md
@@ -1365,72 +1365,62 @@ git add lib/tir/llvm_emit_arith.ml lib/tir/llvm_emit_task.ml lib/tir/llvm_emit_r
 
 **Files:** Create `scripts/refine-oracle.sh`
 
-- [ ] **Step 1: Write the script**
+- [x] **Step 1: Write the script**
+
+The script now lives in the repo — **read `scripts/refine-oracle.sh`, do not re-type
+the draft that used to sit inline here.** That draft **could never run**: it repeated,
+verbatim, the `${x:?…}` bug already documented one phase up in Task 0.1 —
 
 ```bash
-#!/usr/bin/env bash
-# Refinement-diagnostic oracle.  refine_check affects DIAGNOSTICS, not emitted
-# code, so the IR oracle cannot see its regressions.
-#
-# Both caches below produce vacuous green if left warm:
-#   .march/cas/artifacts-v2  -> --refine-report prints NOTHING on a hit
-#   .march/cas/vc            -> verification conditions are reused, masking
-#                               a checker that stopped checking
-# Cleared ONCE here, before the run — never between fixtures.
-set -uo pipefail
-MODE="${1:?usage: refine-oracle.sh {baseline|check} <dir>}"
-DIR="${2:?usage: refine-oracle.sh {baseline|check} <dir>}"
-ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-EXE="$ROOT/_build/default/bin/main.exe"
-OUT="$DIR/refine.txt"
-
-[ -x "$EXE" ] || { echo "FATAL: $EXE not built"; exit 2; }
-rm -rf "$ROOT/.march/cas/artifacts-v2" "$ROOT/.march/cas/vc"
-mkdir -p "$DIR"; : > "$DIR/run.tmp"
-
-n=0
-for f in "$ROOT"/test/native/*.march "$ROOT"/stdlib/*.march; do
-  [ -e "$f" ] || continue
-  tag="$(basename "$(dirname "$f")")_$(basename "$f" .march)"
-  # Normalise absolute paths so the manifest is machine-independent.
-  "$EXE" --check --refine-report "$f" 2>&1 | sed "s|$ROOT/||g" \
-    | sed "s|^|$tag: |" >> "$DIR/run.tmp"
-  n=$((n+1))
-done
-sort "$DIR/run.tmp" > "$DIR/run.sorted"
-lines=$(wc -l < "$DIR/run.sorted")
-echo "fixtures=$n report_lines=$lines"
-
-if [ "$lines" -lt 50 ]; then
-  echo "FATAL: only $lines report lines — the refinement checker is not running"
-  echo "(warm cache? --refine-report short-circuited?).  Refusing to record."
-  exit 2
-fi
-
-case "$MODE" in
-  baseline) cp "$DIR/run.sorted" "$OUT"; echo "baseline recorded: $OUT" ;;
-  check)
-    [ -f "$OUT" ] || { echo "FATAL: no baseline at $OUT"; exit 2; }
-    if diff -u "$OUT" "$DIR/run.sorted" > "$DIR/refine.diff"; then
-      echo "REFINEMENT DIAGNOSTICS IDENTICAL ($lines lines)"; exit 0
-    else
-      echo "DIAGNOSTICS CHANGED:"; head -40 "$DIR/refine.diff"; exit 1
-    fi ;;
-  *) echo "unknown mode: $MODE"; exit 2 ;;
-esac
+MODE="${1:?usage: refine-oracle.sh {baseline|check} <dir>}"   # BROKEN
 ```
 
-- [ ] **Step 2: Record the baseline and prove it is non-vacuous**
+Bash ends a `${x:?word}` expansion at the **first** `}`, which here is the one inside
+`{baseline|check}`, so `MODE` came out as `baseline <dir>}` and every invocation died
+with `unknown mode` before touching a fixture. Task 0.1's copy was annotated `# BROKEN`
+on 2026-08-25; **this copy was missed and stayed live until 2026-08-26**. The committed
+script keeps the usage text in a `}`-free `USAGE` variable. **[corrected 2026-08-26]**
+
+The committed version differs from the draft in two further ways, both found by running it:
+
+- **It runs under a private `HOME`.** `~/.cache/march` holds the Marshal'd stdlib AST and
+  typecheck env (`bin/main.ml`'s `stdlib_decls` / `get_stdlib_tc_env`), keyed by stdlib
+  content plus compiler build id and **shared by every worktree on the box**. The
+  marshalled spans carry the absolute paths of whichever worktree populated the blob, so
+  stdlib diagnostics print *another agent's directory* and the manifest moves with nobody
+  touching the checker — measured as 14 phantom `stdlib_prelude` lines on the first
+  green control run. This is a third shared cache beyond the two the draft names, and it
+  does not live under `.march/`.
+- **It normalises stdlib path prefixes**, because the compiler reaches `prelude.march`
+  as either the staged `_build/default/bin/../stdlib/…` copy or the source tree and the
+  spelling is not a property of the checker.
+
+It also guards on fixture count as well as line count: a sweep that visits fewer than
+100 fixtures is refused, not just one that prints fewer than 50 lines.
+
+- [x] **Step 2: Record the baseline and prove it is non-vacuous**
 
 ```bash
 chmod +x scripts/refine-oracle.sh && scripts/refine-oracle.sh baseline /tmp/refine-base-$SLUG; echo "exit=$?"
 ```
 
-Expected: `report_lines=` a number **≥ 50**, exit 0. A `FATAL: only N report lines` means the cache clear did not take — investigate before proceeding.
+Measured 2026-08-26: `fixtures=297 report_lines=5638`, exit 0, **6m12s**. A
+`FATAL:` line means the cache clear did not take — investigate before proceeding.
+Let it finish; a half-run baseline is worse than none.
 
-Runtime note: ~280 fixtures, each a z3-backed check — expect **minutes, not seconds**. Let it finish. A half-run baseline is worse than none: the guard catches `< 50` lines, but it cannot tell a truncated-yet-large baseline from a complete one.
+**Non-vacuity, executed 2026-08-26** (an oracle nobody has seen fail is not evidence):
 
-- [ ] **Step 3: Commit**
+*RED probe* — two perturbations inside `refine_check.ml`, one message and one verdict:
+`"was NOT verified here"` → `"was NOT PROBEVERIFIED here"`, and in `check_call`'s
+discharge, `| Refine.Verified -> note Obligation.Proved` →
+`note (Obligation.Skipped Obligation.Solver_undecided)`. Result:
+`DIAGNOSTICS CHANGED — 1528 differing lines`, exit 1 (33 of them the reworded message,
+the rest proved/skipped counts across the corpus).
+
+*GREEN control* — probe reverted, a comment-only line appended to the same file, rebuilt:
+`REFINEMENT DIAGNOSTICS IDENTICAL (5638 lines over 297 fixtures)`, exit 0.
+
+- [x] **Step 3: Commit**
 
 ```bash
 git add scripts/refine-oracle.sh && git commit -m "test: add refinement-diagnostic oracle for refine_check refactors"

--- a/specs/progress/2026-08-26-refine-check-decomposition-phase3.md
+++ b/specs/progress/2026-08-26-refine-check-decomposition-phase3.md
@@ -1,0 +1,162 @@
+# `refine_check.ml` navigation and the parameter flood — Phase 3
+
+**Date:** 2026-08-26
+**Plan:** `specs/plans/2026-08-19-compiler-file-decomposition.md`, Phase 3
+**Branch:** `claude/refine-check-phase3`
+
+## What landed
+
+Four commits, one per task.
+
+| | |
+|---|---|
+| `refine_check.ml` | 7,416 → **7,582** lines (comments only: 122 header lines + the record's docstrings) |
+| § section headers | 0 → **23**, plus a table of contents |
+| `check_call` signature | **13 parameters → 8** (7 of them bundled into `call_ctx`) |
+| `refine_check.mli` | new, **198 inferred vals → 17 curated** + 4 types (91% internal) |
+| new script | `scripts/refine-oracle.sh` |
+
+1. **`test: add refinement-diagnostic oracle`** — 297 fixtures, 5,638 pinned
+   report lines.
+2. **`docs(refinecheck): numbered section headers + TOC`** — 122 insertions, 0
+   deletions.
+3. **`refactor(refinecheck): bundle check_call's traversal-constant params`** —
+   the phase's only semantic change.
+4. **`refactor(refinecheck): add refine_check.mli`**.
+
+## The oracle, and why it needed a third cache clear
+
+`refine_check` emits diagnostics, not code, so `scripts/ir-oracle.sh` proves
+*nothing* about it: a checker that stops checking emits byte-identical IR.
+`scripts/refine-oracle.sh` sweeps `--check --refine-report` over
+`test/native/*.march` + `stdlib/*.march` and pins every line.
+
+The plan named two caches that produce vacuous green (`.march/cas/artifacts-v2`,
+`.march/cas/vc`). There is a **third**, and it is not under `.march/`:
+`~/.cache/march` holds the Marshal'd stdlib AST and typecheck env
+(`bin/main.ml`'s `stdlib_decls` / `get_stdlib_tc_env`), keyed by stdlib content
+plus compiler build id and **shared by every worktree on this box**. The
+marshalled spans carry the absolute paths of whichever worktree populated the
+blob, so `stdlib_prelude` diagnostics printed *another agent's directory* and the
+manifest moved with nobody touching the checker — 14 phantom lines on the first
+green-control run, which is exactly the noise floor a real regression would hide
+in. The sweep therefore runs under a private `HOME` inside its baseline
+directory, and stdlib path prefixes are normalised on top of that.
+
+**The plan's inline draft of the script could never have run.** It repeated,
+verbatim, the `${x:?…}` bug already found and fixed in `ir-oracle.sh` on
+2026-08-25: bash ends the expansion at the first `}`, which is the one inside
+`{baseline|check}`, so `MODE` came out as `baseline <dir>}` and every invocation
+died with `unknown mode` before touching a fixture. Task 0.1's copy was
+annotated `# BROKEN`; **the Task 3.1 copy was missed and stayed live for a
+year-and-a-day of plan revisions.** Both the script and the plan text are fixed.
+
+**Non-vacuity** (an oracle nobody has seen fail is not evidence):
+
+- *RED* — two perturbations in `refine_check.ml`, one message
+  (`"was NOT verified here"` → `"was NOT PROBEVERIFIED here"`) and one verdict
+  (in `check_call`'s discharge, `Refine.Verified -> note Obligation.Proved` →
+  `note (Obligation.Skipped Obligation.Solver_undecided)`):
+  **`DIAGNOSTICS CHANGED — 1528 differing lines`, exit 1** (33 the message, the
+  rest proved/skipped counts across the corpus).
+- *GREEN* — probe reverted, comment-only line appended, rebuilt:
+  **`REFINEMENT DIAGNOSTICS IDENTICAL (5638 lines over 297 fixtures)`, exit 0.**
+
+Runtime ~6 min. `--refine-report` output is deterministic run to run (checked
+before recording anything).
+
+## Section headers: how "comments only" was proven
+
+The inserter computes a real in-comment character mask (nested OCaml comments
+*and* string literals) rather than walking back over lines that "look like"
+comments — the documented trap is that **a doc comment containing a blank line**
+defeats naive walk-back and makes an insertion land inside a comment, swallowing
+half of it. It then refuses to write unless the source with every comment
+stripped is byte-identical before and after. Result: 122 insertions, 0
+deletions.
+
+23 sections, not the plan's "~12": at 7,400 lines the finer grain is what makes
+`grep -n '§'` a usable index. `check_call` is §15; its postcondition
+counterparts are §16–§18.
+
+## `check_call`: what is context and what is a parameter
+
+Traced through all three call sites (`visit`'s two `EApp` arms and
+`check_let_annotation`), not one. Seven parameters are the environment an
+obligation is discharged *in* — `root`, `errctx`, `postcond`, `path`, `lets`,
+`sc`, `re` — and became a `call_ctx` record with a docstring per field, which is
+the documentation this 1,361-line function has never had. What differs per
+obligation stays explicit: `~span`/`~callee` (which call), `sg`/`args` (its
+signature and actuals), `rp` (which refined parameter), and the
+`?subject`/`?verdict_out` that only the `let`-annotation caller sets.
+
+**Deviation from the plan's field list.** The plan put `rp` in the record and
+left `path` out. Measurement says the opposite: `rp` varies per iteration of
+`List.iter … sg.refined` at both `visit` sites, while `path` is threaded exactly
+like `lets`/`sc`/`re` and is shadowed with them at the `let`-annotation site.
+Keeping the three fact channels together in one record is also what makes their
+shared retirement discipline statable in one place.
+
+The record is destructured to the body's existing names on the function's first
+line, so the 1,361-line body is untouched: this is a signature change, not a
+rewrite. At the two `visit` sites the record is now built once per call node
+instead of a 13-argument list being respelled per refined parameter.
+
+No `CHANGELOG.md` bullet. The plan predicted Phase 3's hardening would change
+diagnostics; the oracle says it does not, and CLAUDE.md's rule is that a
+refactor with no observable effect gets no entry.
+
+## `.mli`: 198 → 17
+
+`check_module` is the entry point — 52 of the qualified references in the tree
+are to it. The other 16 exist because `precond_infer`, `postcond_infer`,
+`division_safety` and `--check-migration` re-use pieces of the machinery it sets
+up; several of them *require* `check_module` to have run first, because they
+read registration globals it populates, and the interface now says so.
+
+`dune build @check` is the oracle here, as in PR #354: `open` does not
+re-export, so a grep for `Refine_check.<name>` cannot see the `RC.`/`Rc.` alias
+uses in `precond_infer`, `postcond_infer` and `bin/main.ml`. 17 pre-existing
+`forge/test` + `js` errors (missing optional opam dep) before and after, none
+new.
+
+### Finding: three values have no caller at all
+
+`smt_sort_of_marker`, `expr_binds_name` and `register_types_for_check` are dead
+in and out of the module. They are declared under a "Not API" heading because
+hiding them is an `unused-value-declaration` error under warnings-as-errors —
+the same accommodation `lower.ml` needed for three re-exports in PR #354.
+
+`register_types_for_check` is the interesting one. Its own docstring says
+`--check-migration` calls it "to prime the type tables", and it is the only
+thing that *clears* those tables first, "to avoid stale accumulation from prior
+calls". `--check-migration` does not call it: `bin/main.ml`'s `Rc` block calls
+`register_adt_names` and `register_field_sorts` directly, so the clearing never
+happens. Whether that matters is a behavioural question about migration
+checking, deliberately not answered in an interface-only commit.
+
+## Verification
+
+Run after **every** task:
+
+- `scripts/refine-oracle.sh check` — `REFINEMENT DIAGNOSTICS IDENTICAL (5638
+  lines over 297 fixtures)`, exit 0, three times (3.2, 3.3, 3.4). Never
+  anything else.
+- `scripts/ir-oracle.sh check` — `IR IDENTICAL across 240 programs`, exit 0,
+  three times. `refine_check` is a checker; a changed byte of IR would have
+  been a real finding.
+- `dune build --root . bin/main.exe`, exit 0.
+- Suite after 3.3 and after 3.4: **2,763 tests, seven runners, every one exit
+  0** — `run_compiler` 936, `run_codegen` 593, `run_stdlib` 878, `run_eval` 273,
+  `test_stdlib_march` 61, `test_jit` 22 (with `MARCH_BIN` set, else it skips
+  silently), plus `run_snapshots` 33.
+
+## Still open
+
+- `check_call` is still 1,361 lines. Phase 3 was scoped to its signature and to
+  navigation; carving its body is a separate job.
+- The three dead values above: delete, or make `--check-migration` use
+  `register_types_for_check` as its docstring intends.
+- `refine_check.ml` has no sibling modules yet. §5 (ADT/record sorts and the
+  preamble builders, ~600 lines) and §20 (refinement-placement warnings, ~380)
+  are self-contained enough to move if this file needs to shrink.

--- a/specs/todos/2026-08-19-compiler-file-decomposition.md
+++ b/specs/todos/2026-08-19-compiler-file-decomposition.md
@@ -9,7 +9,21 @@ Plan: `specs/plans/2026-08-19-compiler-file-decomposition.md`
 
 ## Status
 
-**Phases 0 and 1 landed (2026-08-25). Phases 2-6 open.**
+**Phases 0-3 landed. Phases 4-6 open.**
+
+- **Phase 3 complete (2026-08-26)** — `lib/refinecheck/refine_check.ml` gains 23
+  § section headers and a table of contents (comments only), `check_call` goes
+  from 13 parameters to 8 behind a documented `call_ctx` record, and a new
+  `refine_check.mli` cuts 198 inferred vals to 17 (91% was internal). New
+  oracle: `scripts/refine-oracle.sh`, 297 fixtures / 5,638 pinned diagnostic
+  lines, proven non-vacuous (RED 1,528 differing lines for a perturbed
+  message + verdict, GREEN for a comment-only edit). Note it needs a private
+  `HOME`: `~/.cache/march`'s Marshal'd stdlib typecheck env is shared across
+  worktrees and its spans carry the populating worktree's paths. Details:
+  `specs/progress/2026-08-26-refine-check-decomposition-phase3.md`.
+
+- **Phase 2 complete (2026-08-26)** — see
+  `specs/progress/2026-08-26-llvm-emit-decomposition-phase2.md`.
 
 - **Phase 1 complete** — `lib/eval/eval.ml` **12,264 → 4,304 lines** (target
   ~5,000), split into `eval_builtins.ml` (5,294), `eval_runtime.ml` (1,242),


### PR DESCRIPTION
Phase 3 of `specs/plans/2026-08-19-compiler-file-decomposition.md`. Four commits, one per task; code motion and semantic change kept separate.

| | |
|---|---|
| `refine_check.ml` | 7,416 → **7,582** lines (comments only: 122 header lines + the record's docstrings) |
| § section headers | 0 → **23**, plus a table of contents |
| `check_call` | **13 parameters → 8**, seven bundled into a documented `call_ctx` |
| `refine_check.mli` | new — **198 inferred vals → 17 curated** (91% was internal) |
| new script | `scripts/refine-oracle.sh` |

### The oracle (`scripts/refine-oracle.sh`)

`refine_check` emits diagnostics, not code, so `scripts/ir-oracle.sh` proves *nothing* about it — a checker that stops checking emits byte-identical IR. This sweeps `--check --refine-report` over 297 fixtures (`test/native` + `stdlib`) and pins all 5,638 output lines.

**Non-vacuity, because an oracle nobody has seen fail is not evidence:**

- **RED** — perturbed one message (`was NOT verified here` → `was NOT PROBEVERIFIED here`) and one verdict (`check_call`'s `Refine.Verified -> note Obligation.Proved` → `note (Skipped Solver_undecided)`): `DIAGNOSTICS CHANGED — 1528 differing lines`, exit 1.
- **GREEN** — probe reverted, comment-only line appended, rebuilt: `REFINEMENT DIAGNOSTICS IDENTICAL (5638 lines over 297 fixtures)`, exit 0.

Two things the plan's inline draft got wrong, both fixed here and in the plan text:

1. **It could never have run.** It repeated the `${x:?…}` bug fixed in `ir-oracle.sh` on 2026-08-25 — bash ends the expansion at the `}` inside `{baseline|check}`, so `MODE` becomes `baseline <dir>}` and every invocation dies with `unknown mode`. Task 0.1's copy was annotated `# BROKEN`; this copy was missed.
2. **There is a third shared cache, and it is not under `.march/`.** `~/.cache/march` holds the Marshal'd stdlib AST/typecheck env, keyed by content + compiler build id and shared by every worktree on the box; its spans carry the *populating worktree's* absolute paths, so stdlib diagnostics printed another agent's directory and the manifest moved with nobody touching the checker (14 phantom lines on the first control run). The sweep now runs under a private `HOME`.

### `check_call`

Traced all three call sites, not one. Seven parameters are the environment an obligation is discharged *in* — `root`, `errctx`, `postcond`, `path`, `lets`, `sc`, `re` — and become a `call_ctx` record with a docstring per field. What differs per obligation stays explicit: `~span`/`~callee`, `sg`/`args`/`rp`, and the `?subject`/`?verdict_out` only the `let`-annotation caller sets.

The plan's field list is wrong in both directions: `rp` varies per iteration of `List.iter … sg.refined` at both `visit` sites, and `path` is threaded and shadowed exactly like `lets`/`sc`/`re`. The record is destructured to the body's existing names on the first line, so the 1,361-line body is untouched — a signature change, not a rewrite.

### `.mli`

`check_module` is the entry point (52 of the qualified references in the tree). The other 16 exist because `precond_infer`, `postcond_infer`, `division_safety` and `--check-migration` re-use machinery it sets up. `dune build @check` is the oracle for the `RC.`/`Rc.` alias uses a grep cannot see: 17 pre-existing `forge/test` + `js` errors before and after, none new.

**Finding:** three values have no caller at all — `smt_sort_of_marker`, `expr_binds_name`, and `register_types_for_check`, whose own docstring says `--check-migration` calls it while `bin/main.ml` calls `register_adt_names`/`register_field_sorts` directly, so the table-clearing it uniquely does never runs. Declared under a "Not API" heading (hiding them is an unused-value error) and recorded as a finding rather than changed in an interface commit.

### Verification (after every task)

- `scripts/refine-oracle.sh check` — `IDENTICAL (5638 lines / 297 fixtures)`, exit 0, three times.
- `scripts/ir-oracle.sh check` — `IR IDENTICAL across 240 programs`, exit 0, three times. Never anything else; a changed byte would have been a real finding.
- Suite **2,763 tests, seven runners, all exit 0** (`run_compiler` 936, `run_codegen` 593, `run_stdlib` 878, `run_eval` 273, `test_stdlib_march` 61, `test_jit` 22, plus `run_snapshots` 33).
- `scripts/check-docs.sh` passes.

No `CHANGELOG.md` bullet: the plan predicted Phase 3 would change diagnostics, the oracle says it does not, and CLAUDE.md excludes refactors with no observable effect.
