### PR TITLE
Construct the CAS cache key in exactly one place (decomposition Phase 5)

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1631,6 +1631,88 @@ let parse_target s =
     exit 1
 
 (* ------------------------------------------------------------------ *)
+(* CAS cache key                                                       *)
+(* ------------------------------------------------------------------ *)
+
+(** The clang -O level actually used: [!opt_level] when explicitly set in
+    range, 2 otherwise.  Shared by [build_cas_key] and the clang invocation so
+    the cached-under level and the compiled-at level cannot drift apart. *)
+let effective_opt () =
+  if !opt_level >= 0 && !opt_level <= 3 then !opt_level else 2
+
+(** Stable string name for a target, used as the CAS key's [~target] component.
+
+    Distinct from [!target_str]: the glibc floor is folded in here, so bumping
+    it invalidates cached cross binaries. *)
+let cas_target_label (target : March_tir.Llvm_emit.target_config) : string =
+  match target with
+  | March_tir.Llvm_emit.Native -> "native"
+  | March_tir.Llvm_emit.LinuxGnu { arch = March_tir.Llvm_emit.X86_64; glibc_min } ->
+    "linux-x86_64-gnu-" ^ glibc_min
+  | March_tir.Llvm_emit.LinuxGnu { arch = March_tir.Llvm_emit.Arm64; glibc_min } ->
+    "linux-arm64-gnu-" ^ glibc_min
+  | March_tir.Llvm_emit.Wasm64Wasi -> "wasm64-wasi"
+  | March_tir.Llvm_emit.Wasm32Wasi -> "wasm32-wasi"
+  | March_tir.Llvm_emit.Wasm32Unknown -> "wasm32-unknown-unknown"
+  | March_tir.Llvm_emit.Js -> "js"
+
+(** Build the CAS cache key: the flag list plus the compilation hash.
+
+    THE only place codegen flags enter the cache key.  A flag that affects the
+    emitted binary but is missing from this list makes two semantically
+    different builds collide on one cache entry, and the cache then serves the
+    wrong binary — a silently stale result, not an error.  Adding a codegen
+    flag anywhere in this file means adding it *here*, once.
+
+    Two call sites use this, at two different cache layers: the early
+    source-level check in [compile] (keyed on the source digest, before parsing)
+    and the post-TIR check (keyed on the module's per-SCC impl hashes).  They
+    differ only in [src_hash]; every flag is shared.  The cross-sysroot digest
+    is computed here rather than passed in, because it is a pure function of
+    [target] and so cannot legitimately diverge between the layers either.
+
+    [MARCH_DEBUG_CASFLAGS=1] prints the resulting key, from both sites. *)
+let build_cas_key ~(target : March_tir.Llvm_emit.target_config)
+      ~(target_label : string) ~(src_hash : string) : string list * string =
+  (* Cross-toolchain identity: the target OpenSSL/zlib .so live OUTSIDE the
+     repo (~/.cache/march/cross-sysroot), so runtime_identity (which digests
+     only runtime/*.c/*.h) does NOT cover them.  Fold a digest of the three
+     sysroot .so files into cas_flags so re-fetching a different
+     OpenSSL/zlib version invalidates cached cross binaries.  The glibc
+     floor is already in target_label. *)
+  let cross_sysroot_tag =
+    match linux_arch_str target with
+    | None -> []
+    | Some arch ->
+      (match cross_sysroot_dir arch with
+       | Some d -> ["xsysroot:" ^ cross_sysroot_digest d]
+       | None -> [])
+  in
+  let cas_flags =
+    (if !opt_enabled then Printf.sprintf "O%d" (effective_opt ()) else "no-opt")
+    :: Printf.sprintf "pmt%d" !pmap_threshold
+    :: (hr_cas_tag () @ ffi_cas_tag () @ codegen_cas_tags ()
+        @ (if !compile_so then ["compile-so"] else [])
+        (* capstrip: the dead-strip link mode (strip_flag/section_cflags
+           below) changes the emitted binary's contents; a pre-strip
+           cached artifact must never satisfy a post-strip build or the
+           cap inspect silently reports every capability. Mirrors the
+           eligibility condition on strip_flag. *)
+        @ (if !compile_so || !hot_reload_prefix <> None
+           then [] else ["capstrip"])
+        (* --cap-sandbox changes the emitted binary (a -D define), so a
+           non-sandboxed cached artifact must never satisfy it. *)
+        @ (if !cap_sandbox then ["capsandbox"] else [])
+        @ (if !cap_strict then ["capstrict"] else [])
+        @ cross_sysroot_tag
+        @ (if !signing_pubkey <> "" then ["spk:" ^ !signing_pubkey] else [])) in
+  let ch = March_cas.Cas.compilation_hash src_hash ~target:target_label ~flags:cas_flags in
+  (if Sys.getenv_opt "MARCH_DEBUG_CASFLAGS" <> None then
+     Printf.eprintf "MARCH_CASFLAGS: target=%s flags=[%s] ch=%s\n%!"
+       target_label (String.concat "," cas_flags) ch);
+  (cas_flags, ch)
+
+(* ------------------------------------------------------------------ *)
 (* Formatter helpers                                                   *)
 (* ------------------------------------------------------------------ *)
 
@@ -2398,49 +2480,12 @@ let compile filename =
         Some (store, ch)
       end else begin (* !do_compile *)
         let target_parsed = parse_target !target_str in
-        let target_label  = match target_parsed with
-          | March_tir.Llvm_emit.Native          -> "native"
-          | March_tir.Llvm_emit.LinuxGnu { arch = March_tir.Llvm_emit.X86_64; glibc_min } ->
-            "linux-x86_64-gnu-" ^ glibc_min
-          | March_tir.Llvm_emit.LinuxGnu { arch = March_tir.Llvm_emit.Arm64; glibc_min } ->
-            "linux-arm64-gnu-" ^ glibc_min
-          | March_tir.Llvm_emit.Wasm64Wasi      -> "wasm64-wasi"
-          | March_tir.Llvm_emit.Wasm32Wasi      -> "wasm32-wasi"
-          | March_tir.Llvm_emit.Wasm32Unknown   -> "wasm32-unknown-unknown"
-          | March_tir.Llvm_emit.Js              -> "js"
-        in
-        let effective_opt = if !opt_level >= 0 && !opt_level <= 3 then !opt_level else 2 in
-        (* Cross target OpenSSL/zlib .so live outside the repo, so fold a digest of
-           them into the key (mirrors the inner CAS check below) — otherwise this
-           source-level early cache would serve a stale cross binary after a
-           sysroot re-fetch changed the linked libs. *)
-        let cross_sysroot_tag =
-          match linux_arch_str target_parsed with
-          | None -> []
-          | Some arch ->
-            (match cross_sysroot_dir arch with
-             | Some d -> ["xsysroot:" ^ cross_sysroot_digest d]
-             | None -> [])
-        in
-        let cas_flags =
-          (if !opt_enabled then Printf.sprintf "O%d" effective_opt else "no-opt")
-          :: Printf.sprintf "pmt%d" !pmap_threshold
-          :: (hr_cas_tag () @ ffi_cas_tag () @ codegen_cas_tags ()
-              @ (if !compile_so then ["compile-so"] else [])
-              (* capstrip: the dead-strip link mode (strip_flag/section_cflags
-                 below) changes the emitted binary's contents; a pre-strip
-                 cached artifact must never satisfy a post-strip build or the
-                 cap inspect silently reports every capability. Mirrors the
-                 eligibility condition on strip_flag. *)
-              @ (if !compile_so || !hot_reload_prefix <> None
-                 then [] else ["capstrip"])
-              (* --cap-sandbox changes the emitted binary (a -D define), so a
-                 non-sandboxed cached artifact must never satisfy it. *)
-              @ (if !cap_sandbox then ["capsandbox"] else [])
-              @ (if !cap_strict then ["capstrict"] else [])
-              @ cross_sysroot_tag
-              @ (if !signing_pubkey <> "" then ["spk:" ^ !signing_pubkey] else [])) in
-        let ch = March_cas.Cas.compilation_hash src_hash ~target:target_label ~flags:cas_flags in
+        let target_label  = cas_target_label target_parsed in
+        (* Source-level early cache: same key construction as the post-TIR check
+           below (build_cas_key), keyed on the source digest instead of the
+           module's impl hashes. *)
+        let (_, ch) =
+          build_cas_key ~target:target_parsed ~target_label ~src_hash in
         let is_wasm  = March_tir.Llvm_emit.is_wasm_target target_parsed in
         let basename = Filename.remove_extension filename in
         let out_bin  =
@@ -3707,17 +3752,7 @@ let compile filename =
           Printf.eprintf "compiled %s\n" out_bin
         end else begin
         (* CAS: check for a cached binary before running clang *)
-        let target_label = match target with
-          | March_tir.Llvm_emit.Native -> "native"
-          | March_tir.Llvm_emit.LinuxGnu { arch = March_tir.Llvm_emit.X86_64; glibc_min } ->
-            "linux-x86_64-gnu-" ^ glibc_min
-          | March_tir.Llvm_emit.LinuxGnu { arch = March_tir.Llvm_emit.Arm64; glibc_min } ->
-            "linux-arm64-gnu-" ^ glibc_min
-          | March_tir.Llvm_emit.Wasm64Wasi -> "wasm64-wasi"
-          | March_tir.Llvm_emit.Wasm32Wasi -> "wasm32-wasi"
-          | March_tir.Llvm_emit.Wasm32Unknown -> "wasm32-unknown-unknown"
-          | March_tir.Llvm_emit.Js -> "js"
-        in
+        let target_label = cas_target_label target in
         let store = March_cas.Cas.create ~project_root:(Sys.getcwd ()) in
         let h_sccs = March_cas.Pipeline.hash_module tir in
         let mod_hash = String.concat "" (List.map March_cas.Pipeline.scc_impl_hash h_sccs) in
@@ -3787,43 +3822,11 @@ let compile filename =
             end
           ) pre_fns
         in
-        let effective_opt = if !opt_level >= 0 && !opt_level <= 3 then !opt_level else 2 in
-        (* Cross-toolchain identity: the target OpenSSL/zlib .so live OUTSIDE the
-           repo (~/.cache/march/cross-sysroot), so runtime_identity (which digests
-           only runtime/*.c/*.h) does NOT cover them.  Fold a digest of the three
-           sysroot .so files into cas_flags so re-fetching a different
-           OpenSSL/zlib version invalidates cached cross binaries.  The glibc
-           floor is already in target_label. *)
-        let cross_sysroot_tag =
-          match linux_arch_str target with
-          | None -> []
-          | Some arch ->
-            (match cross_sysroot_dir arch with
-             | Some d -> ["xsysroot:" ^ cross_sysroot_digest d]
-             | None -> [])
-        in
-        let cas_flags =
-          (if !opt_enabled then Printf.sprintf "O%d" effective_opt else "no-opt")
-          :: Printf.sprintf "pmt%d" !pmap_threshold
-          :: (hr_cas_tag () @ ffi_cas_tag () @ codegen_cas_tags ()
-              @ (if !compile_so then ["compile-so"] else [])
-              (* capstrip: the dead-strip link mode (strip_flag/section_cflags
-                 below) changes the emitted binary's contents; a pre-strip
-                 cached artifact must never satisfy a post-strip build or the
-                 cap inspect silently reports every capability. Mirrors the
-                 eligibility condition on strip_flag. *)
-              @ (if !compile_so || !hot_reload_prefix <> None
-                 then [] else ["capstrip"])
-              (* --cap-sandbox changes the emitted binary (a -D define), so a
-                 non-sandboxed cached artifact must never satisfy it. *)
-              @ (if !cap_sandbox then ["capsandbox"] else [])
-              @ (if !cap_strict then ["capstrict"] else [])
-              @ cross_sysroot_tag
-              @ (if !signing_pubkey <> "" then ["spk:" ^ !signing_pubkey] else [])) in
-        let ch = March_cas.Cas.compilation_hash mod_hash ~target:target_label ~flags:cas_flags in
-        (if Sys.getenv_opt "MARCH_DEBUG_CASFLAGS" <> None then
-           Printf.eprintf "MARCH_CASFLAGS: target=%s flags=[%s] ch=%s\n%!"
-             target_label (String.concat "," cas_flags) ch);
+        (* Post-TIR cache: same key construction as the source-level early
+           check above (build_cas_key), keyed on the module's per-SCC impl
+           hashes instead of the source digest. *)
+        let (_, ch) =
+          build_cas_key ~target ~target_label ~src_hash:mod_hash in
         let cached_ok =
           match March_cas.Cas.lookup_artifact store ch with
           | Some cached_bin ->
@@ -3852,7 +3855,7 @@ let compile filename =
                    Printf.eprintf "march: cannot find runtime for WASM target\n"; exit 1)
             in
             let triple = March_tir.Llvm_emit.target_triple target in
-            let opt_flag = Printf.sprintf " -O%d" effective_opt in
+            let opt_flag = Printf.sprintf " -O%d" (effective_opt ()) in
             (* Locate wasi-sdk for WASI targets, or use system clang for wasm32-unknown-unknown *)
             let clang, sysroot_flag = match target with
               | March_tir.Llvm_emit.Wasm64Wasi | March_tir.Llvm_emit.Wasm32Wasi ->
@@ -3908,7 +3911,7 @@ let compile filename =
               | None ->
                 Printf.eprintf "march: cannot find runtime/march_runtime.c\n"; exit 1
             in
-            let opt_flag = Printf.sprintf " -O%d" effective_opt in
+            let opt_flag = Printf.sprintf " -O%d" (effective_opt ()) in
             let runtime_dir = Filename.dirname runtime in
             let http_c      = Filename.concat runtime_dir "march_http.c" in
             let extras_c2   = Filename.concat runtime_dir "march_extras.c" in

--- a/specs/plans/2026-08-19-compiler-file-decomposition.md
+++ b/specs/plans/2026-08-19-compiler-file-decomposition.md
@@ -1645,7 +1645,18 @@ Order matters — diagnostic actions came first in the original. Verify against 
 
 ---
 
-## Phase 5 — `bin/main.ml`: one CAS-key site, not two
+## Phase 5 — `bin/main.ml`: one CAS-key site, not two — **LANDED 2026-08-26**
+
+**LANDED 2026-08-26** on `claude/cas-flags-phase5` — see
+`specs/progress/2026-08-26-cas-flags-single-constructor.md`. The two flag-list
+expressions turned out to be **byte-identical**, so there was no live
+cache-collision bug to fix — the hazard was latent. `target_label` (also part of
+the key) and `effective_opt` (which feeds both the key and the clang command
+line) were duplicated too and are now single-sourced alongside it. The
+cross-sysroot digest is a pure function of the parsed target, so it moved
+*inside* the constructor rather than becoming the planned `~extra` parameter;
+the only genuine per-site parameters are the hash input (`src_hash` vs
+`mod_hash`) and the target. IR oracle: IDENTICAL across 240 programs.
 
 **[corrected 2026-08-25]** — `bin/main.ml` is **5,402** lines (the draft said 5,162): `--jit` mode (#344), the stdlib typecheck-env cache (#342) and #347 landed in between. `compile` is **2,510** lines (`:2298–4807`, was "2,360"), and the second `cas_flags` site moved.
 
@@ -1662,7 +1673,7 @@ grep -n 'MARCH_DEBUG_CASFLAGS' bin/main.ml     # 3800 (site 2 only)
 
 **Files:** Modify `bin/main.ml`
 
-- [ ] **Step 1: Diff the two sites**
+- [x] **Step 1: Diff the two sites**
 
 ```bash
 A=$(grep -n 'let cas_flags' bin/main.ml | sed -n 1p | cut -d: -f1)
@@ -1672,7 +1683,7 @@ diff <(sed -n "${A},$((A+22))p" bin/main.ml) <(sed -n "${B},$((B+22))p" bin/main
 
 Record every difference. Some are legitimate (the second site adds sysroot `.so` digests per the comment just above it at **:3770**, was :3595); those become parameters, not divergence.
 
-- [ ] **Step 2: Write a single constructor above both sites**
+- [x] **Step 2: Write a single constructor above both sites**
 
 ```ocaml
 (** Build the CAS cache-key flag list.  THE only place codegen flags enter the
@@ -1689,7 +1700,7 @@ let build_cas_flags ~(extra : string list) : string list =
 
 Move the existing `MARCH_DEBUG_CASFLAGS` debug print (**`main.ml:3800-3802`**, was :3625-3627) **into** this function so that every call site logs its flag list identically — that print is what Step 3 verifies against.
 
-- [ ] **Step 3: Prove the flag LIST is unchanged — never compare cache keys across compiler builds**
+- [x] **Step 3: Prove the flag LIST is unchanged — never compare cache keys across compiler builds**
 
 The CAS key includes the digest of the compiler executable itself. Any comparison that spans "rebuild the compiler" therefore **always** yields different keys — an artifact-count check is structurally incapable of validating this refactor, and a naive reading of its inevitable failure invites a wrong "fix". Compare the flag *list* instead.
 
@@ -1720,7 +1731,7 @@ diff <(grep -o 'flags=\[[^]]*\]' /tmp/casflags-before-b-$SLUG.log) <(grep -o 'fl
 
 Expected: `a_exit=0` and `b_exit=0` — the flag lists are byte-identical, so the key is unchanged for any fixed compiler binary. The `ch=` hashes in the before/after logs **will** differ because the compiler was rebuilt between captures; that is the compiler-digest component doing its job, not a regression. Also confirm the `b` list contains `capstrict` and the `a` list does not — otherwise the probe is not exercising flag-sensitivity.
 
-- [ ] **Step 4: Verify and commit**
+- [x] **Step 4: Verify and commit**
 
 ```bash
 dune build --root . bin/main.exe 2>&1 | tail -5 && scripts/ir-oracle.sh check /tmp/ir-base-$SLUG && scripts/run-tests.sh codegen; echo "exit=$?"

--- a/specs/progress/2026-08-26-cas-flags-single-constructor.md
+++ b/specs/progress/2026-08-26-cas-flags-single-constructor.md
@@ -1,0 +1,106 @@
+# CAS cache-key flags built in exactly one place (decomposition Phase 5, Task 5.1)
+
+**Date:** 2026-08-26
+**Plan:** `specs/plans/2026-08-19-compiler-file-decomposition.md`, Phase 5, Task 5.1
+**Files:** `bin/main.ml`
+
+## The hazard
+
+`cas_flags` — the flag list that enters the content-addressed compile cache's key —
+was constructed at **two** separate sites in `bin/main.ml`: the source-level early
+cache check inside `compile` (keyed on the source digest, before parsing) and the
+post-TIR check (keyed on the module's per-SCC impl hashes). A codegen flag added to
+one and not the other makes two semantically *different* builds collide on one cache
+entry, and the cache then serves the wrong binary. The failure mode is a silently
+stale result, not an error — and no standard test suite can see it.
+
+The same duplication also existed for `target_label` (a 10-arm match over
+`target_config`, written out twice) — which is likewise part of the cache key — and
+for `effective_opt` (the clang `-O` level), which fed *both* the cache key and the
+clang command line.
+
+## What was found
+
+The two sites were diffed line-by-line before any edit. Result:
+
+- **The 18-line flag-list expressions were byte-identical.** No flag was present at
+  one site and missing from the other, so there was **no live cache-collision bug** to
+  fix — the risk was latent, waiting for the next codegen flag.
+- The two `cross_sysroot_tag` blocks were semantically identical (only their
+  explanatory comments differed in length). The plan anticipated this as the one
+  *legitimate* divergence, to be threaded through as an `~extra` parameter; in fact it
+  is a pure function of the parsed target, so it moved *inside* the constructor rather
+  than becoming a parameter. That is strictly stronger: it cannot diverge at all now.
+- The two `target_label` matches were semantically identical (whitespace only).
+- **Genuine, legitimate differences (now parameters):** the hash input — `src_hash`
+  (source digest) at the early site vs `mod_hash` (concatenated SCC impl hashes) at the
+  post-TIR site — and the target binding's name. Both are `~src_hash` / `~target` now.
+- **`MARCH_DEBUG_CASFLAGS`** existed at the post-TIR site only. It now lives inside the
+  constructor, so *both* layers log their key.
+
+## What changed
+
+Three top-level helpers added above `compile` (after `parse_target`):
+
+- `effective_opt ()` — the clang `-O` level, shared by the cache key and both clang
+  invocations, so the cached-under level and the compiled-at level cannot drift.
+- `cas_target_label : target_config -> string` — the key's `~target` component.
+- `build_cas_key ~target ~target_label ~src_hash : string list * string` — **the** only
+  place codegen flags enter the cache key. Computes the cross-sysroot digest, builds the
+  flag list, calls `Cas.compilation_hash`, and does the `MARCH_DEBUG_CASFLAGS` print.
+
+Both call sites collapse to a two-line `let (_, ch) = build_cas_key …`.
+
+Net: `bin/main.ml` 5,426 → 5,429 lines (the constructor's doc comment is longer than
+the duplication it removed; the point is one edit site, not fewer lines).
+
+## Verification
+
+**Flag-list identity (the method the plan mandates).** The cache key includes the
+compiler executable's own digest, so *any* comparison spanning a compiler rebuild
+always shows different `ch` values — an artifact-count comparison across builds is
+structurally incapable of validating this refactor. So the *flag list* was compared
+instead. As a print-only preparatory step the `MARCH_DEBUG_CASFLAGS` eprintf was
+copied to the early site, "before" lists captured, then the refactor applied and
+"after" lists recaptured:
+
+```
+before/after, default flags:      flags=[O2,pmt1024,rtcflags2,capstrip,capstrict]      diff exit 0
+before/after, --cap-sandbox --no-trmc --opt 0:
+                                  flags=[O0,pmt1024,rtcflags2,capstrip,capsandbox,capstrict]  diff exit 0
+```
+
+Byte-identical, at both sites, and flag-sensitive (the second list differs), so the
+capture is not vacuous. Cross-target labels also agree across the two sites
+(`--target linux/amd64` → `linux-x86_64-gnu-2.36` printed twice).
+
+**The cache property itself, with a value-revealing program.** `--opt 2` vs `--opt 0`
+on a deeply self-recursive `sum_to(2000000, 0)`: at `-O2` clang's tail-call
+optimization makes it complete; at `-O0` it overflows the stack. So a wrongly reused
+entry surfaces as a *wrong answer*, not merely a suspicious hit. Counting entries under
+`.march/cas/artifacts-v2/` (cleared first; `artifacts/` is the inert v1 pointer store):
+
+| step | command | entries | run result |
+|---|---|---|---|
+| 0 | `rm -rf .march/cas/artifacts-v2` | 0 | — |
+| 1 | `--opt 2` | 2 | prints `2000001000000`, exit 0 |
+| 2 | `--opt 0` | 4 (**distinct**) | exit 138 (stack overflow) |
+| 3 | `--opt 2` again | 4 (**reused**, `compiled … (cached)`) | prints `2000001000000`, exit 0 |
+
+`--trmc` (+2 → 6) and `--cap-sandbox` (+2 → 8) are likewise CAS-distinct. Two entries
+per key because both cache layers store the artifact.
+
+`cmp` of two freshly linked binaries was deliberately **not** used: on macOS they always
+differ by a random `LC_UUID`, which makes it vacuous.
+
+**Standard gates.** `dune build --root . bin/main.exe` exit 0.
+`scripts/ir-oracle.sh check` → **IR IDENTICAL across 240 programs** (emitted=240
+skipped=3) against a baseline recorded before the first edit — this is a driver
+refactor, so emitted code must not move, and it did not. `scripts/run-tests.sh` →
+3,161 tests, 11 suites, exit 0.
+
+## Scope note
+
+Phase 5 deliberately does **not** split `bin/main.ml`'s 2,510-line `compile` function:
+linear driver code is the friendliest shape to work in — no hidden coupling, read the
+window you need. Only the correctness hazard was addressed.

--- a/specs/todos/2026-08-19-compiler-file-decomposition.md
+++ b/specs/todos/2026-08-19-compiler-file-decomposition.md
@@ -9,7 +9,18 @@ Plan: `specs/plans/2026-08-19-compiler-file-decomposition.md`
 
 ## Status
 
-**Phases 0-3 landed. Phases 4-6 open.**
+**Phases 0-3 and 5 landed. Phases 4 and 6 open.**
+
+- **Phase 5 complete (2026-08-26)** — `bin/main.ml`'s CAS cache key is built in
+  exactly one place (`build_cas_key`), alongside `cas_target_label` and
+  `effective_opt`, which were duplicated the same way. The two flag lists were
+  **byte-identical**, so no live cache-collision bug existed — the hazard was
+  latent, waiting for the next codegen flag. Phase 5 deliberately does not split
+  `compile`. Verified by flag-list diff (the CAS key includes the compiler's own
+  digest, so cross-build key comparison is structurally meaningless), by a direct
+  distinct-vs-reused CAS test with a value-revealing program, and by the IR oracle
+  (IDENTICAL across 240 programs). Details:
+  `specs/progress/2026-08-26-cas-flags-single-constructor.md`.
 
 - **Phase 3 complete (2026-08-26)** — `lib/refinecheck/refine_check.ml` gains 23
   § section headers and a table of contents (comments only), `check_call` goes


### PR DESCRIPTION
Phase 5, Task 5.1 of `specs/plans/2026-08-19-compiler-file-decomposition.md`.
This phase guards a **correctness** hazard rather than a readability one, and it
deliberately does **not** split `bin/main.ml`'s 2,510-line `compile` — linear
driver code is the friendliest shape to work in.

## The hazard

`cas_flags` — the flag list that enters the content-addressed compile cache's key —
was constructed at **two** separate sites: the source-level early cache check inside
`compile` (keyed on the source digest, before parsing) and the post-TIR check (keyed
on the module's per-SCC impl hashes). A codegen flag added to one and not the other
makes two semantically *different* builds collide on one cache entry, and the cache
then serves the wrong binary. That is a silent wrong-answer bug, not a slow build —
and no standard test suite can see it.

## What the diff of the two sites found

- **The 18-line flag expressions were byte-identical.** No flag was present at one
  site and missing from the other, so **there was no live cache-collision bug** — the
  hazard was latent, waiting for the next codegen flag.
- The two `cross_sysroot_tag` blocks were semantically identical (only their comments
  differed in length). The plan expected this to be the one legitimate divergence, to
  be threaded through as an `~extra` parameter; in fact it is a pure function of the
  parsed target, so it moved *inside* the constructor instead. Strictly stronger — it
  cannot diverge at all now.
- The two `target_label` matches (also part of the key) were semantically identical.
- **Genuine, legitimate per-site differences, now parameters:** the hash input
  (`src_hash` vs `mod_hash`) and the target binding. Nothing else.
- `MARCH_DEBUG_CASFLAGS` existed at the post-TIR site only; it now lives in the
  constructor, so both layers log.

`effective_opt` was duplicated the same way and fed *both* the cache key and the two
clang invocations, so it is single-sourced too — the cached-under level and the
compiled-at level can no longer drift apart.

## Verification

**Flag-list identity.** The CAS key includes the compiler executable's own digest, so
any comparison spanning a compiler rebuild always shows different `ch` values — an
artifact-count comparison across builds is structurally incapable of validating this.
So the *flag list* was compared, via a print-only preparatory step that added the
existing `MARCH_DEBUG_CASFLAGS` eprintf to the early site:

```
default:                    flags=[O2,pmt1024,rtcflags2,capstrip,capstrict]                    diff exit 0
--cap-sandbox --no-trmc --opt 0:
                            flags=[O0,pmt1024,rtcflags2,capstrip,capsandbox,capstrict]         diff exit 0
```

Byte-identical before/after at both sites, and flag-sensitive, so the capture is not
vacuous. Cross-target labels agree across sites too (`--target linux/amd64` →
`linux-x86_64-gnu-2.36`, printed twice).

**The cache property itself, with a value-revealing program.** `--opt 2` vs `--opt 0`
on a deeply self-recursive `sum_to(2000000, 0)`: at `-O2` clang's tail-call
optimization makes it complete; at `-O0` it overflows the stack. A wrongly reused
entry therefore surfaces as a *wrong answer*, not merely a suspicious hit. Counting
entries under `.march/cas/artifacts-v2/`:

| step | command | entries | run result |
|---|---|---|---|
| 0 | `rm -rf .march/cas/artifacts-v2` | 0 | — |
| 1 | `--opt 2` | 2 | prints `2000001000000`, exit 0 |
| 2 | `--opt 0` | 4 (**distinct**) | exit 138, stack overflow |
| 3 | `--opt 2` again | 4 (**reused**, `compiled … (cached)`) | prints `2000001000000`, exit 0 |

`--trmc` (+2) and `--cap-sandbox` (+2) are likewise CAS-distinct. `cmp` of two freshly
linked binaries was deliberately not used — on macOS they always differ by a random
`LC_UUID`, which makes it vacuous.

**Standard gates.** `dune build --root . bin/main.exe` exit 0.
`scripts/ir-oracle.sh check` → **IR IDENTICAL across 240 programs** against a baseline
recorded before the first edit (this is a driver refactor; emitted code must not move,
and it did not). `scripts/run-tests.sh` → **3,161 tests / 11 suites / exit 0**,
matching the Phase 0 baseline exactly.

## Notes / out of scope

- The `--check` cache key deliberately uses `~target:"check" ~flags:[]`, since a
  typecheck verdict does not depend on codegen flags. Two attempts to construct a
  `--cap-strict` / `--no-cap-strict` verdict divergence that the flag-free key could
  wrongly serve both failed (both spellings rejected). Left unchanged.
- `Cas.Pipeline.compile_scc` also takes a `~flags` list, but has **zero callers** —
  it is not a live third site.
