### PR TITLE
docs(cas): explain why Pipeline.compile_scc is retained but unwired

### DIFF
--- a/lib/cas/pipeline.ml
+++ b/lib/cas/pipeline.ml
@@ -215,6 +215,23 @@ let hash_module (m : tir_module) : hashed_scc list =
     [~compile] is the actual compiler (mono → defun → llvm) injected by the
     caller. It receives the [hashed_scc] and returns an artifact path.
 
+    {b Retained, but deliberately not wired into the driver.}  As of
+    2026-08-26 the only callers are [test/test_cas.ml] and
+    [test/test_stdlib_suite.ml].  [bin/main.ml] caches at {i whole-module}
+    granularity instead: it calls [hash_module], folds every SCC hash into a
+    single source hash via [scc_impl_hash], and stores/serves one artifact —
+    the linked executable — under that key.
+
+    The blocker is not hashing.  [hash_module] above already makes
+    [impl_hash] a true Merkle root over both the call graph and type layout,
+    so a per-SCC key is sound (the cross-SCC stale-inline hazard described
+    against [compile_scc] in specs/hot-code-reload.md predates that fold and
+    is stale on this point).  The blocker is that codegen emits one LLVM
+    module and links one binary, so there is no per-SCC artifact to store or
+    serve.  Wiring this up requires separately-emitted per-SCC objects plus a
+    link step; this function is the tested reference implementation for that
+    day.
+
     On cache hit: returns the stored artifact path, [~compile] is NOT called.
     On cache miss: calls [~compile], stores the result, returns the path. *)
 let compile_scc

--- a/specs/features/content-addressed-system.md
+++ b/specs/features/content-addressed-system.md
@@ -110,7 +110,8 @@ Orchestrates CAS integration with the compilation pipeline. This is **Phase 6** 
   - **Cache-hit fast path:** Computes `compilation_hash` from impl_hash, target, and flags; looks up artifact
   - **Cache miss:** Calls injected `compile` function and stores result
   - Stores all definitions in the CAS before returning artifact path
-  - This is the key integration point: it wraps the actual compiler phases (mono → defun → llvm)
+  - **Not called by the driver** — see "Current Wiring Status" below. Its only callers are
+    `test/test_cas.ml` and `test/test_stdlib_suite.ml`.
 
 ### SCC Module: `lib/cas/scc.ml` (132 lines)
 
@@ -137,14 +138,33 @@ Strongly-Connected Component detection for function dependency graphs using Tarj
 
 ~~**In codegen:** No explicit CAS usage yet~~ → CAS is now active in the compilation pipeline.
 
-~~**In main:** No explicit CAS invocation~~ → The driver initializes the CAS store and routes compilation through `Pipeline.compile_scc`.
+~~**In main:** No explicit CAS invocation~~ → The driver initializes the CAS store and caches
+compiled binaries.
 
-The `Pipeline.compile_scc` function is now called from the driver with:
-1. ✅ CAS store instantiated at compilation startup
-2. ✅ Store passed to `compile_scc` along with target and flags
-3. ✅ `~compile` callback defined (the actual mono → defun → llvm phases)
+**Correction (2026-08-26): the driver caches at *whole-module* granularity, not per SCC.**
+An earlier revision of this document claimed compilation was routed through
+`Pipeline.compile_scc`; it never was. What `bin/main.ml` actually does:
 
-Cache-hit detection is active: unchanged definitions are served from the CAS without recompilation.
+1. ✅ CAS store instantiated at compilation startup (`Cas.create ~project_root`)
+2. ✅ `Pipeline.hash_module` computes the hashed SCCs, and `Pipeline.scc_impl_hash` folds
+   every SCC hash into one module-wide source hash
+3. ✅ That hash plus target and codegen flags goes through `Cas.compilation_hash`, and the
+   linked binary is stored/looked up as a single artifact
+
+`Pipeline.compile_scc` — the per-SCC cache-hit fast path — is **not called by the driver**.
+It is exercised only by `test/test_cas.ml` and `test/test_stdlib_suite.ml`, and it is
+retained deliberately rather than dead by accident.
+
+The blocker is *not* hash granularity. `hash_module` makes `impl_hash` a true Merkle root
+over the call graph and over type layout (commit `3e84c2c0`, "make impl_hash a Merkle root
+over the call graph"), so a per-SCC key is sound. The stale-cross-SCC-inline hazard raised
+against `compile_scc` in `specs/hot-code-reload.md` predates that fold and is stale on that
+point. The actual blocker is that codegen emits one LLVM module and links one binary, so
+there is no per-SCC artifact to store or serve; wiring `compile_scc` up requires
+separately-emitted per-SCC objects plus a link step. The doc comment on `compile_scc` in
+`lib/cas/pipeline.ml` records the same rationale at the definition site.
+
+Cache-hit detection is active: an unchanged module is served from the CAS without recompilation.
 
 ## Test Coverage
 


### PR DESCRIPTION
## What

`lib/cas/pipeline.ml`'s `compile_scc` has no production caller, so it reads as dead API. This documents why it is retained instead of removing it, and corrects a stale claim in the feature spec.

Comment and documentation only — no behavior change.

## Why not just delete it

**It isn't call-site-free.** `forge search --callers compile_scc` reports "no references found" (it indexes March, not OCaml), but grep across tests finds 12 call sites: `test/test_cas.ml` (6 alcotest cases) and `test/test_stdlib_suite.ml`. Deleting it means deleting a tested reference implementation.

**The recorded reason for it being unwired was stale.** `specs/hot-code-reload.md` warns that per-SCC keying is unsound: a caller's `impl_hash` doesn't move when an inlined callee's body changes, so a per-SCC hit could serve a caller with a stale inlined callee. That was true when written, but `3e84c2c0` ("make impl_hash a Merkle root over the call graph") made `hash_module` fold every already-resolved callee's `impl_hash` plus the transitive type-layout closure into each definition's hash. `git merge-base --is-ancestor` confirms the spec commit predates the fix, so the hashing objection no longer holds.

**The actual blocker is downstream.** Codegen emits one LLVM module and links one binary, so the driver has exactly one artifact to cache — `bin/main.ml` folds all SCC hashes into a single module hash and keys the executable off it. There is no per-SCC artifact for `compile_scc` to store or serve. Wiring it up requires separately-emitted per-SCC objects plus a link step.

## Changes

- `lib/cas/pipeline.ml` — doc comment on `compile_scc`: no production caller, what the driver does instead, why the hashing objection is stale, and what wiring it up actually requires.
- `specs/features/content-addressed-system.md` — the "Current Wiring Status" section claimed the driver "routes compilation through `Pipeline.compile_scc`". It never did. Corrected to describe whole-module keying, with the same rationale.

## Verification

- `dune build --root . bin/main.exe` — exit 0
- `scripts/check-docs.sh` — passes (checks A/B/C all ok)
- `scripts/run-tests.sh -q compiler` — 882 tests, exit 0 (covers `test_cas`)

## Left alone

The stale-cache warning in `specs/hot-code-reload.md` is itself now wrong. It's an HCR design doc rather than a current-truth doc, so this PR cross-references it as stale rather than rewriting it.