### PR TITLE
Add .mli interfaces to nine modules created by the decomposition project

### DIFF
--- a/lib/eval/eval_net.mli
+++ b/lib/eval/eval_net.mli
@@ -1,0 +1,120 @@
+(** The interpreter's networking, encoding and file-format runtime: the HTTP
+    server loop, WebSockets, base64, compression stubs, PBKDF2, and the CSV
+    reader.
+
+    [Eval_builtins] dispatches builtins straight to these and [Eval]
+    [include]s the module. Roughly half of what it used to export is
+    scaffolding for the two loops at the bottom of the file: the wire-level
+    read helpers ([http_recv_line], [http_recv_exactly], [ws_recv_exact]), the
+    request parsers ([parse_header_line], [http_find_header_end],
+    [http_parse_request_head], [http_try_parse_request]), the connection state
+    machine ([http_conn_state], [http_conn_new]), the value constructors
+    ([march_string_list], [http_method_of_string], [split_path_info],
+    [build_conn_value], [extract_conn_response], [march_headers_to_string],
+    [http_reason_phrase]), the CSV reader's own table and scanner, the base64
+    alphabet and [ws_accept_key]. None of those had a caller outside this
+    file; all are now private, as is the [Ws_block] effect, which is performed
+    and handled entirely within [run_http_event_loop]'s fiber. *)
+
+open Eval_types
+
+(** {1 HTTP server}
+
+    [run_http_event_loop listen_fd handler] is the entry point: it accepts on
+    [listen_fd] and drives every connection through non-blocking parse,
+    [http_run_pipeline_and_respond], and (for an upgrade) the WebSocket fiber.
+    [handle_http_connection] is the older blocking one-connection-at-a-time
+    path. *)
+
+val run_http_event_loop : Unix.file_descr -> value -> unit
+val handle_http_connection : Unix.file_descr -> value -> unit
+
+type http_outcome =
+  | HttpRespond of string
+  | HttpWsUpgrade of value
+  | HttpDrop
+
+(** [http_run_pipeline_and_respond sock handler meth path headers body] runs
+    the March-side handler pipeline for one already-parsed request. *)
+val http_run_pipeline_and_respond :
+  Unix.file_descr ->
+  value ->
+  string ->
+  string ->
+  (string * string) list ->
+  string ->
+  http_outcome
+
+(** {1 WebSockets}
+
+    Frames are read and written on the raw fd. [ws_wait_ready] parks the
+    calling fiber until the fd is ready in [dir] — it must be called from
+    inside [run_http_event_loop]'s handler, which is what resumes it. *)
+
+type ws_wait_dir = Ws_wait_read | Ws_wait_write
+
+val ws_wait_ready : Unix.file_descr -> ws_wait_dir -> unit
+val ws_recv_frame : Unix.file_descr -> value
+val ws_send_frame : Unix.file_descr -> value -> unit
+
+(** {1 Sockets} *)
+
+(** [tcp_send_all fd s] loops until every byte of [s] is written. *)
+val tcp_send_all : Unix.file_descr -> string -> unit
+
+(** {1 Bytes and values} *)
+
+val march_bytes_of_string : string -> value
+val march_val_to_raw : value -> (string, string) result
+
+(** {1 Encodings} *)
+
+val base64_encode : string -> string
+val base64_decode : string -> (string, string) result
+
+val pbkdf2_hmac_sha256 :
+  password:string -> salt:string -> iterations:int -> dklen:int -> string
+
+(** {1 Compression stubs}
+
+    Implemented in [compress_stubs.c]; each raises on a malformed or
+    unsupported input, which the builtin wrapper turns into an [Err]. *)
+
+external caml_march_gzip_encode : string -> int -> string
+  = "caml_march_gzip_encode"
+
+external caml_march_gzip_decode : string -> string = "caml_march_gzip_decode"
+
+external caml_march_deflate_encode : string -> string
+  = "caml_march_deflate_encode"
+
+external caml_march_deflate_decode : string -> string
+  = "caml_march_deflate_decode"
+
+external caml_march_zstd_encode : string -> int -> string
+  = "caml_march_zstd_encode"
+
+external caml_march_zstd_decode : string -> string = "caml_march_zstd_decode"
+
+external caml_march_brotli_encode : string -> int -> int -> string
+  = "caml_march_brotli_encode"
+
+external caml_march_brotli_decode : string -> string
+  = "caml_march_brotli_decode"
+
+(** {1 File errors}
+
+    Both turn a host error into the March [FileError] value, tagged with the
+    operation name passed as the first argument. *)
+
+val file_error_of_unix : string -> Unix.error -> value
+val file_error_of_sys : string -> string -> value
+
+(** {1 CSV reader}
+
+    Handle-based: [csv_open_impl] returns an integer handle into a table
+    private to this module, and the other two take it back. *)
+
+val csv_open_impl : value list -> value
+val csv_next_row_impl : value list -> value
+val csv_close_impl : value list -> value

--- a/lib/eval/eval_runtime.mli
+++ b/lib/eval/eval_runtime.mli
@@ -1,0 +1,210 @@
+(** Interpreter runtime state and value-rendering helpers shared by the
+    evaluator, the builtin table, and the protocol runtimes.
+
+    This module holds the interpreter's mutable world: the vault (ETS-like)
+    tables, the actor and supervisor registries, the logger, the process and
+    monitor id counters. [Eval] [include]s it and [Eval_builtins],
+    [Eval_net] and [Eval_prim] [open] it, so nearly all of it is genuinely
+    shared — 72 of the 82 values it used to export have a caller elsewhere.
+
+    What is now private is the supervision machinery's internals: the three
+    restart strategies ([one_for_one_restart], [one_for_all_restart],
+    [rest_for_one_restart]), the two supervisor notifications
+    ([notify_supervisor], [notify_dyn_supervisor]), the [monitor_down_*]
+    message constructors, [fresh_monitor_id], [capture_reg_names_pending] and
+    [march_hash_mask]. Those run *inside* a crash cascade and read state that is
+    half-torn-down while they do; the supported entry points are
+    [crash_actor] / [crash_actor_with_reason], which drive them in the right
+    order. *)
+
+open Eval_types
+
+(** {1 Vault — sharded in-memory key-value tables} *)
+
+val vault_num_stripes : int
+
+type vault_row = { vr_value : value; vr_expiry : float option }
+type vault_shard = { vs_data : (string, vault_row) Hashtbl.t; vs_mutex : Mutex.t }
+
+type vault_table = {
+  vt_id : int;
+  vt_name : string;
+  vt_shards : vault_shard array;
+}
+
+val vault_make_table : int -> string -> vault_table
+val vault_registry : (int, vault_table) Hashtbl.t
+val vault_name_registry : (string, int) Hashtbl.t
+val vault_next_id : int ref
+val vault_row_live : vault_row -> bool
+val vault_decode_key : string -> value
+val vault_key_of_value : value -> string
+val vault_lookup : int -> vault_table
+val vault_shard_for : string -> vault_shard array -> vault_shard
+
+(** {1 Value rendering} *)
+
+val is_list_value : value -> bool
+val list_elems : value list -> value -> value list
+val display_tag : string -> string
+val value_to_string : value -> string
+val value_display : value -> string
+val show_dispatch : value -> string
+val type_name_of_value : value -> string option
+val type_tag_of : value -> string option
+
+(** {1 Actors, supervision and monitors} *)
+
+type monitor_down_reason = Normal | Killed | Crash of string
+
+type actor_inst = {
+  ai_name : string;
+  ai_def : March_ast.Ast.actor_def;
+  ai_env_ref : env ref;
+  mutable ai_state : value;
+  mutable ai_alive : bool;
+  mutable ai_terminal_reason : monitor_down_reason;
+  mutable ai_monitors : (int * int) list;
+  mutable ai_mailbox : value Queue.t;
+  mutable ai_supervisor : int option;
+  mutable ai_restart_count : (float * int) list;
+  mutable ai_epoch : int;
+  mutable ai_resources : (string * (unit -> unit)) list;
+  mutable ai_linear_values : (value * value) list;
+  mutable ai_mbox_limit : int;
+  mutable ai_mbox_policy : int;
+}
+
+val actor_defs_tbl : (string, March_ast.Ast.actor_def * env ref) Hashtbl.t
+val actor_registry : (int, actor_inst) Hashtbl.t
+val pending_timers : timer_entry list ref
+val named_registry : (string, int) Hashtbl.t
+val reg_names_pending : (int, string list) Hashtbl.t
+
+type dyn_child_entry = {
+  dce_pid : int;
+  dce_actor_name : string;
+  dce_restart : string;
+}
+
+type dyn_sup_state = {
+  ds_name : string;
+  ds_strategy : string;
+  ds_max_restarts : int;
+  ds_window_secs : int;
+  ds_vpid : int;
+  mutable ds_children : dyn_child_entry list;
+  mutable ds_restart_count : (float * int) list;
+}
+
+val dyn_sup_registry : (string, dyn_sup_state) Hashtbl.t
+val dyn_sup_vpid_map : (int, string) Hashtbl.t
+
+val spawn_child_actor : ?crashed_pid:int option -> string -> int -> int
+
+(** [crash_actor pid reason] tears the actor down and runs whatever
+    supervision applies — restart strategy, monitor DOWN messages, resource
+    release — in the order the OTP semantics require. Prefer these over the
+    private helpers behind them. *)
+val crash_actor : int -> string -> unit
+
+val crash_actor_with_reason : int -> string -> monitor_down_reason -> unit
+val mailbox_enqueue : actor_inst -> value -> unit
+val dropped_messages_count : int ref
+val monitor_actor : watcher_pid:int -> target_pid:int -> int
+val demonitor_actor : int -> unit
+val register_resource_ocaml : int -> string -> (unit -> unit) -> unit
+
+(** {1 Processes, pids and calls} *)
+
+val next_pid : int ref
+val next_monitor_id : int ref
+val current_pid : int option ref
+val process_registry : (string, int) Hashtbl.t
+val pid_to_registry_name : (int, string) Hashtbl.t
+val revocation_table : (int * int, unit) Hashtbl.t
+val pending_replies : (int, value) Hashtbl.t
+val next_call_ref : int ref
+val process_start_time : float
+val uname_info : (string * string) option Lazy.t
+val live_proc_tbl : (int, in_channel * out_channel * int) Hashtbl.t
+val live_proc_next_id : int ref
+
+(** {1 Declaration tables populated at load time} *)
+
+val impl_tbl : (string * string, value) Hashtbl.t
+val ctor_type_tbl : (string, string) Hashtbl.t
+val record_type_tbl : (string, string) Hashtbl.t
+val ffi_type_decl_tbl : (string, March_ast.Ast.type_def) Hashtbl.t
+val protocol_roles_tbl : (string, string list) Hashtbl.t
+
+(** {1 Message tap} *)
+
+val tap_mutex : Mutex.t
+val tap_queue : value Queue.t
+val tap_push : value -> unit
+
+(** {1 Logger} *)
+
+type log_value =
+  | LogStr of string
+  | LogInt of int
+  | LogFloat of float
+  | LogBool of bool
+  | LogAtom of string
+  | LogNull
+
+val logger_level : int ref
+val logger_fields : (string * log_value) list ref
+val logger_appenders : (string * value) list ref
+val logger_module_levels : (string, int) Hashtbl.t
+val log_value_to_string : log_value -> string
+
+(** {1 Captured output}
+
+    When [test_capture_buf] holds a buffer, [capture_write] and friends append
+    to it instead of writing to the real fd. This is how the test harness and
+    the browser build intercept [print]. *)
+
+val test_capture_buf : Buffer.t option ref
+val capture_write : string -> unit
+val capture_writeln : string -> unit
+val capture_ewriteln : string -> unit
+
+(** {1 Ring buffers} *)
+
+val ring_create : int -> 'a ring
+val ring_push : 'a ring -> 'a -> unit
+val ring_get : 'a ring -> int -> 'a option
+val ring_pop_oldest : 'a ring -> 'a option
+
+(** {1 Interpreter control-flow exceptions} *)
+
+exception Match_failure of string
+exception Assert_failure of string
+exception BlockedOnReceive
+
+(** {1 Arithmetic and comparison dispatch}
+
+    Each takes the per-type operation and the builtin's name (for the error
+    message) and returns the builtin's [value]. *)
+
+val arith_num :
+  (int -> int -> int) -> (float -> float -> float) -> string -> value
+
+val cmp_op :
+  (int -> int -> bool) ->
+  (float -> float -> bool) ->
+  (string -> string -> bool) ->
+  (bool -> bool -> bool) ->
+  string ->
+  value
+
+(** {1 Hashing and sockets} *)
+
+val march_hash_int64 : int64 -> int64
+val march_hash_string64 : string -> int64
+val recv_timeout_msg : string
+
+val tcp_wait_readable :
+  Unix.file_descr -> float option -> [ `Error of string | `Ready | `Timeout ]

--- a/lib/eval/eval_session.mli
+++ b/lib/eval/eval_session.mli
@@ -1,0 +1,27 @@
+(** Session-typed channel runtime and multi-party (MPST) runtime, as the
+    tree-walking interpreter implements them.
+
+    [Eval_builtins] dispatches the [chan_*] / [mpst_*] builtins straight to
+    these, and [Eval] [include]s the module so they are also reachable as
+    [Eval.chan_send] and friends. The endpoint-id counter behind [chan_new] is
+    the one value here nothing outside this file touches, and is now private —
+    a caller that bumped it would hand out a duplicate id. *)
+
+open Eval_types
+
+(** [chan_new proto role_a role_b] allocates a fresh pair of endpoints for the
+    two-party protocol [proto]. *)
+val chan_new : string -> string -> string -> chan_endpoint * chan_endpoint
+
+val chan_send : chan_endpoint -> value -> value
+val chan_recv : chan_endpoint -> value
+val chan_close : chan_endpoint -> value
+
+(** [mpst_new proto roles] returns one endpoint value per role, in [roles]
+    order. The [string] argument to [mpst_send] / [mpst_recv] is the peer
+    role. *)
+val mpst_new : string -> string list -> value list
+
+val mpst_send : mpst_endpoint -> string -> value -> value
+val mpst_recv : mpst_endpoint -> string -> value
+val mpst_close : mpst_endpoint -> value

--- a/lib/eval/eval_simd.mli
+++ b/lib/eval/eval_simd.mli
@@ -1,0 +1,63 @@
+(** Simd 128-bit vector ops and NativeArray narrow-width (f32/i32/u8) helpers.
+
+    Unusually for this pass, nothing here turned out to be internal: all 29
+    values have a caller in [Eval_builtins], and a handful of them
+    ([fma32_single_round], [simd_f32_is_highbit], [simd_u8_is_highbit],
+    [simd_hfold], [simd_bounds_check]) are read by [Llvm_emit_simd] as well, so
+    that the compiled and interpreted backends round and wrap identically. This
+    interface therefore restricts nothing — it exists so that the next value
+    added here is added on purpose.
+
+    Boundary rule for the narrow-width helpers: integer stores wrap mod 2^w
+    two's-complement, float stores round to nearest-even binary32, and neither
+    ever traps. *)
+
+(** {1 NativeArray narrow-width helpers} *)
+
+val f32_round : float -> float
+val fma32_single_round : float -> float -> float -> float
+val i32_wrap : int -> int
+val u8_wrap : int -> int
+
+(** {1 Simd lane primitives}
+
+    The bitwise [simd_f{32,64}_*] family reinterprets the float as its bit
+    pattern, so [simd_f32_allones] is the all-ones mask, not a numeric value. *)
+
+val simd_minnum_f : float -> float -> float
+val simd_maxnum_f : float -> float -> float
+val simd_f32_allones : float
+val simd_f32_zero : float
+val simd_f64_allones : float
+val simd_f64_zero : float
+val simd_f32_is_highbit : float -> bool
+val simd_f64_is_highbit : float -> bool
+val simd_f32_and : float -> float -> float
+val simd_f32_or : float -> float -> float
+val simd_f32_xor : float -> float -> float
+val simd_f32_not : float -> float
+val simd_f64_and : float -> float -> float
+val simd_f64_or : float -> float -> float
+val simd_f64_xor : float -> float -> float
+val simd_f64_not : float -> float
+val simd_i32_is_highbit : int -> bool
+val simd_i64_is_highbit : int64 -> bool
+val simd_u8_is_highbit : int -> bool
+
+(** {1 Whole-vector operations} *)
+
+(** [simd_first_set p v] is the index of the first lane satisfying [p], or -1. *)
+val simd_first_set : ('a -> bool) -> 'a array -> int
+
+val simd_any : ('a -> bool) -> 'a array -> bool
+val simd_all : ('a -> bool) -> 'a array -> bool
+
+(** [simd_select p mask a b] takes lane [i] from [a] when [p mask.(i)], else
+    from [b]. *)
+val simd_select : ('a -> bool) -> 'a array -> 'a array -> 'a array -> 'a array
+
+val simd_hfold : ('a -> 'a -> 'a) -> 'a array -> 'a
+
+(** [simd_bounds_check who idx width len] panics if the access is out of
+    range; [who] names the builtin in the message. *)
+val simd_bounds_check : string -> int -> int -> int -> unit

--- a/lib/typecheck/typecheck_builtins.mli
+++ b/lib/typecheck/typecheck_builtins.mli
@@ -1,0 +1,59 @@
+(** The built-in world: the type constants, the capability tables, and the
+    base environment every March module starts from.
+
+    [include]d into [Typecheck] and [open]ed by [Typecheck_caps], so what stays
+    here is what one of those two actually reads (plus what [typecheck.mli]
+    re-exports). Thirteen of the thirty-nine values the band used to export are
+    private to this file: the type constructors nothing outside builds
+    ([t_list], [t_option], [t_pid], [t_vault] and the four dead [_t_*]
+    duplicates), the interface-table constructors ([mk_builtin_iface],
+    [mk_iface_method_scheme], [builtin_interfaces], [builtin_impls]) which
+    exist only to feed [builtin_interface_bindings], and the [builtin_types] /
+    [builtin_ctors] tables which exist only to feed [base_env]. *)
+
+open Typecheck_types
+open Typecheck_env
+
+(** {1 Type constants} *)
+
+val t_int : ty
+val t_float : ty
+val t_bool : ty
+val t_string : ty
+val t_unit : ty
+val t_atom : ty
+val t_result : ty -> ty -> ty
+
+(** {1 Stdlib provenance}
+
+    [stdlib_source_files] is set by the driver before checking; [span_is_stdlib]
+    is the predicate the diagnostic filter reads off it. Mutating the ref after
+    a check has started will not retroactively reclassify spans. *)
+
+val stdlib_source_files : string list ref
+val span_is_stdlib : Ast.span -> bool
+
+(** {1 Capabilities} *)
+
+val cap_strict_ceiling : bool ref
+val builtin_cap_table : (string * string) list
+
+(** [cap_subsumes broad narrow] — whether a grant of [broad] covers [narrow]. *)
+val cap_subsumes : string -> string -> bool
+
+val cap_path_of_names : Ast.name list -> string
+val cap_paths_in_surface_ty : Ast.ty -> string list
+val local_module_paths : env -> string list
+val same_package_namespace : string -> string -> bool
+
+(** {1 Builtin bindings and the base environment} *)
+
+val locally_declared_names_of : Ast.decl list -> (string, unit) Hashtbl.t
+val builtin_interface_bindings : (string * scheme) list
+val builtin_bindings : (string * scheme) list
+val prelude_collision_builtin_names : string list
+val prelude_collision_iface_arities : (string * int) list
+val noncallable_builtin_values : StringSet.t
+
+(** [base_env ctx span_tys] is the environment a fresh module starts from. *)
+val base_env : Err.ctx -> (Ast.span, ty) Hashtbl.t -> env

--- a/lib/typecheck/typecheck_caps.mli
+++ b/lib/typecheck/typecheck_caps.mli
@@ -1,0 +1,45 @@
+(** The capability checker: what a module declares it [needs], and whether the
+    code inside it stays within that grant.
+
+    This module is [include]d into [Typecheck] at the position its band used to
+    occupy, so everything below is re-exported there — but [typecheck.mli] is
+    the wall that decides what actually leaves the library. Four of the
+    fifteen values the band used to export ([cap_annots_in_expr],
+    [path_arg_builtins], [literal_path_uses], [cap_in_solved_ty]) are reached
+    from nowhere outside this file and are now private to it.
+
+    [check_module_needs] is the entry point: given a module's [needs]
+    declaration it walks the module's decls and reports every use that escapes
+    the grant. The [check_*_sites] trio are narrower single-purpose passes over
+    the same environment, and the [fn_*_capability_closures] accessors expose
+    the per-function capability sets the walk computes — the LSP and the
+    capability-audit tooling read those. *)
+
+open Typecheck_types
+open Typecheck_env
+
+val is_migrate_fn_name : string -> bool
+
+val check_module_needs :
+  env -> Ast.name -> cap_qname_prefix:string -> Ast.decl list -> unit
+
+(** Single-purpose capability passes, each run once per [check_module]. *)
+
+val check_cap_narrow_sites : env -> unit
+val check_json_cap_sites : env -> unit
+val check_mint_cap_sites : env -> unit
+
+(** Per-function capability sets, as computed by the walk above. [own] is what
+    a function's own body demands; the [transitive] pair adds everything its
+    callees demand. The [_tbl] forms are the underlying hashtables. *)
+
+val fn_capability_rows_tbl :
+  ?with_rows:bool -> env -> (string, March_caps.Cap_rows.row) Hashtbl.t
+
+val fn_transitive_capability_closures_tbl :
+  env -> (string, string list) Hashtbl.t
+
+val fn_capability_closures : env -> (string * string list) list
+val fn_own_capability_closures : env -> (string * string list) list
+val fn_transitive_capability_closures : env -> (string * string list) list
+val declared_cap_scopes : env -> (string * string option) list

--- a/lib/typecheck/typecheck_tailcall.mli
+++ b/lib/typecheck/typecheck_tailcall.mli
@@ -1,0 +1,25 @@
+(** Tail-call enforcement — March's guarantee that a self- or mutually
+    recursive function in tail position does not grow the stack.
+
+    A pure AST pass: it references nothing in the inference knot, not even
+    [env], [ty] or [scheme], and shares only the error sink. [Typecheck]
+    [include]s it and calls [enforce_tail_calls_in_decls] once per module.
+
+    That single entry point is the whole contract. The call-graph machinery
+    behind it — [collect_pattern_vars], [collect_direct_fn_calls], [find_sccs],
+    [is_infix_op], [is_structurally_smaller], [scrutinee_is_param_or_smaller]
+    and the recursive [check_tail_position] walk — has no caller outside this
+    file and is now private, as is the [Aliases] module the structure uses to
+    keep [Ast]/[Err]/[StringSet] from colliding with [Typecheck]'s own on
+    [include]. *)
+
+(** [enforce_tail_calls_in_decls ~file_mod ctx decls] reports, into [ctx],
+    every recursive call that a [tailrec]-annotated function makes outside
+    tail position. [mod_path] qualifies names in the message when the decls
+    came from a nested module. *)
+val enforce_tail_calls_in_decls :
+  ?mod_path:string ->
+  file_mod:string ->
+  March_errors.Errors.ctx ->
+  March_ast.Ast.decl list ->
+  unit

--- a/lsp/lib/code_actions_ast.mli
+++ b/lsp/lib/code_actions_ast.mli
@@ -1,0 +1,19 @@
+(** The AST-driven code-action engine: the refactorings that need to look at
+    the parsed program rather than at a diagnostic — extract function, inline,
+    introduce pipe, convert lambda, and the rest.
+
+    Unlike most modules in this pass, its surface needed no curating: 1,097
+    lines of source export exactly one value, and everything else was already
+    local to [ast_code_actions] or lives in [Analysis_util]. This interface
+    records that rather than narrowing it.
+
+    [Code_actions_diag] [open]s this module and splices the result of
+    [ast_code_actions] in at its original position in the concatenation, so
+    the two engines together produce the same ordered list [Analysis] always
+    returned. *)
+
+val ast_code_actions :
+  Analysis_util.t ->
+  line:int ->
+  character:int ->
+  Analysis_util.Lsp.Types.CodeAction.t list

--- a/lsp/lib/code_actions_diag.mli
+++ b/lsp/lib/code_actions_diag.mli
@@ -1,0 +1,21 @@
+(** Cursor- and diagnostic-driven code actions: quick fixes attached to a
+    diagnostic (exhaustiveness, unused binding/import, naming, De Morgan, the
+    fix registry, HTML close, refinement) plus the cursor-position
+    refactorings that do not need the raw AST.
+
+    As with [Code_actions_ast], the surface needed no curating — 1,019 lines
+    export one value. [Analysis] re-exports it with
+    [include Code_actions_diag], so [Analysis.code_actions_at] is what callers
+    actually use. *)
+
+(** [code_actions_at a ~line ~character ?diagnostics ()] returns every action
+    offered at that cursor position, AST-driven and diagnostic-driven
+    together, in the order the client should display them. The trailing [unit]
+    is what closes the optional [?diagnostics]. *)
+val code_actions_at :
+  Analysis_util.t ->
+  line:int ->
+  character:int ->
+  ?diagnostics:Analysis_util.Lsp.Types.Diagnostic.t list ->
+  unit ->
+  Analysis_util.Lsp.Types.CodeAction.t list


### PR DESCRIPTION
Nine of the modules the decomposition project extracted shipped without interfaces. This adds them — no `.ml` file changed, no call site adjusted.

| Module | Inferred → curated | Internal |
|---|---|---:|
| `typecheck_tailcall` | 8 → 1 | **88%** |
| `eval_net` | 37 → 17 | 54% |
| `typecheck_builtins` | 39 → 26 | 33% |
| `typecheck_caps` | 15 → 11 | 27% |
| `eval_runtime` | 82 → 72 | 12% (supervision internals now private) |
| `eval_session` | 9 → 8 | 11% |
| `eval_simd` | 29 → 29 | 0% |
| `code_actions_ast` | 1 → 1 | 0% |
| `code_actions_diag` | 1 → 1 | 0% |

The **zeros are the interesting rows**, and they are correct rather than lazy: these modules were extracted as coherent units rather than carved out of a monolith, so they never accumulated accidental surface. `code_actions_ast`/`diag` being a single value each is Phase 4 having done its job precisely. Contrast `typecheck_tailcall` at 88%, which behaves like the pre-existing files did (73–91% in #354, 91% for `refine_check`).

## Honest status on validation

Each module was built and `@check`ed as it landed. The **final full-suite and IR-oracle runs did not complete**: this machine went to a load average of ~300 (with, notably, *zero* compiler processes running — `cfprefsd` and `opendirectoryd` thrashing, not our workload), and the agent doing the work was killed twice by a stall watchdog mid-command.

So **CI is the validator here, not a local green.** Expectations, stated so a reviewer can check them rather than trust them:
- `@check` must show no new errors beyond the 17 pre-existing `forge/test/` + `js/` ones from a missing optional opam dependency.
- The IR oracle must be **identical across 240 programs** — an `.mli` changes visibility, never emitted code. Any movement is a real finding.
- Full suite baseline is 3,161 tests / 11 suites.

If CI disagrees with any of that, the offending commit should be dropped rather than patched — each module is its own commit for exactly this reason.

## Not done

`typecheck_env`, `typecheck_types`, `analysis_util`, `analysis_types`, and the older `lib/tir` group (`perceus`, `llvm_builtins`, `mono`, `llvm_toplevel`). Left for a follow-up.