### PR TITLE
Add .mli interfaces to the remaining interface-less compiler and LSP modules

### DIFF
--- a/lib/tir/llvm_builtins.mli
+++ b/lib/tir/llvm_builtins.mli
@@ -1,0 +1,79 @@
+(** The builtin table, the LLVM preamble, and the extern-name mangling.
+
+    Interface for {!Llvm_builtins}, added 2026-08-27 by the pass that gave the
+    highest-churn compiler files one (see
+    [specs/progress/2026-08-25-mli-interfaces-top-churn-files.md]).
+
+    34 values were exported before this file existed; 22 still are.
+    [Llvm_builtins] is not [include]d by anything, so hiding here is local and
+    checkable.
+
+    {2 What is hidden}
+
+    Twelve values, all of them the private half of a public accessor.  The
+    pattern repeats: a [Hashtbl] built once at module init, plus the function
+    that reads it.  Only the function is anyone's business.
+
+    - [is_builtin_fn_tbl], [builtin_ret_ty_tbl], [builtin_declare_sig_tbl],
+      [mangle_extern_tbl] and [called_syms] — backing tables for
+      [is_builtin_fn], [builtin_ret_ty], [mangle_extern],
+      [reset_called_syms] and [called_c_symbols], which all stay;
+    - [runtime_only_declares], [declare_text], [render_item], [render_items],
+      [core_items], [native_actor_items] and [wasm_scheduler_stub_items] —
+      the preamble construction kit behind {!emit_preamble}.
+
+    [native_net_io_items] is the one [preamble_item] list that does escape
+    ([llvm_emit_simd.ml] reads it), which is why the [preamble_item] type
+    itself stays manifest rather than going private with its siblings.
+
+    {2 [reserved_ctor_tag_limit] is declared but is not API}
+
+    It has no reference anywhere — not in this file, not outside it.  It is
+    declared here only because hiding a value nothing mentions turns it into
+    an unused-value error under warnings-as-errors.  Deleting the [let] and
+    this [val] together is the right follow-up; #368 left the same note
+    against three re-exports in [lower.ml] and thirty-three in [llvm_emit.ml].
+
+    {2 What stays}
+
+    [builtins] has 53 referencing files and [mangle_extern] 13; the tag
+    constants are read by [llvm_toplevel.ml] and are a silent-miscompile
+    hazard if they drift, so the whole family is kept together.
+    [emit_preamble] is pinned by a byte-identical golden in
+    [test/test_codegen.ml]. *)
+
+type builtin = {
+  march_name : string;
+  c_name : string option;
+  ret_ty : Tir.ty option;
+  in_is_builtin : bool;
+  declare_sig : string option;
+}
+val ordinary_ctor_tag_limit : int
+val actor_message_tag_base : int
+val actor_message_tag_limit : int
+val collision_tag_base : int
+val collision_tag_limit : int
+val monitor_down_tag : int
+val monitor_reason_normal_tag : int
+val monitor_reason_killed_tag : int
+val monitor_reason_crash_tag : int
+val reserved_ctor_tag_limit : int
+val builtins : builtin list
+type preamble_item =
+    PComment of string
+  | PDeclare of string
+  | POther of string
+  | PBlank
+val native_net_io_items : preamble_item list
+val emit_preamble :
+  is_wasm:bool -> triple:string -> ?repl:bool -> Buffer.t -> unit
+val is_builtin_fn : string -> bool
+val builtin_ret_ty : string -> Tir.ty option
+val builtin_boxed_generic_params_tbl : (string, int list) Hashtbl.t
+val builtin_param_is_boxed_generic : string -> int -> bool
+val builtin_param_llvm_tys : string -> string list option
+val reset_called_syms : unit -> unit
+val called_c_symbols : unit -> string list
+val mangle_extern : string -> string
+val c_symbol_of_march_name : string -> string

--- a/lib/tir/llvm_toplevel.mli
+++ b/lib/tir/llvm_toplevel.mli
@@ -1,0 +1,81 @@
+(** Top-level LLVM emission: target configuration, function emission, the
+    constructor-tag table, and the module driver.
+
+    Interface for {!Llvm_toplevel}, added 2026-08-27 by the pass that gave the
+    highest-churn compiler files one (see
+    [specs/progress/2026-08-25-mli-interfaces-top-churn-files.md]).
+
+    21 values were exported before this file existed; 18 still are.
+    [Llvm_toplevel] is not [include]d by anything, so hiding here is local and
+    checkable.
+
+    {2 What is hidden}
+
+    Three values, each with an internal caller and no external one:
+    [buffer_contains] (an idempotence guard used before appending to the
+    preamble), [native_triple] (the lazy host-triple probe behind
+    {!target_triple}), and [native_vec_param_idxs] (a vector-ABI helper used
+    by {!emit_fn}).
+
+    {2 Two values are declared here but are dead code}
+
+    [target_arch] and [emit_main_wrapper] have no reference anywhere — not in
+    this file, not in any other, not in the tests.  A grep of
+    [bin/ lib/ lsp/ test/] finds only their own [let] lines.  They are declared
+    only because hiding a value nothing mentions turns it into an unused-value
+    error under warnings-as-errors, and this pass does not edit [.ml] files.
+
+    [emit_main_wrapper] is the interesting one: it is a real function body at
+    [llvm_toplevel.ml:725], not a one-line re-export, and the compiler has
+    evidently been emitting its main wrapper by some other path.  Deleting it,
+    or finding out why it was orphaned, is a worthwhile follow-up — compare
+    [specs/progress/] on [march_println]'s [writev] path, which was dead for
+    thirteen months behind a live-looking declaration.
+
+    {2 What stays}
+
+    [emit_module] has 17 referencing files and [build_ctor_info] 15; the
+    [target_*] family is read by [bin/main.ml] and pinned in
+    [llvm_emit.mli]. *)
+
+type arch = X86_64 | Arm64
+type target_config =
+    Native
+  | LinuxGnu of { arch : arch; glibc_min : string; }
+  | Wasm64Wasi
+  | Wasm32Wasi
+  | Wasm32Unknown
+  | Js
+val is_wasm_target : target_config -> bool
+val is_wasm32 : target_config -> bool
+external get_native_triple : unit -> string = "march_tir_native_triple"
+val target_triple : target_config -> string
+val target_arch : target_config -> arch option
+val target_is_linux : target_config -> bool
+val zig_target : target_config -> string option
+val target_ptr_size : target_config -> int
+val target_ptr_ty : target_config -> string
+val target_int_ty : target_config -> string
+val emit_preamble : ?target:target_config -> ?repl:bool -> Buffer.t -> unit
+val is_leaf_callee : string -> bool
+val expr_has_call : Tir.expr -> bool
+val emit_fn :
+  emit_expr:(Llvm_ctx.ctx -> Tir.expr -> string * string) ->
+  Llvm_ctx.ctx -> Tir.fn_def -> unit
+val fn_declare_str : Tir.fn_def -> string
+val emit_atom_show_table : Llvm_ctx.ctx -> unit
+val build_ctor_info :
+  Llvm_ctx.ctx -> Tir.tir_module -> unit
+val emit_main_wrapper : Buffer.t -> unit
+val emit_module :
+  emit_expr:(Llvm_ctx.ctx -> Tir.expr -> string * string) ->
+  ?fast_math:bool ->
+  ?pmap_threshold:int ->
+  ?target:target_config ->
+  ?hot_reload:Hot_reload.config option ->
+  ?impl_hashes:(string, string) Hashtbl.t ->
+  ?remote_impl_hashes:(string, string) Hashtbl.t ->
+  ?remote_sig_hashes:(string, string) Hashtbl.t ->
+  ?emit_main:bool ->
+  ?cap_attrib:(String.t * string) list ->
+  ?cap_decls:(string * string) list -> Tir.tir_module -> string

--- a/lib/tir/mono.mli
+++ b/lib/tir/mono.mli
@@ -1,0 +1,105 @@
+(** Monomorphization of the typed IR: specialize generic functions per
+    instantiated type, and mangle the specialized names.
+
+    Interface for {!Mono}, added 2026-08-27 by the pass that gave the
+    highest-churn compiler files one (see
+    [specs/progress/2026-08-25-mli-interfaces-top-churn-files.md]).
+
+    21 values were exported before this file existed; 14 still are.  [Mono] is
+    not [include]d by anything, so hiding here is local and checkable.
+
+    {2 What is hidden}
+
+    Seven values, none referenced outside this file:
+
+    - [build_subst], [default_residual_in_subst], [retype_known_vars],
+      [find_first_call] and [ensure_atom_fns] — worklist machinery internal to
+      {!monomorphize};
+    - [subst_branch] and [subst_fn_def] — two members of the [subst_*]
+      recursion with no external caller.  Their siblings [subst_ty],
+      [subst_var], [subst_atom] and [subst_expr] all have one ([inline.ml],
+      [cprop.ml], [repl_jit.ml]) and stay exported.
+
+    [ensure_atom_fns] is worth calling out: its inferred type is
+    [(string, 'a) Hashtbl.t -> (string, 'b) Hashtbl.t -> (string * 'a * 'c list)
+    Queue.t -> ...], three unconstrained variables over the caller's private
+    worklist tables.  That is not a signature anyone should be writing against,
+    and hiding it removes the question rather than answering it.
+
+    {2 What stays}
+
+    [monomorphize] has 14 referencing files, and the [mangle_*] pair is the
+    naming contract [tir_names.ml] and the codegen tests depend on.  [ty_subst]
+    stays a manifest type alias because six exported functions name it. *)
+
+val resolve_impl_by_type : (string * string) list -> string -> string option
+val has_tvar : Tir.ty -> bool
+type ty_subst = (string * Tir.ty) list
+val subst_ty : ty_subst -> Tir.ty -> Tir.ty
+val default_residual_tvars : Tir.ty -> Tir.ty
+val subst_var : ty_subst -> Tir.var -> Tir.var
+val subst_atom : ty_subst -> Tir.atom -> Tir.atom
+val subst_expr : ty_subst -> Tir.expr -> Tir.expr
+val mangle_ty : Tir.ty -> string
+val mangle_name : string -> Tir.ty list -> string
+val match_ty : Tir.ty -> Tir.ty -> ty_subst -> ty_subst
+module SSet :
+  sig
+    type elt = String.t
+    type t = Set.Make(String).t
+    val empty : t
+    val add : elt -> t -> t
+    val singleton : elt -> t
+    val remove : elt -> t -> t
+    val union : t -> t -> t
+    val inter : t -> t -> t
+    val disjoint : t -> t -> bool
+    val diff : t -> t -> t
+    val cardinal : t -> int
+    val elements : t -> elt list
+    val min_elt : t -> elt
+    val min_elt_opt : t -> elt option
+    val max_elt : t -> elt
+    val max_elt_opt : t -> elt option
+    val choose : t -> elt
+    val choose_opt : t -> elt option
+    val find : elt -> t -> elt
+    val find_opt : elt -> t -> elt option
+    val find_first : (elt -> bool) -> t -> elt
+    val find_first_opt : (elt -> bool) -> t -> elt option
+    val find_last : (elt -> bool) -> t -> elt
+    val find_last_opt : (elt -> bool) -> t -> elt option
+    val iter : (elt -> unit) -> t -> unit
+    val fold : (elt -> 'acc -> 'acc) -> t -> 'acc -> 'acc
+    val map : (elt -> elt) -> t -> t
+    val filter : (elt -> bool) -> t -> t
+    val filter_map : (elt -> elt option) -> t -> t
+    val partition : (elt -> bool) -> t -> t * t
+    val split : elt -> t -> t * bool * t
+    val is_empty : t -> bool
+    val mem : elt -> t -> bool
+    val equal : t -> t -> bool
+    val compare : t -> t -> int
+    val subset : t -> t -> bool
+    val for_all : (elt -> bool) -> t -> bool
+    val exists : (elt -> bool) -> t -> bool
+    val to_list : t -> elt list
+    val of_list : elt list -> t
+    val to_seq_from : elt -> t -> elt Seq.t
+    val to_seq : t -> elt Seq.t
+    val to_rev_seq : t -> elt Seq.t
+    val add_seq : elt Seq.t -> t -> t
+    val of_seq : elt Seq.t -> t
+  end
+val atom_ty : Tir.atom -> Tir.ty
+val rewrite_calls :
+  (string, Tir.fn_def) Hashtbl.t ->
+  (string, unit) Hashtbl.t ->
+  (string * Tir.fn_def * ty_subst) Queue.t ->
+  (string, (string * string) list) Hashtbl.t ->
+  (string, string) Hashtbl.t ->
+  SSet.t -> Tir.expr -> Tir.expr
+val refine_field_types : Tir.expr -> Tir.expr
+val monomorphize :
+  ?iface_methods:(string, (string * string) list) Hashtbl.t ->
+  Tir.tir_module -> Tir.tir_module

--- a/lib/tir/perceus.mli
+++ b/lib/tir/perceus.mli
@@ -1,0 +1,197 @@
+(** Perceus reference-count insertion over the typed IR.
+
+    Interface for {!Perceus}, added 2026-08-27 by the pass that gave the
+    highest-churn compiler files one (see
+    [specs/progress/2026-08-25-mli-interfaces-top-churn-files.md]).  At 66
+    commits in six months this is the most-edited file in [lib/tir/].
+
+    36 values were exported before this file existed; 25 still are.  Unlike
+    [Typecheck_env] and [Typecheck_types], [Perceus] is not [include]d by
+    anything, so hiding here is a local, checkable change rather than one that
+    acts at a distance.
+
+    {2 What is hidden, and why it was safe}
+
+    Eleven values, none of them referenced anywhere outside this file:
+
+    - the whole RC-statistics family — [rc_counts] and its type,
+      [zero_counts], [add_counts], [count_rc_ops_expr], [count_rc_ops_module],
+      [print_perceus_stats], and the [_perceus_debug] lazy flag that gates
+      them.  These exist to serve one [if Lazy.force _perceus_debug] block at
+      the end of {!perceus}; the type went with them because nothing outside
+      names it either;
+    - [fresh_rc_var] — the RC temporary generator.  Note that its counter
+      [_rc_fresh_ctr] stays exported: [lower_state.ml] resets it and
+      [test_snapshots.ml] needs that reset to keep TIR golden snapshots
+      deterministic across run order.  The counter is API, the generator is
+      not;
+    - [collect_moved_vars] and [collect_actor_sent_vars] — per-function
+      analyses whose results are stashed in {!env} by [preprocess_fn];
+    - [wrap_incrcs] and [rename_borrowed_shadows] — internal steps of the
+      per-function RC walk.
+
+    {2 What stays, and why the list is still long}
+
+    The Perceus pass is split across five sibling files
+    ([perceus_liveness], [perceus_elide], [perceus_fbip], [perceus_scrut] and
+    [borrow]) that call back into this one, and several helpers
+    ([same_arity], [needs_rc], [is_apply_fn], [name_free_in]) are used far
+    outside [lib/tir/] — [needs_rc] reaches [lsp/lib/analysis.ml], and
+    [perceus] itself has 32 referencing files.  Everything with a caller was
+    kept; nothing was hidden by editing a consumer.
+
+    [env] and [live_set] are left manifest because exposed functions
+    ([empty_env], [find_inc_vars], [insert_rc_expr], [elide_expr],
+    [live_before]) name them in their own types. *)
+
+module StringSet :
+  sig
+    type elt = String.t
+    type t = Set.Make(String).t
+    val empty : t
+    val add : elt -> t -> t
+    val singleton : elt -> t
+    val remove : elt -> t -> t
+    val union : t -> t -> t
+    val inter : t -> t -> t
+    val disjoint : t -> t -> bool
+    val diff : t -> t -> t
+    val cardinal : t -> int
+    val elements : t -> elt list
+    val min_elt : t -> elt
+    val min_elt_opt : t -> elt option
+    val max_elt : t -> elt
+    val max_elt_opt : t -> elt option
+    val choose : t -> elt
+    val choose_opt : t -> elt option
+    val find : elt -> t -> elt
+    val find_opt : elt -> t -> elt option
+    val find_first : (elt -> bool) -> t -> elt
+    val find_first_opt : (elt -> bool) -> t -> elt option
+    val find_last : (elt -> bool) -> t -> elt
+    val find_last_opt : (elt -> bool) -> t -> elt option
+    val iter : (elt -> unit) -> t -> unit
+    val fold : (elt -> 'acc -> 'acc) -> t -> 'acc -> 'acc
+    val map : (elt -> elt) -> t -> t
+    val filter : (elt -> bool) -> t -> t
+    val filter_map : (elt -> elt option) -> t -> t
+    val partition : (elt -> bool) -> t -> t * t
+    val split : elt -> t -> t * bool * t
+    val is_empty : t -> bool
+    val mem : elt -> t -> bool
+    val equal : t -> t -> bool
+    val compare : t -> t -> int
+    val subset : t -> t -> bool
+    val for_all : (elt -> bool) -> t -> bool
+    val exists : (elt -> bool) -> t -> bool
+    val to_list : t -> elt list
+    val of_list : elt list -> t
+    val to_seq_from : elt -> t -> elt Seq.t
+    val to_seq : t -> elt Seq.t
+    val to_rev_seq : t -> elt Seq.t
+    val add_seq : elt Seq.t -> t -> t
+    val of_seq : elt Seq.t -> t
+  end
+module StringMap :
+  sig
+    type key = String.t
+    type 'a t = 'a Map.Make(String).t
+    val empty : 'a t
+    val add : key -> 'a -> 'a t -> 'a t
+    val add_to_list : key -> 'a -> 'a list t -> 'a list t
+    val update : key -> ('a option -> 'a option) -> 'a t -> 'a t
+    val singleton : key -> 'a -> 'a t
+    val remove : key -> 'a t -> 'a t
+    val merge :
+      (key -> 'a option -> 'b option -> 'c option) -> 'a t -> 'b t -> 'c t
+    val union : (key -> 'a -> 'a -> 'a option) -> 'a t -> 'a t -> 'a t
+    val cardinal : 'a t -> int
+    val bindings : 'a t -> (key * 'a) list
+    val min_binding : 'a t -> key * 'a
+    val min_binding_opt : 'a t -> (key * 'a) option
+    val max_binding : 'a t -> key * 'a
+    val max_binding_opt : 'a t -> (key * 'a) option
+    val choose : 'a t -> key * 'a
+    val choose_opt : 'a t -> (key * 'a) option
+    val find : key -> 'a t -> 'a
+    val find_opt : key -> 'a t -> 'a option
+    val find_first : (key -> bool) -> 'a t -> key * 'a
+    val find_first_opt : (key -> bool) -> 'a t -> (key * 'a) option
+    val find_last : (key -> bool) -> 'a t -> key * 'a
+    val find_last_opt : (key -> bool) -> 'a t -> (key * 'a) option
+    val iter : (key -> 'a -> unit) -> 'a t -> unit
+    val fold : (key -> 'a -> 'acc -> 'acc) -> 'a t -> 'acc -> 'acc
+    val map : ('a -> 'b) -> 'a t -> 'b t
+    val mapi : (key -> 'a -> 'b) -> 'a t -> 'b t
+    val filter : (key -> 'a -> bool) -> 'a t -> 'a t
+    val filter_map : (key -> 'a -> 'b option) -> 'a t -> 'b t
+    val partition : (key -> 'a -> bool) -> 'a t -> 'a t * 'a t
+    val split : key -> 'a t -> 'a t * 'a option * 'a t
+    val is_empty : 'a t -> bool
+    val mem : key -> 'a t -> bool
+    val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+    val compare : ('a -> 'a -> int) -> 'a t -> 'a t -> int
+    val for_all : (key -> 'a -> bool) -> 'a t -> bool
+    val exists : (key -> 'a -> bool) -> 'a t -> bool
+    val to_list : 'a t -> (key * 'a) list
+    val of_list : (key * 'a) list -> 'a t
+    val to_seq : 'a t -> (key * 'a) Seq.t
+    val to_rev_seq : 'a t -> (key * 'a) Seq.t
+    val to_seq_from : key -> 'a t -> (key * 'a) Seq.t
+    val add_seq : (key * 'a) Seq.t -> 'a t -> 'a t
+    val of_seq : (key * 'a) Seq.t -> 'a t
+  end
+val _rc_fresh_ctr : int ref
+type env = {
+  borrow_map : Borrow.borrow_map;
+  type_defs : Tir.type_def list;
+  collision_set : (string, string list) Hashtbl.t;
+  extern_names : StringSet.t;
+  current_fn_name : string;
+  closure_fvs : StringSet.t;
+  actor_sent : StringSet.t;
+  moved_vars : StringSet.t;
+  borrowed_field_vars : StringSet.t;
+  var_ctx : Tir.var StringMap.t;
+}
+val empty_env : env
+val scrutinee_shares_payload_storage : env -> Tir.ty -> bool
+val collect_closure_fvs : Tir.fn_def -> StringSet.t
+val incrc_for :
+  env -> Tir.var -> Tir.atom -> Tir.expr
+val decrc_for :
+  env -> Tir.var -> Tir.atom -> Tir.expr
+val needs_rc : Tir.ty -> bool
+val is_apply_fn : string -> bool
+val vars_of_atom :
+  Tir.atom -> Perceus_liveness.StringSet.t
+val vars_of_atoms :
+  Tir.atom list -> Perceus_liveness.StringSet.t
+val fbip_arity_marker : string
+val same_arity : Tir.ty -> int -> bool
+type live_set = Perceus_liveness.live_set
+val live_before :
+  Tir.expr ->
+  Perceus_liveness.live_set -> Perceus_liveness.live_set
+val name_free_in : string -> Tir.expr -> bool
+val find_inc_vars :
+  ?include_borrowed_fields:bool ->
+  env -> Tir.atom list -> live_set -> Tir.var list
+val insert_rc_expr :
+  env -> Tir.expr -> live_set -> Tir.expr * StringSet.t
+val dup_field_results : Tir.expr -> Tir.expr
+val insert_apply_fn_clo_drop :
+  repl:bool -> Tir.expr -> Tir.expr
+val insert_rc :
+  module_env:env ->
+  ?repl:bool ->
+  ?borrowed:StringSet.t -> Tir.fn_def -> Tir.fn_def
+val elide_expr : Tir.expr -> Tir.expr
+val elide_cancel_pairs : Tir.fn_def -> Tir.fn_def
+val fbip_expr : Tir.expr -> Tir.expr
+val insert_fbip : Tir.fn_def -> Tir.fn_def
+val preprocess_fn : Tir.fn_def -> Tir.fn_def
+val perceus :
+  ?repl:bool ->
+  ?repl_vars:string list ->
+  Tir.tir_module -> Tir.tir_module

--- a/lib/typecheck/typecheck_env.mli
+++ b/lib/typecheck/typecheck_env.mli
@@ -1,0 +1,281 @@
+(** The type environment: what is in scope, and how it is entered and left.
+
+    Interface for {!Typecheck_env}, added 2026-08-27 by the same pass that gave
+    the four highest-churn compiler files one (see
+    [specs/progress/2026-08-25-mli-interfaces-top-churn-files.md]).
+
+    {2 This module is [include]d, so this interface is load-bearing at a
+        distance}
+
+    [Typecheck] does [include Typecheck_env], not [open], which means every
+    name declared here becomes part of [Typecheck]'s own surface and is reached
+    by consumers through [let open Typecheck] and through the [Tc.] / [TC.] /
+    [T.] aliases that no grep can see.  Anything omitted here disappears from
+    [Typecheck] too.  So the curation below is deliberately minimal: of the 42
+    values the module exported before this file existed, 40 are still exported.
+    Only [edit_distance] and [suggest_module_name] are hidden — both are used
+    solely by the [suggest_*] helpers in this file, and nothing anywhere else
+    refers to either.
+
+    That near-zero reduction is the correct answer, not a lazy one.  This band
+    was lifted verbatim out of [Typecheck] as a coherent unit on 2026-08-26, so
+    unlike the older files it never had time to accumulate accidental surface.
+
+    The record types are all left manifest.  [env] in particular is threaded
+    through the entire checker by field access; making it abstract would be a
+    rewrite, not an interface.
+
+    The mutable cells declared in the implementation stay single physical
+    cells: [include] aliases them rather than copying them, and declaring them
+    here does not change that. *)
+
+type lin_entry = {
+  le_name : string;
+  le_lin : Typecheck_types.Ast.linearity;
+  le_used : bool ref;
+  le_first_use : Typecheck_types.Ast.span option ref;
+}
+type ctor_info = {
+  ci_type : string;
+  ci_params : string list;
+  ci_arg_tys : Typecheck_types.Ast.ty list;
+  ci_vis : Typecheck_types.Ast.visibility;
+  ci_module : string;
+  ci_is_actor_msg : bool;
+}
+type import_entry = {
+  ie_span : Typecheck_types.Ast.span;
+  ie_desc : string;
+  ie_matches : string -> bool;
+  ie_used : bool ref;
+  ie_used_names : (string, unit) Hashtbl.t;
+}
+type import_index = {
+  ie_exact_index : (string, import_entry list) Hashtbl.t;
+  ie_prefix_index : (string, import_entry list) Hashtbl.t;
+}
+val make_import_index : unit -> import_index
+val import_index_add_exact : import_index -> string -> import_entry -> unit
+val import_index_add_prefix : import_index -> string -> import_entry -> unit
+type proto_info = {
+  pi_def : Typecheck_types.Ast.protocol_def;
+  pi_projections : (string * Typecheck_types.session_ty) list;
+  pi_span : Typecheck_types.Ast.span;
+}
+module StrMap :
+  sig
+    type key = String.t
+    type 'a t = 'a Map.Make(String).t
+    val empty : 'a t
+    val add : key -> 'a -> 'a t -> 'a t
+    val add_to_list : key -> 'a -> 'a list t -> 'a list t
+    val update : key -> ('a option -> 'a option) -> 'a t -> 'a t
+    val singleton : key -> 'a -> 'a t
+    val remove : key -> 'a t -> 'a t
+    val merge :
+      (key -> 'a option -> 'b option -> 'c option) -> 'a t -> 'b t -> 'c t
+    val union : (key -> 'a -> 'a -> 'a option) -> 'a t -> 'a t -> 'a t
+    val cardinal : 'a t -> int
+    val bindings : 'a t -> (key * 'a) list
+    val min_binding : 'a t -> key * 'a
+    val min_binding_opt : 'a t -> (key * 'a) option
+    val max_binding : 'a t -> key * 'a
+    val max_binding_opt : 'a t -> (key * 'a) option
+    val choose : 'a t -> key * 'a
+    val choose_opt : 'a t -> (key * 'a) option
+    val find : key -> 'a t -> 'a
+    val find_opt : key -> 'a t -> 'a option
+    val find_first : (key -> bool) -> 'a t -> key * 'a
+    val find_first_opt : (key -> bool) -> 'a t -> (key * 'a) option
+    val find_last : (key -> bool) -> 'a t -> key * 'a
+    val find_last_opt : (key -> bool) -> 'a t -> (key * 'a) option
+    val iter : (key -> 'a -> unit) -> 'a t -> unit
+    val fold : (key -> 'a -> 'acc -> 'acc) -> 'a t -> 'acc -> 'acc
+    val map : ('a -> 'b) -> 'a t -> 'b t
+    val mapi : (key -> 'a -> 'b) -> 'a t -> 'b t
+    val filter : (key -> 'a -> bool) -> 'a t -> 'a t
+    val filter_map : (key -> 'a -> 'b option) -> 'a t -> 'b t
+    val partition : (key -> 'a -> bool) -> 'a t -> 'a t * 'a t
+    val split : key -> 'a t -> 'a t * 'a option * 'a t
+    val is_empty : 'a t -> bool
+    val mem : key -> 'a t -> bool
+    val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+    val compare : ('a -> 'a -> int) -> 'a t -> 'a t -> int
+    val for_all : (key -> 'a -> bool) -> 'a t -> bool
+    val exists : (key -> 'a -> bool) -> 'a t -> bool
+    val to_list : 'a t -> (key * 'a) list
+    val of_list : (key * 'a) list -> 'a t
+    val to_seq : 'a t -> (key * 'a) Seq.t
+    val to_rev_seq : 'a t -> (key * 'a) Seq.t
+    val to_seq_from : key -> 'a t -> (key * 'a) Seq.t
+    val add_seq : (key * 'a) Seq.t -> 'a t -> 'a t
+    val of_seq : (key * 'a) Seq.t -> 'a t
+  end
+type ref_record = {
+  callee : string;
+  caller : string;
+  ref_kind : [ `Call | `Ctor | `TypeRef ];
+  ref_file : string;
+  ref_line : int;
+}
+val qualify_ref_name : string -> string -> string
+type env = {
+  vars : Typecheck_types.scheme StrMap.t;
+  types : int StrMap.t;
+  ctors : ctor_info list StrMap.t;
+  records :
+    (string list * (string * Typecheck_types.Ast.ty) list)
+    StrMap.t;
+  level : int;
+  lin : lin_entry list;
+  errors : Typecheck_types.Err.ctx;
+  pending_constraints : Typecheck_types.constraint_ list ref;
+  type_map :
+    (Typecheck_types.Ast.span,
+     Typecheck_types.ty)
+    Hashtbl.t;
+  refs : ref_record list ref;
+  current_decl : string ref;
+  scheme_witnesses :
+    (int list,
+     Typecheck_types.constraint_ list *
+     Typecheck_types.ty)
+    Hashtbl.t;
+  inst_witnesses :
+    (Typecheck_types.Ast.span,
+     int list * Typecheck_types.ty list)
+    Hashtbl.t;
+  interfaces : Typecheck_types.Ast.interface_def StrMap.t;
+  sigs : (string * Typecheck_types.Ast.sig_def) list;
+  mod_needs : string list;
+  mod_need_scopes : (string * string option) list;
+  module_caps : (string * string list) list;
+  protocols : proto_info StrMap.t;
+  impls :
+    (Typecheck_types.ty *
+     Typecheck_types.Ast.span * string option)
+    list StrMap.t;
+  import_tracker : import_entry list ref;
+  import_idx : import_index;
+  local_fns : unit StrMap.t;
+  fn_arities : (int * Typecheck_types.Ast.span) StrMap.t;
+  qual_fn_names : unit StrMap.t;
+  plain_let_names : Typecheck_types.StringSet.t;
+  proof_caps : (string * string) list;
+  always_linear_types : string list;
+  current_module : string;
+  root_cap_allowed : bool;
+  cur_fn_public : bool;
+  cap_qual_prefix : string;
+  enclosing_package : string;
+  no_panic_mod : bool;
+  no_panic_modules : string list;
+  nonexhaustive_match_spans :
+    Typecheck_types.Ast.span list ref;
+  cap_producer_ivars :
+    (int, Typecheck_types.Ast.span) Hashtbl.t;
+  cap_narrow_factory_fns :
+    (string, Typecheck_types.Ast.span) Hashtbl.t;
+  mint_cap_sites :
+    (Typecheck_types.Ast.span *
+     Typecheck_types.ty * bool * string)
+    list ref;
+  cap_narrow_sites :
+    (Typecheck_types.Ast.span *
+     Typecheck_types.ty)
+    list ref;
+  json_cap_sites :
+    (Typecheck_types.Ast.span *
+     Typecheck_types.ty * string)
+    list ref;
+  pure_mod : bool;
+  no_extern_mod : bool;
+  deterministic_mod : bool;
+  cap_closures : (string, string list) Hashtbl.t;
+  own_cap_closures : (string, string list) Hashtbl.t;
+  body_cap_closures : (string, string list) Hashtbl.t;
+  stdlib_fns : (string, unit) Hashtbl.t;
+  ceiling_extra_roots : (string, unit) Hashtbl.t;
+  fn_refs : (string, string list) Hashtbl.t;
+  fn_row_bodies :
+    (string, (string list * Typecheck_types.Ast.expr) list)
+    Hashtbl.t;
+  fn_grant_points :
+    (string, string list * Typecheck_types.Ast.span)
+    Hashtbl.t;
+  local_mods : string list StrMap.t;
+  offer_conts :
+    (Typecheck_types.session_ty ref *
+     (string * Typecheck_types.session_ty) list)
+    list ref;
+  offer_labels :
+    (string *
+     (Typecheck_types.session_ty ref *
+      (string * Typecheck_types.session_ty) list))
+    list;
+  offer_unrefined : Typecheck_types.session_ty ref list ref;
+}
+val make_env :
+  Typecheck_types.Err.ctx ->
+  (Typecheck_types.Ast.span,
+   Typecheck_types.ty)
+  Hashtbl.t -> env
+val enter_level : env -> env
+val leave_level : env -> env
+val with_no_caller : env -> (unit -> 'a) -> 'a
+val offer_ref_unrefined :
+  env -> Typecheck_types.session_ty ref -> bool
+val offer_catchall_depth : int ref
+val offer_unrefined_message : string -> string
+val demote_to_monomorphic : Typecheck_types.ty -> unit
+val demote_vault_handle_vars : Typecheck_types.ty -> unit
+val tag_cap_producer_result :
+  env ->
+  Typecheck_types.ty ->
+  Typecheck_types.Ast.span -> unit
+val ty_has_tagged_cap_producer :
+  env -> Typecheck_types.ty -> bool
+val lookup_var :
+  StrMap.key -> env -> Typecheck_types.scheme option
+val lookup_type : StrMap.key -> env -> int option
+val resolves_always_linear : string -> env -> bool
+val lookup_ctor : StrMap.key -> env -> ctor_info option
+val lookup_ctor_same_module : string -> env -> ctor_info option
+val lookup_ctor_in_type : StrMap.key -> string -> env -> ctor_info option
+val lookup_ctor_in_type_unique :
+  StrMap.key -> string -> env -> ctor_info option
+val add_ctor :
+  string -> ctor_info -> ctor_info list StrMap.t -> ctor_info list StrMap.t
+val split_qualified : string -> (string * string) option
+val inject_iface_exports_ref :
+  (string -> March_modules.Module_registry.module_exports -> env -> env) ref
+val load_module_into_env :
+  string -> March_modules.Module_registry.module_exports -> env -> env
+val resolve_qualified_var :
+  string -> env -> env * Typecheck_types.scheme option
+val resolve_qualified_type : string -> env -> env * int option
+val resolve_qualified_ctor : string -> env -> env * ctor_info option
+val suggest_var_in_scope : string -> env -> string option
+val is_confirmed_private_qualified : string -> env -> bool
+val qualified_error_msg : string -> env -> string
+val all_ctors_named : string -> env -> string list
+val all_ctor_candidates_named : string -> env -> (string * string) list
+val suggest_ctors : string -> env -> (string * string) list
+val bind_var :
+  StrMap.key -> Typecheck_types.scheme -> env -> env
+val bind_vars :
+  (StrMap.key * Typecheck_types.scheme) list -> env -> env
+val bind_linear :
+  StrMap.key ->
+  Typecheck_types.Ast.linearity ->
+  Typecheck_types.ty -> env -> env
+val generalize :
+  int ->
+  Typecheck_types.ty ->
+  Typecheck_types.scheme
+val instantiate :
+  ?use_span:Typecheck_types.Ast.span ->
+  int ->
+  env ->
+  Typecheck_types.scheme ->
+  Typecheck_types.ty

--- a/lib/typecheck/typecheck_types.mli
+++ b/lib/typecheck/typecheck_types.mli
@@ -1,0 +1,156 @@
+(** The type language, its printer and the message renderer.
+
+    Interface for {!Typecheck_types}, added 2026-08-27 by the same pass that
+    gave the four highest-churn compiler files one (see
+    [specs/progress/2026-08-25-mli-interfaces-top-churn-files.md]).
+
+    {2 This module is [include]d, so this interface is load-bearing at a
+        distance}
+
+    [Typecheck] does [include Typecheck_types], not [open], so every name
+    declared here becomes part of [Typecheck]'s own surface and is reached by
+    consumers through [let open Typecheck] and through the [Tc.] / [TC.] / [T.]
+    aliases no grep can see.  Anything omitted here disappears from [Typecheck]
+    too, which is why the curation is minimal: 23 values were exported before
+    this file existed, 19 still are.
+
+    Four are hidden, all of them local helpers with no reference anywhere
+    outside this file:
+
+    - [tvar_display_name] — feeds [pp_ty]'s [Unbound] case only;
+    - [record_field_sig] and [recover_record_name] — the [_record_names]
+      lookup path, used only by [pp_ty];
+    - [free_vars_block] — the [Ast.EBlock] arm of the [free_vars_expr]
+      recursion.  Its two siblings [free_vars_expr] and [free_vars_pattern]
+      do have external callers and stay exported; splitting the family is
+      slightly unpleasant but the block case genuinely has none.
+
+    {2 The mutable cells stay exported on purpose}
+
+    [_counter], [_tvar_names], [_tvar_ctr] and [_record_names] are all
+    declared here even though only [_counter] and [_record_names] have
+    external references (they are marshalled by [bin/main.ml] for the REPL
+    cache).  [include] aliases these cells rather than copying them, and that
+    aliasing is what keeps the marshalled state pointing at the cells the
+    checker actually mutates.  Rather than split the group on a grep result,
+    all four are declared; the two without callers are cheap insurance in a
+    place where getting it wrong is silent.
+
+    [Ast], [Err] and [StringSet] are re-exported because the [include] is what
+    supplies those aliases to [Typecheck] and to everything reading its types. *)
+
+module Ast = March_ast.Ast
+module Err = March_errors.Errors
+module StringSet :
+  sig
+    type elt = String.t
+    type t = Set.Make(String).t
+    val empty : t
+    val add : elt -> t -> t
+    val singleton : elt -> t
+    val remove : elt -> t -> t
+    val union : t -> t -> t
+    val inter : t -> t -> t
+    val disjoint : t -> t -> bool
+    val diff : t -> t -> t
+    val cardinal : t -> int
+    val elements : t -> elt list
+    val min_elt : t -> elt
+    val min_elt_opt : t -> elt option
+    val max_elt : t -> elt
+    val max_elt_opt : t -> elt option
+    val choose : t -> elt
+    val choose_opt : t -> elt option
+    val find : elt -> t -> elt
+    val find_opt : elt -> t -> elt option
+    val find_first : (elt -> bool) -> t -> elt
+    val find_first_opt : (elt -> bool) -> t -> elt option
+    val find_last : (elt -> bool) -> t -> elt
+    val find_last_opt : (elt -> bool) -> t -> elt option
+    val iter : (elt -> unit) -> t -> unit
+    val fold : (elt -> 'acc -> 'acc) -> t -> 'acc -> 'acc
+    val map : (elt -> elt) -> t -> t
+    val filter : (elt -> bool) -> t -> t
+    val filter_map : (elt -> elt option) -> t -> t
+    val partition : (elt -> bool) -> t -> t * t
+    val split : elt -> t -> t * bool * t
+    val is_empty : t -> bool
+    val mem : elt -> t -> bool
+    val equal : t -> t -> bool
+    val compare : t -> t -> int
+    val subset : t -> t -> bool
+    val for_all : (elt -> bool) -> t -> bool
+    val exists : (elt -> bool) -> t -> bool
+    val to_list : t -> elt list
+    val of_list : elt list -> t
+    val to_seq_from : elt -> t -> elt Seq.t
+    val to_seq : t -> elt Seq.t
+    val to_rev_seq : t -> elt Seq.t
+    val add_seq : elt Seq.t -> t -> t
+    val of_seq : elt Seq.t -> t
+  end
+type reason =
+    RAnnotation of Ast.span
+  | RFnReturn of string * Ast.span
+  | RFnArg of Ast.span * int
+  | RMatchArm of Ast.span
+  | RLetBind of Ast.span
+  | RBuiltin of string
+  | RBecause of reason * string
+val span_of_reason : reason -> Ast.span option
+val string_of_reason : reason -> string
+type ty =
+    TCon of string * ty list
+  | TVar of tvar ref
+  | TArrow of ty * ty
+  | TTuple of ty list
+  | TRecord of (string * ty) list
+  | TLin of Ast.linearity * ty
+  | TNat of int
+  | TNatOp of Ast.nat_op * ty * ty
+  | TChan of session_ty ref
+  | TError
+  | TRefine of ty * string * Ast.expr
+and session_ty =
+    SSend of ty * session_ty
+  | SRecv of ty * session_ty
+  | SChoose of (string * session_ty) list
+  | SOffer of (string * session_ty) list
+  | SEnd
+  | SRec of string * session_ty
+  | SVar of string
+  | SError
+  | SMSend of string * ty * session_ty
+  | SMRecv of string * ty * session_ty
+and tvar = Unbound of int * int | Link of ty
+type constraint_ =
+    CNum of ty
+  | COrd of ty
+  | CInterface of string * ty
+  | CADTBound of string * ty
+  | CTNatBound of ty
+type scheme = Mono of ty | Poly of int list * constraint_ list * ty
+val _counter : int ref
+val fresh_id : unit -> int
+val fresh_var : int -> ty
+val repr : ty -> ty
+val occurs : int -> int -> ty -> bool
+val _tvar_names : (int, string) Hashtbl.t
+val _tvar_ctr : int ref
+val _record_names : (string, string option) Hashtbl.t
+val register_record_name : name:string -> string list -> unit
+val pp_ty : ?parens:bool -> ty -> string
+val pp_ty_pretty : ?indent:int -> ?width:int -> ty -> string
+val find_arg_mismatch :
+  'a -> ty list -> ty list -> (int * 'a * ty * ty) option
+val pp_session_ty : session_ty -> string
+type message_part =
+    MPText of string
+  | MPCode of string
+  | MPType of ty
+  | MPBreak
+  | MPBullet of message_part list
+val render_parts : message_part list -> string
+val span_of_expr : Ast.expr -> Ast.span
+val free_vars_expr : string list -> Ast.expr -> string list
+val free_vars_pattern : Ast.pattern -> string list

--- a/lsp/lib/analysis_util.mli
+++ b/lsp/lib/analysis_util.mli
@@ -1,0 +1,251 @@
+(** Shared AST/type helpers for march-lsp.
+
+    Interface for {!Analysis_util}, added 2026-08-27 by the same pass that gave
+    the compiler's highest-churn files one (see
+    [specs/progress/2026-08-25-mli-interfaces-top-churn-files.md]).
+
+    {2 This module sits in the middle of an [include] chain}
+
+    [Analysis_util] does [include Analysis_types], and [Analysis] in turn does
+    [include Analysis_util].  [Analysis] has no interface of its own, so
+    everything declared here is re-exported all the way out to [Server],
+    [Query_cli], [Depot] and the [lsp/test/] suites under the [Analysis.] name.
+    Anything omitted here disappears from [Analysis] too — a breakage at two
+    removes.  The curation is therefore minimal: 36 values were exported before
+    this file existed, 33 still are.
+
+    Three are hidden, all with no reference anywhere outside this file:
+
+    - [march_operators] — the literal operator list behind
+      [is_march_operator], which is the name consumers actually call;
+    - [pat_bound_names] — the pattern-binder walk used by [iter_expr]'s block
+      and match arms;
+    - [span_byte_bounds] — the offset pair [slice_span] is built on.
+
+    {2 The [Analysis_types] re-exports are manifest, not fresh declarations}
+
+    Every [type foo = Analysis_types.foo = { ... }] below must keep its
+    [Analysis_types.] equation.  Writing the record inline instead would
+    declare a *new* nominal type, and [Code_actions_ast] / [Code_actions_diag]
+    — which name [Analysis_types.t] directly to avoid a dependency cycle back
+    through [Analysis] — would stop type-checking against it. *)
+
+module Lsp = Linol_lsp.Lsp
+module Ast = March_ast.Ast
+module Tc = March_typecheck.Typecheck
+module Err = March_errors.Errors
+module Pos = Position
+type call_site =
+  Analysis_types.call_site = {
+  cs_fn_name : string option;
+  cs_span : Ast.span;
+  cs_args : Ast.expr list;
+}
+type consume_modes =
+  Analysis_types.consume_modes = {
+  cm_fn_name : string;
+  cm_consumes : bool list;
+}
+type import_sel =
+  Analysis_types.import_sel =
+    ISAll
+  | ISNames of Ast.name list
+  | ISExcept of string list
+  | ISSingle
+type import_info =
+  Analysis_types.import_info = {
+  ii_module : string;
+  ii_sel : import_sel;
+  ii_span : Ast.span;
+}
+type cg_node =
+  Analysis_types.cg_node = {
+  cg_name : string;
+  cg_name_span : Ast.span;
+  cg_full_span : Ast.span;
+  cg_calls : (string * Ast.span) list;
+}
+type match_site =
+  Analysis_types.match_site = {
+  ms_span : Ast.span;
+  ms_missing_cases : string list;
+  ms_matched_type : string option;
+  ms_ctor_sigs : (string * Ast.ty list) list;
+}
+type annotation_kind =
+  Analysis_types.annotation_kind =
+    AnnLet
+  | AnnFnReturn
+  | AnnFnParam
+type annotation_site =
+  Analysis_types.annotation_site = {
+  as_name_span : Ast.span;
+  as_rhs_span : Ast.span;
+  as_kind : annotation_kind;
+}
+type html_issue =
+  Analysis_types.html_issue = {
+  hi_open_span : Ast.span;
+  hi_tag : string;
+  hi_insert_span : Ast.span;
+  hi_closer : string;
+}
+type consumption =
+  Analysis_types.consumption = {
+  con_name : string;
+  con_def : Ast.span;
+  con_uses : Ast.span list;
+}
+type naming_violation =
+  Analysis_types.naming_violation = {
+  nv_name : string;
+  nv_suggested : string;
+  nv_span : Ast.span;
+  nv_kind : [ `Function | `Type ];
+}
+type demorgan_site =
+  Analysis_types.demorgan_site = {
+  dm_span : Ast.span;
+  dm_form : [ `NegatedBinop of string | `PairOfNegs of string ];
+  dm_left_span : Ast.span;
+  dm_right_span : Ast.span;
+}
+type perf_insight_kind =
+  Analysis_types.perf_insight_kind =
+    NonTailCall of { pi_fn_name : string; pi_blocking : string; }
+  | ActorSendCopy of { pi_value_desc : string; pi_ty : string; }
+  | ClosureCapture of { pi_count : int; pi_names : string list; }
+  | StackPromoted of { pi_count : int; }
+  | FbipReuse of { pi_count : int; }
+  | TirIndirectCall of { pi_fn_name : string; pi_count : int; }
+  | IndirectCall of { pi_callee : string; }
+  | RecursiveAlloc of { pi_alloc : string; }
+  | Parallelizable of { pi_op : string; pi_par : string;
+      pi_name_span : Ast.span;
+    }
+type perf_insight =
+  Analysis_types.perf_insight = {
+  pi_span : Ast.span;
+  pi_kind : perf_insight_kind;
+  pi_message : string;
+}
+type tir_fn_insight =
+  Analysis_types.tir_fn_insight = {
+  tfi_fn_name : string;
+  tfi_stack_allocs : int;
+  tfi_reuse_ops : int;
+  tfi_indirect_calls : int;
+  tfi_heap_allocs : int;
+}
+type code_lens_item =
+  Analysis_types.code_lens_item = {
+  cl_range : Lsp.Types.Range.t;
+  cl_title : string;
+  cl_command : string option;
+  cl_args : Yojson.Safe.t list;
+}
+type h_sigil =
+  Analysis_types.h_sigil = {
+  hs_content : string;
+  hs_base_ofs : int;
+  hs_close_ofs : int;
+  hs_span : Ast.span;
+}
+type t =
+  Analysis_types.t = {
+  src : string;
+  filename : string;
+  doc : Utf16.doc;
+  type_map : (Ast.span, Tc.ty) Hashtbl.t;
+  def_map : (string, Ast.span) Hashtbl.t;
+  use_map : (Ast.span, string) Hashtbl.t;
+  vars : (string * Tc.scheme) list;
+  types : (string * int) list;
+  ctors : (string * string) list;
+  interfaces : (string * Ast.interface_def) list;
+  impls : (string * Tc.ty) list;
+  impl_sites : (string, Ast.span list) Hashtbl.t;
+  actors : (string * Ast.actor_def) list;
+  doc_map : (string, string) Hashtbl.t;
+  refs_map : (string, Ast.span list) Hashtbl.t;
+  sym_defs : (int, Ast.span) Hashtbl.t;
+  sym_uses : (Ast.span, int) Hashtbl.t;
+  sym_id_uses : (int, Ast.span list) Hashtbl.t;
+  sym_name : (int, string) Hashtbl.t;
+  sym_scope : (int, Ast.span) Hashtbl.t;
+  call_sites : call_site list;
+  call_graph : cg_node list;
+  imports : import_info list;
+  module_index : (string * string list) list;
+  consumption : consumption list;
+  reuse_hints : Ast.span list;
+  match_sites : match_site list;
+  diagnostics : Lsp.Types.Diagnostic.t list;
+  ctor_arities : (string * int) list;
+  fold_ranges : (int * int * string) list;
+  annotation_sites : annotation_site list;
+  unused_fns : string list;
+  html_issues : html_issue list;
+  h_sigils : h_sigil list;
+  type_matches : (string * match_site list) list;
+  naming_violations : naming_violation list;
+  demorgan_sites : demorgan_site list;
+  perf_insights : perf_insight list;
+  consume_modes : consume_modes list;
+  tir_fn_insights : tir_fn_insight list;
+  code_lens_items : code_lens_item list;
+  decls : Ast.decl list;
+  depot_source_decls : Ast.decl list;
+  depot_schemas : Depot.schema list;
+  depot_col_occs : Depot.col_occ list;
+  depot_table_occs : Depot.table_occ list;
+  protocols : (string * Ast.protocol_def) list;
+  transitions_index : (string * Ast.transition list) list;
+  always_linear_names : string list;
+  param_name_map : (string, string list) Hashtbl.t;
+  proof_cap_defs : (string, Ast.span) Hashtbl.t;
+}
+val find_uses : string -> Ast.expr -> Ast.span list -> Ast.span list
+val span_of_expr : Ast.expr -> Ast.span
+val is_march_operator : string -> bool
+val iter_expr : (Ast.expr -> unit) -> Ast.expr -> unit
+val lambda_free_vars : Ast.param list -> Ast.expr -> string list
+val collect_lambda_captures :
+  (String.t -> bool) -> Ast.expr -> (Ast.span * Ast.span * string list) list
+val perf_insight_to_diag : perf_insight -> Lsp.Types.Diagnostic.t
+val clause_param_names : Ast.fn_clause -> string list
+val contains_call : string -> Ast.expr -> bool
+val unwrap_arrows : Tc.ty -> string list * string
+val local_symbol_at : t -> line:int -> character:int -> int option
+val span_in_user_file : t -> Ast.span -> bool
+val locations_of_spans : t -> Ast.span list -> Lsp.Types.Location.t list
+val symbol_spans_at :
+  t -> line:int -> character:int -> (Ast.span option * Ast.span list) option
+val references_at :
+  t ->
+  include_declaration:bool ->
+  line:int -> character:int -> Lsp.Types.Location.t list
+val rename_at :
+  t ->
+  line:int -> character:int -> new_name:string -> Lsp.Types.TextEdit.t list
+val offset_of_pos : string -> int -> int -> int
+val slice_span : string -> Ast.span -> string
+val indent_of_line : string -> int -> string
+val iter_decl_exprs : (Ast.expr -> unit) -> Ast.decl -> unit
+val all_exprs : Ast.decl list -> Ast.expr list
+val smallest_expr_at :
+  t ->
+  line:int -> character:int -> pred:(Ast.expr -> bool) -> Ast.expr option
+val find_name_ofs : string -> string -> int -> int option
+val find_end_before_span : string -> Ast.span -> int option
+type fix_gen = t -> Lsp.Types.Diagnostic.t -> Lsp.Types.CodeAction.t list
+val fix_registry : (string, fix_gen) Hashtbl.t
+val apply_fix_registry :
+  t -> Lsp.Types.Diagnostic.t list -> Lsp.Types.CodeAction.t list
+val surface_ty : Ast.ty -> string
+val split_arrow : Ast.ty -> Ast.ty list * Ast.ty
+val scheme_ty : Tc.scheme -> Tc.ty
+val ty_head_name : Tc.ty -> string option
+val ty_arrow_arity : Tc.ty -> int
+val is_ident_name : string -> bool
+val substitute_idents : string -> (string * string) list -> string

--- a/specs/progress/2026-08-27-mli-interfaces-remaining-modules.md
+++ b/specs/progress/2026-08-27-mli-interfaces-remaining-modules.md
@@ -1,0 +1,130 @@
+# `.mli` files for the remaining interface-less modules
+
+Landed 2026-08-27.
+
+Finishes the pass begun in
+[`2026-08-25-mli-interfaces-top-churn-files.md`](2026-08-25-mli-interfaces-top-churn-files.md)
+(four files, PR #368a) and continued by the nine-module decomposition follow-up
+(PR #368). Six more files now have an interface; one candidate was deliberately
+skipped.
+
+## What landed
+
+One `.mli` per file, one commit each, **no `.ml` line moved and no call site
+adjusted**. Where a value had a caller anywhere — including a test — it was
+exposed and the interface says so; nothing was hidden by editing a consumer.
+
+| File | Inferred vals | Curated vals | Internal |
+|---|---:|---:|---:|
+| `lib/typecheck/typecheck_env.ml` | 42 | 40 | 5% |
+| `lib/typecheck/typecheck_types.ml` | 23 | 19 | 17% |
+| `lsp/lib/analysis_util.ml` | 36 | 33 | 8% |
+| `lib/tir/perceus.ml` | 36 | 25 | 31% |
+| `lib/tir/mono.ml` | 21 | 14 | 33% |
+| `lib/tir/llvm_builtins.ml` | 34 | 22 | 35% |
+| `lib/tir/llvm_toplevel.ml` | 21 | 18 | 14% |
+| **total** | **213** | **171** | **20%** |
+
+20% against #368's 73% is the honest headline, and the split inside the table
+explains it. See "What the numbers mean" below.
+
+## Skipped, on purpose: `lsp/lib/analysis_types.ml`
+
+302 lines, **zero `let` bindings** — twenty-odd record and variant declarations
+and nothing else. An interface for it could only be a verbatim copy of every
+one of those declarations, all necessarily manifest (`Code_actions_ast`,
+`Code_actions_diag` and `Analysis` all pattern-match the fields), hiding
+nothing and abstracting nothing, and requiring a lockstep edit on every field
+added anywhere. That is pure cost. The file is left as it is.
+
+## What the numbers mean
+
+The table splits cleanly in two, and the reason is *when the file was written*,
+not how carefully it was curated.
+
+**The three extracted modules — `typecheck_env` (5%), `analysis_util` (8%),
+`typecheck_types` (17%) — are supposed to be near zero.** They were lifted
+verbatim out of their parents as coherent units within the last few days. They
+never had time to accumulate accidental surface, so there is almost none to
+remove. Manufacturing a reduction here would mean hiding something a sibling
+reaches through an alias.
+
+**The four older `lib/tir/` files (31–35%) are the ones with real rot,** and it
+is the same shape every time: a private table plus its public accessor, both
+exported. `llvm_builtins` alone had five `Hashtbl`s (`is_builtin_fn_tbl`,
+`builtin_ret_ty_tbl`, `builtin_declare_sig_tbl`, `mangle_extern_tbl`,
+`called_syms`) sitting in the public surface next to the five functions that
+read them.
+
+### The `include` hazard
+
+`typecheck_env` and `typecheck_types` are `include`d by `typecheck.ml`;
+`analysis_util` `include`s `analysis_types` and is itself `include`d by
+`analysis.ml`, which has no interface of its own. For those, an `.mli`
+restricts **what the parent re-exports** — a name dropped here vanishes from
+`Typecheck.` or `Analysis.` and breaks a consumer two removes away, reached
+through `let open` or a `Tc.` / `TC.` / `T.` / `An.` alias that no grep can
+see. Curation there was deliberately minimal, and `dune build @check` (which
+typechecks `test/` and `lsp/`) was the only oracle that could confirm it.
+
+The four `lib/tir/` files are `include`d by nothing, which is most of why they
+could be cut harder.
+
+### Three values that are declared but are not API
+
+Hiding a value that *nothing* mentions — not even its own file — makes it an
+unused-value error under warnings-as-errors. Since this pass edits no `.ml`,
+three had to be declared anyway, each with a comment saying so:
+
+- `llvm_builtins.reserved_ctor_tag_limit`
+- `llvm_toplevel.target_arch`
+- `llvm_toplevel.emit_main_wrapper`
+
+The last is worth a look. It is a real function body at
+`lib/tir/llvm_toplevel.ml:725`, not a one-line re-export, and nothing calls it —
+so the compiler emits its main wrapper by some other path. Compare
+`march_println`'s `writev` path, dead for thirteen months behind a live-looking
+declaration. #368 left the same class of note against three re-exports in
+`lower.ml` and thirty-three in `llvm_emit.ml`.
+
+### One counter that had to stay
+
+`perceus.fresh_rc_var` is hidden but its counter `_rc_fresh_ctr` is exported:
+`lower_state.ml` resets it and `test_snapshots.ml` depends on that reset to keep
+the TIR golden snapshots deterministic across run order. The counter is API;
+the generator is not.
+
+## Verification
+
+- `dune build @check` after **every** module: 17 errors throughout, the same 17
+  pre-existing ones in `forge/test/` and `js/` from a missing optional opam
+  dependency, never an 18th. Baselined before the first edit.
+- `dune build bin/main.exe` after every module: exit 0.
+- `scripts/ir-oracle.sh check` after each group: **IR IDENTICAL across 240
+  programs**, every time. An `.mli` changes visibility, never emitted code.
+- `scripts/run-tests.sh` and `scripts/check-docs.sh` at the end.
+
+### An oracle trap worth recording
+
+The first oracle check came back with a large-looking diff that was **not** an
+IR change. Every `+` line carried a hash *identical* to the context line above
+it: the manifest had 141 duplicated tags. Two other agents were running
+concurrently against the same session scratchpad — one of them running
+`ir-oracle.sh` itself, one running `main.exe --emit-llvm` with a *relative*
+path — and the shared work directory was being written by both. The baseline
+manifest was later truncated from 243 lines to 2 by the same interference.
+
+Deduplicating both manifests and diffing showed them exactly equal, and a clean
+re-run in a private directory (`/tmp/ir-<worktree-slug>`) reported IR IDENTICAL.
+
+The lesson generalises: **give the IR oracle a private directory suffixed with
+the worktree slug**, never the shared scratchpad. A hash-identical `+`/context
+pair is the signature of manifest duplication, not of a refactor that moved
+code — read the diff before believing the exit code.
+
+## Follow-ups
+
+- Delete the three dead values above together with their `val`s, plus #368's
+  three in `lower.ml` and thirty-three in `llvm_emit.ml`.
+- `lib/eval/eval.ml` and `bin/main.ml` remain the largest files with no
+  interface.


### PR DESCRIPTION
Finishes the interface pass begun in #368. Six more compiler/LSP modules get an
`.mli`; one candidate is skipped on purpose.

**No `.ml` line moved and no call site was adjusted.** Where a value had a
caller anywhere — including a test — it was exposed and the interface says so.
One commit per module, so a bad one can be dropped without losing the others.

## Per module

| File | Inferred vals | Curated vals | Internal |
|---|---:|---:|---:|
| `lib/typecheck/typecheck_env.ml` | 42 | 40 | 5% |
| `lib/typecheck/typecheck_types.ml` | 23 | 19 | 17% |
| `lsp/lib/analysis_util.ml` | 36 | 33 | 8% |
| `lib/tir/perceus.ml` | 36 | 25 | 31% |
| `lib/tir/mono.ml` | 21 | 14 | 33% |
| `lib/tir/llvm_builtins.ml` | 34 | 22 | 35% |
| `lib/tir/llvm_toplevel.ml` | 21 | 18 | 14% |
| **total** | **213** | **171** | **20%** |

## Skipped on purpose: `lsp/lib/analysis_types.ml`

302 lines, **zero `let` bindings** — twenty-odd record and variant declarations
and nothing else. An interface could only be a verbatim copy of all of them,
necessarily manifest (`Code_actions_ast`, `Code_actions_diag` and `Analysis` all
pattern-match the fields), hiding nothing, abstracting nothing, and requiring a
lockstep edit on every field added anywhere. Pure cost; left as it is.

## Why 20% and not #368's 73%

The table splits in two, and the reason is *when the file was written*.

The three **extracted** modules — `typecheck_env` (5%), `analysis_util` (8%),
`typecheck_types` (17%) — are supposed to be near zero. They were lifted
verbatim out of their parents within the last few days and never had time to
accumulate accidental surface. Manufacturing a reduction there would mean
hiding something a sibling reaches through an alias.

The four older `lib/tir/` files (31–35%) are where the real rot is, and it is
the same shape every time: a private table plus its public accessor, both
exported. `llvm_builtins` alone had five `Hashtbl`s in the public surface next
to the five functions that read them.

### The `include` hazard

`typecheck_env` and `typecheck_types` are `include`d by `typecheck.ml`;
`analysis_util` `include`s `analysis_types` and is itself `include`d by
`analysis.ml`, which has no interface of its own. For those, an `.mli`
restricts **what the parent re-exports** — a name dropped here vanishes from
`Typecheck.` or `Analysis.` and breaks a consumer two removes away, reached
through `let open` or a `Tc.`/`TC.`/`T.`/`An.` alias no grep can see. Curation
there was deliberately minimal; `dune build @check` was the only oracle that
could confirm it. The four `lib/tir/` files are `include`d by nothing, which is
most of why they could be cut harder.

## Three values declared but not API — a follow-up

Hiding a value that *nothing* mentions, not even its own file, is an
unused-value error under warnings-as-errors. Since this pass edits no `.ml`,
three had to be declared anyway, each with a comment saying so:

- `llvm_builtins.reserved_ctor_tag_limit`
- `llvm_toplevel.target_arch`
- `llvm_toplevel.emit_main_wrapper`

**The last is worth a look.** It is a real function body at
`lib/tir/llvm_toplevel.ml:725`, not a one-line re-export, and nothing calls it —
so the compiler emits its main wrapper by some other path. Compare
`march_println`'s `writev` path, dead for thirteen months behind a live-looking
declaration.

One deliberate asymmetry: `perceus.fresh_rc_var` is hidden but its counter
`_rc_fresh_ctr` is exported — `lower_state.ml` resets it and `test_snapshots.ml`
depends on that reset to keep TIR golden snapshots deterministic across run
order. The counter is API; the generator is not.

## Verification

- `dune build --root . @check` after **every** module: 17 errors throughout —
  the same 17 pre-existing ones in `forge/test/` and `js/` from a missing
  optional opam dependency, never an 18th. Baselined before the first edit.
- `dune build --root . bin/main.exe` after every module: exit 0.
- `scripts/ir-oracle.sh check` after each group: **IR IDENTICAL across 240
  programs**, every time, never anything else. An `.mli` changes visibility,
  never emitted code.
- `scripts/run-tests.sh`: **3,161 tests across 11 suites, 0 failures, exit 0** —
  "All suites passed", matching the recorded baseline exactly.
- `scripts/check-docs.sh`: exit 0.

### One oracle trap, recorded in the spec

The first oracle check returned a large-looking diff that was **not** an IR
change: every `+` line carried a hash *identical* to the context line above it,
and the manifest had 141 duplicated tags. Two other agents were running
concurrently against the same session scratchpad — one running `ir-oracle.sh`
itself, one running `main.exe --emit-llvm` with a relative path — and the shared
work directory was being written by both; the baseline manifest was later
truncated from 243 lines to 2 by the same interference. Deduplicating both
manifests and diffing showed them exactly equal, and a clean re-run in a private
directory reported IR IDENTICAL. Every subsequent check ran in
`/tmp/ir-<worktree-slug>`.

The generalisable bit is in `specs/progress/`: a hash-identical `+`/context pair
is the signature of manifest duplication, not of a refactor that moved code.

## Note for reviewers

`lib/tir/llvm_emit.ml` was being edited by another session while this branch was
built. This branch does not touch it, but `llvm_toplevel.mli` and
`llvm_builtins.mli` do constrain names that `llvm_emit.ml` calls. If that work
lands first and adds a call to one of the hidden values, `@check` will say so
precisely; re-widening the `val` is the fix.
