### PR TITLE
Delete three dead lib/tir values orphaned by the .mli-only pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ git log is authoritative for exact commits.
 
 ### Changed
 
+- Removed three uncalled `lib/tir` values (`emit_main_wrapper`, `target_arch`,
+  `reserved_ctor_tag_limit`) left over from an earlier `.mli`-only pass that
+  could not edit `.ml` files. No behavior change -- the IR oracle is
+  byte-identical across 241 programs.
+
 - `bin/main.ml` is 1,231 lines smaller (5,429 -> 4,198): host/stdlib/runtime
   discovery and link flags, the command-line flag cells, the `--check-migration`
   tool and the `--emit-core-ast` writer now live in their own `bin/` modules. No

--- a/lib/tir/llvm_builtins.ml
+++ b/lib/tir/llvm_builtins.ml
@@ -98,7 +98,6 @@ let monitor_down_tag = 0x7f00_0000
 let monitor_reason_normal_tag = 0x7f00_0001
 let monitor_reason_killed_tag = 0x7f00_0002
 let monitor_reason_crash_tag = 0x7f00_0003
-let reserved_ctor_tag_limit = 0x7f00_0004
 
 let builtins : builtin list = [
   { march_name = "print"; c_name = Some "march_print"; ret_ty = Some Tir.TUnit;

--- a/lib/tir/llvm_builtins.mli
+++ b/lib/tir/llvm_builtins.mli
@@ -26,14 +26,6 @@
     ([llvm_emit_simd.ml] reads it), which is why the [preamble_item] type
     itself stays manifest rather than going private with its siblings.
 
-    {2 [reserved_ctor_tag_limit] is declared but is not API}
-
-    It has no reference anywhere — not in this file, not outside it.  It is
-    declared here only because hiding a value nothing mentions turns it into
-    an unused-value error under warnings-as-errors.  Deleting the [let] and
-    this [val] together is the right follow-up; #368 left the same note
-    against three re-exports in [lower.ml] and thirty-three in [llvm_emit.ml].
-
     {2 What stays}
 
     [builtins] has 53 referencing files and [mangle_extern] 13; the tag
@@ -58,7 +50,6 @@ val monitor_down_tag : int
 val monitor_reason_normal_tag : int
 val monitor_reason_killed_tag : int
 val monitor_reason_crash_tag : int
-val reserved_ctor_tag_limit : int
 val builtins : builtin list
 type preamble_item =
     PComment of string

--- a/lib/tir/llvm_toplevel.ml
+++ b/lib/tir/llvm_toplevel.ml
@@ -66,11 +66,6 @@ let target_triple = function
   | Wasm32Unknown   -> "wasm32-unknown-unknown"
   | Js              -> "js"
 
-(** Architecture, when meaningful (native's arch is the host, decided by clang). *)
-let target_arch = function
-  | LinuxGnu { arch; _ } -> Some arch
-  | Native | Wasm64Wasi | Wasm32Wasi | Wasm32Unknown | Js -> None
-
 let target_is_linux = function
   | LinuxGnu _ -> true
   | Native | Wasm64Wasi | Wasm32Wasi | Wasm32Unknown | Js -> false
@@ -718,19 +713,6 @@ let build_ctor_info ctx (m : Tir.tir_module) =
       Hashtbl.replace ctx.Llvm_ctx.ctor_info _name
         { Llvm_ctx.ce_tag = 0; ce_fields = field_tys }
   ) m.Tir.tm_types
-
-(** Dead code, carried verbatim from [llvm_emit.ml] (Wave 3 Task 7 move):
-    no caller exists anywhere in the tree (grepped at move time). Not a
-    behavior change to leave in place — see specs/todos.md filing. *)
-let emit_main_wrapper (buf : Buffer.t) =
-  Buffer.add_string buf
-    "\ndeclare void @march_process_argv_init(i32 %argc, ptr %argv)\n\
-     declare void @march_spawn_main(ptr %fn)\n\
-     define i32 @main(i32 %argc, ptr %argv) {\nentry:\n\
-       call void @march_process_argv_init(i32 %argc, ptr %argv)\n\
-       call void @march_spawn_main(ptr @march_main)\n\
-       call void @march_run_scheduler()\n\
-       ret i32 0\n}\n"
 
 let emit_module ~emit_expr
     ?(fast_math=false) ?(pmap_threshold=1024) ?(target=Native)

--- a/lib/tir/llvm_toplevel.mli
+++ b/lib/tir/llvm_toplevel.mli
@@ -17,21 +17,6 @@
     {!target_triple}), and [native_vec_param_idxs] (a vector-ABI helper used
     by {!emit_fn}).
 
-    {2 Two values are declared here but are dead code}
-
-    [target_arch] and [emit_main_wrapper] have no reference anywhere — not in
-    this file, not in any other, not in the tests.  A grep of
-    [bin/ lib/ lsp/ test/] finds only their own [let] lines.  They are declared
-    only because hiding a value nothing mentions turns it into an unused-value
-    error under warnings-as-errors, and this pass does not edit [.ml] files.
-
-    [emit_main_wrapper] is the interesting one: it is a real function body at
-    [llvm_toplevel.ml:725], not a one-line re-export, and the compiler has
-    evidently been emitting its main wrapper by some other path.  Deleting it,
-    or finding out why it was orphaned, is a worthwhile follow-up — compare
-    [specs/progress/] on [march_println]'s [writev] path, which was dead for
-    thirteen months behind a live-looking declaration.
-
     {2 What stays}
 
     [emit_module] has 17 referencing files and [build_ctor_info] 15; the
@@ -50,7 +35,6 @@ val is_wasm_target : target_config -> bool
 val is_wasm32 : target_config -> bool
 external get_native_triple : unit -> string = "march_tir_native_triple"
 val target_triple : target_config -> string
-val target_arch : target_config -> arch option
 val target_is_linux : target_config -> bool
 val zig_target : target_config -> string option
 val target_ptr_size : target_config -> int
@@ -66,7 +50,6 @@ val fn_declare_str : Tir.fn_def -> string
 val emit_atom_show_table : Llvm_ctx.ctx -> unit
 val build_ctor_info :
   Llvm_ctx.ctx -> Tir.tir_module -> unit
-val emit_main_wrapper : Buffer.t -> unit
 val emit_module :
   emit_expr:(Llvm_ctx.ctx -> Tir.expr -> string * string) ->
   ?fast_math:bool ->

--- a/specs/progress/2026-08-27-delete-three-dead-tir-values.md
+++ b/specs/progress/2026-08-27-delete-three-dead-tir-values.md
@@ -1,0 +1,47 @@
+# Delete three dead `lib/tir` values found by the `.mli` pass
+
+Landed 2026-08-27.
+
+PR #370's `.mli` pass (and the earlier #368) operated under a no-`.ml`-edits
+constraint: three values had zero callers anywhere in the tree, but hiding an
+unused value in an `.mli` turns it into an unused-value error under
+warnings-as-errors, so each was kept public with a doc comment explaining it
+was dead and naming deletion as the right follow-up. This is that follow-up.
+
+## What was deleted
+
+- `emit_main_wrapper` (`lib/tir/llvm_toplevel.ml`) — a real function body
+  (not a re-export), carried verbatim from `llvm_emit.ml` in the Wave 3 file
+  split. The compiler evidently emits its main wrapper by some other path.
+- `target_arch` (`lib/tir/llvm_toplevel.ml`)
+- `reserved_ctor_tag_limit` (`lib/tir/llvm_builtins.ml`)
+
+Each had exactly one reference in the whole tree: its own `let`. Re-verified
+with `forge search --callers <name>` (no references) and
+`grep -rn <name> lib bin lsp forge test` (definition/declaration only) before
+deleting the `.ml` definition and the matching `.mli` `val` (and doc-comment
+callout) together.
+
+## Why these three and not `inject_iface_exports_ref`
+
+This project has now found dead-but-declared code eight and nine times over
+(see `2026-08-26-compiler-file-decomposition-complete.md` and the
+`effects.ml` / `register_types_for_check` / `compile_scc` todos). Not every
+instance is rot: `inject_iface_exports_ref` reads as a breadcrumb for
+unfinished work and was deliberately left alone. These three carry no such
+signal — both `.mli` doc comments were explicit that deletion was the correct
+next step, and `emit_main_wrapper`'s sibling in the `march_println`/`writev`
+incident (dead 13 months behind a live-looking declaration) was the
+cautionary comparison, not a reason to keep it.
+
+## Verification
+
+- `dune build --root . @check --force`: stayed at the pre-existing 17
+  `Unbound module "Alcotest"` errors (forge/test infra gap, unrelated to this
+  change) — same 17, reordered by parallel build scheduling.
+- `scripts/ir-oracle.sh baseline|check`: IR IDENTICAL across 241 programs
+  (baselined against a private `HOME`, per
+  `project_home_cache_path_contamination_oracles`). Deleting genuinely dead
+  code cannot move emitted output; a diff here would have meant one of the
+  three was live and the deletion should stop.
+- `scripts/run-tests.sh`: all suites passed (exit 0).


### PR DESCRIPTION
## Summary
- `emit_main_wrapper`, `target_arch` (`lib/tir/llvm_toplevel.ml`), and `reserved_ctor_tag_limit` (`lib/tir/llvm_builtins.ml`) had exactly one reference each in the whole tree: their own definition.
- All three were kept public by PR #370's `.mli`-only pass solely because that pass could not edit `.ml` files, and hiding an unused value turns it into an unused-value error under warnings-as-errors. Both `.mli` doc comments named deletion as the correct follow-up.
- Re-verified with `forge search --callers <name>` and `grep -rn <name> lib bin lsp forge test` before deleting each `.ml` definition and its matching `.mli` `val` (plus doc-comment callout) in the same commit.
- Left `inject_iface_exports_ref` alone — that one reads as a breadcrumb for unfinished work, not rot (per the note in the previous decomposition pass).

## Test plan
- [x] `dune build --root . @check --force` stays at the pre-existing 17 baseline errors (`Unbound module "Alcotest"` in `forge/test/*`, unrelated to this change) — confirmed byte-for-byte same 17 errors, just reordered by parallel build scheduling.
- [x] `scripts/ir-oracle.sh baseline|check` (private `HOME`): IR IDENTICAL across 241 programs, both before and after the deletion.
- [x] `scripts/run-tests.sh`: all 11 suites pass, exit 0.
- [x] `scripts/check-docs.sh`: doc-lint passed.