### PR TITLE
ci(release): land the native arm64 aarch64 leg on main; revert nightly scaffold

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,11 +25,18 @@ jobs:
             platform: linux-x86_64
             ocaml-compiler: 5.3.0
             static: true
-          - os: ubuntu-24.04
+          # Native arm64 host (GitHub-hosted `ubuntu-24.04-arm`, free for
+          # public repos). This leg used to run on an x86_64 runner with
+          # docker/setup-qemu-action and `--platform linux/arm64`; building
+          # ocaml-base-compiler.5.3.0 from source under that emulation took 52
+          # minutes on its own (nightly run 33358635235). The Alpine container
+          # stays — it is what provides musl for the `static: true` artifact —
+          # but on an arm64 host it runs natively, with no QEMU.
+          - os: ubuntu-24.04-arm
             platform: linux-aarch64
             ocaml-compiler: 5.3.0
             static: true
-            cross: true
+            alpine: true
 
     runs-on: ${{ matrix.os }}
 
@@ -41,27 +48,26 @@ jobs:
 
       # --- Linux static builds (musl) ---
 
+      # Only the x86_64 leg builds musl-static on the runner host. The
+      # aarch64 leg builds inside Alpine, which is musl-native already, so
+      # installing musl-tools on its host would be pure waste.
       - name: Install musl toolchain (Linux)
-        if: matrix.static
+        if: matrix.static && !matrix.alpine
         run: |
           sudo apt-get update
           sudo apt-get install -y musl-tools
 
-      - name: Set up QEMU (Linux aarch64 cross)
-        if: matrix.cross
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
-
-      # For aarch64, we build inside Alpine (musl-native) under QEMU.
-      # This avoids cross-compilation complexity with OCaml.
+      # aarch64 builds inside Alpine because the artifact must be
+      # musl-static, not because of any cross-compilation: the runner is
+      # already arm64, so the container is a plain native `docker run` with no
+      # `--platform` and no QEMU. Do not reintroduce either without also moving
+      # this leg back to an x86_64 `os:` — they only made sense together.
       - name: Build in Alpine container (Linux aarch64)
-        if: matrix.cross
+        if: matrix.alpine
         uses: addnab/docker-run-action@v3
         with:
           image: alpine:3.21
           options: >-
-            --platform linux/arm64
             -v ${{ github.workspace }}:/work
             -w /work
           run: |
@@ -93,11 +99,13 @@ jobs:
               /tmp/blake3/c/blake3.c /tmp/blake3/c/blake3_dispatch.c \
               /tmp/blake3/c/blake3_portable.c /tmp/blake3/c/blake3_neon.c
             cp /tmp/blake3/c/blake3.h /usr/include/blake3.h
-            # NOT covered by .github/actions/opam-deps (which the native legs
-            # below use): this runs inside an ephemeral Alpine container and
-            # creates a GLOBAL switch in the container's own opam root, not the
-            # `_opam` local switch that action caches. Caching across the
-            # docker-run boundary would be a separate mechanism; left uncached.
+            # NOT covered by .github/actions/opam-deps (which the host-built
+            # legs below use): this runs inside an ephemeral Alpine container
+            # and creates a GLOBAL switch in the container's own opam root, not
+            # the `_opam` local switch that action caches. Caching across the
+            # docker-run boundary would be a separate mechanism; left uncached
+            # — tolerable now that the switch is built natively rather than
+            # emulated.
             opam init --disable-sandboxing --bare -y
             opam switch create 5.3.0 ocaml-base-compiler.5.3.0
             eval $(opam env)
@@ -111,8 +119,13 @@ jobs:
             cp runtime/*.c runtime/*.h _dist/runtime/
             cp LICENSE _dist/ 2>/dev/null || true
 
-      # --- macOS and Linux x86_64 native builds ---
+      # --- macOS and Linux x86_64: built on the runner host ---
 
+      # Runs on the two legs that build directly on the runner host, i.e.
+      # everything except the Alpine-container leg above (every leg is now
+      # native-arch, so `!matrix.alpine` is a host-vs-container distinction,
+      # not a native-vs-emulated one).
+      #
       # Sets up OCaml (pinning setup-ocaml@v3.7.0 — the first release with a
       # stable-opam entry for macos-15, our minimum macOS target; the older @v3
       # failed with "no matching opam release" on darwin-arm64, and forcing a
@@ -125,15 +138,15 @@ jobs:
       # is deliberately NOT the common one, because release artifacts need a
       # STATIC libblake3.a (no Homebrew dylib dependency on the user's machine)
       # rather than ci.yml's plain `brew install blake3`.
-      - name: Set up OCaml + install opam dependencies (cached, native)
-        if: "!matrix.cross"
+      - name: Set up OCaml + install opam dependencies (cached, host)
+        if: "!matrix.alpine"
         timeout-minutes: 12
         uses: ./.github/actions/opam-deps
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
-      - name: Install system dependencies (native)
-        if: "!matrix.cross"
+      - name: Install system dependencies (host)
+        if: "!matrix.alpine"
         run: |
           if [ "$RUNNER_OS" = "macOS" ]; then
             brew install blake3 zstd brotli llvm
@@ -161,7 +174,7 @@ jobs:
           fi
 
       - name: Build (Linux x86_64)
-        if: matrix.static && !matrix.cross
+        if: matrix.static && !matrix.alpine
         run: |
           eval $(opam env)
           dune build --force bin/main.exe forge/bin/main.exe

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -111,17 +111,9 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       version: ${{ needs.version.outputs.version }}
-      # TEMPORARY TEST SCAFFOLD — REVERT BEFORE MERGE.
-      # Normally `main`. Pointed at this branch so a manual dispatch actually
-      # builds the branch's SOURCE, not just its workflow files. Without this,
-      # a dispatch tests workflow-level changes only and silently ignores every
-      # source fix on the branch.
-      ref: claude/git-ls-files-error-12a534
+      ref: main
 
   publish:
-    # TEMPORARY TEST SCAFFOLD — REVERT BEFORE MERGE.
-    # Never publish a public nightly release built from an unmerged branch.
-    if: false
     needs: [version, build]
     runs-on: ubuntu-24.04
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ git log is authoritative for exact commits.
 
 ## [Unreleased]
 
+### Fixed
+
+- ARM Linux (`linux-aarch64`) has a working release artifact for the first
+  time. Every v0.2.0 and v0.3.0 ARM archive shipped with an empty `bin/` and no
+  compiler at all. Three defects were stacked behind one another: git refusing
+  the bind-mounted checkout inside the Alpine build container
+  (`safe.directory`), the LLVM 19/20 guard bug noted below, and libblake3 built
+  without `blake3_neon.c` on aarch64, which links but leaves
+  `blake3_hash_many_neon` undefined in every executable that uses it.
+
+### Changed
+
+- The `linux-aarch64` release leg builds on a native arm64 runner
+  (`ubuntu-24.04-arm`) instead of QEMU emulation on an x86_64 host. It still
+  builds inside Alpine, which is what makes the artifact musl. Building the
+  OCaml 5.3.0 switch alone took 52 minutes under emulation; the entire leg now
+  takes under 5 minutes.
+
 ### Added
 
 - Refinement failures now come with concrete, interpreter-validated

--- a/specs/github_release_builds.md
+++ b/specs/github_release_builds.md
@@ -11,6 +11,13 @@ This spec defines how March compiler binaries are built, packaged, and published
 > illustrative rather than current — `.github/workflows/build.yml` is the
 > source of truth for what actually builds. Intel macOS has no prebuilt;
 > `install.sh` detects it and points at building from source.
+>
+> **Update 2026-08-31:** the AArch64 row above is corrected (it is a native
+> arm64 runner now, not `ubuntu-22.04` + QEMU), but the YAML further down is
+> still the old illustrative snapshot and does not match the workflow: it
+> quotes `alpine:3.19`, a `matrix.cross` flag, `docker/setup-qemu-action` and
+> `--platform linux/arm64`, none of which exist any more. Read
+> `.github/workflows/build.yml`, not the snippet.
 
 
 All builds target OCaml 5.3.0 and produce native binaries for four platforms:
@@ -19,7 +26,7 @@ All builds target OCaml 5.3.0 and produce native binaries for four platforms:
 |-------|-------------|---------------------|------------------|------------|
 | macOS | Apple Silicon | `macos-14`          | `darwin-arm64`   | dynamic    |
 | Linux | x86-64       | `ubuntu-22.04`      | `linux-x86_64`   | static (musl) |
-| Linux | AArch64      | `ubuntu-22.04` + QEMU | `linux-aarch64`  | static (musl) |
+| Linux | AArch64      | `ubuntu-24.04-arm`  | `linux-aarch64`  | static (musl) |
 
 Platform strings match the forge version manager's platform detection table exactly (see `forge_version_manager.md § Platform Detection`).
 

--- a/specs/progress/2026-08-31-linux-aarch64-release-build-native-arm64.md
+++ b/specs/progress/2026-08-31-linux-aarch64-release-build-native-arm64.md
@@ -1,4 +1,4 @@
-`[P1]` # Every linux-aarch64 release archive ships with an empty `bin/`
+# Every linux-aarch64 release archive ships with an empty `bin/` — RESOLVED 2026-08-31
 
 Found 2026-08-23 while checking the v0.3.0 release assets, after noticing the
 aarch64 archive was 692 KB against 11 MB for linux-x86_64.
@@ -190,7 +190,10 @@ B2 (fixed guard >= 21):     compiled clean
 So the LLVM fix is now compile-verified against LLVM 19, not merely inferred
 from reading upstream headers.
 
-## Why this stays open
+## Why this stayed open (superseded — see the resolution below)
+
+*Everything in this section was true when written and is kept for the record.
+All three conditions it lists were met on 2026-08-31.*
 
 The blake3 and LLVM-guard fixes are verified in isolation but
 **unverified end to end against the real leg**. It cannot be reproduced or tested locally (no arm64
@@ -211,11 +214,103 @@ failure. Even with the git fix, this leg is very slow and is a plausible future
 timeout; caching the container's opam root, or moving to a native arm64 runner,
 is worth considering separately.
 
-## Acceptance
+## Resolution 2026-08-31: native arm64 runner, verified end to end
+
+The "fourth failure behind these two" the section above warned about did not
+materialise. With the three fixes in place — `safe.directory`, the LLVM 21
+guard, and blake3 NEON — the leg builds clean.
+
+### The leg moved off QEMU onto a native arm64 runner
+
+`ubuntu-24.04-arm` is available to this repo (public repo, free-plan org), and
+that was confirmed on a live run rather than assumed: runner image
+`ubuntu24-arm64/20260823.101`, `uname -m` = `aarch64`, docker server arch
+`arm64`.
+
+The Alpine container **stays** — it is what makes the artifact musl — but on an
+arm64 host it is a plain native `docker run`, so `docker/setup-qemu-action` and
+`--platform linux/arm64` are both gone. They only ever made sense together with
+an x86_64 `os:`; the workflow now carries a comment saying so, because
+reintroducing either one alone would silently re-emulate.
+
+The `cross: true` matrix flag became `alpine: true`. Nothing about this leg is
+a cross-compile any more; what the flag actually selects — and always actually
+selected — is "built inside the container" versus "built on the runner host".
+The `!matrix.cross` → `!matrix.alpine` gates preserve the exact same partition
+(host legs get `opam-deps` and the native build steps, the container leg does
+not). `Install musl toolchain` is now additionally skipped on this leg, where
+installing musl-tools on the host was pure waste.
+
+**Wall-clock.** Installing `ocaml-compiler.5.3.0` alone took **52 minutes**
+under emulation. The whole leg — apk, blake3 from source, opam init, a
+from-source 5.3.0 switch, every opam dep, and `dune build` of both binaries —
+now takes **4m51s** (run 33410265258). The 100-minute CI round trip per attempt
+that made this item so expensive to work on is gone.
+
+This also removes the motivation for caching the container's opam root across
+the docker-run boundary: the switch is cheap to rebuild natively.
+
+## Acceptance — met
 
 A `linux-aarch64` archive whose `bin/march` and `bin/forge` are present,
 non-empty, and executable; and a deliberately broken build leg fails the job
 rather than publishing.
+
+Verified on run 33410265258 (all three legs green, so the LLVM guard change
+regressed neither x86_64 nor macOS), artifact `march-probe-linux-aarch64.tar.gz`
+— **12.8 MB**, against 692 KB for the empty v0.3.0 one:
+
+```
+bin/march  24,113,976 bytes  ELF 64-bit LSB pie executable, ARM aarch64,
+                             interpreter /lib/ld-musl-aarch64.so.1
+bin/forge  16,457,880 bytes  (same)
+```
+
+Both binaries were then actually **run** — not merely inspected — in a native
+arm64 `alpine:3.21` container on an Apple Silicon host, the same local-repro
+technique recorded above: `march --version` → `march 0.3.0`, `forge --version`
+→ `0.3.0`, and a hello-world module interpreted correctly
+(`hello from aarch64`).
+
+This is the first working ARM Linux build artifact the project has produced.
+
+Verification deliberately did **not** go through a `nightly.yml` dispatch: that
+publishes a public release tag, and `nightly.yml` hardcodes `ref: main`, so it
+would have built main's source rather than the branch's. A temporary workflow
+called `build.yml` directly instead, and was removed afterwards. (The
+`TEMP(test scaffold)` edit to `nightly.yml` on the fix branch solves the same
+problem a different way and is still marked REVERT BEFORE MERGE.)
+
+## Three things found while verifying — all pre-existing, all still open
+
+None of these were introduced by this work and none block the acceptance above,
+but they were observed directly and should not be lost.
+
+1. **Neither Linux leg is actually statically linked**, despite `static: true`.
+   Both come out `dynamically linked` with `NEEDED` entries for
+   `libLLVM.so.{18,19}.1`, `libblake3.so`, `libz`, `libzstd` and brotli —
+   `libblake3.so` being one the workflow itself builds from source and that
+   exists on no user's machine. On a bare `alpine:3.21` the aarch64 binary
+   aborts with ~20 `symbol not found` relocations; it runs once those libraries
+   are installed. `static: true` today gates only the `musl-tools` install.
+   Since x86_64 has the identical shape and has shipped that way for two
+   releases, this is a general release-portability problem, not an ARM one.
+   → `specs/todos/2026-08-31-linux-release-binaries-are-not-static.md`
+
+2. **`strip` silently does nothing on the container leg.** `_dist` is written
+   by root inside the container as mode `-r-xr-xr-x`; the host `strip` runs as
+   uid 1001, cannot write the files, and the failure is eaten by `|| true` —
+   the same swallowing pattern this item was originally filed about. The step
+   reports success and the binaries ship `not stripped` with debug_info, hence
+   24 MB.
+
+3. **The bundled C runtime does not compile on musl**, so `march --compile`
+   from the aarch64 prebuilt fails at `march_runtime.c:27: fatal error:
+   'execinfo.h' file not found`. `execinfo.h` is a glibc extension. Confirmed
+   to be the *only* remaining blocker once zlib/openssl/zstd dev headers are
+   present. The interpreter is unaffected — the prebuilt can interpret March
+   but not compile it.
+   → `specs/todos/2026-08-31-runtime-execinfo-h-breaks-musl-compile.md`
 
 ## Note on the currently-published assets
 

--- a/specs/todos/2026-08-31-linux-release-binaries-are-not-static.md
+++ b/specs/todos/2026-08-31-linux-release-binaries-are-not-static.md
@@ -1,0 +1,47 @@
+`[P1]` # Both Linux release legs are dynamically linked despite `static: true`
+
+Found 2026-08-31 while verifying the first working `linux-aarch64` artifact
+(see `specs/progress/2026-08-31-linux-aarch64-release-build-native-arm64.md`).
+
+## The defect
+
+`.github/workflows/build.yml` marks both Linux legs `static: true`, and
+`specs/github_release_builds.md` promises "the resulting binary has zero
+runtime dependencies and runs on any Linux kernel 3.2+". Neither is true.
+`readelf -d` on the artifacts of run 33410265258:
+
+```
+linux-x86_64   NEEDED libLLVM.so.18.1, libblake3.so, libz.so.1, libzstd.so.1,
+                      libbrotlienc.so.1, libbrotlidec.so.1, libm.so.6, libc.so.6
+linux-aarch64  NEEDED libLLVM.so.19.1, libblake3.so, libz.so.1, libzstd.so.1,
+                      libbrotlienc.so.1, libbrotlidec.so.1, libc.musl-aarch64.so.1
+```
+
+`libblake3.so` in particular is built from source *by the workflow* and exists
+on no user's machine at all.
+
+Observed directly: on a bare `alpine:3.21` the aarch64 binary does not start —
+it aborts with ~20 `Error relocating ... symbol not found` lines for the LLVM,
+zstd and blake3 symbols. It runs correctly once those libraries are installed.
+
+## Why it is like this
+
+`static: true` today gates exactly two things: the `musl-tools` apt install and
+the choice of build step. Nothing in the workflow passes `-static` to anything.
+The old illustrative snippet in `specs/github_release_builds.md` still shows
+`OCAMLPARAM='_,ccopt=-static' dune build --force`; the real workflow has plain
+`dune build --force`. Whenever that flag was dropped, the legs kept the label.
+
+This is a *general* release-portability problem, not an ARM one — x86_64 has
+the identical shape and has been shipping to users for two releases.
+
+## Acceptance
+
+Either the Linux archives genuinely link statically (and a CI check runs the
+produced binary in a scratch container with no dev packages installed), or the
+`static: true` label and the "zero runtime dependencies" claim in
+`specs/github_release_builds.md` are corrected to say what actually ships and
+`install.sh` grows the dependency list.
+
+A test that would have caught this: run `bin/march --version` inside a bare
+`alpine:3.21` / `debian:stable-slim` as part of the build job.

--- a/specs/todos/2026-08-31-runtime-execinfo-h-breaks-musl-compile.md
+++ b/specs/todos/2026-08-31-runtime-execinfo-h-breaks-musl-compile.md
@@ -1,0 +1,38 @@
+`[P2]` # `march --compile` fails on musl: `execinfo.h` is glibc-only
+
+Found 2026-08-31 while exercising the first working `linux-aarch64` release
+artifact (see
+`specs/progress/2026-08-31-linux-aarch64-release-build-native-arm64.md`).
+
+## The defect
+
+`runtime/march_runtime.c:27` does an unconditional `#include <execinfo.h>`.
+That header is a glibc extension; musl does not have it. So on Alpine — which
+is exactly what the musl-targeted `linux-aarch64` prebuilt is built for and
+most likely to be run on — `march --compile` dies compiling its own bundled
+runtime:
+
+```
+runtime/march_runtime.c:27:10: fatal error: 'execinfo.h' file not found
+   27 | #include <execinfo.h>
+```
+
+Confirmed to be the **only** remaining blocker: with `zlib-dev`, `openssl-dev`,
+`zstd-dev`, `brotli-dev`, `clang19` and a locally built `libblake3.so` present
+in an `alpine:3.21` container, `execinfo.h` is the single `fatal error` left.
+
+The interpreter path is unaffected — `march file.march` runs correctly on musl.
+It is only the ahead-of-time compile that breaks, i.e. the aarch64 prebuilt can
+interpret March but cannot compile it.
+
+## Likely fix
+
+`execinfo.h` is used for `backtrace`/`backtrace_symbols` in the crash handler.
+Guard it (`#if defined(__GLIBC__)`) and degrade to no symbolic backtrace on
+musl, rather than dropping the feature for glibc users.
+
+## Acceptance
+
+`march --compile` produces and runs a binary from a hello-world module inside
+`alpine:3.21` (aarch64 and x86_64), using only the runtime sources bundled in
+the release archive.


### PR DESCRIPTION
Two things #384 and #385 left undone on `main`.

## 1. #385's content never reached `main`

#385 was stacked on #384's branch, and merged **into that branch** 12 seconds
after #384 squash-merged to `main`. GitHub only auto-retargets a stacked PR when
its base branch is deleted, and this one survived — so the merge went to the
branch, not to `main`.

Net effect: `main` still had `matrix.cross`, `docker/setup-qemu-action` and
`--platform linux/arm64`. **The aarch64 release leg is still running under
emulation on `main` right now.** This re-applies #385 on top of `main`.

(The two source fixes from #385 — the LLVM 21 guard and blake3 NEON — *are*
already on `main`; they came in via #384's squash. Only the runner change and
its docs were lost.)

## 2. The `REVERT BEFORE MERGE` scaffold is live on `main`

#384's squash carried in the `TEMPORARY TEST SCAFFOLD` block. `nightly.yml` on
`main` currently reads:

```yaml
  build:
      ref: claude/git-ls-files-error-12a534   # not `main`
  publish:
    if: false                                 # never publishes
```

So the nightly builds an unmerged feature branch and publishes nothing. If that
branch is ever deleted, it fails outright instead. `nightly.yml` here is
restored byte-identical to its pre-scaffold state (`d18aa14d`) — verified with
`diff`, not by eye.

## What lands

- `linux-aarch64` builds on `ubuntu-24.04-arm`. The Alpine container **stays** —
  it is what makes the artifact musl — but on an arm64 host it is a plain native
  `docker run`, so QEMU and the platform flag are gone.
- `cross:` → `alpine:`. Nothing about the leg is a cross-compile any more; the
  flag selects "built in the container" vs "built on the runner host". The
  `!matrix.cross` → `!matrix.alpine` gates preserve the exact same partition.
  `Install musl toolchain` is additionally skipped on this leg, where installing
  musl-tools on the host was pure waste.
- `nightly.yml` scaffold reverted.
- `specs/todos/2026-08-23-…-has-no-binaries.md` removed — #385 superseded it with
  the progress entry, but #384's squash left the todo behind, so `main` currently
  has both.

## Verification

Measured on run 33410265258, all three legs green:

| | before | after |
|---|---|---|
| `ocaml-compiler.5.3.0` install | **52 min** | — |
| whole leg | never completed | **4m51s** |
| archive | 692 KB, empty `bin/` | 12.8 MB, both binaries |

Both binaries were **actually run**, not just inspected, in a native arm64
`alpine:3.21` container: `march --version` → `march 0.3.0`, `forge --version` →
`0.3.0`, hello-world interpreted correctly. First working ARM Linux artifact the
project has produced.

`scripts/check-docs.sh` green on this tree.

## Still open (pre-existing, documented in the progress entry)

1. Neither Linux leg is actually statically linked despite `static: true` —
   `x86_64` has the identical shape and has shipped that way for two releases.
2. `march --compile` fails on musl (`execinfo.h` is glibc-only).
3. `strip` silently no-ops on the container leg (root-owned files, `|| true`).
