### PR TITLE
fix(ci): revert nightly test scaffold that merged to main in #384

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -111,17 +111,9 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       version: ${{ needs.version.outputs.version }}
-      # TEMPORARY TEST SCAFFOLD — REVERT BEFORE MERGE.
-      # Normally `main`. Pointed at this branch so a manual dispatch actually
-      # builds the branch's SOURCE, not just its workflow files. Without this,
-      # a dispatch tests workflow-level changes only and silently ignores every
-      # source fix on the branch.
-      ref: claude/git-ls-files-error-12a534
+      ref: main
 
   publish:
-    # TEMPORARY TEST SCAFFOLD — REVERT BEFORE MERGE.
-    # Never publish a public nightly release built from an unmerged branch.
-    if: false
     needs: [version, build]
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
**Merge this promptly** — `main`'s nightly is currently misconfigured.

#384 was squashed and merged while a temporary test scaffold was still in `nightly.yml`. On `main` right now:

```yaml
      ref: claude/git-ls-files-error-12a534    # should be: main

  publish:
    if: false                                  # should not be here
```

## Effect on main today

- The scheduled nightly builds **a feature branch instead of main**.
- It **publishes nothing**, silently — a skipped job is not a failure, so nothing alerts.
- Once that branch is deleted, the build starts failing outright.

Nothing is corrupted and no bad release was published (the disabled `publish` is, ironically, what prevented one). But nightly coverage of main is effectively off until this lands.

## How it happened

The scaffold was added deliberately in cb32bfb2, with `REVERT BEFORE MERGE` on both hunks and a callout in the PR discussion. It existed because dispatching Nightly on a branch otherwise builds *main's* source and silently ignores every source-tree fix on the branch — the trap that had already cost one wasted 100-minute run.

The revert was written and pushed to the branch, but #384 had already been squashed and merged by then. A `REVERT BEFORE MERGE` comment is a note to a human, not a gate — the real lesson is that a scaffold like this should be enforced mechanically (a CI check failing on `if: false` in `publish`, or a `ref:` that is not `main`) rather than trusted to a comment.

## This change

Restores `ref: main` and re-enables `publish`. Nothing else.

Verified: `git diff` against the pre-#384 `nightly.yml` is empty — this restores it exactly.
