### PR TITLE
test(run-tests): cover test_refinecheck, guard against z3-less false green

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,15 +58,16 @@ scripts/run-tests.sh -q stdlib         # quick subset
 scripts/run-tests.sh stdlib_march      # the .march test files under test/stdlib/
 scripts/run-tests.sh test_jit          # REPL-JIT / --jit alcotest suite
 scripts/run-tests.sh lsp               # the LSP analysis suite (lsp/test/)
+scripts/run-tests.sh refinecheck       # z3-backed refinement-check suite (full-run only, ~4min)
 
 # Suites: compiler, eval, codegen, stdlib, stdlib_march, test_jit, lsp, utf16,
-# jsonrpc, incremental, query_cli. The last five are the LSP suites and live
-# under lsp/test/, not test/. An unknown
+# jsonrpc, incremental, query_cli, refinecheck. The five before refinecheck are
+# the LSP suites and live under lsp/test/, not test/. An unknown
 # name is a hard error listing the known suites, not a confusing dune build
 # failure.
 
 # 2. Direct binary invocation (no dune RPC at execution time)
-dune build test/run_compiler.exe test/run_eval.exe test/run_codegen.exe test/run_stdlib.exe test/test_stdlib_march.exe test/test_jit.exe
+dune build test/run_compiler.exe test/run_eval.exe test/run_codegen.exe test/run_stdlib.exe test/test_stdlib_march.exe test/test_jit.exe test/test_refinecheck.exe
 ./_build/default/test/run_compiler.exe -e
 ./_build/default/test/run_eval.exe -e
 ./_build/default/test/run_codegen.exe -e
@@ -76,6 +77,11 @@ dune build test/run_compiler.exe test/run_eval.exe test/run_codegen.exe test/run
 # silently skip (reported as passing) — scripts/run-tests.sh sets this for
 # you; direct invocation needs it explicitly:
 MARCH_BIN="$PWD/_build/default/bin/main.exe" ./_build/default/test/test_jit.exe -e
+# test_refinecheck needs z3 on PATH or its ~550 z3-gated cases all report
+# [SKIP] while alcotest still exits 0 ("Test Successful") — scripts/run-tests.sh
+# checks for z3 and fails loudly if it's missing; direct invocation does not,
+# so check `command -v z3` yourself first.
+./_build/default/test/test_refinecheck.exe -e
 # The LSP suites live under lsp/test/. test_jsonrpc drives a real march-lsp
 # process over stdio, so lsp/bin/main.exe must be built or all 22 of its cases
 # die with Unix.ENOENT; and they are cwd-sensitive -- run them from the repo

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -13,17 +13,27 @@
 #   scripts/run-tests.sh stdlib_march    # the .march stdlib test files
 #   scripts/run-tests.sh test_jit        # the REPL-JIT / --jit alcotest suite
 #   scripts/run-tests.sh lsp             # the LSP analysis suite (lsp/test/)
+#   scripts/run-tests.sh refinecheck     # the z3-backed refinement-check suite
 #
 # Suites: compiler, eval, codegen, stdlib, stdlib_march, test_jit, lsp, utf16,
-# jsonrpc, incremental, query_cli.  The first four are test/run_<name>.exe;
-# stdlib_march is test/test_stdlib_march.exe, which runs the .march test files
-# under test/stdlib/; test_jit is test/test_jit.exe, which drives the REPL JIT
-# / `march --jit` as subprocesses of a freshly built bin/main.exe.  The last
-# five live under lsp/test/, not test/ — see LSP_RUNNERS below.
+# jsonrpc, incremental, query_cli, refinecheck.  The first four are
+# test/run_<name>.exe; stdlib_march is test/test_stdlib_march.exe, which runs
+# the .march test files under test/stdlib/; test_jit is test/test_jit.exe,
+# which drives the REPL JIT / `march --jit` as subprocesses of a freshly built
+# bin/main.exe; refinecheck is test/test_refinecheck.exe, the z3-gated
+# refinement-checker corpus (~550 cases, ~3.5-4.5 min with z3 present — see
+# the z3 checks below). The next five live under lsp/test/, not test/ — see
+# LSP_RUNNERS below.
 #
 # Slow tests skipped by -q: repl_compiler_parity (JIT parity, ~5s),
 #   compiled adversarial regressions (~5s), pbkdf2 key derivation (~3s), and
 #   test_jit's ORC/clang REPL-session and --jit-file cases (~5-10s).
+#   test_refinecheck is FULL-RUN-ONLY: none of its cases carry a `Slow tag (so
+#   -q would not shorten it anyway; it takes -e/-q like every alcotest binary,
+#   but every case is `Quick), and at ~4 minutes it dominates a "quick" loop's
+#   budget for no savings.  -q with no suite names therefore excludes it from
+#   the default set; name it explicitly (`scripts/run-tests.sh refinecheck` or
+#   `-q refinecheck`) to run it anyway.
 #
 # test_jit is NOT a plain alcotest exe: `dune runtest` normally runs it with
 # HOME and MARCH_BIN pinned (see the `(test (name test_jit) ...)` stanza in
@@ -91,9 +101,13 @@ fi
 # feature in the tree and still see a fully green `scripts/run-tests.sh`.  They
 # live under lsp/test/, not test/, so the exe path is per-runner from here on.
 ALL_RUNNERS=(run_compiler run_eval run_codegen run_stdlib test_stdlib_march test_jit
-             test_lsp test_utf16 test_jsonrpc test_incremental test_query_cli)
+             test_lsp test_utf16 test_jsonrpc test_incremental test_query_cli test_refinecheck)
 # Suites whose executable is lsp/test/<name>.exe rather than test/<name>.exe.
 LSP_RUNNERS=(test_lsp test_utf16 test_jsonrpc test_incremental test_query_cli)
+# Runners excluded from the DEFAULT (no suite names given) set under -q; see
+# the "test_refinecheck is FULL-RUN-ONLY" note above.  Naming a runner
+# explicitly always runs it, -q or not — this list only affects defaulting.
+QUICK_DEFAULT_EXCLUDE=(test_refinecheck)
 QUICK_FLAG=""
 
 is_lsp_runner() {
@@ -135,7 +149,18 @@ for arg in "$@"; do
     exit 2
   fi
 done
-[[ ${#RUNNERS[@]} -eq 0 ]] && RUNNERS=("${ALL_RUNNERS[@]}")
+if [[ ${#RUNNERS[@]} -eq 0 ]]; then
+  RUNNERS=("${ALL_RUNNERS[@]}")
+  if [[ -n "$QUICK_FLAG" ]]; then
+    FILTERED=()
+    for r in "${RUNNERS[@]}"; do
+      excluded=0
+      for e in "${QUICK_DEFAULT_EXCLUDE[@]}"; do [[ "$r" == "$e" ]] && excluded=1; done
+      [[ $excluded -eq 0 ]] && FILTERED+=("$r")
+    done
+    RUNNERS=("${FILTERED[@]}")
+  fi
+fi
 
 # Optionally clear stale daemon before starting (useful after a crashed session)
 if [[ -n "${MARCH_DUNE_SHUTDOWN:-}" ]]; then
@@ -177,7 +202,32 @@ FAILED=0
 for runner in "${RUNNERS[@]}"; do
   echo ""
   echo "==> ${runner}"
-  if [[ "$runner" == "test_jit" ]]; then
+  if [[ "$runner" == "test_refinecheck" ]]; then
+    # test_refinecheck's ~550 z3-gated cases call Alcotest.skip when no z3
+    # binary is found (see the `gated` helper and its comment in
+    # test/test_refinecheck.ml). Alcotest.skip is reported as [SKIP], not
+    # [OK], so it does not lie case-by-case -- but alcotest still EXITS 0 and
+    # prints "Test Successful" when EVERY test it ran was a skip, so a bare
+    # `run-tests.sh` on a z3-less machine would show this suite as green
+    # while verifying almost nothing about lib/refinecheck/. Check for z3
+    # directly (the same signal test/test_refinecheck.ml's z3_available ()
+    # uses) rather than parsing alcotest's text output, and fail the whole
+    # script loudly instead of letting that silently pass as "All suites
+    # passed."
+    if ! command -v z3 &>/dev/null; then
+      echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" >&2
+      echo "!! z3 not found on PATH.  test_refinecheck's ~550 z3-gated cases"     >&2
+      echo "!! will ALL report [SKIP], and alcotest still exits 0 ('Test"         >&2
+      echo "!! Successful') on an all-skipped run -- this run verifies almost"    >&2
+      echo "!! NOTHING about lib/refinecheck/.  Install z3 (see"                  >&2
+      echo "!! .github/actions/march-setup/action.yml) and re-run."               >&2
+      echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" >&2
+      FAILED=1
+    fi
+    if ! $TIMEOUT_CMD ./_build/default/test/${runner}.exe -e $QUICK_FLAG; then
+      FAILED=1
+    fi
+  elif [[ "$runner" == "test_jit" ]]; then
     # test_jit spawns bin/main.exe as a subprocess for REPL/--jit sessions
     # (see test/dune's `(test (name test_jit) ...)` stanza) and silently
     # SKIPS those cases — reported as passing — if MARCH_BIN doesn't resolve

--- a/specs/progress/2026-09-01-run-tests-sh-missing-test-refinecheck.md
+++ b/specs/progress/2026-09-01-run-tests-sh-missing-test-refinecheck.md
@@ -1,0 +1,44 @@
+# scripts/run-tests.sh silently skipped the refinement-checker suite
+
+`test/dune` gives `test_refinecheck` (the ~550-case, z3-gated integration
+suite for `lib/refinecheck/`) its own alcotest executable stanza, but
+`scripts/run-tests.sh`'s `ALL_RUNNERS` array never listed it and
+`test/run_compiler.ml` does not pull its test bodies in either. `dune runtest`
+covered it; the documented agent-safe invocation (CLAUDE.md
+"Parallel-agent / reliable test invocation") did not. A fully green
+`scripts/run-tests.sh` therefore said nothing about the refinement checker —
+discovered 2026-09-01 while diagnosing solver-undecided behavior on branch
+`claude/refinement-errors-improvement-de2bdc`, where every task had to invoke
+the exe directly.
+
+Separately, `test/test_refinecheck.ml`'s `gated` helper calls `Alcotest.skip`
+(not a silent pass) when no z3 binary is found, but alcotest still exits 0 and
+prints "Test Successful" on an all-skipped run — so a z3-less machine could
+see this suite reported green while verifying almost nothing.
+
+## Fix
+
+- Added `test_refinecheck` to `ALL_RUNNERS` in `scripts/run-tests.sh`, so
+  `scripts/run-tests.sh refinecheck` (or `test_refinecheck`) resolves via the
+  existing bare-name convention, and the full run includes it.
+- None of its cases carry a `Slow` tag (so `-q` doesn't shorten it), and at
+  ~3.5-4.5 min with z3 present it would dominate a "quick" loop's budget for
+  no savings. Added a `QUICK_DEFAULT_EXCLUDE` list (currently just
+  `test_refinecheck`) so `-q` with no suite names skips it by default, while
+  naming it explicitly (`-q refinecheck` or `refinecheck`) still runs it.
+  Documented the choice in the script's header comment.
+- Added an explicit `command -v z3` check before running `test_refinecheck`
+  in the script's execution phase, printing an unmissable banner and setting
+  `FAILED=1` for the whole run when z3 is missing — mirroring how the script
+  already avoids `test_jit`'s silent-skip hazard by fixing up `MARCH_BIN`
+  itself, except here there is no environment fix-up available (z3 is an
+  external binary), so the script fails loudly instead.
+- Updated CLAUDE.md's "Suites:" list and the `dune build test/...` direct-
+  invocation line to include `test/test_refinecheck.exe`, plus a z3 caveat for
+  the direct-invocation path.
+
+## Verification
+
+`scripts/run-tests.sh -q refinecheck` (z3 present locally): builds
+`test/test_refinecheck.exe` and runs it directly, printing the real per-suite
+`[OK]` count (551 tests run with z3 4.16.0) rather than a vacuous green.


### PR DESCRIPTION
## Summary
- `scripts/run-tests.sh` never ran `test_refinecheck` (the ~550-case, z3-backed refinement-checker suite) — `dune runtest` covered it, but the documented agent-safe invocation did not, so a fully green `run-tests.sh` said nothing about `lib/refinecheck/`.
- Added it as the `refinecheck` suite (resolves via the existing bare-name convention); excluded it from `-q`'s default set (none of its cases are `Slow`-tagged, so `-q` wouldn't shorten its ~4 min runtime — it would just eat a "quick" loop's budget), while still running it when named explicitly.
- Guarded against the z3-less hazard already documented in `test/test_refinecheck.ml`: alcotest exits 0 with "Test Successful" even when every case was skipped for lack of z3. The script now checks for z3 directly and fails the whole run loudly if it's missing, instead of reporting false green.
- Updated `CLAUDE.md`'s suite list and direct-invocation instructions to match.
- Filed `specs/progress/2026-09-01-run-tests-sh-missing-test-refinecheck.md`.

## Test plan
- [x] `scripts/run-tests.sh -q refinecheck` — built `test/test_refinecheck.exe` and ran it directly; output ended with `Test Successful in 5518.370s. 551 tests run.` / `All suites passed.`, confirming the real `[OK]` count now surfaces instead of being silently skipped by the script.