### PR TITLE
witness: decline return-contract witnesses on nested refinements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ git log is authoritative for exact commits.
 
 ### Fixed
 
+- A return-contract counterexample no longer names an input the parameter's
+  own type excludes when the refinement sits below the top of the type (a
+  refined record field such as `{ v : {Int | _ > 0} }`, a refined type
+  argument, or a refinement under a linear wrapper). Such witnesses are now
+  declined, the same rule the call-site precondition path already applied;
+  a refinement at the top of the parameter type still confirms as before.
 - ARM Linux (`linux-aarch64`) has a working release artifact for the first
   time. Every v0.2.0 and v0.3.0 ARM archive shipped with an empty `bin/` and no
   compiler at all. Three defects were stacked behind one another: git refusing

--- a/lib/refinecheck/witness.ml
+++ b/lib/refinecheck/witness.ml
@@ -583,6 +583,77 @@ let call_fn ~(name : string) ~(args : V.value list) : exec_result =
    §6  Confirmation: admissibility + execute + check
    ================================================================= *)
 
+(* A parameter type is *witness-safe* when [admissible] genuinely decides it.
+
+   [admissible] pattern-matches a single [A.TyRefine] at the top of the
+   declared type; a refinement anywhere else is silently unchecked.  Three
+   such places exist and all three parse today: a type argument
+   (`List({Int | _ > 0})`), a record field (`type Box = { v : {Int | _ > 0} }`)
+   and a [TyLinear] wrapper around the outer refinement (which [strip_refine]
+   sees through and [admissible] does not).  A zero-filled decode may then
+   produce a value the DECLARED type excludes, and confirming a panic on it
+   would report a requirement the caller never had.
+
+   Stated precisely, because the obvious phrasing overclaims: the checker does
+   not enforce nested refinements TODAY — `g([0, -5])` against
+   `List({Int | _ > 0})` passes `--check` in silence — so such a value is not
+   currently unconstructible, and this walk is defence-in-depth rather than a
+   live bug fix.  It closes the hole the moment nested enforcement lands, at
+   the cost of declining a witness (return-contract or call-site promotion)
+   whose parameters carry one.  Shared by [confirm_enumerative],
+   [confirm_post] and [confirm_precond_reachable].
+
+   So the walk rejects any refinement below the outermost position, and treats
+   an unknown type name as unsafe — an unregistered name may expand to
+   anything.
+
+   A type VARIABLE carries no refinement and is allowed here; a parameter
+   actually typed by one is declined further down by [decode_model], which has
+   no zero value for it. *)
+let rec refinement_free ~(seen : string list) (ty : A.ty) : bool =
+  match ty with
+  | A.TyRefine _ -> false
+  | A.TyLinear (_, t) -> refinement_free ~seen t
+  | A.TyVar _ | A.TyArrow _ | A.TyNat _ | A.TyNatOp _ | A.TyChan _ -> true
+  | A.TyTuple ts -> List.for_all (refinement_free ~seen) ts
+  | A.TyRecord fs -> List.for_all (fun (_, t) -> refinement_free ~seen t) fs
+  | A.TyCon (n, args) ->
+    List.for_all (refinement_free ~seen) args
+    && named_refinement_free ~seen n.A.txt
+
+(* A REGISTERED definition always wins over the built-in allowlist below: a
+   user is free to declare `type Option = Weird({Int | _ > 0})`, and
+   [zero_value] would build `Weird(0)` from that definition, so answering from
+   the allowlist would declare safe a type whose own definition is refined. *)
+and named_refinement_free ~(seen : string list) (name : string) : bool =
+  (* A recursive type is being proved by the frame that pushed it. *)
+  if List.mem name seen then true
+  else
+    let seen' = name :: seen in
+    match Hashtbl.find_opt type_ctors name with
+    | Some ctors ->
+      List.for_all
+        (fun (_, ats) -> List.for_all (refinement_free ~seen:seen') ats)
+        ctors
+    | None ->
+      (match Hashtbl.find_opt record_fields name with
+       | Some fs -> List.for_all (fun (_, t) -> refinement_free ~seen:seen' t) fs
+       | None ->
+         (* Not declared in this program: the primitives and the containers
+            [zero_value] builds structurally, whose arguments the caller
+            already walked.  Anything else may expand to anything. *)
+         (match name with
+          | "Int" | "Float" | "Bool" | "String" | "Char" | "Bytes" | "Unit"
+          | "List" | "Option" -> true
+          | _ -> false))
+
+(* [admissible] decides this parameter, and nothing below it hides a
+   refinement it cannot see. *)
+let witness_safe_param ((_, ty) : string * A.ty) : bool =
+  match ty with
+  | A.TyRefine (base, _, _) -> refinement_free ~seen:[] base
+  | t -> refinement_free ~seen:[] t
+
 (* Every parameter whose declared type carries a refinement must satisfy it —
    a "witness" the contract already excludes would blame the caller for an
    input the function never promises to handle.  Zero-filled don't-cares are
@@ -796,6 +867,7 @@ let confirm_enumerative ~(fn_name : string)
   | None -> None
   | Some params ->
     if params = [] then None
+    else if not (List.for_all witness_safe_param params) then None
     else
       let run cand =
         if admissible ~params cand then
@@ -946,75 +1018,6 @@ let render_entries (entries : (string * V.value) list) : string option =
    [annotated_params], [shrink], [battery] and [free_vars], all defined below
    that point.  (Names, not line numbers: the numbers rot on every edit.)
    ================================================================= *)
-
-(* A parameter type is *witness-safe* when [admissible] genuinely decides it.
-
-   [admissible] pattern-matches a single [A.TyRefine] at the top of the
-   declared type; a refinement anywhere else is silently unchecked.  Three
-   such places exist and all three parse today: a type argument
-   (`List({Int | _ > 0})`), a record field (`type Box = { v : {Int | _ > 0} }`)
-   and a [TyLinear] wrapper around the outer refinement (which [strip_refine]
-   sees through and [admissible] does not).  A zero-filled decode may then
-   produce a value the DECLARED type excludes, and confirming a panic on it
-   would report a requirement the caller never had.
-
-   Stated precisely, because the obvious phrasing overclaims: the checker does
-   not enforce nested refinements TODAY — `g([0, -5])` against
-   `List({Int | _ > 0})` passes `--check` in silence — so such a value is not
-   currently unconstructible, and this walk is defence-in-depth rather than a
-   live bug fix.  It closes the hole the moment nested enforcement lands, at
-   the cost of declining a promotion whose parameters carry one.
-
-   So the walk rejects any refinement below the outermost position, and treats
-   an unknown type name as unsafe — an unregistered name may expand to
-   anything.
-
-   A type VARIABLE carries no refinement and is allowed here; a parameter
-   actually typed by one is declined further down by [decode_model], which has
-   no zero value for it. *)
-let rec refinement_free ~(seen : string list) (ty : A.ty) : bool =
-  match ty with
-  | A.TyRefine _ -> false
-  | A.TyLinear (_, t) -> refinement_free ~seen t
-  | A.TyVar _ | A.TyArrow _ | A.TyNat _ | A.TyNatOp _ | A.TyChan _ -> true
-  | A.TyTuple ts -> List.for_all (refinement_free ~seen) ts
-  | A.TyRecord fs -> List.for_all (fun (_, t) -> refinement_free ~seen t) fs
-  | A.TyCon (n, args) ->
-    List.for_all (refinement_free ~seen) args
-    && named_refinement_free ~seen n.A.txt
-
-(* A REGISTERED definition always wins over the built-in allowlist below: a
-   user is free to declare `type Option = Weird({Int | _ > 0})`, and
-   [zero_value] would build `Weird(0)` from that definition, so answering from
-   the allowlist would declare safe a type whose own definition is refined. *)
-and named_refinement_free ~(seen : string list) (name : string) : bool =
-  (* A recursive type is being proved by the frame that pushed it. *)
-  if List.mem name seen then true
-  else
-    let seen' = name :: seen in
-    match Hashtbl.find_opt type_ctors name with
-    | Some ctors ->
-      List.for_all
-        (fun (_, ats) -> List.for_all (refinement_free ~seen:seen') ats)
-        ctors
-    | None ->
-      (match Hashtbl.find_opt record_fields name with
-       | Some fs -> List.for_all (fun (_, t) -> refinement_free ~seen:seen' t) fs
-       | None ->
-         (* Not declared in this program: the primitives and the containers
-            [zero_value] builds structurally, whose arguments the caller
-            already walked.  Anything else may expand to anything. *)
-         (match name with
-          | "Int" | "Float" | "Bool" | "String" | "Char" | "Bytes" | "Unit"
-          | "List" | "Option" -> true
-          | _ -> false))
-
-(* [admissible] decides this parameter, and nothing below it hides a
-   refinement it cannot see. *)
-let witness_safe_param ((_, ty) : string * A.ty) : bool =
-  match ty with
-  | A.TyRefine (base, _, _) -> refinement_free ~seen:[] base
-  | t -> refinement_free ~seen:[] t
 
 (* One clause parameter as [annotated_params] wants it. *)
 let clause_param (fp : A.fn_param) : string * A.ty option =
@@ -1266,6 +1269,13 @@ let confirm_post ~(fn_name : string) ~(fn_params : (string * A.ty option) list)
   match annotated_params fn_params with
   | None -> None
   | Some params ->
+    (* Same gate as [confirm_precond_reachable]: [admissible] cannot see a
+       refinement below the outermost position, so a zero-filled decode of
+       `Box = { v : {Int | _ > 0} }` yields `{ v: 0 }` and the reported
+       "but f({ v: 0 }) returns 0" blames an input the declared type
+       excludes.  Decline rather than duplicate the check. *)
+    if not (List.for_all witness_safe_param params) then None
+    else
     (match decode_model ~params ~model with
      | None -> None
      | Some args ->

--- a/specs/plans/2026-09-01-refinement-error-diagnosis-plan.md
+++ b/specs/plans/2026-09-01-refinement-error-diagnosis-plan.md
@@ -855,6 +855,10 @@ return-contract witnesses — Task 9's CHANGELOG entry must mention it.
    type name as unsafe. This is the answer to "can `admissible` accept
    something no caller could pass"; refined type ALIASES do not parse, so that
    variant of the hole does not exist.
+   Follow-up (2026-09-01): `confirm_post` and `confirm_enumerative` had the
+   same hole (`but f({ v: 0 }) returns 0.` against `Box = { v : {Int | _ > 0} }`)
+   and now share this gate; the walk lives in §6 beside `admissible`. See
+   `specs/progress/2026-09-01-witness-nested-refinement-guard-return-contracts.md`.
 2. *Guarded clause.* A single clause carrying an `fc_guard` has a second
    acceptance condition `admissible` does not model; a candidate failing it
    crashes with a clause-match error rather than with the requirement being

--- a/specs/progress/2026-09-01-witness-nested-refinement-guard-return-contracts.md
+++ b/specs/progress/2026-09-01-witness-nested-refinement-guard-return-contracts.md
@@ -1,0 +1,42 @@
+`[P3]` Return-contract witnesses decline parameters with a nested refinement (filed 2026-09-01, landed 2026-09-01)
+
+`Witness.confirm_post` and `Witness.confirm_enumerative` (the return-contract
+counterexample paths from `specs/progress/2026-08-30-counterexample-surfacing.md`)
+ran `annotated_params → decode_model → admissible`, and `admissible` only
+inspects a single top-level `A.TyRefine` per parameter. A refinement nested
+in a record field, a type argument, or under a `TyLinear` wrapper was
+unchecked, so a zero-filled decoded witness could violate it:
+
+```march
+mod P9 do
+  type Box = { v : {Int | _ > 0} }
+  fn f(b : Box) : {Int | _ >= 5} do b.v end
+end
+```
+
+reported `but f({ v: 0 }) returns 0.` with `v = 0` violating the field's
+own refinement.
+
+Fix: both functions now run the same `witness_safe_param` gate that
+`confirm_precond_reachable` (Task 5 of
+`specs/plans/2026-09-01-refinement-error-diagnosis-plan.md`) already used.
+The walk (`refinement_free` / `named_refinement_free`) moved from §8b to §6
+next to `admissible` so all three callers share one definition; it follows
+registered ADT/record definitions with a visited set, consults
+`type_ctors` / `record_fields` BEFORE the builtin-name allowlist, and treats
+an unregistered type name as unsafe. A declined witness leaves the
+obligation `Skipped Solver_undecided`, which is silent outside
+`cap verified`.
+
+Not a live false positive today: nested refinements are not enforced at
+construction anywhere, so `f({ v: 0 })` is accepted from a caller. This is
+defence-in-depth that becomes load-bearing the day they are; the coupling is
+recorded in `specs/todos/2026-09-01-nested-refinement-enforcement.md`.
+
+Tests (`test/test_refinecheck.ml`): two gated end-to-end declines (record
+field, type argument) plus a gated positive control (`but gpos(1) returns
+1.`), and a solver-free `post-nested-unit` suite driving
+`confirm_enumerative` directly with hand-built types (record field, type
+argument, `TyLinear`) plus a control asserting the minimal witness `f(1)`.
+RED control run: with the guard reverted, all five decline cases fail and
+both controls still pass.

--- a/specs/todos/2026-09-01-nested-refinement-enforcement.md
+++ b/specs/todos/2026-09-01-nested-refinement-enforcement.md
@@ -1,0 +1,31 @@
+`[P3]` Nested refinements are parsed but never enforced (filed 2026-09-01)
+
+A refinement below the outermost position of a type parses and typechecks
+but is not checked anywhere:
+
+```march
+type Box = { v : {Int | _ > 0} }
+fn f(b : Box) : Int do b.v end
+fn main() : Int do f({ v: 0 }) end     -- accepted in silence today
+```
+
+The same holds for a refinement inside a type argument
+(`List({Int | _ > 0})`) and under a `TyLinear` wrapper. Only a `TyRefine`
+at the top of a declared parameter type is enforced at call sites.
+
+**Coupled work in `lib/refinecheck/witness.ml`.** Three confirmation paths
+execute a decoded model against the function and would otherwise report a
+zero-filled value the declared type excludes (`but f({ v: 0 }) returns 0.`):
+`confirm_post`, `confirm_enumerative` (return contracts, closed 2026-09-01,
+see `specs/progress/2026-09-01-witness-nested-refinement-guard-return-contracts.md`)
+and `confirm_precond_reachable` (call-site promotion). All three share one
+gate, `witness_safe_param` / `refinement_free`, which DECLINES any parameter
+carrying a refinement below the outermost position, so a function whose
+parameter type nests a refinement gets no executed witness at all.
+
+When nested enforcement lands, revisit that gate in the same change: either
+teach `admissible` to check nested refinements against the decoded value (and
+`zero_value` / `battery_values` to build values that satisfy them), then drop
+the decline, or keep the decline and document that such functions never get
+a witness. Do not lift the decline first; without it the enforcement change
+turns a silent decline into a false-positive witness.

--- a/test/test_refinecheck.ml
+++ b/test/test_refinecheck.ml
@@ -10231,6 +10231,45 @@ let witness_e2e_suite =
             (decl "  fn fpos(x : {Int | _ > 0}) : {Int | _ >= 5} do x end") in
         Alcotest.(check bool) "never blames the excluded input" false
           (contains text "fpos(0)"))
+  ; gated "a refinement hidden in a record field declines the witness" (fun () ->
+        (* [admissible] sees only a refinement at the TOP of the parameter
+           type.  The one on `v` is invisible to it, so before the
+           witness-safety gate a zero-filled decode reported
+           "but f({ v: 0 }) returns 0." — blaming an input the declared type
+           excludes.  A declined witness leaves the obligation
+           solver-undecided, which is silent outside `cap verified`. *)
+        let text =
+          refine_error_text_d
+            {|mod P9 do
+  type Box = { v : {Int | _ > 0} }
+  fn f(b : Box) : {Int | _ >= 5} do b.v end
+end|} in
+        Alcotest.(check bool) "no witness naming the excluded input" false
+          (contains text "but f(");
+        Alcotest.(check bool) "no definite violation either" false
+          (contains text "does not satisfy its return type constraint"))
+  ; gated "a refinement hidden in a type argument declines the witness" (fun () ->
+        let text =
+          refine_error_text_d
+            {|mod P10 do
+  fn f(xs : List({Int | _ > 0})) : {Int | _ >= 5} do
+    match xs do
+    Nil -> 0
+    Cons(h, _) -> h
+    end
+  end
+end|} in
+        Alcotest.(check bool) "no witness naming the excluded input" false
+          (contains text "but f("))
+  ; gated "positive control: a top-level refined parameter still confirms" (fun () ->
+        (* The same shape with the refinement where [admissible] CAN see it.
+           Without this the two declines above would also pass if the gate
+           simply declined everything. *)
+        let text =
+          refine_error_text_d
+            (decl "  fn gpos(x : {Int | _ > 0}) : {Int | _ >= 5} do x end") in
+        Alcotest.(check bool) "witness confirmed" true
+          (contains text "but gpos(1) returns 1."))
   ; gated "cap verified: a confirmed violation reports the witness, not cannot-verify" (fun () ->
         (* One error, the strong one: the witness proves the contract is
            WRONG, which supersedes "the checker could not verify it".  The
@@ -10880,6 +10919,68 @@ end|}
           (confirm ~arg:"ys" fn [ ("len$ys", "0") ] = None))
   ]
 
+(* Direct, solver-free coverage for the witness-safety gate on the RETURN
+   contract path.  [confirm_enumerative] needs no model, so a hand-built
+   parameter type exercises the gate exactly; the e2e cases above depend on
+   z3 producing a model and skip without one. *)
+let post_nested_unit_suite =
+  let module W = March_refinecheck.Witness in
+  let module A = March_ast.Ast in
+  let module V = March_eval.Eval_types in
+  let dsp = A.dummy_span in
+  let nm t = { A.txt = t; A.span = dsp } in
+  let evar t = A.EVar (nm t) in
+  let eint n = A.ELit (A.LitInt n, dsp) in
+  let eapp f args = A.EApp (evar f, args, dsp) in
+  let ge5 = eapp ">=" [ evar "_"; eint 5 ] in
+  let int_ty = A.TyCon (nm "Int", []) in
+  let pos_int = A.TyRefine (int_ty, None, eapp ">" [ evar "_"; eint 0 ]) in
+  let register src = W.set_module (March_desugar.Desugar.desugar_module (parse src)) in
+  let confirm fn_name fn_params =
+    W.confirm_enumerative ~fn_name ~fn_params ~binder:"_" ~ret_pred:ge5
+  in
+  [ Alcotest.test_case "enumerative: a refined record field declines" `Quick
+      (fun () ->
+        register
+          {|mod Q1 do
+  type Box = { v : {Int | _ > 0} }
+  fn f(b : Box) : {Int | _ >= 5} do b.v end
+end|};
+        Alcotest.(check bool) "declined" true
+          (confirm "f" [ ("b", Some (A.TyCon (nm "Box", []))) ] = None))
+  ; Alcotest.test_case "enumerative: a refined type argument declines" `Quick
+      (fun () ->
+        register
+          {|mod Q2 do
+  fn f(xs : List(Int)) : {Int | _ >= 5} do
+    match xs do
+    Nil -> 0
+    Cons(h, _) -> h
+    end
+  end
+end|};
+        Alcotest.(check bool) "declined" true
+          (confirm "f" [ ("xs", Some (A.TyCon (nm "List", [ pos_int ]))) ] = None))
+  ; Alcotest.test_case "enumerative: a refinement under a linear wrapper declines" `Quick
+      (fun () ->
+        register {|mod Q3 do
+  fn f(x : Int) : {Int | _ >= 5} do x end
+end|};
+        Alcotest.(check bool) "declined" true
+          (confirm "f" [ ("x", Some (A.TyLinear (A.Linear, pos_int))) ] = None))
+  ; Alcotest.test_case "enumerative: a top-level refined parameter still confirms" `Quick
+      (fun () ->
+        (* Discriminating control: the gate must pass what [admissible] can
+           decide, or the three declines above prove nothing. *)
+        register {|mod Q4 do
+  fn f(x : Int) : {Int | _ >= 5} do x end
+end|};
+        match confirm "f" [ ("x", Some pos_int) ] with
+        | Some ((_, V.VInt 1) :: [], V.VInt 1) -> ()
+        | Some _ -> Alcotest.fail "confirmed, but not the minimal witness f(1)"
+        | None -> Alcotest.fail "the top-level refined parameter was declined")
+  ]
+
 let () =
   Alcotest.run "march-refinecheck"
     [ ("refinecheck", suite);
@@ -10952,4 +11053,5 @@ let () =
       ("witness-core", witness_core_suite);
       ("witness-e2e", witness_e2e_suite);
       ("precond-promotion", promotion_suite);
-      ("precond-reachable-unit", reachable_unit_suite) ]
+      ("precond-reachable-unit", reachable_unit_suite);
+      ("post-nested-unit", post_nested_unit_suite) ]


### PR DESCRIPTION
## Summary

`Witness.confirm_post` and `Witness.confirm_enumerative` ran `annotated_params → decode_model → admissible`, and `admissible` only inspects a single top-level `A.TyRefine` per parameter. A refinement nested in a record field, a type argument, or under a `TyLinear` wrapper was unchecked, so a zero-filled decoded witness could violate it:

```march
mod P9 do
  type Box = { v : {Int | _ > 0} }
  fn f(b : Box) : {Int | _ >= 5} do b.v end
end
```

reported `but f({ v: 0 }) returns 0.` with `v = 0` violating the field's own refinement.

Both functions now run the same `witness_safe_param` gate that `confirm_precond_reachable` (Task 5 of the diagnosis plan) already uses. The walk moves from §8b to §6 beside `admissible` so all three confirmers share one definition. A declined witness leaves the obligation solver-undecided, which is silent outside `cap verified`.

Not a live false positive today: nested refinements are not enforced at construction anywhere. The coupling is filed in `specs/todos/2026-09-01-nested-refinement-enforcement.md` so the gate is revisited in the same change that adds enforcement.

Stacked on `claude/refinement-errors-improvement-de2bdc` (the walk only exists there); this PR targets that branch.

## Tests

- Gated end-to-end: record-field decline (the `Box` repro), type-argument decline, and a positive control asserting `but gpos(1) returns 1.`.
- New solver-free `post-nested-unit` suite driving `confirm_enumerative` with hand-built types: record field, type argument, `TyLinear`, plus a control asserting the minimal witness `f(1)`.
- RED control: with the guard reverted, all five decline cases fail and both controls pass.

## Verification

- `scripts/run-tests.sh`: all suites passed.
- `test_refinecheck.exe -e`: 592 run with z3 present, none skipped.
- `scripts/check-docs.sh`: passed.