### PR TITLE
fix(lsp,format): rank completions by origin; stop the formatter deleting attributes; report non-tail calls once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ git log is authoritative for exact commits.
   `--test` emits a different program (a test-runner entry point) but was absent
   from the cache key, so whichever ran first won: `forge build` could hand you
   the test runner, or `forge test` the plain binary.
+- Completions now offer what you defined in the file you are editing before
+  anything from the standard library. Ranking was by category alone — locals,
+  keywords, values, types, constructors — so every stdlib function outranked
+  your own types and constructors, and typing `B` in a module declaring
+  `BTree`/`Branch` offered all of `Base64` and `BigInt` first. Ranking is now
+  by origin first, then category.
 
 - Typing in the editor no longer silently rewrites the same identifier
   elsewhere in the file. The LSP answered `textDocument/linkedEditingRange`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,20 @@ git log is authoritative for exact commits.
 
 ### Fixed
 
+- The formatter no longer deletes compiler attributes. `format.ml` never read
+  `fn_attrs`, so every `@[...]` was silently dropped — and that is not
+  cosmetic: `@[no_warn_recursion]` suppresses a hard error, so format-on-save
+  turned a compiling file into one that no longer builds.
+
+- A non-tail recursive call is no longer reported twice. The typechecker's
+  tail-call checker already reports every one of them, and the LSP emitted its
+  own `perf/non-tail-call` diagnostic at the same span, so the editor showed
+  two near-identical messages in one hover. The compiler's is kept — it is the
+  authority on error-vs-warning and it honours `@[no_warn_recursion]`.
+
+- Both non-tail-recursion hints now mention `@[no_warn_recursion]` as the
+  option when the depth is bounded and the stack use is acceptable.
+
 - `forge build` and `forge test` no longer share a compilation-cache entry.
   `--test` emits a different program (a test-runner entry point) but was absent
   from the cache key, so whichever ran first won: `forge build` could hand you

--- a/lib/format/format.ml
+++ b/lib/format/format.ml
@@ -1150,6 +1150,15 @@ and emit_fn ctx fn =
      in
      line ctx (Printf.sprintf "doc \"\"\"%s\"\"\"" escaped)
   );
+  (* Compiler attributes (`@[no_warn_recursion]`, …). Dropping these is not a
+     cosmetic loss: `@[no_warn_recursion]` suppresses a HARD ERROR, so a
+     format-on-save that ate it turned a compiling file into one that no longer
+     builds. Emitted for every clause because a multi-head function is printed
+     as one `fn` declaration per clause, and the attribute binds to the
+     declaration in the grammar (`nonempty_list(fn_attr); fn_decl`). *)
+  let emit_attrs () =
+    List.iter (fun a -> line ctx (Printf.sprintf "@[%s]" a)) fn.fn_attrs
+  in
   match fn.fn_clauses with
   | [] -> ()
   | [clause] ->
@@ -1158,6 +1167,7 @@ and emit_fn ctx fn =
       | None   -> ""
       | Some g -> " when " ^ expr_inline g
     in
+    emit_attrs ();
     line ctx (Printf.sprintf "%s %s(%s)%s%s do" kw fn.fn_name.txt ps ret guard);
     indented ctx (fun () -> emit_body ctx clause.fc_body);
     line ctx "end"
@@ -1170,6 +1180,7 @@ and emit_fn ctx fn =
         | None   -> ""
         | Some g -> " when " ^ expr_inline g
       in
+      emit_attrs ();
       line ctx (Printf.sprintf "%s %s(%s)%s%s do" kw fn.fn_name.txt ps ret guard);
       indented ctx (fun () -> emit_body ctx clause.fc_body);
       line ctx "end";

--- a/lib/typecheck/typecheck_tailcall.ml
+++ b/lib/typecheck/typecheck_tailcall.ml
@@ -303,8 +303,13 @@ let rec check_tail_position
             if is_boolop then
               "Hint: `&&`/`||` evaluate both sides in March. Rewrite `a || b` as \
                `if a do true else b end` (and `a && b` as `if a do b else false end`) \
-               to put the right-hand call in tail position."
-            else "Hint: Consider using an accumulator parameter."
+               to put the right-hand call in tail position.\n\
+               If the depth is bounded and you accept the stack use, annotate \
+               the function with `@[no_warn_recursion]`."
+            else
+              "Hint: Consider using an accumulator parameter.\n\
+               If the depth is bounded and you accept the stack use, annotate \
+               the function with `@[no_warn_recursion]`."
           in
           Err.error errors ~span:sp
             (Printf.sprintf

--- a/lsp/lib/analysis.ml
+++ b/lsp/lib/analysis.ml
@@ -3196,7 +3196,28 @@ let analyse ~filename ~src : t =
          @ List.filter_map make_diag (Depot.fk_column_diagnostics depot_schemas ops))
     in
     let diags =
-      (Err.sorted errors |> List.filter_map (diag_to_lsp ~filename))
+      let compiler_diags =
+        Err.sorted errors |> List.filter_map (diag_to_lsp ~filename)
+      in
+      (* The typechecker's own tail-call checker already reports every
+         non-tail recursive call, at the same span, saying the same thing —
+         so emitting the `perf/non-tail-call` insight as well put two
+         near-identical messages in one hover. Keep the compiler's (it is the
+         authority on whether this is an error or a warning, and it honours
+         `@[no_warn_recursion]`) and drop the duplicate. Other perf insights
+         have no compiler counterpart and are unaffected. *)
+      let perf_diags =
+        let covered (d : Lsp.Types.Diagnostic.t) =
+          List.exists (fun (c : Lsp.Types.Diagnostic.t) -> c.range = d.range)
+            compiler_diags
+        in
+        List.filter (fun (d : Lsp.Types.Diagnostic.t) ->
+            match d.code with
+            | Some (`String "perf/non-tail-call") -> not (covered d)
+            | _ -> true)
+          perf_diags
+      in
+      compiler_diags
       @ !dead_code_diags
       @ unused_fn_diags
       @ perf_diags

--- a/lsp/lib/analysis.ml
+++ b/lsp/lib/analysis.ml
@@ -4167,18 +4167,42 @@ let completions_at (a : t) ~line ~character =
                           `Assoc [("module", `String m); ("name", `String short)])])
           ())
   in
-  (* Rank by category via sortText: locals < keywords < top-level/stdlib values
-     < types < constructors < interfaces < sigils < auto-imports. *)
+  (* Rank by ORIGIN first, then category.
+     
+     This used to rank by category alone — locals, keywords, values, types,
+     constructors, ... — which put every stdlib function above the user's own
+     types and constructors, because values outrank both. Typing `B` in a
+     module declaring `BTree` and `Branch` therefore offered `Base64.decode`
+     and the whole of `BigInt` first, and the two names actually in scope were
+     below the fold. What you defined in the file you are editing is almost
+     always what you mean, so it goes first regardless of category.
+
+     Match the edited file exactly rather than reusing [span_in_user_file],
+     which also accepts empty / "<unknown>" spans — those belong to builtins,
+     and promoting the entire builtin surface is the bug over again. *)
+  let defined_here name =
+    a.filename <> "" && a.filename <> "<unknown>" &&
+    (match Hashtbl.find_opt a.def_map name with
+     | Some sp -> sp.Ast.file = a.filename
+     | None -> false)
+  in
   let rank s items =
     List.map (fun it -> { it with CompletionItem.sortText = Some s }) items
   in
-  rank "0" local_items
-  @ rank "1" kw_items
-  @ rank "2" var_items
-  @ rank "3" type_items
-  @ rank "4" ctor_items
-  @ rank "5" iface_items
-  @ rank "6" sigil_items
+  (* [cat] is the within-band category digit; the leading digit is the band:
+     0 = defined in this file, 1 = language-level, 2 = imported/stdlib. *)
+  let rank_by_origin cat items =
+    List.map (fun (it : CompletionItem.t) ->
+        let band = if defined_here it.CompletionItem.label then "0" else "2" in
+        { it with CompletionItem.sortText = Some (band ^ cat) }) items
+  in
+  rank "00" local_items
+  @ rank "10" kw_items
+  @ rank_by_origin "2" var_items
+  @ rank_by_origin "3" type_items
+  @ rank_by_origin "4" ctor_items
+  @ rank_by_origin "5" iface_items
+  @ rank "16" sigil_items
   @ auto_items
   ) (* end match island_items *)
   ) (* end match depot_table_items *)

--- a/lsp/test/test_lsp.ml
+++ b/lsp/test/test_lsp.ml
@@ -405,7 +405,7 @@ let () =
       "tail-recursive call not flagged",          `Quick, test_perf_tail_call_not_flagged;
       "non-tail inside constructor detected",     `Quick, test_perf_non_tail_inside_constructor;
       "ctor-wrapped advice states TRMC is opt-in",   `Quick, test_perf_constructor_wrapped_advice_is_not_accumulator;
-      "non-tail produces warning diagnostic",     `Quick, test_perf_non_tail_produces_warning_diagnostic;
+      "non-tail reported once, not duplicated",     `Quick, test_perf_non_tail_produces_warning_diagnostic;
       "non-recursive call not flagged",           `Quick, test_perf_non_tail_not_flagged_for_non_recursive;
     ];
     "perf insights: closure captures", [

--- a/lsp/test/test_lsp_features.ml
+++ b/lsp/test/test_lsp_features.ml
@@ -908,10 +908,25 @@ end|} in
   Alcotest.(check bool) "in-scope param offered"  true  (has "alpha");
   Alcotest.(check bool) "in-scope let offered"    true  (has "beta");
   Alcotest.(check bool) "out-of-scope local hidden" false (has "gamma");
-  let alpha = List.find (fun (i : Lsp.Types.CompletionItem.t) ->
-      i.Lsp.Types.CompletionItem.label = "alpha") items in
-  Alcotest.(check (option string)) "locals rank first (sortText 0)"
-    (Some "0") alpha.Lsp.Types.CompletionItem.sortText
+  (* Assert the PROPERTY (a local outranks a non-local), not a literal
+     sortText. The literal was "0" until origin-aware ranking widened these to
+     two-character bands ("00" for locals) so that symbols defined in the file
+     being edited sort above imported/stdlib ones — an assertion on the exact
+     string breaks on any such re-banding while telling you nothing about
+     whether ordering is still correct. Clients sort lexicographically, so
+     compare the way a client would. *)
+  let sort_text_of label =
+    let it = List.find (fun (i : Lsp.Types.CompletionItem.t) ->
+        i.Lsp.Types.CompletionItem.label = label) items in
+    match it.Lsp.Types.CompletionItem.sortText with
+    | Some s -> s
+    | None -> Alcotest.fail (label ^ ": expected a sortText")
+  in
+  let alpha_rank = sort_text_of "alpha" in
+  (* `f` is a top-level fn in the same file: still ranked, but below locals. *)
+  let f_rank = sort_text_of "f" in
+  Alcotest.(check bool) "locals rank first (before same-file top-level fns)"
+    true (String.compare alpha_rank f_rank < 0)
 
 (* ------------------------------------------------------------------ *)
 (* Semantic tokens: ownership modifiers + use-site fidelity           *)

--- a/lsp/test/test_lsp_perf.ml
+++ b/lsp/test/test_lsp_perf.ml
@@ -210,13 +210,29 @@ mod Test do
 end
 |} in
   let a = analyse src in
-  let has_warning = List.exists (fun (d : Lsp.Types.Diagnostic.t) ->
-      match d.code with
-      | Some (`String "perf/non-tail-call") -> true
-      | _ -> false
-    ) a.An.diagnostics
+  (* This used to assert a diagnostic carrying the `perf/non-tail-call` code.
+     That code is the LSP's own perf insight, and the typechecker's tail-call
+     checker ALREADY reports every non-tail recursive call at the same span —
+     so asserting the LSP's copy was asserting a duplicate, and the editor
+     showed the same complaint twice in one hover. What matters is that the
+     call is reported, once. Assert that instead of a particular producer. *)
+  let mentions_tail (d : Lsp.Types.Diagnostic.t) =
+    match d.message with
+    | `String m ->
+      let needle = "tail" in
+      let n = String.length needle and l = String.length m in
+      let rec go i = i + n <= l && (String.sub m i n = needle || go (i + 1)) in
+      go 0
+    | _ -> false
   in
-  Alcotest.(check bool) "non_tail_call warning in diagnostics" true has_warning
+  let tail_diags = List.filter mentions_tail a.An.diagnostics in
+  Alcotest.(check bool) "the non-tail call is reported" true
+    (List.length tail_diags >= 1);
+  (* No two reports of it at the same span — that was the duplication. *)
+  let spans = List.map (fun (d : Lsp.Types.Diagnostic.t) -> d.range) tail_diags in
+  let uniq = List.sort_uniq compare spans in
+  Alcotest.(check int) "reported once per span, not duplicated"
+    (List.length uniq) (List.length spans)
 
 let test_perf_non_tail_not_flagged_for_non_recursive () =
   (* foo calls bar, not itself — no TCO warning *)

--- a/test/test_fmt.ml
+++ b/test/test_fmt.ml
@@ -232,6 +232,38 @@ end|} in
   check_parses "record pattern" src;
   check_idempotent "record pattern" src
 
+let test_fn_attribute_preserved () =
+  (* `@[no_warn_recursion]` is load-bearing: it suppresses a HARD ERROR, so a
+     formatter that drops it turns a compiling file into one that does not
+     build. The attribute was silently discarded (format.ml never read
+     [fn_attrs]) — format-on-save ate it on every save. Multi-head, because
+     each clause is printed as its own `fn` declaration and the attribute has
+     to reappear on every one of them. *)
+  let src = {|mod Test do
+type BTree = Tip | Branch(BTree, Int, BTree)
+@[no_warn_recursion]
+fn has_val(Tip, _target : Int) : Bool do
+  false
+end
+@[no_warn_recursion]
+fn has_val(Branch(l, v, r), target : Int) : Bool do
+  v == target || has_val(l, target) || has_val(r, target)
+end
+end|} in
+  check_parses "fn attribute" src;
+  check_idempotent "fn attribute" src;
+  let out = fmt src in
+  let count_attrs s =
+    let needle = "@[no_warn_recursion]" in
+    let n = String.length needle and l = String.length s in
+    let rec go i acc =
+      if i + n > l then acc
+      else go (i + 1) (if String.sub s i n = needle then acc + 1 else acc)
+    in
+    go 0 0
+  in
+  Alcotest.(check int) "attribute kept on every clause" 2 (count_attrs out)
+
 let test_local_fn () =
   let src = {|mod Test do
 fn fib(n : Int) : Int do
@@ -475,6 +507,7 @@ let () =
       test_case "tuple"           `Quick test_tuple;
       test_case "record literal"  `Quick test_record_literal;
       test_case "record pattern"  `Quick test_record_pattern;
+      test_case "fn attribute"    `Quick test_fn_attribute_preserved;
       test_case "local fn"        `Quick test_local_fn;
       test_case "use decl"        `Quick test_use_decl;
       test_case "doc comment"     `Quick test_doc_comment;


### PR DESCRIPTION
Follow-up to #390 — this fix was pushed just after that PR merged, so it
missed the cut.

## The problem

Typing `B` in a module that declares `BTree` and `Branch` offered `Base64.decode`
and the whole of `BigInt` first, with the two names actually in scope below the
fold.

Completions were ranked by category alone:

```
locals "0" | keywords "1" | values "2" | types "3" | constructors "4" | ...
```

Every stdlib function is a value, so the standard library outranked whatever the
user had just defined two lines up.

## The fix

Rank by **origin first, then category** — symbols defined in the file being
edited come before imported/stdlib ones:

```
sortText=03  BTree           <- your type
sortText=04  Branch          <- your constructor
sortText=22  Base64.decode   <- stdlib, below
sortText=22  BigInt.abs
```

Origin is decided by an exact match on the edited file's path, deliberately
**not** by `span_in_user_file` — that also accepts empty and `<unknown>` spans,
which belong to builtins, so reusing it would promote the entire builtin surface
and reproduce the bug in a new form.

## Note for reviewers

The existing test asserted the literal `sortText` `"0"` for locals. Two-character
bands break that string while the property it names — locals rank first — still
holds exactly. It now compares a local's rank against a same-file top-level fn's
the way a client sorts, so it tests ordering rather than a magic value.

That is the fourth test in this line of work found asserting an incidental or
outright wrong detail rather than the intended behaviour (the others: linked
editing "links all occurrences", and the TRMC "compiles to a loop" claim, both
in #390). Worth a wider look at that pattern separately.

## Testing

`scripts/run-tests.sh` green (0 failures) on this branch rebased onto current
main, and the ordering re-verified against the running server after the rebase.
