### PR TITLE
docs: correct docker_images.md claim that `march --compile` emits static binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -453,6 +453,27 @@ git log is authoritative for exact commits.
   silently, and both the REPL and the CLI sweep stale staging files left by
   processes that crashed mid-write.
 
+### Documentation
+
+- **`specs/docker_images.md` no longer claims `march --compile` emits a static
+  binary.** It said a compiled March program "can be copied into `scratch` or a
+  distroless image, producing a deploy image of a few megabytes with zero
+  runtime dependencies", and built its whole recommended deploy pattern on that.
+  In fact the link command passes no `-static` on any path: every compiled
+  program carries `DT_NEEDED` entries for libssl, libcrypto, libz, libblake3
+  and (host-dependent) libzstd/libbrotli, plus libucontext on musl — verified on
+  `alpine:3.21` aarch64 and, identically, on macOS arm64. `libblake3` is the
+  worst of them: March's own release workflow compiles it from source because
+  there is no package to install, so a user's program depended on a library they
+  had no packaged way to obtain. The spec now carries a table of what is
+  actually linked and where each entry comes from, a deploy pattern with a real
+  base image and package list, and an explicit note that `scratch` and
+  `distroless-static` do not work today. Static output is filed as its own item
+  (`specs/todos/2026-09-02-march-compile-output-is-not-static.md`), with
+  acceptance criteria that require running the artifact in a bare container.
+  This is separate from the release-archive static defect, which concerns the
+  distributed `march`/`forge` binaries rather than the output of `--compile`.
+
 ## [0.3.0] - 2026-08-23
 
 ### Added

--- a/specs/docker_images.md
+++ b/specs/docker_images.md
@@ -8,18 +8,19 @@ This spec defines the official Docker images March should publish, how they are 
 
 `march --compile` shells out to `clang` + LLVM to build the bundled C runtime, so native compilation needs a C toolchain on the host — the one prerequisite that is awkward to install and version-pin reliably across machines. A published toolchain image removes that friction: pull one image and `forge build` works, identically, on any host with Docker, in CI, and on a contributor's laptop.
 
-Separately, March compiles to a **statically linked** native binary (musl on Linux). A compiled March program — most usefully a [bastion](bastion/architecture.md)/conduit web server — therefore needs **no runtime base image at all**: the binary can be copied into `scratch` or a distroless image, producing a deploy image of a few megabytes with zero runtime dependencies. This is a strong, distinctive deployment story that the project should make turnkey.
+Separately, a compiled March program — most usefully a [bastion](bastion/architecture.md)/conduit web server — wants a small, boring deploy image. Today that image is a **slim distro base**, not `scratch`: `march --compile` links the bundled C runtime **dynamically** against the host's TLS, compression and hashing libraries (see [What `march --compile` actually links](#what-march---compile-actually-links) below). Making the output binary self-contained enough for `scratch` is real, tractable work — tracked separately as the static-musl profile — and would be a strong, distinctive deployment story; this spec documents the deploy pattern that works **now** and marks the `scratch` variant as a dependency, not an assumption.
 
 ## Goals
 
 - A published, multi-arch **toolchain image** that can `forge build` / `march --compile` out of the box.
-- A documented, copy-pasteable **multi-stage deploy pattern** that yields a minimal static-binary image for web apps.
+- A documented, copy-pasteable **multi-stage deploy pattern** that yields a minimal deploy image for web apps — a slim distro base today, `scratch`/distroless once the static-musl profile lands.
 - Images built from the **prebuilt release artifacts** (fast, reproducible) rather than compiled from source per build.
 - Multi-architecture (`linux/amd64`, `linux/arm64`) matching the release platform matrix.
 
 ## Non-Goals
 
-- A standalone "runtime" image. Compiled March binaries are self-contained; the multi-stage deploy pattern covers running them without a dedicated image.
+- A standalone "runtime" image. The multi-stage deploy pattern's final stage is a stock slim base plus a short `apt`/`apk` line, which is cheaper to document than to publish and version.
+- **Making `march --compile` emit a static binary.** That is the static-musl profile (a `--static`/`--target linux/<arch> static` mode), scoped as future work in [2026-07-04-cross-compile-linux-hot-deploy-design.md](2026-07-04-cross-compile-linux-hot-deploy-design.md) and filed as [`specs/todos/2026-09-02-march-compile-output-is-not-static.md`](todos/2026-09-02-march-compile-output-is-not-static.md). This spec depends on it for the `scratch` variant; it does not deliver it.
 - Replacing `ci/Dockerfile.ubuntu`. That image builds the compiler **from source** to reproduce the CI environment for contributors — a different audience and lifecycle. It stays as-is.
 - Windows containers. Out of scope until a Windows native target exists.
 
@@ -34,7 +35,7 @@ A ready-to-use March development/build environment.
 - `clang` + LLVM and a minimal C toolchain (required by `march --compile`).
 - `git` and `curl` (forge fetches git/registry dependencies).
 
-**Base image.** A slim Debian/Ubuntu base (`debian:stable-slim` or `ubuntu:24.04`) — LLVM packaging is reliable there and it matches the `linux-x86_64` release toolchain. Alpine is rejected for the toolchain image because LLVM/clang on musl is more fragile; the *output* binary is still static and Alpine-friendly.
+**Base image.** A slim Debian/Ubuntu base (`debian:stable-slim` or `ubuntu:24.04`) — LLVM packaging is reliable there and it matches the `linux-x86_64` release toolchain. Alpine is rejected for the toolchain image because LLVM/clang on musl is more fragile. Note this choice also fixes the ABI of every binary the image produces: a glibc toolchain image emits glibc-dynamic programs, so the deploy stage must be a glibc base too.
 
 **Install method.** The Dockerfile installs `clang`/`llvm`/`git`/`curl` via the base package manager, then runs the published `install.sh` pinned to the image's version (`MARCH_VERSION=<tag>`), so the image tracks releases automatically with no source build.
 
@@ -58,22 +59,68 @@ CMD ["forge", "build"]
 
 ### 2. Multi-stage deploy pattern (documentation + template)
 
-Not a published image — a documented `Dockerfile` users add to their project, plus optionally a `forge new --docker` stub that scaffolds it. It builds in the toolchain image and copies the **static binary** into a minimal final stage:
+Not a published image — a documented `Dockerfile` users add to their project, plus optionally a `forge new --docker` stub that scaffolds it. It builds in the toolchain image and copies the binary into a small final stage that carries the runtime's shared libraries:
 
 ```dockerfile
 # ---- build stage ----
 FROM ghcr.io/march-language/march:latest AS build
 WORKDIR /app
 COPY . .
-RUN forge build --release            # produces a static native binary
+RUN forge build --release
 
 # ---- runtime stage ----
-FROM gcc:distroless    # or: scratch
+FROM debian:stable-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      libssl3 zlib1g libzstd1 libbrotli1 ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+# libblake3 has no distro package — carry it over from the build stage.
+COPY --from=build /usr/lib/libblake3.so* /usr/lib/
 COPY --from=build /app/bin/myapp /usr/local/bin/myapp
 ENTRYPOINT ["/usr/local/bin/myapp"]
 ```
 
-Because the Linux binary is musl-static, `scratch` works for pure-compute programs; distroless (with CA certs) is recommended for servers that make TLS connections. The exact `forge build` output path and a `--release` flag are dependencies to confirm (see Open Questions).
+`scratch` and `distroless-static` do **not** work today, and a stock slim base
+does not work on its own either — hence both the package line and the
+`libblake3` copy. The next section says where each of those comes from.
+
+### What `march --compile` actually links
+
+The link command is assembled in `bin/main.ml` (the `Printf.sprintf` that builds
+`cmd`, around the `math_flag` binding) with helpers in `bin/toolchain.ml`. It
+passes **no `-static`** on any path. The cross path goes further and links
+positional `.so` paths precisely so the target soname is recorded in
+`DT_NEEDED`. Every library below is a `DT_NEEDED` entry on the output binary.
+
+| Library | Comes from | Notes |
+|---------|-----------|-------|
+| `libssl`, `libcrypto` | `runtime/march_tls.c` | linked whenever the runtime source is present — i.e. always, not only for programs that use TLS |
+| `libz` | `runtime/march_compress.c` | mandatory (gzip/deflate) |
+| `libzstd`, `libbrotlienc`, `libbrotlidec` | `runtime/march_compress.c` | added when the build host has the headers, so the dependency set varies by build machine |
+| `libblake3` | `runtime/march_blake3.c` | see below |
+| `libucontext` (musl only) | scheduler green threads | musl has no `ucontext` in libc |
+| `libc` / `libc.musl-<arch>` | always | |
+
+Verified 2026-09-02 two ways. On `alpine:3.21` aarch64 under Docker, `readelf -d`
+on a compiled hello-world lists `libssl.so.3`, `libcrypto.so.3`, `libz.so.1`,
+`libzstd.so.1`, `libbrotlienc.so.1`, `libbrotlidec.so.1`, `libblake3.so`,
+`libucontext.so.1` and `libc.musl-aarch64.so.1`. On macOS arm64 the same program
+gives the identical set via `otool -L` (`libSystem` and no `libucontext` in place
+of the musl pair) — this is a property of the link command, not of one host.
+
+**`libblake3` is the sharp edge.** There is no `libblake3` package to install on
+the distro bases March itself uses: `.github/workflows/build.yml` clones
+BLAKE3 and compiles `libblake3.so` from source on **both** Linux release legs,
+and builds a static `libblake3.a` on macOS because Homebrew ships only the dylib.
+So the `apt`/`apk` line above cannot supply it, and a user's compiled program
+depends on a library they have no packaged way to install — which is why the
+deploy stage above copies it out of the build stage explicitly. That `COPY`
+path is whatever the toolchain image put it at (`/usr/lib` for the Linux
+release build); confirm it when the toolchain Dockerfile is written.
+
+The durable fix is to stop emitting the dependency at all — link the static
+`libblake3.a` (which `lib/cas/discover.ml` already prefers on macOS when one is
+present) or vendor the BLAKE3 C sources into `runtime/` the way `tweetnacl.c` is
+vendored — rather than shipping the `.so` around.
 
 ## Tags
 
@@ -97,7 +144,7 @@ All tags are multi-arch manifests covering `linux/amd64` and `linux/arm64`.
 
 - The toolchain image is large (LLVM is ~1 GB). Acceptable for a build image; documented so users aren't surprised.
 - Layer order puts the slow, rarely-changing apt install first and the `install.sh` step last, so version bumps only rebuild the small final layer.
-- The deploy-pattern final image is a few MB (just the static binary + optional CA certs).
+- The deploy-pattern final image is a slim base (~30 MB for `debian:stable-slim`) plus the binary, its shared libraries and CA certs — not the "few MB" a `scratch` image would give. The static-musl profile is what closes that gap.
 
 ## Security
 
@@ -111,15 +158,16 @@ All tags are multi-arch manifests covering `linux/amd64` and `linux/arm64`.
 - **`ci/Dockerfile.ubuntu`** — unchanged. From-source CI reproduction for contributors.
 - **`install.sh`** — reused verbatim inside the toolchain Dockerfile; the image is "a host with `install.sh` already run + clang."
 - **`forge toolchain`** — works inside the container (writable `~/.march`), so users can switch March versions within an image if needed.
-- **Static linking** ([progress.md](progress.md), 2026-06-13 entries) — the reason the deploy stage can be `scratch`/distroless.
+- **Static linking** — applies to the *distributed compiler* binaries (`march`/`forge`), not to the output of `march --compile`. Making the deploy stage `scratch`/distroless-capable is the separate static-musl profile; until it lands the deploy stage needs a base with the libraries listed above.
 
 ## Open Questions
 
 1. **`forge build --release` and output path.** The deploy pattern assumes a release build mode and a predictable binary path. Confirm/define `forge build`'s output location and whether a `--release` flag exists.
-2. **CA certificates in the deploy image.** Servers doing outbound TLS need certs; decide whether to recommend distroless-with-certs by default and document the `scratch` caveat.
+2. **CA certificates in the deploy image.** Servers doing outbound TLS need certs. The pattern above installs `ca-certificates`; decide whether that stays the default recommendation and how it carries over to a future `scratch` image, which would need the bundle copied in explicitly.
 3. **`forge new --docker`.** Worth scaffolding the multi-stage Dockerfile from `forge new`, or leave it as docs only?
 4. **Image namespace.** `ghcr.io/march-language/march` vs. a dedicated `…/toolchain` repo if more images appear later.
-5. **glibc vs musl in the toolchain image.** The image's *own* `march`/`forge` come from the `linux-x86_64`/`linux-aarch64` musl-static release, so they run on any base; confirm clang in a glibc base compiles user programs to musl-static as the release builds do, or document that container-built binaries are glibc-dynamic unless a musl target is selected.
+5. **glibc vs musl in the toolchain image.** Resolved as far as this spec is concerned: the image's *own* `march`/`forge` come from the release tarball and run on any base, but user programs built in it are **glibc-dynamic** (see [What `march --compile` actually links](#what-march---compile-actually-links)) — the toolchain image's base therefore fixes the ABI of everything it builds, and the deploy stage must match it. Documented rather than changed.
+6. **Ordering vs. the static-musl profile.** Publishing the toolchain image does not depend on static output and should not wait for it; the `scratch` deploy variant is a documentation follow-up once [`specs/todos/2026-09-02-march-compile-output-is-not-static.md`](todos/2026-09-02-march-compile-output-is-not-static.md) lands.
 
 ## Implementation Plan (when approved)
 

--- a/specs/progress/2026-09-02-docker-images-spec-claimed-static-user-binaries.md
+++ b/specs/progress/2026-09-02-docker-images-spec-claimed-static-user-binaries.md
@@ -1,0 +1,83 @@
+# `specs/docker_images.md` claimed `march --compile` emits static binaries — corrected
+
+`specs/docker_images.md` asserted, as present-tense fact, that "March compiles to
+a **statically linked** native binary (musl on Linux)" and that a compiled
+program "needs **no runtime base image at all**: the binary can be copied into
+`scratch` or a distroless image, producing a deploy image of a few megabytes
+with zero runtime dependencies." Neither is true, and the whole multi-stage
+deploy pattern the spec recommended was built on it.
+
+This is a **different** defect from the release-archive one
+(`specs/todos/2026-08-31-linux-release-binaries-are-not-static.md`), which is
+about the `march`/`forge` binaries we distribute. This one is about the output
+of `march --compile` for a user's own program.
+
+## What was verified
+
+Two independent observations, both 2026-09-02:
+
+- `alpine:3.21` aarch64 under Docker: `readelf -d` on a hello-world compiled
+  with `march --compile` lists `libssl.so.3`, `libcrypto.so.3`, `libz.so.1`,
+  `libzstd.so.1`, `libbrotlienc.so.1`, `libbrotlidec.so.1`, `libblake3.so`,
+  `libucontext.so.1`, `libc.musl-aarch64.so.1`.
+- macOS arm64, this worktree, `MARCH_ECHO_CC=1 march --compile`: the emitted
+  clang line contains `-lssl -lcrypto -lz -lzstd -lbrotlienc -lbrotlidec
+  -lblake3 -lm` and **no** `-static`; `otool -L` on the output shows the same
+  set (`libSystem` and no `libucontext` in place of the musl pair).
+
+The second is what makes it a property of the link command rather than of one
+container: `grep` over `bin/`, `lib/` and `forge/` finds no `-static` on any
+compile path (the single textual hit is the phrase "file-static" in a comment in
+`lib/tir/llvm_toplevel.ml`). The cross-compile path goes the other way on
+purpose — `bin/toolchain.ml`'s sysroot resolution links positional `.so` paths
+specifically so the target soname lands in `DT_NEEDED`.
+
+`libblake3` is the sharp edge: `.github/workflows/build.yml` clones BLAKE3 and
+compiles `libblake3.so` from source on both Linux release legs (and builds a
+static `libblake3.a` on macOS, since Homebrew ships only the dylib), because
+there is no package to install on those bases. A user's compiled program
+therefore depends on a library they have no packaged way to obtain.
+
+## Decision: correct the spec, file the feature separately
+
+The spec is marked **Status: Proposed — not yet implemented**; the static claim
+was a design assumption that turned out false, not a regression against shipped
+behaviour. Implementing `--static` here would mean sourcing static archives for
+six libraries across two libcs, vendoring or statically linking BLAKE3, and
+standing up a bare-container CI check — a feature in its own right, already
+scoped as the static-musl profile under "Future work" in
+`specs/2026-07-04-cross-compile-linux-hot-deploy-design.md`. Shipping a
+`--static` flag that only appends `-static` to the link line would be a fake fix.
+
+So: the spec now says what actually ships, and the feature is filed as
+`specs/todos/2026-09-02-march-compile-output-is-not-static.md` with acceptance
+criteria that require **running** the artifact in a `scratch` container, plus
+three prerequisites worth doing on their own merits (drop the `libblake3`
+dependency, make TLS/compression opt-in, make the zstd/brotli probe
+deterministic rather than build-host-dependent).
+
+## Changes to `specs/docker_images.md`
+
+- **Motivation** — no longer claims static output; states that the deploy image
+  is a slim distro base today and that `scratch` depends on the static-musl
+  profile.
+- **New section "What `march --compile` actually links"** — a table of every
+  `DT_NEEDED` entry, where in `runtime/` it comes from, the two verifications
+  above, and the `libblake3` problem with the `COPY --from=build` workaround
+  and the two durable fixes.
+- **Deploy pattern** — the final stage is now `debian:stable-slim` with an
+  explicit `apt-get install libssl3 zlib1g libzstd1 libbrotli1 ca-certificates`,
+  and the text says plainly that `scratch`/`distroless-static` do not work.
+- **Non-Goals** — gained an explicit "making `march --compile` emit a static
+  binary is not in this spec" bullet pointing at the new todo; the stale "compiled
+  March binaries are self-contained" justification for having no runtime image
+  was replaced with the real one (a stock base plus a short package line is
+  cheaper to document than to publish and version).
+- **Toolchain base image** — notes that the image's base fixes the ABI of every
+  binary it builds, so the deploy stage must match it.
+- **Size & Caching / Relationship / Open Questions** — the "few MB" figure, the
+  "static linking is why the deploy stage can be `scratch`" bullet, and Open
+  Question 5 (glibc vs musl) all corrected; a sixth open question records that
+  the toolchain image should not wait on the static work.
+
+Documentation only — no compiler change, no test-count change.

--- a/specs/todos/2026-09-02-march-compile-output-is-not-static.md
+++ b/specs/todos/2026-09-02-march-compile-output-is-not-static.md
@@ -1,0 +1,78 @@
+`[P2]` # `march --compile` output is dynamically linked — no `scratch`/distroless deploy
+
+Filed 2026-09-02 while correcting `specs/docker_images.md`, which asserted the
+opposite (see `specs/progress/2026-09-02-docker-images-spec-claimed-static-user-binaries.md`).
+
+Sibling of, and distinct from, `2026-08-31-linux-release-binaries-are-not-static.md`:
+that one is about the **compiler** binaries we ship in the release archives.
+This one is about the binary a **user's** program compiles to.
+
+## The defect
+
+`march --compile` never passes `-static`. The link command (`bin/main.ml`, the
+`Printf.sprintf` building `cmd` near the `math_flag` binding; helpers in
+`bin/toolchain.ml`) links the bundled C runtime against the host's shared
+libraries, so every compiled March program carries `DT_NEEDED` entries for:
+
+| Library | Source |
+|---------|--------|
+| `libssl`, `libcrypto` | `runtime/march_tls.c` — linked unconditionally, not only for programs that use TLS |
+| `libz` | `runtime/march_compress.c` (mandatory) |
+| `libzstd`, `libbrotlienc`, `libbrotlidec` | `runtime/march_compress.c`, added when the **build host** has the headers — so the dependency set varies by build machine |
+| `libblake3` | `runtime/march_blake3.c` |
+| `libucontext` | musl only; `runtime/march_scheduler.c` green threads (`swapcontext`) |
+| `libc` / `libc.musl-<arch>` | always |
+
+Verified 2026-09-02 on `alpine:3.21` aarch64 under Docker (`readelf -d` on a
+compiled hello-world lists exactly that set) and independently on macOS arm64,
+where `otool -L` on the same program gives the identical set (`libSystem`, no
+`libucontext`). It is a property of the link command, not of one host.
+
+`libblake3` is the worst of these: there is no package for it on the distro
+bases March itself uses — `.github/workflows/build.yml` clones BLAKE3 and
+compiles `libblake3.so` from source on both Linux release legs — so a user's
+compiled program depends on a library they have no packaged way to install.
+
+## Consequences
+
+- A compiled March program cannot run in `scratch` or `distroless-static`, and
+  will not run on a stock slim base either without an explicit `apt`/`apk` line
+  **plus** a hand-copied `libblake3.so`.
+- The "few megabytes, zero runtime dependencies" deploy story is not available.
+- Because zstd/brotli are keyed off build-host headers, the same source can
+  produce binaries with different dependency sets on different machines.
+
+## Acceptance
+
+A `--static` mode (or the static-musl target profile scoped as future work in
+`specs/2026-07-04-cross-compile-linux-hot-deploy-design.md`) such that:
+
+1. `march --compile --static hello.march` produces a binary with no `DT_NEEDED`
+   entries (`readelf -d` shows none; `file` reports "statically linked").
+2. A CI check **runs** that binary in a `scratch` (or `distroless-static`)
+   container with nothing else in the image, and asserts its output. A link
+   that merely succeeds is not evidence; this class of defect ships precisely
+   because nobody executed the artifact in a bare environment.
+3. Its failure mode when a static archive is missing is a clear diagnostic
+   naming the library and the package that provides it — not a wall of
+   linker `undefined reference` output.
+
+Prerequisites worth doing on their own merits, each of which shrinks the
+problem before any `-static` flag exists:
+
+- **Stop depending on `libblake3` at all** — vendor the BLAKE3 C sources into
+  `runtime/` the way `tweetnacl.c` is vendored, or link the static
+  `libblake3.a` (`lib/cas/discover.ml` already prefers it on macOS when
+  present). This removes the one dependency users cannot install.
+- **Make TLS/compression opt-in** — `libssl`/`libcrypto` are linked into every
+  program including pure-compute ones. Linking them only when the program
+  reaches TLS would shrink both the dependency set and the binary.
+- **Make the zstd/brotli probe deterministic** rather than build-host-dependent,
+  so a program's dependency set is a function of its source and flags.
+
+## Non-acceptance
+
+Adding a `--static` flag that merely appends `-static` to the link line, without
+the static archives being resolvable and without a bare-container run in CI, is
+worse than the status quo: it converts an honest dynamic binary into a link
+error or a silently-still-dynamic one.


### PR DESCRIPTION
`specs/docker_images.md` asserted, as present-tense fact, that "March compiles to a **statically linked** native binary (musl on Linux)" and that a compiled program "needs **no runtime base image at all**: the binary can be copied into `scratch` or a distroless image, producing a deploy image of a few megabytes with zero runtime dependencies" — and built its entire recommended multi-stage deploy pattern on that.

It isn't true. This is a **different** defect from the release-archive one (`specs/todos/2026-08-31-linux-release-binaries-are-not-static.md`), which concerns the distributed `march`/`forge` binaries; this one is about the output of `march --compile` for a *user's* program.

## What was verified

The link command (`bin/main.ml`, the `Printf.sprintf` building `cmd` near `math_flag`; helpers in `bin/toolchain.ml`) passes **no `-static`** on any path — `grep -- -static bin/ lib/ forge/` finds only the phrase "file-static" in a comment. The cross path goes the other way on purpose, linking positional `.so` paths so the target soname lands in `DT_NEEDED`.

Two independent observations, both 2026-09-02:

- `alpine:3.21` aarch64 under Docker — `readelf -d` on a compiled hello-world lists `libssl.so.3`, `libcrypto.so.3`, `libz.so.1`, `libzstd.so.1`, `libbrotlienc.so.1`, `libbrotlidec.so.1`, `libblake3.so`, `libucontext.so.1`, `libc.musl-aarch64.so.1`.
- macOS arm64 — `MARCH_ECHO_CC=1 march --compile` emits `-lssl -lcrypto -lz -lzstd -lbrotlienc -lbrotlidec -lblake3 -lm`, and `otool -L` shows the identical set (`libSystem`, no `libucontext`).

The second is what makes it a property of the link command rather than of one container.

`libblake3` is the sharp edge: `.github/workflows/build.yml:97-101` clones BLAKE3 and compiles `libblake3.so` from source on **both** Linux release legs (and builds a static `.a` on macOS, since Homebrew ships only the dylib) because there is no package to install. A user's compiled program therefore depended on a library they have no packaged way to obtain.

## Why correct the doc rather than add `--static`

The spec is marked **Status: Proposed — not yet implemented**, so the static claim was a design assumption that turned out false, not a regression against shipped behaviour. Static output means sourcing static archives for six libraries across two libcs, vendoring or statically linking BLAKE3, and standing up a bare-container CI check — a feature in its own right, already scoped as the static-musl profile under "Future work" in `specs/2026-07-04-cross-compile-linux-hot-deploy-design.md`. A `--static` flag that merely appends `-static` to the link line would be a fake fix: it converts an honest dynamic binary into a link error or a silently-still-dynamic one.

So the spec now says what actually ships, and the feature is filed with acceptance criteria that require **running** the artifact in a `scratch` container — a successful link is not evidence, since this class of defect ships precisely because nobody executed the binary in a bare environment.

## Changes

- **`specs/docker_images.md`** — motivation no longer claims static output; new **"What `march --compile` actually links"** section with a table mapping each `DT_NEEDED` entry to its `runtime/*.c` source, both verifications, and the `libblake3` problem; the deploy pattern's final stage is now `debian:stable-slim` with an explicit package line and a `COPY --from=build /usr/lib/libblake3.so*`; explicit "`scratch` and `distroless-static` do not work today"; Non-Goals, Size & Caching, Relationship, and Open Question 5 corrected, plus a sixth recording that the toolchain image should not wait on the static work.
- **`specs/todos/2026-09-02-march-compile-output-is-not-static.md`** — the feature, with three prerequisites worth doing on their own merits: drop the `libblake3` dependency (vendor it the way `tweetnacl.c` is vendored, or link the `.a` that `lib/cas/discover.ml` already prefers on macOS), make TLS/compression opt-in (libssl is linked into pure-compute programs today), and make the zstd/brotli probe deterministic rather than build-host-dependent.
- **`specs/progress/2026-09-02-docker-images-spec-claimed-static-user-binaries.md`** + a `### Documentation` CHANGELOG bullet.

## Also worth flagging

`libzstd`/`libbrotli*` are linked **only when the build host has the headers**, so the same source compiles to different dependency sets on different machines. That is arguably a worse problem than the dynamic linking itself; it's captured as a prerequisite in the new todo.

## Testing

Documentation only — no compiler change, no test-count change. `scripts/check-docs.sh` passes.
