### PR TITLE
feat(caps): lift the one-capability-per-actor limit on capture at spawn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,15 @@ git log is authoritative for exact commits.
 
 ### Fixed
 
+- An actor whose handlers reach **two or more capabilities** (it logs *and*
+  reads the clock, the ordinary shape) can now be mocked; previously only
+  one-capability actors were captured at spawn, and an actor over that limit
+  kept its real IO with no warning. The spawn site now captures a record of
+  every capability the actor needs, and a partial mock works: an actor
+  reaching `IO.Console` and `IO.Clock`, spawned inside a Console-only
+  `with_cap`, gets the mocked Console and the real Clock. Compiled `--test`
+  builds only, as before.
+
 - `march --emit-io-ops` printed every multi-argument operation in the wrong
   spelling: `(A, B) -> C`, which in March is a function of one *tuple*
   argument (`Tuple.apply` calls its `f : (a, b) -> c` as `f(t)`). Copying that

--- a/lib/tir/cap_passing.ml
+++ b/lib/tir/cap_passing.ml
@@ -367,18 +367,36 @@ let actor_of_dispatch (n : string) : string option =
   if ln > ls && String.sub n (ln - ls) ls = sfx
   then Some (String.sub n 0 (ln - ls)) else None
 
-(** The single capability an actor's dispatch needs, if there is exactly one.
+(** The capabilities an actor's dispatch needs, sorted and de-duplicated;
+    empty when [fd] is not a dispatch or reaches no capability.
 
-    v1 deliberately handles ONE.  An actor performing two different
-    capabilities' operations would need a record of them captured at spawn, and
-    that is additive; one capability covers the ordinary actor (it logs, or it
-    reads the clock) and proves the whole path — spawn-site capture, runtime
-    metadata, dispatch read — end to end. *)
-let dispatch_cap (need : (string, string list) Hashtbl.t) (fd : T.fn_def)
-  : string option =
+    v1 handled exactly ONE capability and returned [None] for two or more, so
+    an actor that logged AND read the clock got nothing captured at all.  Now
+    every capability the dispatch reaches is captured, as one record of them
+    built at the spawn site (see [thread]) — one shape for one capability and
+    for many, so the two cannot disagree about WHICH capabilities an actor
+    needs. *)
+let dispatch_caps (need : (string, string list) Hashtbl.t) (fd : T.fn_def)
+  : string list =
   match actor_of_dispatch fd.T.fn_name with
-  | None -> None
-  | Some _ -> (match caps_reached need fd.T.fn_body with [ c ] -> Some c | _ -> None)
+  | None -> []
+  | Some _ -> caps_reached need fd.T.fn_body
+
+(** The record of an actor's captured capabilities, as [(field, capability)]:
+    one field per capability, named [cap_param_name c] (the `$cap_IO_Console`
+    spelling the parameters already use), SORTED BY FIELD NAME — the
+    [T.TRecord] invariant ([tir.ml]) that [Llvm_data.field_index_for] relies
+    on to compute each projection's index.  Sorted here explicitly rather than
+    inherited from [caps_reached]'s capability order: the field name swaps `.`
+    for `_`, and `_` sorts after every capital letter, so a capability-sorted
+    list is not field-sorted in general (`IO.A` < `IOB` but
+    `$cap_IO_A` > `$cap_IOB`). *)
+let caps_record_fields (caps : string list) : (string * string) list =
+  List.sort (fun (a, _) (b, _) -> String.compare a b)
+    (List.map (fun c -> (cap_param_name c, c)) caps)
+
+let caps_record_ty (caps : string list) : T.ty =
+  T.TRecord (List.map (fun (f, c) -> (f, cap_ty c)) (caps_record_fields caps))
 
 (* ── threading ────────────────────────────────────────────────────────── *)
 
@@ -462,26 +480,44 @@ let rec thread ?(dispatch = false) ?(spawn_caps = Hashtbl.create 1)
   (* Spawn-site capture.  Lower emits
        let $raw_actor = Name_spawn() in spawn($raw_actor)
      and `march_spawn` is what CREATES the actor's runtime metadata, so the
-     capability has to be attached after it, not before:
-       let $raw_actor = Name_spawn() in
-       let $pid = spawn($raw_actor) in
-       set_actor_caps($raw_actor, <cap>); $pid
-     The actor's dispatch reads it back — see [ops_in]/[dispatch_cap]. *)
+     capabilities have to be attached after it, not before:
+       let $raw_actor  = Name_spawn() in
+       let $pid        = spawn($raw_actor) in
+       let $spawn_caps = { $cap_c1: <supply c1>, …, $cap_cn: <supply cn> } in
+       set_actor_caps($raw_actor, $spawn_caps); $pid
+     One record on the meta's single pointer regardless of how many
+     capabilities the actor needs; a capability this site cannot supply is the
+     ambient sentinel in its field, so a PARTIAL mock (Console mocked, Clock
+     real) works.  The actor's dispatch reads it back — see [dispatch_caps]
+     and the projection in [elaborate].
+
+     RC: [needs_rc (TRecord _)] is false, so the record itself is never
+     inc'd/dec'd — it is retained forever on the meta, matching the meta's own
+     leak-don't-free discipline.  The +1 on each capability now comes from the
+     record build (Perceus dups an owned copy of every field into it), NOT
+     from the builtin's owned argument as it did for the bare pointer; that is
+     what lets a mock outlive the `with_cap` scope that supplied it. *)
   | T.ELet (raw, (T.EApp (sf, []) as spawn_call), T.EApp (sp, [ T.AVar raw' ]))
     when sp.T.v_name = "spawn" && raw'.T.v_name = raw.T.v_name
       && (match actor_of_spawn sf.T.v_name with Some _ -> true | None -> false) ->
     let actor = Option.get (actor_of_spawn sf.T.v_name) in
     (match Hashtbl.find_opt spawn_caps actor with
-     | None -> e
-     | Some cap ->
+     | None | Some [] -> e
+     | Some caps ->
        let pid = { T.v_name = "$pid_cap"; T.v_ty = T.TPtr T.TUnit; T.v_lin = T.Unr } in
        let setter =
          { T.v_name = "set_actor_caps"; T.v_ty = T.TPtr T.TUnit; T.v_lin = T.Unr }
        in
+       let fields = caps_record_fields caps in
+       let caps_var =
+         { T.v_name = "$spawn_caps"; T.v_ty = caps_record_ty caps; T.v_lin = T.Unr }
+       in
        T.ELet (raw, spawn_call,
          T.ELet (pid, T.EApp (sp, [ T.AVar raw ]),
-           T.ESeq (T.EApp (setter, [ T.AVar raw; supply cap ]),
-                   T.EAtom (T.AVar pid)))))
+           T.ELet (caps_var,
+             T.ERecord (List.map (fun (f, c) -> (f, supply c)) fields),
+             T.ESeq (T.EApp (setter, [ T.AVar raw; T.AVar caps_var ]),
+                     T.EAtom (T.AVar pid))))))
   | T.ELet (v, e1, e2) ->
     (* `with_cap(mock, fn _ -> body)`: inside that lambda, the capability is
        the MOCK rather than whatever the enclosing scope was supplying.  Lower
@@ -569,11 +605,11 @@ let elaborate ?(dispatch = false) (m : T.tir_module) : T.tir_module =
   else
     (* Which capability each actor's dispatch needs, so a spawn site knows what
        to capture and the dispatch knows what to read back. *)
-    let spawn_caps : (string, string) Hashtbl.t = Hashtbl.create 8 in
+    let spawn_caps : (string, string list) Hashtbl.t = Hashtbl.create 8 in
     List.iter
       (fun (fd : T.fn_def) ->
-         match actor_of_dispatch fd.T.fn_name, dispatch_cap need fd with
-         | Some actor, Some cap -> Hashtbl.replace spawn_caps actor cap
+         match actor_of_dispatch fd.T.fn_name, dispatch_caps need fd with
+         | Some actor, (_ :: _ as caps) -> Hashtbl.replace spawn_caps actor caps
          | _ -> ())
       m.T.tm_fns;
     let changed = ref 0 in
@@ -587,23 +623,72 @@ let elaborate ?(dispatch = false) (m : T.tir_module) : T.tir_module =
            else
              (* An actor's dispatch is entered from the scheduler, so its arity
                 is frozen and it has no capability parameter to supply.  Read
-                the one captured at the spawn site off the actor's runtime
-                metadata instead, and bind it for the body — the handler bodies
-                are already inlined here, so this reaches their operations. *)
+                the record captured at the spawn site off the actor's runtime
+                metadata instead, project one variable per capability out of
+                it, and bind those for the body — the calls it makes to the
+                threaded handlers then supply them instead of the sentinel:
+
+                  let $caps_opt : Option({…}) = actor_caps($actor) in
+                  let $caps : {…} = case $caps_opt of
+                                      Some($r) -> $r
+                                      None()   -> { $cap_c: root_cap, … } in
+                  let $spawn_cap_c = $caps.$cap_c in …
+
+                The read is NULL for any actor this pass did not capture for —
+                a supervised child, a respawned one, anything spawned through a
+                shape the rewrite does not match — and v1's bare pointer read
+                that as the sentinel for free.  A record projection cannot, so
+                the read is typed as the niche `Option` (`None` IS null) and
+                matched exactly as the generated `cap_dict` wrappers match
+                theirs; the `None` arm builds a record of sentinels, so the
+                uncaptured actor keeps release behaviour instead of a wild
+                field load.
+
+                RC: `$caps` MUST be typed [TRecord] — [needs_rc] false — so
+                Perceus never decs the retained record at scope end (a [TCon]
+                here would be a use-after-free on the second message).  The
+                `Some` payload moves into it without a dec of the scrutinee,
+                the same shape the `cap_dict` wrappers already exercise; each
+                projection is a borrowed-field var, dup'd when it escapes into
+                a handler call and never dec'd locally. *)
              let (extra_binds, wrap) =
-               match actor_of_dispatch fd.T.fn_name, dispatch_cap need fd with
-               | Some actor, Some cap when Hashtbl.mem spawn_caps actor ->
+               match actor_of_dispatch fd.T.fn_name, dispatch_caps need fd with
+               | Some actor, (_ :: _ as caps) when Hashtbl.mem spawn_caps actor ->
                  (match fd.T.fn_params with
                   | actor_param :: _ ->
-                    let cv =
-                      { T.v_name = "$spawn_cap"; T.v_ty = cap_ty cap; T.v_lin = T.Unr }
+                    let fields = caps_record_fields caps in
+                    let rec_ty = caps_record_ty caps in
+                    let opt_ty = T.TCon ("Option", [ rec_ty ]) in
+                    let mk name ty = { T.v_name = name; T.v_ty = ty; T.v_lin = T.Unr } in
+                    let caps_opt = mk "$caps_opt" opt_ty in
+                    (* [TVar "_"] for the branch binder, as lower's own case
+                       compilation does; the typed rebinding is the let. *)
+                    let caps_some = mk "$caps_some" (T.TVar "_") in
+                    let caps_var = mk "$caps" rec_ty in
+                    let reader = mk "actor_caps" opt_ty in
+                    let proj =
+                      List.map
+                        (fun (f, c) ->
+                           (* `$cap_IO_Console` -> `$spawn_cap_IO_Console` *)
+                           let pn = cap_param_name c in
+                           (c, f, mk ("$spawn_" ^ String.sub pn 1 (String.length pn - 1))
+                                    (cap_ty c)))
+                        fields
                     in
-                    let reader =
-                      { T.v_name = "actor_caps"; T.v_ty = cap_ty cap; T.v_lin = T.Unr }
-                    in
-                    ([ (cap, T.AVar cv) ],
+                    (List.map (fun (c, _, v) -> (c, T.AVar v)) proj,
                      fun body ->
-                       T.ELet (cv, T.EApp (reader, [ T.AVar actor_param ]), body))
+                       T.ELet (caps_opt, T.EApp (reader, [ T.AVar actor_param ]),
+                         T.ELet (caps_var,
+                           T.ECase (T.AVar caps_opt,
+                             [ { T.br_tag = "Some"; T.br_vars = [ caps_some ];
+                                 T.br_body = T.EAtom (T.AVar caps_some) };
+                               { T.br_tag = "None"; T.br_vars = [];
+                                 T.br_body =
+                                   T.ERecord (List.map (fun (f, c) -> (f, ambient_atom c)) fields) } ],
+                             Some (Lower_state.nonexhaustive_panic ())),
+                           List.fold_right
+                             (fun (_, f, v) acc -> T.ELet (v, T.EField (T.AVar caps_var, f), acc))
+                             proj body)))
                   | [] -> ([], fun b -> b))
                | _ -> ([], fun b -> b)
              in

--- a/lib/tir/cap_passing.mli
+++ b/lib/tir/cap_passing.mli
@@ -25,6 +25,14 @@ val needed_caps : Tir.tir_module -> (string, string list) Hashtbl.t
 (** Each function that must carry capabilities, mapped to them (sorted).
     Functions whose arity cannot safely change are excluded. *)
 
+val actor_of_dispatch : string -> string option
+(** The actor name when the argument is an actor's dispatch function. *)
+
+val dispatch_caps : (string, string list) Hashtbl.t -> Tir.fn_def -> string list
+(** Every capability an actor's dispatch reaches (sorted, de-duplicated),
+    i.e. what its spawn site captures; empty when the function is not a
+    dispatch or reaches none.  Takes the table from [needed_caps]. *)
+
 val elaborate : ?dispatch:bool -> Tir.tir_module -> Tir.tir_module
 (** Add the implicit capability parameters and thread them from callers.
     Threading only: nothing consumes them yet, so the program must behave

--- a/specs/progress/2026-09-01-actor-capability-capture-at-spawn.md
+++ b/specs/progress/2026-09-01-actor-capability-capture-at-spawn.md
@@ -172,6 +172,10 @@ One capability per actor. An actor whose handlers reach two would need a record
 of them captured instead — additive. `dispatch_cap` returns `None` for that
 case, so such an actor keeps today's behaviour rather than getting a wrong one.
 
+*(Lifted 2026-09-03: `2026-09-02-lift-one-cap-per-actor.md` in this directory
+captures a record of every capability the dispatch reaches; `dispatch_cap` is
+now `dispatch_caps : … -> string list`.)*
+
 ### Test
 
 `test/cap_mock/cap_mock_actor.march`. Two actors: one spawned inside

--- a/specs/progress/2026-09-02-lift-one-cap-per-actor.md
+++ b/specs/progress/2026-09-02-lift-one-cap-per-actor.md
@@ -1,6 +1,7 @@
 # Lift the one-capability-per-actor limit on capture at spawn
 
-**Status:** specced 2026-09-02, not started. Parent design:
+**Status:** specced 2026-09-02, **shipped 2026-09-03** (see "What shipped" at
+the end). Parent design:
 `2026-08-31-cap-runtime-dictionaries.md` (§"Actor handlers: capture at spawn",
 landed in #397). Full account of the landed v1 in
 `specs/progress/2026-09-01-actor-capability-capture-at-spawn.md`.
@@ -262,3 +263,101 @@ gate.
 
 Estimated size: ~60 lines in `cap_passing.ml`, one fixture, one unit test. No
 runtime, ABI, builtin, or typechecker change.
+
+---
+
+## What shipped (2026-09-03)
+
+All in `lib/tir/cap_passing.ml`, plus tests and docs. No runtime, ABI,
+builtin, or typechecker change, as designed.
+
+- **Analysis.** `dispatch_cap : … -> string option` became
+  `dispatch_caps : … -> string list` (sorted, from `caps_reached`);
+  `spawn_caps` maps actor → list. Exported with `actor_of_dispatch` in the
+  `.mli` so `test/test_cap_dict.ml` can pin the analysis directly: a
+  two-capability actor yields `["IO.Clock"; "IO.Console"]`, a one-capability
+  actor a one-element list. Landing this step alone left every existing golden
+  byte-identical, as the plan required.
+- **Spawn site.** `let $spawn_caps : { $cap_c1 : Cap(c1), … } = { … } in
+  set_actor_caps($raw_actor, $spawn_caps)`. Fields are `cap_param_name c`,
+  sorted **by field name** explicitly (`caps_record_fields`) rather than by
+  inheriting the capability order: `.` → `_` is not monotone under `String.compare`
+  (`IO.A` < `IOB` but `$cap_IO_A` > `$cap_IOB`), so the spec's "sorting the
+  caps sorts the fields" would have held for today's names and broken for a
+  future one. A capability the site cannot supply is `root_cap` in its field,
+  which is what makes the partial-mock rows of the golden work.
+- **Dispatch, with one addition the spec did not have: the read is
+  null-safe.** `march_actor_caps` returns NULL for any actor this pass did not
+  capture for — a `supervise` child, a **respawned** child (`march_respawn_child`
+  goes through `find_or_create_meta`, whose `spawn_cap` is zeroed), anything
+  spawned through a shape the rewrite does not match. v1's bare `Cap` read
+  that as the sentinel for free; a record projection from NULL is a wild
+  load. So the dispatch reads
+
+  ```
+  let $caps_opt : Option({…}) = actor_caps($actor) in
+  let $caps : {…} = case $caps_opt of Some($r) -> $r
+                                      None()   -> { $cap_c: root_cap, … } in
+  let $spawn_cap_c = $caps.$cap_c in …
+  ```
+
+  typed as the niche `Option` (`None` IS null, `Some(x)` IS `x`) and matched
+  exactly the way the generated `cap_dict` wrappers match theirs; the `None`
+  arm builds a record of sentinels so an uncaptured actor keeps release
+  behaviour. The red control below happens to prove this arm too: with the
+  spawn-site build disabled every actor ran through it and printed `real`
+  rather than crashing. `$caps` stays `TRecord` (contract item 2).
+- **Single-capability actors** go through the same record path;
+  `cap_mock_actor` stayed green throughout.
+- **Golden** `test/cap_mock/cap_mock_actor_two.march`: the four spawns from
+  the table above, plus a **second message** to the `both` and `outside`
+  actors, because a record freed after the first dispatch read (the UAF the
+  RC contract guards against) is invisible on a one-message trace.
+- **Supervised children** are still never captured, on any capability count:
+  filed as `specs/todos/2026-09-03-supervised-children-not-captured.md`.
+
+### Red control
+
+Spawn-site record build disabled (`| Some _ when true -> e`), compiler
+rebuilt, CAS cleared, golden diffed:
+
+```
+< MOCK[both@1234]        > both@real
+< MOCK[both2@1234]       > both2@real
+< clock@1234             > clock@real
+< MOCK[console@real]     > console@real
+```
+
+Restored byte-for-byte, rebuilt: both actor goldens green again.
+
+### RC proof (`MARCH_DUMP_TXT=perceus` on the fixture)
+
+Contract item 3, the +1 moving from the builtin argument to the record build:
+
+```
+let $spawn_caps : { $cap_IO_Clock : Cap(IO.Clock), $cap_IO_Console : Cap(IO.Console) } = inc_rc mock_clock;
+inc_rc mock_console;
+{ $cap_IO_Clock = mock_clock, $cap_IO_Console = mock_console } in
+set_actor_caps($raw_actor, $spawn_caps);
+```
+
+(the Console-only site shows `inc_rc mock_console` alone with `root_cap` in
+the Clock field; the `inc_rc root_cap` at the uncaptured site is a no-op on
+the null sentinel). Contract items 2 and 4, the dispatch:
+
+```
+let $caps : { … } = case $caps_opt of
+  Some($caps_some) -> $caps_some
+  None() -> inc_rc root_cap; { $cap_IO_Clock = root_cap, $cap_IO_Console = root_cap }
+  _ -> dec_rc $caps_opt; panic("non-exhaustive pattern match") in
+let $spawn_cap_IO_Clock : Cap(IO.Clock) = $caps.$cap_IO_Clock in
+let $spawn_cap_IO_Console : Cap(IO.Console) = $caps.$cap_IO_Console in
+case $msg of
+  Say($Say_s) -> inc_rc $spawn_cap_IO_Clock;
+inc_rc $spawn_cap_IO_Console;
+Stamper_Say($spawn_cap_IO_Clock, $spawn_cap_IO_Console, $actor, $Say_s)
+```
+
+No dec of `$caps` or `$caps_opt` on the live path; each projection is dup'd
+where it escapes into the handler call. The two-message rows of the golden
+are the runtime witness.

--- a/specs/todos/2026-08-31-cap-runtime-dictionaries.md
+++ b/specs/todos/2026-08-31-cap-runtime-dictionaries.md
@@ -1013,8 +1013,17 @@ in the test; `Session.attach` is the only mint.
 
 ### Order of remaining work
 
-1. An actor-hosted endpoint, once the one-capability-per-actor limit is lifted.
-2. The monomorphic-`with` limitation only if a parameterised dictionary ever
+1. Lift the one-capability-per-actor limit on capture at spawn — specced in
+   `2026-09-02-lift-one-cap-per-actor.md`. An actor that logs AND reads the
+   clock is already over the limit, so no such actor can be mocked at all.
+2. An actor-hosted endpoint. **Not blocked on item 1**, contrary to what this
+   list said before 2026-09-02: `Cap(Session.Live)` is a `proof cap`, passed
+   explicitly and never threaded, and a probe shows it reaching an actor
+   handler as a message payload on both backends (the probe is in item 1's
+   file). What the endpoint needs is a way to receive its capability, and a
+   message does that today. Item 1 matters to it only when its handlers also
+   perform two IO capabilities' builtins.
+3. The monomorphic-`with` limitation only if a parameterised dictionary ever
    has a use.
 
 ## Explicitly OUT OF SCOPE — do not re-expand

--- a/specs/todos/2026-08-31-cap-runtime-dictionaries.md
+++ b/specs/todos/2026-08-31-cap-runtime-dictionaries.md
@@ -26,7 +26,7 @@ section, and nothing else in the file should be read as overriding them.
 | Compiler-inserted capability passing (`--test` builds) | **landed** (#389) — analysis + threading + dispatch wrappers, in TIR |
 | `with_cap` binding site; `cap_ops_empty` base | **landed** (#389) |
 | Mocking an IO capability, end to end | **landed** (#389); three CI fixtures under `test/cap_mock/` |
-| Actor handlers reached (capture at spawn) | **landed** (#397) — one capability per actor |
+| Actor handlers reached (capture at spawn) | **landed** (#397); the one-capability-per-actor limit **lifted** (#404, `specs/progress/2026-09-02-lift-one-cap-per-actor.md`) — a record of every capability the actor reaches |
 | `--test` in the CAS cache key (pre-existing bug) | **fixed** (#389) |
 | Session transport dictionary (`stdlib/session.march`) | **landed** (v1) — `test/session/stream_replay.march` replays `Stream` deterministically on both backends |
 
@@ -863,9 +863,12 @@ Because capture is per-actor at spawn, a mock reaches an actor spawned inside
 closes, so a global or dynamically-scoped slot would give the right answer for
 the wrong reason.
 
-**Limit: one capability per actor.** An actor whose handlers reach two would
-need a record of them captured; `dispatch_cap` returns `None` for that case, so
-such an actor keeps the previous behaviour rather than a partly-wrong one.
+**The v1 limit, one capability per actor, is lifted** (#404; design and
+RC contract in `specs/progress/2026-09-02-lift-one-cap-per-actor.md`). The spawn
+site now builds a record of every capability the dispatch reaches, on the same
+meta pointer, and the dispatch projects them back out; a capability the spawn
+site cannot supply is the sentinel in its field, so a partial mock works.
+`test/cap_mock/cap_mock_actor_two.march` is the guard.
 
 The bug worth remembering from building it: the first version scanned the
 dispatch BODY for interceptable operations and found none, because handlers are
@@ -1013,9 +1016,11 @@ in the test; `Session.attach` is the only mint.
 
 ### Order of remaining work
 
-1. Lift the one-capability-per-actor limit on capture at spawn — specced in
-   `2026-09-02-lift-one-cap-per-actor.md`. An actor that logs AND reads the
-   clock is already over the limit, so no such actor can be mocked at all.
+1. ~~Lift the one-capability-per-actor limit on capture at spawn~~ — **done**
+   (#404; `specs/progress/2026-09-02-lift-one-cap-per-actor.md`). An
+   actor that logs AND reads the clock can now be mocked, wholly or partially.
+   Supervised children are still never captured, on any capability count:
+   `2026-09-03-supervised-children-not-captured.md`.
 2. An actor-hosted endpoint. **Not blocked on item 1**, contrary to what this
    list said before 2026-09-02: `Cap(Session.Live)` is a `proof cap`, passed
    explicitly and never threaded, and a probe shows it reaching an actor

--- a/specs/todos/2026-09-02-lift-one-cap-per-actor.md
+++ b/specs/todos/2026-09-02-lift-one-cap-per-actor.md
@@ -1,0 +1,264 @@
+# Lift the one-capability-per-actor limit on capture at spawn
+
+**Status:** specced 2026-09-02, not started. Parent design:
+`2026-08-31-cap-runtime-dictionaries.md` (§"Actor handlers: capture at spawn",
+landed in #397). Full account of the landed v1 in
+`specs/progress/2026-09-01-actor-capability-capture-at-spawn.md`.
+
+## What the limit is, precisely
+
+`lib/tir/cap_passing.ml` threads IO capabilities into ordinary functions as
+extra parameters, one `$cap_<X>` per capability the function reaches, in
+sorted order, any number of them. The ACTOR boundary is the one place that is
+single-capability:
+
+- `dispatch_cap need fd` returns `Some c` only when `caps_reached` for the
+  actor's `_dispatch` function is a list of EXACTLY one; two or more → `None`.
+- `spawn_caps : actor -> cap` (one string), filled from `dispatch_cap`.
+- The spawn-site rewrite stores that one `Cap` pointer:
+  `set_actor_caps($raw_actor, <cap>)`.
+- The dispatch opens with `let $spawn_cap : Cap(c) = actor_caps($actor)` and
+  binds it for that one capability.
+- The runtime slot is one pointer: `march_actor_meta.spawn_cap`
+  (`runtime/march_runtime.c:1934`), set/read by `march_set_actor_caps` /
+  `march_actor_caps`.
+
+An actor whose handlers reach two capabilities gets nothing captured at all,
+so none of its operations can be mocked. It keeps release behaviour rather
+than a partly-wrong one, which was the right v1 call; it is also the ordinary
+actor — one that logs (`IO.Console`) and reads the clock (`IO.Clock`) is
+already over the limit.
+
+## What the limit is NOT (correcting the parent spec)
+
+The parent spec's "Order of remaining work" put "an actor-hosted endpoint,
+once the one-capability-per-actor limit is lifted" first, as if the endpoint
+were blocked on it. It is not. `Cap(Session.Live)` is a user `proof cap`; it
+is passed EXPLICITLY, never threaded, and `cap_of_interceptable_op` only knows
+the IO builtins. Probe, 2026-09-02, identical on both backends:
+
+```march
+mod CapByMsg do
+  needs IO
+  needs IO.Console
+  needs Session.Live
+  actor Ep do
+    state { n : Int }
+    init  { n: 0 }
+    on Attach(c : Cap(Session.Live)) do
+      let _ = Session.close(c, 7)
+      { state with n: state.n + 1 }
+    end
+  end
+  fn main(io : Cap(IO)) do
+    let ops = { register: fn (ap, role) -> ap + role,
+                emit: fn (ep, to, msg) -> ep,
+                suspend: fn (ep, h) -> ep,
+                close: fn ep -> print_line("closed " ++ int_to_string(ep)) }
+    let sess = Session.attach(io, ops)
+    let p = spawn(Ep)
+    send(p, Attach(sess))
+    run_until_idle()
+  end
+end
+-- prints: closed 7     (interpreted AND --compile, no --test)
+```
+
+A session capability reaches a handler as a message payload
+(`typecheck_caps.ml` H9: handlers may receive `Cap(X)` message arguments
+under the module's `needs`). What an actor-hosted endpoint actually needs is
+a way to GET the capability into the actor — by message, as above, since there
+is deliberately no ambient transport — and that works today. The one-cap limit
+only matters to it if its handlers also perform two IO capabilities' worth of
+builtins, which a logging endpoint with a clock-based timeout would.
+
+So this item is worth doing on its own merits (any two-capability actor), and
+the actor-hosted endpoint is unblocked independently of it. The parent spec's
+remaining-work list is corrected in the same commit as this file.
+
+## Design: a record of capabilities on the existing pointer
+
+This is the shape #397's own diagnosis sketched ("one pointer rather than N
+keeps the struct and the spawn ABI fixed regardless of how many capabilities
+an actor needs") and then deferred. Nothing outside `cap_passing.ml` changes.
+
+### Analysis
+
+`dispatch_cap : … -> string option` becomes `dispatch_caps : … -> string list`
+(sorted, possibly empty). `spawn_caps` becomes `actor -> string list`.
+`caps_reached` already returns the sorted, de-duplicated list; the change is
+to stop discarding it when its length is not one.
+
+### Spawn site
+
+For an actor with caps `[c1; …; cn]` (n ≥ 1), the rewrite becomes
+
+```
+let $raw_actor = Name_spawn() in
+let $pid       = spawn($raw_actor) in
+let $caps      = { $cap_c1: <supply c1>, …, $cap_cn: <supply cn> } in
+set_actor_caps($raw_actor, $caps); $pid
+```
+
+- Field names are `cap_param_name c` (the `$cap_IO_Console` spelling already
+  used for parameters: `$` keeps it out of the user namespace, dots become
+  underscores). `$cap_…` does not collide with the closure free-variable
+  convention, which is `Tir_names.is_fv_field` = prefix `$fv`.
+- The record is an ordinary `T.ERecord`; its var is typed
+  `T.TRecord [(field, cap_ty c)]` **sorted by field name**, the TRecord
+  invariant (`tir.ml:12`) that `Llvm_data.field_index_for` relies on to
+  compute the projection index. Since `caps_reached` is sorted by capability
+  name and `cap_param_name` is monotone in it (only dots change), sorting the
+  caps sorts the fields; assert it anyway (`test_cap_dict` already pins the
+  same invariant for dictionary fields).
+- `<supply c>` is what it is today: the enclosing function's own `$cap_c`
+  parameter, a `with_cap` mock, or — when the spawn site cannot supply that
+  capability — the ambient sentinel `root_cap`, which is NULL in the record
+  field and reads back as "no dictionary". **Partial mocks therefore work:**
+  an actor reaching Console and Clock, spawned inside a Console-only
+  `with_cap`, gets a mocked Console and a real Clock.
+- `set_actor_caps`'s C signature is already `(ptr actor, ptr caps)`; a record
+  is a `ptr` (`llvm_ctx.ml:443`). No builtin, declaration, or runtime change,
+  so the nine-site new-builtin dance does not apply.
+
+### Dispatch
+
+```
+fn Name_dispatch($actor, $msg) =
+  let $caps       : TRecord{…} = actor_caps($actor) in
+  let $spawn_cap_c1 : Cap(c1)  = $caps.$cap_c1 in
+  …
+  <body, threaded with binds [(c1, $spawn_cap_c1); …]>
+```
+
+`actor_caps`'s builtin return type in the table is `Cap(a)`; the CALL is
+emitted from the table (`llvm_emit_call.ml:298`) as returning `ptr`, and the
+let-bound var carries the `TRecord` type the projections need. Both are `ptr`
+at the LLVM level, so no coercion is involved — and no erased-i64 hazard,
+since neither side is ever an i64.
+
+### Single-capability actors: unify, do not special-case
+
+Recommend routing n = 1 through the same record shape rather than keeping the
+bare-pointer path alongside it. One shape, one RC argument, one test surface;
+the cost is a one-field record per spawn in `--test` builds only. The existing
+`test/cap_mock/cap_mock_actor.march` golden is the guard that the unified path
+still produces `MOCK[A:in] / A:out`. (If it turns out the bare path has to
+stay — e.g. a snapshot outside our control depends on its TIR — the two paths
+must share `dispatch_caps` so they cannot disagree about WHICH caps an actor
+needs.)
+
+## The RC contract, stated so it can be checked
+
+This is the only part with a way to be subtly wrong, so it is spelled out.
+
+1. **The record is retained forever, on purpose.** `march_actor_meta` is
+   never freed ("leak-don't-free", `march_runtime.c:2040`, `:2086`), and
+   `spawn_cap` is one raw pointer on it with no release path. Today that
+   retains the single `Cap`; tomorrow it retains the record. Per spawn, in a
+   `--test` build, that is one small allocation, matching the meta's own
+   discipline.
+2. **`needs_rc (TRecord _) = false`** (`rc_types.ml:122`): Perceus never
+   emits inc/dec on a record aggregate; it reconciles at the FIELD level
+   through `borrowed_field_vars` (`perceus_core.ml:137`, `:770`). So the
+   `$caps` var in the dispatch, bound from a builtin call, gets no aggregate
+   dec at scope end — the UAF that a `TCon`-typed result WOULD have produced
+   on the second message does not arise. Do not type `$caps` as anything but
+   `TRecord`.
+3. **Fields entering the record at spawn** are ordinary `ERecord` atoms;
+   Perceus treats a record build as consuming owned copies of its fields, so
+   each `Cap` (a dictionary pointer, `needs_rc = true`) is dup'd into the
+   record and outlives the `with_cap` scope that supplied it — the property
+   that lets `cap_mock_actor`'s `outside` actor be sent to after the block
+   closes. Today the same +1 comes from `set_actor_caps`'s argument being
+   owned (`set_actor_caps` is not in `Borrow.extern_borrow_table`, so its
+   parameters are owned, and the runtime never decs). With the record, the
+   builtin's owned argument is the record itself, whose `needs_rc` is false:
+   **the caps' +1 now comes from the record build, not the builtin call.**
+   Prove it, don't assume it: `MARCH_DUMP_TXT=perceus` on the fixture must
+   show an `EIncRC` on each cap atom feeding the `ERecord` (or the cap being
+   consumed there as its last use).
+4. **Projections in the dispatch** (`let $spawn_cap_c = $caps.$cap_c`) are
+   borrowed-field vars; when one escapes into a threaded handler call as an
+   owned argument, Perceus incs it there (the `borrowed_field_vars` escape
+   rule). No dec is emitted for the projection itself. This is the same
+   shape as closure `$fv` fields and record-param field reads that the rest
+   of the pipeline already exercises.
+5. **The sanitize-gate CI leg** (ASAN over the native corpus) must run the
+   new fixture; locally ASAN needs Docker (`ci/Dockerfile.ubuntu`; build only
+   `bin/main.exe` there), so the local proof is the Perceus dump plus the
+   fixture's output, and the ASAN proof is CI's.
+
+## Tests
+
+### Golden: `test/cap_mock/cap_mock_actor_two.march` (+ `.expected`, dune rule)
+
+An actor whose handler performs BOTH `IO.Console` and `IO.Clock` builtins
+(`cap_mock_clock` already proves Clock is interceptable), and four spawns that
+together pin every property above:
+
+| actor spawned … | expected |
+|---|---|
+| inside `with_cap(console)` inside `with_cap(clock)` | both mocked |
+| inside `with_cap(console)` only | Console mocked, real Clock (partial) |
+| inside `with_cap(clock)` only | Clock mocked, real Console (partial) |
+| outside any `with_cap`, sent to AFTER the blocks close | neither mocked |
+
+Print through the mocked Console so the Clock's value is visible in the trace
+(mock the clock to a fixed number; the real clock's line is matched only by
+shape, e.g. printed as `real`, since its value varies). Compiled `--test`
+only, like the other three `cap_mock_*` rules (`test/dune` ~L1351), because
+capture exists only where the elaboration runs.
+
+**Red control, mandatory:** disable the spawn-site record build and watch the
+first row become unmocked; then restore. A golden that has never been red has
+proven nothing (see the parent spec's history on this).
+
+### Unit: `test/test_cap_dict.ml`
+
+Next to the existing "a nested local fn's IO is charged to its enclosing fn"
+case (which drives `Cap_passing.needed_caps` on lowered TIR, L459): lower a
+two-capability actor and assert `dispatch_caps` returns
+`["IO.Clock"; "IO.Console"]` — and that a one-capability actor returns a
+one-element list, not `None`-shaped anything, so the unified path is pinned
+at the analysis level as well as the golden.
+
+### Existing guards that must stay green
+
+`cap_mock_actor` (single cap, unified path), `cap_mock_file`, `cap_mock_clock`,
+`stream_replay`, and the TIR snapshots (`test/run_snapshots.exe`) — the spawn
+rewrite shape changes only under `--test`, and the snapshot corpus is compiled
+without it, so an unexpected snapshot diff means the change leaked past the
+gate.
+
+## Out of scope, filed or noted
+
+- **Supervised children are never captured, today or after this.** The
+  `thread` rewrite matches exactly `let $raw = Name_spawn() in spawn($raw)`.
+  A `supervise` block's children are spawned through `spawn_supervised` inside
+  `lower_actor.ml`'s `wrap_sup` (L354–L363, L452–L461), a different shape the
+  pattern does not see, so a mock never reaches a supervised child. That is a
+  pre-existing gap independent of the capability count; it deserves its own
+  todo and its own fixture once this lands, because its fix is a second
+  pattern in the same place and must not be confused with this one.
+- **Interpreter.** Capture is compiled-`--test`-only (#397's scope): the
+  elaboration runs on TIR, and `set_actor_caps`/`actor_caps` have no eval
+  implementation. Unchanged here.
+- **Release builds** are untouched by construction: the pass does not run.
+
+## Order of work
+
+1. `dispatch_caps` + `spawn_caps` as lists; the unit test. (Analysis only;
+   nothing changes in emitted code yet — every existing golden must be
+   byte-identical.)
+2. Spawn-site record build + dispatch projections, single-cap unified.
+   `cap_mock_actor` stays green.
+3. The two-cap golden, red control first, then green.
+4. RC proof: the Perceus dump shows the +1s in the right place (contract item
+   3); push and let the sanitize-gate leg run the fixture.
+5. Parent spec status row + this file to `specs/progress/`, CHANGELOG
+   (`### Fixed`: "an actor whose handlers reach two capabilities can now be
+   mocked; previously only one-capability actors were captured at spawn").
+
+Estimated size: ~60 lines in `cap_passing.ml`, one fixture, one unit test. No
+runtime, ABI, builtin, or typechecker change.

--- a/specs/todos/2026-09-03-supervised-children-not-captured.md
+++ b/specs/todos/2026-09-03-supervised-children-not-captured.md
@@ -1,0 +1,54 @@
+# Supervised children never get their capabilities captured at spawn
+
+**Status:** filed 2026-09-03 out of `2026-09-02-lift-one-cap-per-actor.md`
+(now in `specs/progress/`), which lifted the one-capability-per-actor limit on
+capture at spawn and deliberately left this gap alone. Pre-existing; it is
+independent of how many capabilities an actor needs.
+
+## The gap
+
+`lib/tir/cap_passing.ml`'s `thread` captures capabilities onto an actor's
+runtime metadata by matching EXACTLY the shape `lower` emits for a plain
+`spawn(Name)`:
+
+```
+let $raw_actor = Name_spawn() in spawn($raw_actor)
+```
+
+A `supervise` block's children are spawned through a different builtin and a
+different shape. `lib/tir/lower_actor.ml` binds each declared child with
+`$sup_child_raw_<field> = Child_spawn()` and hands it to `spawn_supervised`
+(around L350–L370), then `wrap_sup` (around L453) registers each child with
+the supervisor after the supervisor's own `spawn`. The capture pattern does not
+see any of that, so a supervised child's dispatch reads back an empty slot and
+its operations run unmocked — `actor_caps` returns the sentinel, exactly as
+every actor did before #397. A mock reaching the supervisor itself does not
+propagate: the child is a separate actor with its own metadata.
+
+## What to build
+
+A second pattern in `thread`, next to the plain-spawn one, that recognises
+the `spawn_supervised` shape and attaches the same capability record after the
+runtime call that creates the child's metadata (`march_spawn_supervised`, like
+`march_spawn`, is what creates it, so the setter has to follow it). It must
+share `dispatch_caps` / `spawn_caps` with the plain path so the two cannot
+disagree about WHICH capabilities a child needs; the record shape, field
+names, and the dispatch-side projection are unchanged.
+
+Keep the two patterns distinct in code and in tests: the plain-spawn one is
+guarded by `test/cap_mock/cap_mock_actor.march` and
+`test/cap_mock/cap_mock_actor_two.march`, and neither exercises a supervisor.
+
+## Test
+
+A golden under `test/cap_mock/` (compiled `--test` only, like the other
+`cap_mock_*` rules in `test/dune`): a supervisor with one declared child whose
+handler performs an interceptable `IO.Console` builtin, started inside
+`with_cap`, and the child's output must come through the mock. Red control
+first: without the second pattern the child's line is unmocked.
+
+## Out of scope
+
+Children spawned dynamically by a supervisor at runtime (not declared in the
+block) go through whichever shape their spawn site lowers to; check which
+before assuming they are covered.

--- a/test/cap_mock/cap_mock_actor_two.expected
+++ b/test/cap_mock/cap_mock_actor_two.expected
@@ -1,0 +1,6 @@
+MOCK[both@1234]
+MOCK[both2@1234]
+clock@1234
+MOCK[console@real]
+out@real
+out2@real

--- a/test/cap_mock/cap_mock_actor_two.march
+++ b/test/cap_mock/cap_mock_actor_two.march
@@ -1,0 +1,76 @@
+mod CapMockActorTwo do
+  -- Capability mocking reaching an actor whose handler performs TWO
+  -- capabilities' operations: it logs (IO.Console) and reads the clock
+  -- (IO.Clock).
+  --
+  -- v1 of capture-at-spawn stored one `Cap` pointer per actor and captured
+  -- nothing for an actor over that limit, so an actor like this one could not
+  -- be mocked at all. Now the spawn site builds a RECORD of every capability
+  -- the actor's handlers reach and the dispatch projects them back out, so a
+  -- mock reaches each operation independently.
+  --
+  -- Four spawns, and which operations are mocked in each is the whole test:
+  --   both     : inside with_cap(clock) inside with_cap(console) -> both mocked
+  --   clock    : inside with_cap(clock) only  -> Clock mocked, real Console
+  --   console  : inside with_cap(console) only -> Console mocked, real Clock
+  --   out      : outside any with_cap, and sent to AFTER every block has
+  --              closed -> neither mocked
+  -- The two partial rows pin that a capability the spawn site cannot supply
+  -- falls back to the real one (the record field is the ambient sentinel),
+  -- rather than the whole actor losing its mocks. `out` pins, as
+  -- cap_mock_actor does, that capture is per-actor at spawn and not a global
+  -- or dynamically-scoped slot.
+  --
+  -- The clock is mocked to a fixed value; the real clock's reading varies, so
+  -- the handler prints it by SHAPE only ("real" for anything but the mock's
+  -- value) and the trace stays byte-comparable.
+  needs IO
+  needs IO.Console
+  needs IO.Clock
+
+  actor Stamper do
+    state { n : Int }
+    init  { n: 0 }
+    on Say(s : String) do
+      let t = unix_time_ms()
+      let shown = if t == 1234 do "1234" else "real" end
+      print_line(s ++ "@" ++ shown)
+      { state with n: state.n + 1 }
+    end
+  end
+
+  fn main(io : Cap(IO)) do
+    let console : Cap(IO.Console) = cap_narrow(io)
+    let clock : Cap(IO.Clock) = cap_narrow(io)
+    let outside = spawn(Stamper)
+    let mock_console = cap_impl(console, { cap_ops_empty(console) with
+      print_line: Some(fn s -> print("MOCK[" ++ s ++ "]\n")) })
+    let mock_clock = cap_impl(clock, { cap_ops_empty(clock) with
+      unix_time_ms: Some(fn _ -> 1234) })
+    with_cap(mock_clock, fn _ -> do
+      with_cap(mock_console, fn _ -> do
+        let both = spawn(Stamper)
+        send(both, Say("both"))
+        run_until_idle()
+        -- a SECOND message to the same actor: the captured record is read
+        -- again on every dispatch, so a record freed after the first read
+        -- (an RC bug in the dispatch's projection) shows up here and not on
+        -- a single-message trace
+        send(both, Say("both2"))
+        run_until_idle()
+      end)
+      let clock_only = spawn(Stamper)
+      send(clock_only, Say("clock"))
+      run_until_idle()
+    end)
+    with_cap(mock_console, fn _ -> do
+      let console_only = spawn(Stamper)
+      send(console_only, Say("console"))
+      run_until_idle()
+    end)
+    send(outside, Say("out"))
+    run_until_idle()
+    send(outside, Say("out2"))
+    run_until_idle()
+  end
+end

--- a/test/dune
+++ b/test/dune
@@ -1372,6 +1372,36 @@ printf 'mod CsHelper do\\n\\n  fn double(x : Int) : Int do\\n    x * 2\\n  end\\
  (alias runtest)
  (action (diff cap_mock/cap_mock_actor.expected cap_mock_actor.out)))
 
+; ── Capability mocking reaching an actor that performs TWO capabilities ───
+; cap_mock_actor above pins capture at spawn for an actor over one capability.
+; The runtime slot is one pointer, so an actor reaching two (it logs AND reads
+; the clock, the ordinary shape) needs a RECORD of its capabilities built at
+; the spawn site and projected back out in the dispatch. Four spawns: both
+; mocked, each partial mock (the other capability falls back to the real one),
+; and one outside every block sent to after they close.
+(rule
+ (targets cap_mock_actor_two_bin cap_mock_actor_two.out)
+ (deps (file %{exe:../bin/main.exe})
+       (file ../runtime/march_runtime.c) (file ../runtime/march_runtime.h)
+       (file ../runtime/march_scheduler.c) (file ../runtime/march_scheduler.h)
+       (file ../runtime/march_heap.c) (file ../runtime/march_heap.h)
+       (file ../runtime/march_gc.c) (file ../runtime/march_gc.h)
+       (file ../runtime/march_message.c) (file ../runtime/march_message.h)
+       (file ../runtime/march_deque.h)
+       (file ../runtime/march_extras.c) (file ../runtime/march_ctx_escape.c) (file ../runtime/march_compress.c)
+       (file ../runtime/base64.c) (file ../runtime/sha1.c)
+       (source_tree ../stdlib)
+       (file cap_mock/cap_mock_actor_two.march))
+ (action
+  (progn
+   (run %{exe:../bin/main.exe} --compile --test -o cap_mock_actor_two_bin
+        cap_mock/cap_mock_actor_two.march)
+   (with-stdout-to cap_mock_actor_two.out (system "./cap_mock_actor_two_bin")))))
+
+(rule
+ (alias runtest)
+ (action (diff cap_mock/cap_mock_actor_two.expected cap_mock_actor_two.out)))
+
 ; ── Capability mocking as a user writes it: inside a `test` block ─────────
 ; Companion to cap_mock_io above, which drives `main` and diffs stdout. This
 ; one uses the real API surface -- a `test` block, `root_cap` attenuated to the

--- a/test/test_cap_dict.ml
+++ b/test/test_cap_dict.ml
@@ -472,6 +472,59 @@ end|}
          | Some caps -> List.mem "IO.FileRead" caps
          | None -> false))
 
+(* ── what an actor's dispatch needs, as the spawn site will capture it ─── *)
+
+(* v1 captured ONE capability per actor and returned `None` for two or more,
+   so an actor that logged AND read the clock could not be mocked at all. The
+   analysis now returns every capability the dispatch reaches, sorted, and the
+   one-capability actor goes through the same list-shaped path rather than a
+   special case -- pinned here at the analysis level so the two spawn shapes
+   cannot drift apart, and by the `cap_mock_actor` / `cap_mock_actor_two`
+   goldens at the emitted-code level. *)
+let dispatch_caps_lists_every_capability =
+  Alcotest.test_case "an actor's dispatch reports every capability it reaches"
+    `Quick (fun () ->
+      let m =
+        parse_and_desugar {|mod D do
+  needs IO.Console
+  needs IO.Clock
+  actor Two do
+    state { n : Int }
+    init  { n: 0 }
+    on Tick(s : String) do
+      print_line(s ++ int_to_string(unix_time_ms()))
+      { state with n: state.n + 1 }
+    end
+  end
+  actor One do
+    state { n : Int }
+    init  { n: 0 }
+    on Say(s : String) do
+      print_line(s)
+      { state with n: state.n + 1 }
+    end
+  end
+end|}
+      in
+      let (_errors, type_map) = March_typecheck.Typecheck.check_module m in
+      let tir =
+        March_tir.Lower.lower_module ~type_map ~test_mode:false ~hot_reload:false m
+      in
+      let need = March_tir.Cap_passing.needed_caps tir in
+      let dispatch_of actor =
+        List.find
+          (fun (fd : March_tir.Tir.fn_def) ->
+             March_tir.Cap_passing.actor_of_dispatch fd.March_tir.Tir.fn_name
+             = Some actor)
+          tir.March_tir.Tir.tm_fns
+      in
+      Alcotest.(check (list string)) "two-capability actor: both, sorted"
+        [ "IO.Clock"; "IO.Console" ]
+        (March_tir.Cap_passing.dispatch_caps need (dispatch_of "Two"));
+      Alcotest.(check (list string)) "one-capability actor: a one-element list"
+        [ "IO.Console" ]
+        (March_tir.Cap_passing.dispatch_caps need (dispatch_of "One")))
+
 (* ── the surface spelling of a multi-argument field ───────────────────── *)
 
 (* `Io_ops_gen.march_ty` once rendered a curried arrow as `(A, B) -> C`. In
@@ -520,5 +573,6 @@ let tests = [
   io_console_shape; shadow_list_matches_stdlib; io_clock_zero_arg; io_mut_has_no_dictionary;
   excluded_ops_are_documented; dict_fields_sorted;
   analysis_attributes_locals_to_their_owner;
+  dispatch_caps_lists_every_capability;
   rendered_multi_arg_is_curried;
 ]


### PR DESCRIPTION
Builds `specs/todos/2026-09-02-lift-one-cap-per-actor.md` (the spec commit from #402's branch is the first commit here; the spec now lives in `specs/progress/` with a "What shipped" section).

## Problem

Capture-at-spawn (#397) stored one `Cap` pointer per actor and captured nothing for an actor whose handlers reached two capabilities. An actor that logs *and* reads the clock is over that limit, so no operation of such an actor could be mocked.

## Design

All in `lib/tir/cap_passing.ml`. No runtime, ABI, builtin, or typechecker change.

- **Analysis.** `dispatch_cap : … -> string option` → `dispatch_caps : … -> string list` (sorted, from `caps_reached`); `spawn_caps` maps actor → list. This step alone left every existing golden byte-identical.
- **Spawn site.** Builds `let $spawn_caps : { $cap_c1 : Cap(c1), … } = { … }` and passes the record to the existing `set_actor_caps`. Fields are sorted **by field name** explicitly: `.` → `_` is not monotone under `String.compare` (`IO.A` < `IOB` but `$cap_IO_A` > `$cap_IOB`), so inheriting the capability order would have broken the `TRecord` invariant for a future name. A capability the site cannot supply is `root_cap` in its field, so a partial mock works.
- **Dispatch, null-safe** — the one thing the spec did not have. `actor_caps` returns NULL for any actor this pass did not capture for (a supervised child, a **respawned** child via `find_or_create_meta`, any spawn shape the rewrite does not match). v1's bare `Cap` read that as the sentinel for free; a record projection from NULL is a wild load. So the read is typed as the niche `Option` (`None` IS null) and matched exactly as the generated `cap_dict` wrappers match theirs, the `None` arm building a record of sentinels. `$caps` itself stays `TRecord` (`needs_rc = false`) so Perceus never decs the retained record.
- **Single-capability actors** go through the same record path; `cap_mock_actor` stayed green throughout.

## Red control (done)

Spawn-site record build disabled (`| Some _ when true -> e`), compiler rebuilt, CAS cleared:

```
< MOCK[both@1234]        > both@real
< MOCK[both2@1234]       > both2@real
< clock@1234             > clock@real
< MOCK[console@real]     > console@real
```

That run also exercised the dispatch's `None` arm (the actors ran unmocked instead of crashing). Restored byte-for-byte: both actor goldens green.

## RC proof (`MARCH_DUMP_TXT=perceus` on the fixture)

Contract item 3 — the +1 on each capability now comes from the record build, not from the builtin's owned argument:

```
let $spawn_caps : { $cap_IO_Clock : Cap(IO.Clock), $cap_IO_Console : Cap(IO.Console) } = inc_rc mock_clock;
inc_rc mock_console;
{ $cap_IO_Clock = mock_clock, $cap_IO_Console = mock_console } in
set_actor_caps($raw_actor, $spawn_caps);
```

Items 2/4 — the dispatch: no dec of `$caps` or `$caps_opt` on the live path, each projection dup'd where it escapes into the handler call:

```
let $caps : { … } = case $caps_opt of
  Some($caps_some) -> $caps_some
  None() -> inc_rc root_cap; { $cap_IO_Clock = root_cap, $cap_IO_Console = root_cap }
  _ -> dec_rc $caps_opt; panic("non-exhaustive pattern match") in
let $spawn_cap_IO_Clock : Cap(IO.Clock) = $caps.$cap_IO_Clock in
let $spawn_cap_IO_Console : Cap(IO.Console) = $caps.$cap_IO_Console in
case $msg of
  Say($Say_s) -> inc_rc $spawn_cap_IO_Clock;
inc_rc $spawn_cap_IO_Console;
Stamper_Say($spawn_cap_IO_Clock, $spawn_cap_IO_Console, $actor, $Say_s)
```

## Tests

- `test/cap_mock/cap_mock_actor_two.march` (+ `.expected`, `test/dune` rule, compiled `--test` only): both mocked; Console-only; Clock-only; outside every block and sent to after they close — plus a **second message** to two of the actors, since a record freed after the first dispatch read is invisible on a one-message trace.
- `test/test_cap_dict.ml`: `dispatch_caps` on lowered TIR yields `["IO.Clock"; "IO.Console"]` for a two-capability actor and a one-element list for a one-capability one.
- `scripts/run-tests.sh` (full, with Slow) green; `dune build --root . --force @test/runtest` green; `run_snapshots.exe` 33/33 (the snapshot corpus is compiled without `--test`, so no diff there means nothing leaked past the gate).
- The sanitize-gate CI leg is the ASAN proof for the new fixture (locally ASAN needs Docker).

## Out of scope

Supervised children are never captured, before or after this: filed as `specs/todos/2026-09-03-supervised-children-not-captured.md`. Interpreter capture unchanged.
