### PR TITLE
feat(caps): a nested supervisor passes its capabilities on to its own children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,11 @@ git log is authoritative for exact commits.
 
 ### Fixed
 
+- A supervisor **nested under another supervisor** now passes its
+  capabilities on to its own children, including the fresh children it
+  creates each time it is restarted. Previously only a top-level supervisor's
+  direct children were captured, so a mock stopped one level down.
+
 - Capability mocking now reaches a **supervised child**. A `supervise` block's
   children are spawned by the supervisor itself, not by user code, so a mock
   that reached a plain actor never reached one under a supervisor. The

--- a/lib/tir/cap_passing.ml
+++ b/lib/tir/cap_passing.ml
@@ -86,6 +86,14 @@ let ambient_atom (cap : string) : T.atom =
 
 (* ── analysis ─────────────────────────────────────────────────────────── *)
 
+(** [actor_of_spawn n] is the actor name when [n] is a spawn glue function. *)
+let actor_of_spawn (n : string) : string option =
+  let sfx = Tir_names.actor_spawn_suffix in
+  let ls = String.length sfx and ln = String.length n in
+  if ln > ls && String.sub n (ln - ls) ls = sfx
+  then Some (String.sub n 0 (ln - ls)) else None
+
+
 module StrSet = Set.Make (String)
 
 type facts = {
@@ -129,6 +137,23 @@ let rec scan (f : facts) (owner : string) (bound : StrSet.t) (e : T.expr) : unit
   let atoms = List.iter atom in
   let go = scan f owner bound in
   match e with
+  | T.EApp (v, args) when v.T.v_name = "register_supervisor_child" ->
+    (* The spawn glue named as this call's third argument is passed as a
+       VALUE (the runtime re-runs it on respawn), but it is not a value use
+       that freezes the glue's arity: [thread] replaces it with a closure
+       that CALLS the glue with the capabilities the enclosing glue carries.
+       So record it as a call edge, exactly like the head-position call the
+       supervised-child shape already makes to it, and never as [unsafe] —
+       otherwise a supervisor nested under another supervisor could never
+       carry its own children's capabilities. *)
+    add f.calls owner v.T.v_name;
+    List.iteri
+      (fun i a ->
+         match i, a with
+         | 2, T.AVar sf when actor_of_spawn sf.T.v_name <> None ->
+           add f.calls owner sf.T.v_name
+         | _ -> atom a)
+      args
   | T.EApp (v, args) ->
     add f.calls owner v.T.v_name;
     (match cap_of_interceptable_op v.T.v_name with
@@ -188,13 +213,6 @@ let rec scan (f : facts) (owner : string) (bound : StrSet.t) (e : T.expr) : unit
   | T.ESeq (e1, e2) -> go e1; go e2
   | T.EAllocHole (tok, _, ats, _) -> Option.iter atom tok; atoms ats
   | T.ESetField (o, _, v) -> atom o; atom v
-
-(** [actor_of_spawn n] is the actor name when [n] is a spawn glue function. *)
-let actor_of_spawn (n : string) : string option =
-  let sfx = Tir_names.actor_spawn_suffix in
-  let ls = String.length sfx and ln = String.length n in
-  if ln > ls && String.sub n (ln - ls) ls = sfx
-  then Some (String.sub n 0 (ln - ls)) else None
 
 (** The actors [e] spawns as SUPERVISED CHILDREN.  A `supervise` block's
     children are spawned inside the supervisor's own spawn glue
@@ -513,6 +531,41 @@ let rec thread ?(dispatch = false) ?(spawn_caps = Hashtbl.create 1)
       | _ -> { v with T.v_name = name }
     in
     T.EApp (v, supply cap :: args)
+  | T.EApp (v, [ sup; ptr; T.AVar sf; idx; restart ])
+    when v.T.v_name = "register_supervisor_child"
+      && actor_of_spawn sf.T.v_name <> None && Hashtbl.mem need sf.T.v_name ->
+    (* The respawn value for a child whose spawn glue now CARRIES capabilities
+       (a supervisor nested under this one).  The runtime re-runs whatever it
+       is handed with no arguments on every respawn — `march_respawn_child`
+       reads the `$clo_wrap` pointer out of the closure cell and calls it with
+       the cell as its only argument — so hand it a zero-argument closure that
+       calls the glue with the capabilities in scope here, the same threaded
+       call the supervised-child shape makes for the original spawn:
+
+         let $respawn = letrec [ fn $respawn() = Mid_spawn($cap_c1, …) ] in $respawn
+         in register_supervisor_child(sup, ptr, $respawn, idx, restart)
+
+       Built the way lower's [ELam] case builds a lambda thunk, so Defun lifts
+       it like any other; its free variables are exactly this glue's `$cap`
+       parameters, which Defun captures and Perceus dups at the capture.  A
+       glue that carries nothing keeps the static function reference — the
+       cheapest thing to pass, and the shape every existing supervisor test
+       compiles to.
+
+       RC: every apply function drops the closure it is handed, and the
+       runtime calls the SAME cell on every respawn, so `march_respawn_child`
+       incs it before each call; without that the second respawn would be a
+       use-after-free (`cap_mock_supervised_nested`'s third row). *)
+    let name = Lower_state.fresh_name "respawn" in
+    let fn_var =
+      { T.v_name = name; T.v_ty = T.TFn ([], T.TPtr T.TUnit); T.v_lin = T.Unr }
+    in
+    let fd : T.fn_def =
+      { T.fn_name = name; T.fn_params = []; T.fn_ret_ty = T.TPtr T.TUnit;
+        T.fn_body = go (T.EApp (sf, [])); T.fn_kind = T.FnLambda }
+    in
+    T.ELet (fn_var, T.ELetRec ([ fd ], T.EAtom (T.AVar fn_var)),
+            T.EApp (v, [ sup; ptr; T.AVar fn_var; idx; restart ]))
   | T.EApp (v, args) ->
     (match Hashtbl.find_opt need v.T.v_name with
      | None -> e
@@ -587,6 +640,12 @@ let rec thread ?(dispatch = false) ?(spawn_caps = Hashtbl.create 1)
     when ss.T.v_name = "spawn_supervised" && raw'.T.v_name = raw.T.v_name
       && (match actor_of_spawn cs.T.v_name with Some _ -> true | None -> false) ->
     let child = Option.get (actor_of_spawn cs.T.v_name) in
+    (* [go child_call]: a child that is itself a supervisor carries ITS
+       children's capabilities as parameters (see [scan]'s
+       `register_supervisor_child` case), so its spawn call gains arguments
+       here like the plain pattern's does.  Re-emitting it bare would be an
+       arity mismatch that dies at runtime, not a compile error. *)
+    let child_call = go child_call in
     (match Hashtbl.find_opt spawn_caps child with
      | None | Some [] -> T.ELet (raw, child_call, T.ELet (ptr, sup_call, go rest))
      | Some caps ->

--- a/runtime/march_runtime.c
+++ b/runtime/march_runtime.c
@@ -3244,6 +3244,15 @@ static void *march_respawn_child(void *supervisor, march_actor_meta *sup_meta, i
     typedef void *(*spawn_clo_fn_t)(void *);
     void **clo_fields = (void **)((char *)child->spawn_clo + 16);
     spawn_clo_fn_t fn_ptr = (spawn_clo_fn_t)(*clo_fields);
+    /* Every apply function drops the closure it is handed (Perceus's
+     * callee-side $clo release), and this cell is called on EVERY respawn of
+     * the slot, so keep our reference: without the inc the first respawn
+     * frees the cell and the second is a use-after-free.  For the static
+     * <Actor>_spawn reference a non-capturing child passes, IS_HEAP_PTR
+     * makes this a no-op, exactly as the drop is.  (A --test build passes a
+     * heap closure here when the child is itself a supervisor whose spawn
+     * glue carries capabilities; see cap_passing.ml.) */
+    march_incrc(child->spawn_clo);
     void *raw = fn_ptr(child->spawn_clo);
     void *new_child = march_spawn_supervised(raw);
     march_actor_meta *new_meta = find_or_create_meta(new_child);

--- a/specs/progress/2026-09-02-lift-one-cap-per-actor.md
+++ b/specs/progress/2026-09-02-lift-one-cap-per-actor.md
@@ -185,7 +185,10 @@ This is the only part with a way to be subtly wrong, so it is spelled out.
    rule). No dec is emitted for the projection itself. This is the same
    shape as closure `$fv` fields and record-param field reads that the rest
    of the pipeline already exercises.
-5. **The sanitize-gate CI leg** (ASAN over the native corpus) must run the
+5. *(Wrong as written — see the correction in
+   `2026-09-03-nested-supervisor-children-not-captured.md`: sanitize-gate
+   sweeps `specs/lang/golden/`, not `test/cap_mock/`.)*
+   **The sanitize-gate CI leg** (ASAN over the native corpus) must run the
    new fixture; locally ASAN needs Docker (`ci/Dockerfile.ubuntu`; build only
    `bin/main.exe` there), so the local proof is the Perceus dump plus the
    fixture's output, and the ASAN proof is CI's.

--- a/specs/progress/2026-09-03-nested-supervisor-children-not-captured.md
+++ b/specs/progress/2026-09-03-nested-supervisor-children-not-captured.md
@@ -1,6 +1,6 @@
 # Capture capabilities for the children of a NESTED supervisor
 
-**Status:** specced 2026-09-03, not started. Parent: `specs/progress/2026-09-03-supervised-children-not-captured.md` (#405), whose "Still not covered" note this is; grandparent: `specs/progress/2026-09-02-lift-one-cap-per-actor.md` (#404), whose RC contract and null-safe dispatch this relies on.
+**Status:** specced 2026-09-03, **shipped 2026-09-03** (see "What shipped" at the end). Parent: `specs/progress/2026-09-03-supervised-children-not-captured.md` (#405), whose "Still not covered" note this is; grandparent: `specs/progress/2026-09-02-lift-one-cap-per-actor.md` (#404), whose RC contract and null-safe dispatch this relies on.
 
 ## What the gap is, precisely
 
@@ -89,3 +89,69 @@ Lower the three-level module; assert `need["Top_spawn"] = need["Mid_spawn"] = ["
 4. Parent progress file's "Still not covered" bullet → done; this file to `specs/progress/`; CHANGELOG `### Fixed` ("a supervisor nested under another supervisor now passes its capabilities on to its own children, including after a restart").
 
 Estimated size: ~50 lines in `cap_passing.ml`, 1 line + comment in the runtime, one fixture, one unit test.
+
+---
+
+## What shipped (2026-09-03)
+
+Exactly the design above; the four steps landed as written.
+
+- **`scan`** treats the third argument of `register_supervisor_child` as a
+  call edge to the named glue rather than a value use, so a nested
+  supervisor's glue is no longer `unsafe`; `needed_caps` then gives it its
+  children's caps and the top glue picks them up through the existing
+  fixpoint (unit test: `need[Mid_spawn] = need[Top_spawn] = ["IO.Console"]`,
+  `Leaf_spawn` absent).
+- **Supervised-child pattern** threads the child's spawn call (`go child_call`)
+  in both arms.
+- **Closure rewrite** in `thread`: `register_supervisor_child` with a glue in
+  `need` as its respawn value gets
+  `let $respawnN = letrec [fn $respawnN() = Mid_spawn($cap_…)] in $respawnN`,
+  built as lower's `ELam` case builds a thunk (`FnLambda`, `TFn ([], Ptr)`),
+  the body being the same `go (EApp (sf, []))` the spawn shape threads. A glue
+  that carries nothing keeps the static reference: `cap_mock_supervised`'s
+  lower dump still reads `register_supervisor_child(…, Logger_spawn, …)`.
+- **Runtime:** `march_incrc(child->spawn_clo)` before the respawn call in
+  `march_respawn_child`, with the reason in a comment.
+
+### Red controls
+
+- **A** (analysis special case disabled, so the nested glue is frozen again):
+  `MOCK[leaf:in]`/`MOCK[leaf:again]`/`MOCK[leaf:third]` → `leaf:in`/`leaf:again`/`leaf:third`;
+  `leaf:out` unchanged.
+- **B** (runtime inc removed): the spec worried this might "happen to still
+  print MOCK". It did not: the second respawn dies with SIGBUS (exit 138)
+  right after `MOCK[leaf:again]`, three runs out of three, and the golden
+  rule fails on the missing third and fourth lines.
+
+  **Correction to this spec and its two parents:** the sanitize-gate CI leg
+  does NOT run `test/cap_mock/` — `scripts/sanitize.sh` sweeps
+  `specs/lang/golden/*.march` plus a curated SIMD/NativeArray list
+  (`.github/workflows/ci.yml` ~L351). So there is no ASAN witness for any
+  `cap_mock_*` fixture in CI; the deterministic SIGBUS above is this
+  control's red, and #404/#405's "the sanitize leg is the ASAN proof" lines
+  were wrong (corrected in the same commit). Running the fixtures under
+  ASAN needs the Docker recipe (`ci/Dockerfile.ubuntu`, build only
+  `bin/main.exe`), not yet done for any of the three.
+
+Both restored byte-for-byte: green.
+
+### RC proof (`MARCH_DUMP_TXT=perceus`, items 6–7)
+
+```
+fn Top_spawn($cap_IO_Console : Cap(IO.Console)) : Ptr(Unit) =
+  …
+let $sup_child_raw_m : Ptr(Unit) = inc_rc $cap_IO_Console;
+Mid_spawn($cap_IO_Console) in
+let $sup_child_ptr_m : Ptr(Unit) = spawn_supervised($sup_child_raw_m) in
+…
+let $reg_child_m : Unit = let $respawn30586 : () -> Ptr(Unit) = alloc $Clo_$respawn30586$3620($respawn30586$apply$3620, $cap_IO_Console) in
+inc_rc $spawned;
+call_ptr register_supervisor_child($spawned, $sup_child_ptr_m, $respawn30586, 0, 0) in
+```
+
+The parameter is dup'd at its non-last use (the threaded spawn call) and
+moved into the closure at its last use (the `alloc $Clo_…` capture, no inc):
+one +1 per reference, as item 7 requires. `Mid` itself has no handlers, so
+no record is set on it, and `Mid_spawn`'s body sets `Leaf`'s record from the
+parameter the closure re-supplies on every respawn.

--- a/specs/progress/2026-09-03-supervised-children-not-captured.md
+++ b/specs/progress/2026-09-03-supervised-children-not-captured.md
@@ -128,9 +128,10 @@ get a dup at their non-last uses by the same rule.
 - A supervisor that is itself a supervised child of another supervisor: its
   spawn fn is then passed as a value (frozen), so it cannot carry its own
   children's capabilities. Its grandchildren are uncaptured (null-safe:
-  they run unmocked). Needs a different mechanism (e.g. the record itself
-  carried through the glue's closure), not filed as a todo until someone
-  hits it.
+  they run unmocked). Specced as
+  `specs/todos/2026-09-03-nested-supervisor-children-not-captured.md`: the
+  respawn value becomes a closure carrying the caps, so the glue stops being
+  frozen, plus one runtime `march_incrc` per respawn call.
 - Children a supervisor spawns dynamically at runtime go through whatever
   shape their spawn site lowers to (a plain `spawn` inside a handler is the
   plain pattern, supplied from the handler's threaded capabilities).

--- a/specs/progress/2026-09-03-supervised-children-not-captured.md
+++ b/specs/progress/2026-09-03-supervised-children-not-captured.md
@@ -128,10 +128,10 @@ get a dup at their non-last uses by the same rule.
 - A supervisor that is itself a supervised child of another supervisor: its
   spawn fn is then passed as a value (frozen), so it cannot carry its own
   children's capabilities. Its grandchildren are uncaptured (null-safe:
-  they run unmocked). Specced as
-  `specs/todos/2026-09-03-nested-supervisor-children-not-captured.md`: the
-  respawn value becomes a closure carrying the caps, so the glue stops being
-  frozen, plus one runtime `march_incrc` per respawn call.
+  they run unmocked). **Done right after**, see
+  `2026-09-03-nested-supervisor-children-not-captured.md` in this directory:
+  the respawn value becomes a closure carrying the caps, so the glue stops
+  being frozen, plus one runtime `march_incrc` per respawn call.
 - Children a supervisor spawns dynamically at runtime go through whatever
   shape their spawn site lowers to (a plain `spawn` inside a handler is the
   plain pattern, supplied from the handler's threaded capabilities).

--- a/specs/todos/2026-09-03-nested-supervisor-children-not-captured.md
+++ b/specs/todos/2026-09-03-nested-supervisor-children-not-captured.md
@@ -1,0 +1,91 @@
+# Capture capabilities for the children of a NESTED supervisor
+
+**Status:** specced 2026-09-03, not started. Parent: `specs/progress/2026-09-03-supervised-children-not-captured.md` (#405), whose "Still not covered" note this is; grandparent: `specs/progress/2026-09-02-lift-one-cap-per-actor.md` (#404), whose RC contract and null-safe dispatch this relies on.
+
+## What the gap is, precisely
+
+#405 gives a supervisor's spawn glue (`Sup_spawn`) its children's capabilities as parameters: `needed_caps` models the glue as calling each child's dispatch, the user's `spawn(Sup)` site threads the caps in, and the supervised-child pattern in `thread` builds each child's record inside the glue from those parameters. That works because `Sup_spawn` is only ever a CALL HEAD.
+
+A supervisor that is itself a supervised child is different. `lower_actor.ml`'s `mk_reg_child_calls` (~L420–L447) emits, for every declared child `f` of type `Mid`,
+
+```
+let $reg_child_f = register_supervisor_child($spawned, $sup_child_ptr_f, Mid_spawn, <word_idx>, <restart>) in …
+```
+
+passing `Mid_spawn` AS A VALUE (`Tir.AVar child_spawn_fn_var`) so the runtime can re-run it on respawn (`march_respawn_child`, `runtime/march_runtime.c` ~L3227: it reads the `$clo_wrap` pointer out of the closure cell at offset 16 and calls it with the cell as its only argument). `scan`'s `mark` (`cap_passing.ml` ~L116) sees that `AVar` and puts `Mid_spawn` in `unsafe`, so `needed_caps` drops it: its arity is frozen. Frozen means it carries no parameters, so inside it the supervised-child pattern has nothing to supply — it sees `binds = []` and, per #405, deliberately sets no record (so the child stays NULL rather than getting a record of sentinels). `Mid`'s own record IS set, by the pattern inside `Top_spawn`; only `Mid`'s children — `Top`'s grandchildren — are uncaptured. Their dispatch reads NULL, takes #404's `None` arm, and runs unmocked. No crash; wrong answer under `--test` only.
+
+Reproducer shape (compiled `--test`):
+
+```march
+actor Leaf do … on Say(s) do print_line("leaf:" ++ s) … end
+actor Mid do state { l : Int }  supervise do strategy one_for_one  max_restarts 5 within 60  Leaf l end end
+actor Top do state { m : Int }  supervise do strategy one_for_one  max_restarts 5 within 60  Mid m end end
+-- inside with_cap(mock, …): spawn(Top); send(<Top.m.l>, Say("hi"))   → prints leaf:hi, expected MOCK[leaf:hi]
+```
+
+## Design: replace the frozen value with a closure that carries the caps
+
+The value the runtime needs is "something it can call with no arguments to get a fresh `Mid`". It does not need that to be `Mid_spawn` itself. So:
+
+1. **`Mid_spawn` stops being frozen.** In `scan`, the third argument of a `register_supervisor_child` call is NOT a value use of a top-level function: it is a reference `thread` is about to rewrite. Handle the `EApp (v, args)` case for `v.v_name = "register_supervisor_child"` specially — record the call head as usual, `atom` every argument EXCEPT the spawn-fn one (which is instead recorded as a call edge, `add f.calls owner sf.v_name`, so the glue's needs flow to the enclosing glue exactly as a plain call would). With that, `Mid_spawn` enters `need` with its children's caps (the supervised-child modelling from #405 already gives it those), and `Top_spawn` — which calls `Mid_spawn` as a call head in the supervised-child shape — picks them up transitively through the existing fixpoint. No new table.
+
+2. **The spawn-site rewrites thread the child's spawn call.** #405's supervised-child pattern re-emits `child_call` unchanged (`T.ELet (raw, child_call, …)`), which was correct while a child's glue could never carry parameters. Now it can: use `go child_call` in BOTH arms of that pattern (captured and not), exactly as #405 did for the plain pattern's `spawn_call`. Missing this is an arity mismatch that dies at runtime, not a compile error — the same class as the SIGBUS in `scan`'s docstring.
+
+3. **The respawn value becomes a closure.** In `thread`, a new `EApp` arm for `register_supervisor_child` whose third argument is `AVar sf` with `actor_of_spawn sf.v_name = Some _` and `Hashtbl.mem need sf.v_name` (a glue that now carries caps; one that carries none is left alone — a static function reference stays the cheapest thing to pass):
+
+   ```
+   let $respawn_f = letrec [ fn $respawn_f() : Ptr(Unit) = Mid_spawn(<supply c1>, …, <supply cn>) ]
+                    in $respawn_f
+   in register_supervisor_child($spawned, $sup_child_ptr_f, $respawn_f, <idx>, <restart>)
+   ```
+
+   Build the `fn_def` the way `lower_expr.ml`'s `ELam` case does (~L741–L815): `fn_params = []`, `fn_ret_ty = TPtr TUnit`, `fn_kind = FnLambda`, name from a fresh counter, and the `ELetRec ([fd], EAtom (AVar fn_var))` shape with `fn_var.v_ty = TFn ([], TPtr TUnit)` — that shape is what Defun's `lift_lambda` consumes. The body is the SAME threaded call the supervised-child pattern would emit for `Mid_spawn`, so the two cannot disagree; factor one helper for it. `<supply c>` is the enclosing glue's own `$cap_c` parameter (it has all of them by step 1), so the lambda's free variables are exactly those parameters; Defun captures them into the closure struct and Perceus dups them at the capture (they are also used by the child's record build in the same scope, so the capture is a non-last use → `inc_rc`; prove it in the dump).
+
+   The lambda's apply function takes ONLY the closure cell: verified 2026-09-03 on `let f = fn -> k + 1` — Perceus dump shows `$lam…$apply$…(f)`, one argument. That matches `spawn_clo_fn_t (void *)` in `march_respawn_child`, and the return is the uniform ptr ABI, which for `Ptr(Unit)` is the pointer itself. No runtime ABI change.
+
+4. **One runtime line, and it is load-bearing.** Every apply function drops its closure at entry (`Perceus.insert_apply_fn_clo_drop`, `perceus.ml` ~L304: the caller transfers ownership of the cell). `march_respawn_child` calls the closure on EVERY respawn of the same child slot. With today's immortal static reference that drop is a no-op; with a heap closure the FIRST respawn frees the cell and the SECOND is a use-after-free. So before the call:
+
+   ```c
+   march_incrc(child->spawn_clo);   /* the apply fn drops what it is handed; keep ours */
+   void *raw = fn_ptr(child->spawn_clo);
+   ```
+
+   `march_incrc` is `IS_HEAP_PTR`-guarded (`march_runtime.c` ~L338), so it stays a no-op for the static reference that non-capturing children keep passing. `register_supervisor_child` stores the cell forever (the meta is never freed), which is the +1 the caller's owned argument hands it; nothing else changes. Edit `runtime/*.c` → remember `dune build bin/main.exe` does not restage the runtime; build a target with a runtime dep (`@test/runtest` or the golden's `.out`).
+
+What this buys beyond the grandchild case: when `Mid` is respawned, its NEW children are spawned by `Mid_spawn(<caps>)` through the closure, so they get fresh, correct records from the same capabilities the original spawn site supplied — a better respawn story than #405's pointer carry-over gives `Mid` itself (which stays as it is: the carry-over copies `Mid`'s own record; the closure re-creates the grandchildren's).
+
+### Rejected: inherit up the supervisor chain at read time
+
+Have `march_actor_caps` walk `meta->supervisor` when `spawn_cap` is NULL, and project by field NAME (an erased record type routes `EField` through the shape-id lookup in `Llvm_emit_data.emit_field`). Needs every supervisor's record to be the UNION of its descendants' caps, a needs_rc-false erased type for the dispatch read (`TRecord []`?) whose by-name miss must be proved to yield the sentinel, and it gives a respawned nested supervisor's children borrowed records instead of their own. Three unproven mechanisms against one line of runtime; not worth it.
+
+## RC contract additions (the parent's items 1–5 still hold)
+
+6. **The closure is retained forever**, like the record: `register_supervisor_child` takes it owned and the meta never releases it. The per-respawn `march_incrc` balances the apply function's entry drop exactly; no other RC op touches the cell.
+7. **Capability parameters captured by the closure** are dup'd at the capture (non-last use — the child's record build in the same glue is another use). Prove: `MARCH_DUMP_TXT=perceus` on the fixture shows `inc_rc $cap_IO_Console` feeding the `alloc $Clo_$respawn…` (or the record build, whichever comes second takes the parameter's own +1; the first must show the dup).
+
+## Tests
+
+### Golden `test/cap_mock/cap_mock_supervised_nested.march` (+ `.expected`, `test/dune` rule mirroring `cap_mock_supervised`, compiled `--test` only)
+
+Three levels: `Top` supervises `Mid` supervises `Leaf` (Console). Inside `with_cap(mock, …)`: `spawn(Top)`, read the grandchild pid through the two state fields (`get_actor_field` twice, as `cap_mock_supervised`'s `child_of` does), send → `MOCK[leaf:in]`. Then `kill` `Mid` (not `Leaf`): the runtime respawns `Mid` through the closure, which spawns a NEW `Leaf`; read the new grandchild pid, send → `MOCK[leaf:again]`. Then `kill` `Mid` a SECOND time and send once more → `MOCK[leaf:third]` — this row is the one that only the runtime `march_incrc` makes possible (see red control B). Finally a `Top` spawned outside every block, sent to after they close → `leaf:out`.
+
+**Red controls, both mandatory:**
+- A. Disable the closure rewrite (step 3 falls through to passing `Mid_spawn`; keep step 1 so it stays threaded — then `Mid_spawn` has parameters and the runtime calls it with none: expect the original spawn to still mock `leaf:in` and the respawned rows to be wrong or to crash). If that is too ugly a red, disable step 1 instead: `leaf:in` goes real, which is the honest "nothing captured" red. Either way say which in the commit.
+- B. Restore A, remove the runtime `march_incrc`: the first respawn works and the SECOND (`leaf:third`) is a use-after-free — locally it may print anything or die; the sanitize-gate CI leg is the definitive red for this control, so push the control commit to a scratch branch or run the ASAN Docker recipe (`ci/Dockerfile.ubuntu`, build only `bin/main.exe`) and quote it. A control whose red is only "it happened to still print MOCK" has not proven the inc is needed.
+
+### Unit, `test/test_cap_dict.ml`, next to `supervisor_glue_carries_children_caps`
+
+Lower the three-level module; assert `need["Top_spawn"] = need["Mid_spawn"] = ["IO.Console"]` and `Hashtbl.mem need "Leaf_spawn" = false` (a leaf's glue is still a plain value reference and still needs nothing).
+
+### Existing guards that must stay green
+
+`cap_mock_supervised` (single level — the closure rewrite must not fire for a child whose glue carries nothing, so its `register_supervisor_child` call is byte-identical in the lower dump), the other four `cap_mock_*`, `stream_replay`, the native supervisor goldens (`supervisor_*_restart`, `actor_registry_restart*`, `actor_crash_rc_restore`: they compile WITHOUT `--test`, so the pass does not run, but they exercise the runtime line under repeated respawn), and the TIR snapshots.
+
+## Order of work
+
+1. `scan` special case + `go child_call`; unit test. Every existing golden byte-identical (nothing is rewritten yet — `Mid_spawn` gains parameters only when something captures, and no existing fixture nests).
+2. Closure rewrite + runtime inc; the nested golden, red controls A then B, then green.
+3. RC proof from the Perceus dump (items 6–7); push and let sanitize-gate run the fixture.
+4. Parent progress file's "Still not covered" bullet → done; this file to `specs/progress/`; CHANGELOG `### Fixed` ("a supervisor nested under another supervisor now passes its capabilities on to its own children, including after a restart").
+
+Estimated size: ~50 lines in `cap_passing.ml`, 1 line + comment in the runtime, one fixture, one unit test.

--- a/test/cap_mock/cap_mock_supervised_nested.expected
+++ b/test/cap_mock/cap_mock_supervised_nested.expected
@@ -1,0 +1,4 @@
+MOCK[leaf:in]
+MOCK[leaf:again]
+MOCK[leaf:third]
+leaf:out

--- a/test/cap_mock/cap_mock_supervised_nested.march
+++ b/test/cap_mock/cap_mock_supervised_nested.march
@@ -1,0 +1,80 @@
+mod CapMockSupervisedNested do
+  -- Capability mocking reaching the child of a NESTED supervisor.
+  --
+  -- Top supervises Mid supervises Leaf. Mid's spawn glue used to be passed
+  -- to register_supervisor_child as a VALUE (for respawn), which froze its
+  -- arity, so it could carry nothing to Leaf and Leaf ran unmocked. The
+  -- respawn value is now a closure that calls Mid's glue with the
+  -- capabilities in scope, so Mid's glue carries them like Top's does.
+  --
+  -- Four lines, and which are mocked is the whole test:
+  --   in    : the grandchild of a Top spawned inside with_cap -> mocked
+  --   again : after `kill`ing Mid, the NEW Leaf its respawn created -> still
+  --           mocked (the closure re-supplies the caps)
+  --   third : after killing Mid a SECOND time -> still mocked; this row is
+  --           the one only the runtime's per-respawn inc of the closure
+  --           makes possible (the apply fn drops what it is handed)
+  --   out   : the grandchild of a Top spawned outside, sent to AFTER the
+  --           block closes -> real
+  needs IO.Console
+
+  actor Leaf do
+    state { n : Int }
+    init  { n: 0 }
+    on Say(s : String) do
+      print_line("leaf:" ++ s)
+      { state with n: state.n + 1 }
+    end
+  end
+
+  actor Mid do
+    state { l : Int }
+    init  { l: 0 }
+    supervise do
+      strategy one_for_one
+      max_restarts 5 within 60
+      Leaf l
+    end
+  end
+
+  actor Top do
+    state { m : Int }
+    init  { m: 0 }
+    supervise do
+      strategy one_for_one
+      max_restarts 5 within 60
+      Mid m
+    end
+  end
+
+  fn field_pid(p, name) do
+    match get_actor_field(p, name) do
+      None    -> pid_of_int(-1)
+      Some(n) -> pid_of_int(n)
+    end
+  end
+
+  fn mid_of(top) do field_pid(top, "m") end
+  fn leaf_of(top) do field_pid(mid_of(top), "l") end
+
+  fn main(c : Cap(IO.Console)) do
+    let outside = spawn(Top)
+    let mock = cap_impl(c, { cap_ops_empty(c) with
+      print_line: Some(fn s -> print("MOCK[" ++ s ++ "]\n")) })
+    with_cap(mock, fn _ -> do
+      let inside = spawn(Top)
+      send(leaf_of(inside), Say("in"))
+      run_until_idle()
+      kill(mid_of(inside))
+      run_until_idle()
+      send(leaf_of(inside), Say("again"))
+      run_until_idle()
+      kill(mid_of(inside))
+      run_until_idle()
+      send(leaf_of(inside), Say("third"))
+      run_until_idle()
+    end)
+    send(leaf_of(outside), Say("out"))
+    run_until_idle()
+  end
+end

--- a/test/dune
+++ b/test/dune
@@ -1432,6 +1432,36 @@ printf 'mod CsHelper do\\n\\n  fn double(x : Int) : Int do\\n    x * 2\\n  end\\
  (alias runtest)
  (action (diff cap_mock/cap_mock_supervised.expected cap_mock_supervised.out)))
 
+; ── Capability mocking reaching the child of a NESTED supervisor ───────────
+; Top supervises Mid supervises Leaf. Mid's spawn glue was passed to
+; register_supervisor_child as a value (for respawn), freezing its arity, so it
+; carried nothing to Leaf. The respawn value is now a closure calling the glue
+; with the capabilities in scope; the runtime incs it per respawn call. Four
+; lines: mocked, mocked after Mid's first restart, mocked after its second,
+; real for a Top spawned outside the block and sent to after it closes.
+(rule
+ (targets cap_mock_supervised_nested_bin cap_mock_supervised_nested.out)
+ (deps (file %{exe:../bin/main.exe})
+       (file ../runtime/march_runtime.c) (file ../runtime/march_runtime.h)
+       (file ../runtime/march_scheduler.c) (file ../runtime/march_scheduler.h)
+       (file ../runtime/march_heap.c) (file ../runtime/march_heap.h)
+       (file ../runtime/march_gc.c) (file ../runtime/march_gc.h)
+       (file ../runtime/march_message.c) (file ../runtime/march_message.h)
+       (file ../runtime/march_deque.h)
+       (file ../runtime/march_extras.c) (file ../runtime/march_ctx_escape.c) (file ../runtime/march_compress.c)
+       (file ../runtime/base64.c) (file ../runtime/sha1.c)
+       (source_tree ../stdlib)
+       (file cap_mock/cap_mock_supervised_nested.march))
+ (action
+  (progn
+   (run %{exe:../bin/main.exe} --compile --test -o cap_mock_supervised_nested_bin
+        cap_mock/cap_mock_supervised_nested.march)
+   (with-stdout-to cap_mock_supervised_nested.out (system "./cap_mock_supervised_nested_bin")))))
+
+(rule
+ (alias runtest)
+ (action (diff cap_mock/cap_mock_supervised_nested.expected cap_mock_supervised_nested.out)))
+
 ; ── Capability mocking as a user writes it: inside a `test` block ─────────
 ; Companion to cap_mock_io above, which drives `main` and diffs stdout. This
 ; one uses the real API surface -- a `test` block, `root_cap` attenuated to the

--- a/test/test_cap_dict.ml
+++ b/test/test_cap_dict.ml
@@ -574,6 +574,57 @@ end|}
       Alcotest.(check (option (list string))) "Logger_spawn stays frozen (passed as a value)"
         None (Hashtbl.find_opt need "Logger_spawn"))
 
+(* A supervisor nested under another supervisor: its spawn glue is passed as
+   a value to register_supervisor_child (for respawn), which used to freeze it.
+   That argument is now a call reference the threading pass replaces with a
+   closure, so the nested glue carries its children's capabilities and the
+   top glue picks them up transitively. A leaf's glue still needs nothing. *)
+let nested_supervisor_glue_carries_caps =
+  Alcotest.test_case "a nested supervisor's spawn glue carries its children's capabilities"
+    `Quick (fun () ->
+      let m =
+        parse_and_desugar {|mod N do
+  needs IO.Console
+  actor Leaf do
+    state { n : Int }
+    init  { n: 0 }
+    on Say(s : String) do
+      print_line(s)
+      { state with n: state.n + 1 }
+    end
+  end
+  actor Mid do
+    state { l : Int }
+    init  { l: 0 }
+    supervise do
+      strategy one_for_one
+      max_restarts 5 within 60
+      Leaf l
+    end
+  end
+  actor Top do
+    state { m : Int }
+    init  { m: 0 }
+    supervise do
+      strategy one_for_one
+      max_restarts 5 within 60
+      Mid m
+    end
+  end
+end|}
+      in
+      let (_errors, type_map) = March_typecheck.Typecheck.check_module m in
+      let tir =
+        March_tir.Lower.lower_module ~type_map ~test_mode:false ~hot_reload:false m
+      in
+      let need = March_tir.Cap_passing.needed_caps tir in
+      Alcotest.(check (option (list string))) "Mid_spawn carries Leaf's caps"
+        (Some [ "IO.Console" ]) (Hashtbl.find_opt need "Mid_spawn");
+      Alcotest.(check (option (list string))) "Top_spawn carries them transitively"
+        (Some [ "IO.Console" ]) (Hashtbl.find_opt need "Top_spawn");
+      Alcotest.(check (option (list string))) "Leaf_spawn still needs nothing"
+        None (Hashtbl.find_opt need "Leaf_spawn"))
+
 (* ── the surface spelling of a multi-argument field ───────────────────── *)
 
 (* `Io_ops_gen.march_ty` once rendered a curried arrow as `(A, B) -> C`. In
@@ -624,5 +675,6 @@ let tests = [
   analysis_attributes_locals_to_their_owner;
   dispatch_caps_lists_every_capability;
   supervisor_glue_carries_children_caps;
+  nested_supervisor_glue_carries_caps;
   rendered_multi_arg_is_curried;
 ]


### PR DESCRIPTION
Builds `specs/todos/2026-09-03-nested-supervisor-children-not-captured.md` (the spec commit from #406 is the first commit here; the spec now lives in `specs/progress/` with a "What shipped" section). Supersedes #406.

## Problem

A supervisor nested under another supervisor could not carry its children's capabilities. Its spawn glue is passed as a *value* to `register_supervisor_child` so the runtime can re-run it on respawn, and that one reference froze the glue's arity. Its children (the top supervisor's grandchildren) read NULL and ran unmocked.

## Design (as specced)

- **Analysis.** `register_supervisor_child`'s third argument is a call edge to the named glue, not a value use, so the nested glue is no longer frozen; `needed_caps` gives it its children's capabilities and the top glue picks them up through the existing fixpoint.
- **Threading.** The supervised-child pattern threads the child's spawn call in both arms. A new arm replaces the respawn value with a zero-argument closure that calls the glue with the capabilities in scope, built the way lower builds a lambda thunk. Its apply function takes only the closure cell, matching the runtime's `spawn_clo_fn_t(void *)`. A glue carrying nothing keeps the static reference: `cap_mock_supervised`'s lower dump is unchanged.
- **Runtime, one line.** `march_incrc(child->spawn_clo)` before the respawn call. Every apply function drops the closure it is handed and the runtime calls the same cell on every respawn, so without it the second respawn is a use-after-free. Heap-pointer guarded, so a no-op for the static reference.

## Red controls (both done)

Fixture `test/cap_mock/cap_mock_supervised_nested.march`: Top supervises Mid supervises Leaf. Inside `with_cap`: send to the grandchild, `kill` Mid, send to the new grandchild, `kill` Mid again, send again. A Top spawned outside is sent to after the block closes.

- **A**, analysis special case disabled (glue frozen again): all three mocked lines went real, `leaf:out` unchanged.
- **B**, runtime inc removed: the second respawn dies with SIGBUS (exit 138) right after `MOCK[leaf:again]`, three runs out of three. The spec worried this control might "happen to still print MOCK"; it did not.

Both restored byte-for-byte: green.

## RC proof (`MARCH_DUMP_TXT=perceus`), spec items 6 and 7

```
let $sup_child_raw_m : Ptr(Unit) = inc_rc $cap_IO_Console;
Mid_spawn($cap_IO_Console) in
…
let $reg_child_m : Unit = let $respawn30586 : () -> Ptr(Unit) = alloc $Clo_$respawn30586$3620($respawn30586$apply$3620, $cap_IO_Console) in
call_ptr register_supervisor_child($spawned, $sup_child_ptr_m, $respawn30586, 0, 0) in
```

The parameter is dup'd at its non-last use (the threaded spawn call) and moved into the closure at its last use: one +1 per reference.

## Correction to #404 and #405

The sanitize-gate CI leg sweeps `specs/lang/golden/` plus a curated list, **not** `test/cap_mock/`. The lines in those two PRs' progress files calling it "the ASAN proof for the new fixture" were wrong and are corrected here. An ASAN run over the `cap_mock` fixtures still needs the Docker recipe and has not been done for any of the three.

## Tests

- The golden above (+ `.expected`, `test/dune` rule, compiled `--test` only).
- `test/test_cap_dict.ml`: `need[Mid_spawn]` = `need[Top_spawn]` = `["IO.Console"]`, `Leaf_spawn` absent.
- `scripts/run-tests.sh` (full) green; `dune build --root . --force @test/runtest` green (includes the native supervisor-restart goldens against the runtime line); `run_snapshots.exe` 33/33; doc-lint green.
