### PR TITLE
perf(runtime): per-thread live-object gauge instead of one global atomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -353,6 +353,25 @@ git log is authoritative for exact commits.
 
 ### Changed
 
+- **The live-object gauge (`march_live_allocs`) no longer serialises parallel
+  allocation.** The gauge is always on, so its single process-wide atomic sat
+  on the two hottest paths in the runtime — `march_alloc`, and every RC
+  free-on-zero branch — making every thread in the program read-modify-write
+  one cache line there. That was enough on its own to make allocation-heavy
+  parallel code scale *negatively*: measured on an M3 Max (14 cores) with a
+  `List.pmap_n` over 64 cons-allocating tasks, the same program took 3022 ms
+  on 14 scheduler threads against 1875 ms on 1. It is now a per-thread
+  counter summed on read — an exiting thread folds its residual into a
+  process-wide total via a `pthread_key_t` destructor and releases its slot
+  for reuse, so the sum stays correct across thread lifetimes even though
+  allocation and freeing are not thread-affine. The same program now runs in
+  471 ms on 14 threads (6.4x faster than before, and 4.8x faster than its own
+  1-thread time), matching a build with the counter compiled out entirely.
+  `march_live_allocs()` keeps its existing semantics and single-threaded
+  results; `test/test_ffi.c` gains a multi-threaded case that allocates on
+  eight threads, lets them exit, and frees each thread's objects from a
+  different thread.
+
 - `unreflectable-predicate` no longer misattributes a subject failure to the
   predicate. An arithmetic actual (`n - 1`, `i + 1`) now reflects through the
   same scope as the variable it uses, so a guard on `n` reaches `n - 1`

--- a/runtime/march_runtime.c
+++ b/runtime/march_runtime.c
@@ -279,14 +279,104 @@ static void gc_trace_atexit(void) {
 /* ── Allocation ──────────────────────────────────────────────────────── */
 
 /* Net count of live march objects (alloc +, free-on-rc=0 -).  An FFI/test
- * leak gauge exposed via march_live_allocs(); relaxed atomics keep the hot
- * RC paths cheap.  See specs/2026-06-19-c-ffi-abi-design.md §14.4. */
-static _Atomic int64_t march_live_alloc_count = 0;
-int64_t march_live_allocs(void) {
-    return atomic_load_explicit(&march_live_alloc_count, memory_order_relaxed);
+ * leak gauge exposed via march_live_allocs(); see
+ * specs/2026-06-19-c-ffi-abi-design.md §14.4.
+ *
+ * PER-THREAD slots, summed on read.  This gauge is always on -- not behind a
+ * debug flag -- so it sits on the two hottest paths in the runtime
+ * (march_alloc, and every RC free-on-zero branch).  A single process-wide
+ * atomic made every scheduler thread read-modify-write ONE cache line there,
+ * which is enough on its own to make allocation-heavy parallel code scale
+ * negatively: on an M3 Max, a List.pmap_n over 64 cons-allocating tasks ran
+ * ~3x SLOWER on 14 scheduler threads than on 1, where the same code without
+ * the counter sped up ~3.4x.
+ *
+ * Each thread writes only its own slot, with a relaxed load/store pair rather
+ * than an atomic RMW -- a plain ldr/str, no bus lock, no sharing.  The slot is
+ * _Atomic solely so the reader's concurrent load is defined behaviour instead
+ * of a data race.
+ *
+ * Allocation and freeing are NOT thread-affine: an object allocated on one
+ * scheduler thread is routinely freed on another, so an individual slot can go
+ * arbitrarily negative or positive and only the SUM is meaningful.  For the
+ * sum to stay correct across thread lifetimes, an exiting thread folds its
+ * residual into march_live_residual (via a pthread_key_t destructor) and
+ * releases its slot for reuse; the reader walks the slot list and adds the
+ * residual.  Slots are never freed, so the walk is lock-free.
+ *
+ * Exactness under concurrency is neither required nor previously provided --
+ * the gauge is read between frames by FFI/leak tests, and memory_order_relaxed
+ * already gave no ordering guarantee. */
+typedef struct march_live_slot {
+    _Atomic int64_t count;                   /* owner-written, anyone-read */
+    _Atomic int in_use;                      /* 0 = free for a new thread   */
+    struct march_live_slot *_Atomic next;
+} march_live_slot;
+
+static march_live_slot *_Atomic march_live_slot_head = NULL;
+static _Atomic int64_t march_live_residual = 0;   /* folded from exited threads */
+static _Thread_local march_live_slot *march_live_self = NULL;
+static pthread_key_t march_live_key;
+static pthread_once_t march_live_once = PTHREAD_ONCE_INIT;
+
+/* Thread-exit: move this thread's net count into the process-wide residual and
+ * hand the slot back.  The exchange makes the move atomic with respect to a
+ * concurrent reader, so the count is never seen twice nor lost. */
+static void march_live_slot_release(void *arg) {
+    march_live_slot *s = (march_live_slot *)arg;
+    int64_t n = atomic_exchange_explicit(&s->count, 0, memory_order_relaxed);
+    if (n) atomic_fetch_add_explicit(&march_live_residual, n, memory_order_relaxed);
+    march_live_self = NULL;
+    atomic_store_explicit(&s->in_use, 0, memory_order_release);
 }
-#define MARCH_ALLOC_BUMP() atomic_fetch_add_explicit(&march_live_alloc_count, 1, memory_order_relaxed)
-#define MARCH_FREE_BUMP()  atomic_fetch_sub_explicit(&march_live_alloc_count, 1, memory_order_relaxed)
+
+static void march_live_key_init(void) {
+    pthread_key_create(&march_live_key, march_live_slot_release);
+}
+
+/* Claim a free slot (a thread that has since exited), else push a new one. */
+static march_live_slot *march_live_slot_acquire(void) {
+    pthread_once(&march_live_once, march_live_key_init);
+    for (march_live_slot *s = atomic_load_explicit(&march_live_slot_head, memory_order_acquire);
+         s; s = atomic_load_explicit(&s->next, memory_order_acquire)) {
+        int expected = 0;
+        if (atomic_compare_exchange_strong_explicit(&s->in_use, &expected, 1,
+                memory_order_acq_rel, memory_order_relaxed)) {
+            march_live_self = s;
+            pthread_setspecific(march_live_key, s);
+            return s;
+        }
+    }
+    march_live_slot *s = (march_live_slot *)calloc(1, sizeof *s);
+    if (!s) { fputs("march: out of memory\n", stderr); exit(1); }
+    atomic_store_explicit(&s->in_use, 1, memory_order_relaxed);
+    march_live_slot *head = atomic_load_explicit(&march_live_slot_head, memory_order_relaxed);
+    do {
+        atomic_store_explicit(&s->next, head, memory_order_relaxed);
+    } while (!atomic_compare_exchange_weak_explicit(&march_live_slot_head, &head, s,
+                 memory_order_release, memory_order_relaxed));
+    march_live_self = s;
+    pthread_setspecific(march_live_key, s);
+    return s;
+}
+
+static inline void march_live_bump(int64_t d) {
+    march_live_slot *s = march_live_self;
+    if (__builtin_expect(s == NULL, 0)) s = march_live_slot_acquire();
+    atomic_store_explicit(&s->count,
+        atomic_load_explicit(&s->count, memory_order_relaxed) + d,
+        memory_order_relaxed);
+}
+
+int64_t march_live_allocs(void) {
+    int64_t total = atomic_load_explicit(&march_live_residual, memory_order_relaxed);
+    for (march_live_slot *s = atomic_load_explicit(&march_live_slot_head, memory_order_acquire);
+         s; s = atomic_load_explicit(&s->next, memory_order_acquire))
+        total += atomic_load_explicit(&s->count, memory_order_relaxed);
+    return total;
+}
+#define MARCH_ALLOC_BUMP() march_live_bump(1)
+#define MARCH_FREE_BUMP()  march_live_bump(-1)
 
 /* If [p] is an FFI resource cell (MARCH_RESOURCE_TAG), run its destructor on
  * the wrapped native pointer before the cell itself is freed.  Called from

--- a/specs/progress/2026-09-04-live-object-gauge-per-thread-counters.md
+++ b/specs/progress/2026-09-04-live-object-gauge-per-thread-counters.md
@@ -1,0 +1,85 @@
+- ✅ **The always-on live-object gauge no longer serialises parallel allocation
+  (`runtime/march_runtime.c`, 2026-09-04).** `march_live_allocs()` — the FFI/test
+  leak gauge described in `specs/2026-06-19-c-ffi-abi-design.md` §14.4 — was a single
+  `_Atomic int64_t` bumped by `MARCH_ALLOC_BUMP()` in `march_alloc` and by
+  `MARCH_FREE_BUMP()` in every RC free-on-zero path (`march_decrc`,
+  `march_decrc_freed`, the resource-dtor branch, and `march_string_alloc`/its free).
+  It is **not** behind a debug flag — unlike the neighbouring `str_stats_on()` /
+  `obj_alloc_count` counters, which are opt-in and were left alone — so every thread
+  in the process read-modify-wrote **one cache line** on the two hottest paths there
+  are.
+
+  **Why it hid.** Nothing about the gauge is wrong: it is correct, it is cheap in
+  isolation (an uncontended relaxed `fetch_add` is a few ns), and every existing test
+  of it is single-threaded, where it costs nothing measurable. The defect is visible
+  only as a *scaling* property, and only on allocation-dominated parallel work — which
+  is exactly the workload the runtime's scheduler exists to serve. It was found while
+  root-causing a voxel engine's whole-world meshing throughput, where `march_alloc`
+  was the single largest March symbol in the `sample` profile (10,552 top-of-stack
+  samples); replacing the counter moved it outside the top 25 and took meshing from
+  1.6x to 2.1x on 14 threads.
+
+  **Fix: per-thread slots, summed on read.** Each thread owns a `march_live_slot`
+  that it alone writes, with a relaxed load/store *pair* rather than an atomic RMW —
+  a plain `ldr`/`str`, no bus lock, no sharing. The slot's counter is `_Atomic` solely
+  so the reader's concurrent load is defined behaviour instead of a data race.
+
+  **The subtlety that makes a naive version wrong.** Allocation and freeing are not
+  thread-affine: an object allocated on one scheduler thread is routinely freed on
+  another, so an individual slot goes arbitrarily negative or positive and only the
+  SUM is meaningful. That is fine for a gauge — but only if the sum survives thread
+  *exit*. A `pthread_key_t` destructor folds an exiting thread's residual into a
+  process-wide `march_live_residual` (via `atomic_exchange`, so the count is never
+  seen twice nor lost by a concurrent reader) and releases the slot for reuse by a
+  later thread; `march_live_allocs()` returns the residual plus a lock-free walk of
+  the slot list. Slots are never freed, so the walk needs no lock.
+
+  Exactness under concurrency is neither required nor regressed: the gauge is read
+  between frames by FFI/leak tests, and `memory_order_relaxed` already gave no
+  ordering guarantee.
+
+  **Non-vacuousness.** The new multi-threaded case in `test/test_ffi.c` — eight
+  threads allocate 512 objects each and **exit**, then eight fresh threads each free a
+  slot they did not allocate (rotate by one) — was proved RED against a deliberately
+  naive `_Thread_local int64_t` with no cross-thread aggregation (`Assertion failed:
+  march_live_allocs() == base + MT_THREADS * MT_PER_THREAD`, test_ffi.c:222) before the
+  real implementation was written. That same broken variant also trips a pre-existing
+  assertion at test_ffi.c:204, which reads the gauge from a `march_run_blocking_i`
+  OS thread — so the naive form was never reachable undetected.
+
+  **Measured** (M3 Max, 14 cores, runtime built with `-DMARCH_NUM_SCHEDULERS=16`;
+  `List.pmap_n` over 64 tasks each building and summing 2000-element cons lists 300
+  times; best of 3 per cell). The machine was **saturated by other agents' compiler
+  runs at load average 120–170**, so every absolute number is inflated and only the
+  ratios carry meaning:
+
+  | scheduler threads | global atomic (before) | per-thread (after) | gauge compiled out |
+  |---|---|---|---|
+  | 1  | 1875 ms | 2250 ms | 1867 ms |
+  | 4  | 2198 ms |  917 ms |  938 ms |
+  | 10 | 2700 ms |  474 ms |  621 ms |
+  | 14 | 3022 ms |  471 ms |  546 ms |
+
+  Before: 14 threads were **1.6x slower than 1 thread**. After: 14 threads are 4.8x
+  faster than 1, and 6.4x faster than the old code at the same width — matching, at
+  this noise level, a build with the gauge compiled out entirely. The 1-thread
+  per-thread cell above is an outlier from machine load, not a real single-thread
+  regression: a follow-up with 5 reps per variant, run twice, gave global 1774/1725,
+  per-thread 1876/1675, compiled-out 1655/1741 — mutually indistinguishable. (TLS
+  access is not free on macOS — `_tlv_get_addr` appears in profiles of this runtime —
+  so this was measured rather than assumed.)
+
+  **Verification.** `dune build @runtest` green (exit 0; `test/` alone: 693
+  refinecheck cases + the rest, "Test Successful"). The three RC-sensitive
+  benchmarks, compiled `--opt 2` and run as a same-box A/B against a compiler
+  built with the old runtime (best of 5, interleaved): `binary_trees` 447 → 432 ms,
+  `tree_transform` 861 → 866 ms, `list_ops` 135 → 109 ms — no regression, and stdout
+  byte-identical between the two variants with the documented checksums
+  (`tree_transform` 104857600, `list_ops` 333333666666). `.march/cas/artifacts-v2`
+  was cleared before each runtime variant.
+
+  **Out of scope, deliberately.** The stock runtime's compile-time cap of 4 scheduler
+  threads (`MARCH_NUM_SCHEDULERS` in `runtime/march_scheduler.h`; the env var can only
+  lower it) is a separate bug — the header was bumped to 16 for the measurement above
+  and reverted, not changed here. `str_stats_on()` / `obj_alloc_count` and friends are
+  already flag-gated and untouched.

--- a/test/dune
+++ b/test/dune
@@ -6079,7 +6079,7 @@ printf 'mod CsHelper do\\n\\n  fn double(x : Int) : Int do\\n    x * 2\\n  end\\
 ; (PR #269 removed this probe's prior Darwin-only gate), at max RSS
 ; 128,761,856 B -- not a leak, just Linux's ~122 MB process baseline that the
 ; macOS-derived band never accounted for. live_allocs() reads the runtime's
-; always-on march_live_alloc_count -- incremented in march_alloc, decremented
+; always-on live-object gauge -- incremented in march_alloc, decremented
 ; on every free-on-rc-zero path -- so it counts the defect directly: no
 ; allocator free-list behaviour, no page-granularity rounding, no OS/platform
 ; baseline. Same conversion, same rationale, as

--- a/test/native/native_arr_fold_leak_probe.march
+++ b/test/native/native_arr_fold_leak_probe.march
@@ -13,7 +13,7 @@
 -- guards only memory.)
 --
 -- SIGNAL: live_allocs(), NOT RSS. live_allocs() reads the runtime's
--- always-on march_live_alloc_count -- incremented in march_alloc,
+-- always-on live-object gauge -- incremented in march_alloc,
 -- decremented on every free-on-rc-zero path. A leak is exactly "objects
 -- allocated and never freed", so this counts the defect directly: no
 -- allocator free-list behaviour, no page-granularity rounding, no

--- a/test/native/simd_leak_probe.march
+++ b/test/native/simd_leak_probe.march
@@ -14,7 +14,7 @@
 --
 -- SIGNAL: live_allocs(), NOT RSS -- same rationale, and same conversion, as
 -- native_arr_fold_leak_probe.march. march_simd_alloc cells are March heap
--- objects, so live_allocs() (the runtime's always-on march_live_alloc_count,
+-- objects, so live_allocs() (the runtime's always-on live-object gauge,
 -- incremented in march_alloc/decremented on every free-on-rc-zero path)
 -- counts a leaked box directly, with no allocator free-list behaviour, no
 -- page-granularity rounding, and no OS/platform baseline to calibrate away.

--- a/test/test_ffi.c
+++ b/test/test_ffi.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <pthread.h>
 
 /* Resource destructor for the resources test: frees the native allocation and
  * records that it ran (so the test can assert dtor-on-drop). */
@@ -20,6 +21,44 @@ static void test_res_dtor(void *p) { res_dtor_calls++; free(p); }
  * march_extras.c too) — no local stub needed any more; the real
  * implementation runs, and its id is only stored in the header pad word,
  * still not exercised by this test. */
+
+
+/* ── multi-threaded live-gauge harness ────────────────────────────────────
+ * The gauge is a process-wide net count, but allocation and freeing are not
+ * thread-affine: an object allocated on one scheduler thread is routinely
+ * freed on another, and the threads that did the allocating may have exited
+ * by the time the gauge is read.  A per-thread counter implementation is only
+ * correct if (a) it sums across all live threads and (b) an exiting thread
+ * folds its residual into a process-wide total instead of dropping it.
+ *
+ * MT_THREADS allocator threads each allocate MT_PER_THREAD objects into their
+ * own slot of mt_cells and then EXIT.  A second, disjoint set of threads then
+ * frees them, each freeing a slot it did not allocate (rotate by one), so
+ * every participating thread ends with a non-zero net count of its own — one
+ * positive, one negative — and only the sum is meaningful. */
+#define MT_THREADS    8
+#define MT_PER_THREAD 512
+static void *mt_cells[MT_THREADS][MT_PER_THREAD];
+
+static void *mt_alloc_thread(void *arg) {
+    long id = (long)arg;
+    for (int i = 0; i < MT_PER_THREAD; i++) mt_cells[id][i] = march_alloc(16);
+    return NULL;
+}
+
+static void *mt_free_thread(void *arg) {
+    long id = (long)arg;                       /* frees the PREVIOUS slot */
+    long src = (id + MT_THREADS - 1) % MT_THREADS;
+    for (int i = 0; i < MT_PER_THREAD; i++)
+        march_drop(march_from_ptr(mt_cells[src][i]));
+    return NULL;
+}
+
+static void mt_run(void *(*fn)(void *)) {
+    pthread_t th[MT_THREADS];
+    for (long i = 0; i < MT_THREADS; i++) pthread_create(&th[i], NULL, fn, (void *)i);
+    for (int i = 0; i < MT_THREADS; i++) pthread_join(th[i], NULL);
+}
 
 int main(void) {
     /* ── version handshake ─────────────────────────────────────────────── */
@@ -175,6 +214,15 @@ int main(void) {
             march_drop(o);
         }
         assert(march_live_allocs() == base);   /* no leak */
+    }
+
+    /* ── leak gauge sums across threads, including exited ones ────────── */
+    {
+        int64_t base = march_live_allocs();
+        mt_run(mt_alloc_thread);   /* allocating threads exit before the read */
+        assert(march_live_allocs() == base + (int64_t)MT_THREADS * MT_PER_THREAD);
+        mt_run(mt_free_thread);    /* each frees another thread's objects */
+        assert(march_live_allocs() == base);
     }
 
     printf("test_ffi: OK\n");


### PR DESCRIPTION
## The problem

`march_live_allocs()` is an **always-on** leak gauge — not behind a debug flag — so its single process-wide `_Atomic int64_t` sat on the two hottest paths in the runtime: `march_alloc`, and every RC free-on-zero branch (`march_decrc`, `march_decrc_freed`, the resource-dtor branch, `march_string_alloc` and its free). Every thread in the process therefore read-modify-wrote **one cache line** there.

That is enough on its own to make allocation-heavy parallel code scale *negatively*. Found while root-causing a voxel engine's whole-world meshing throughput, where `march_alloc` was the single largest March symbol in the `sample` profile (10,552 top-of-stack samples).

## The fix

Per-thread slots, summed on read. Each thread owns a `march_live_slot` it alone writes, with a relaxed load/store **pair** rather than an atomic RMW — a plain `ldr`/`str`, no bus lock, no sharing. The slot is `_Atomic` solely so the reader's concurrent load is defined behaviour instead of a data race.

The subtlety that makes a naive version wrong: allocation and freeing are **not** thread-affine — an object allocated on one scheduler thread is routinely freed on another, so an individual slot goes arbitrarily negative or positive and only the SUM is meaningful. For that sum to survive thread *exit*, a `pthread_key_t` destructor folds the exiting thread's residual into a process-wide `march_live_residual` (via `atomic_exchange`, so a concurrent reader neither double-counts nor loses it) and releases the slot for reuse. `march_live_allocs()` returns the residual plus a lock-free walk of the slot list; slots are never freed.

Exactness under concurrency is neither required nor regressed — the gauge is read between frames by FFI/leak tests, and `memory_order_relaxed` already gave no ordering guarantee.

## Measured

M3 Max (14 cores), runtime built `-DMARCH_NUM_SCHEDULERS=16`, `List.pmap_n` over 64 cons-allocating tasks, best of 3.

**The machine was saturated by other work at load average 120–170**, so every absolute number is inflated and only the ratios are meaningful:

| scheduler threads | before | after | gauge compiled out |
|---|---|---|---|
| 1  | 1875 ms | 2250 ms | 1867 ms |
| 4  | 2198 ms |  917 ms |  938 ms |
| 10 | 2700 ms |  474 ms |  621 ms |
| 14 | 3022 ms |  471 ms |  546 ms |

Before, 14 threads were **1.6x slower** than 1 thread. After, 14 threads are 4.8x faster than 1 and **6.4x faster than the old code at the same width** — indistinguishable, at this noise level, from a build with the gauge compiled out entirely.

The 1-thread "after" cell is load noise, not a TLS regression. Re-measured with 5 reps per variant, run twice: global 1774/1725, per-thread 1876/1675, compiled-out 1655/1741 — mutually indistinguishable. (TLS access is not free on macOS — `_tlv_get_addr` shows up in profiles of this runtime — so this was measured rather than assumed.)

## Test coverage

Existing coverage was `test/test_ffi.c`, single-threaded, plus one pre-existing cross-thread assert at line 204 that reads the gauge from a `march_run_blocking_i` OS thread.

Added a multi-threaded case: eight threads allocate 512 objects each and **exit**, then eight fresh threads each free a slot they did not allocate (rotate by one), so every participating thread ends with a non-zero net count of its own — one positive, one negative.

Proved **RED first** against a deliberately naive `_Thread_local int64_t` with no cross-thread aggregation (`Assertion failed: march_live_allocs() == base + MT_THREADS * MT_PER_THREAD`, test_ffi.c:222) before the real implementation was written.

## Verification

- `dune build @runtest` green (exit 0, zero `[FAIL]`/`[ERROR]`). One earlier run returned 130 — SIGINT from another worktree's `dune shutdown` — and was discarded rather than counted.
- RC-sensitive benchmarks, compiled `--opt 2`, same-box A/B against a compiler built with the old runtime (best of 5, interleaved): `binary_trees` 447 → 432 ms, `tree_transform` 861 → 866 ms, `list_ops` 135 → 109 ms. No regression; stdout byte-identical between variants, checksums 104857600 / 333333666666 as documented in `specs/benchmarks.md`.
- `.march/cas/artifacts-v2` cleared before each runtime variant.
- `scripts/check-docs.sh` passes.

## Out of scope, deliberately

The stock runtime's compile-time cap of 4 scheduler threads (`MARCH_NUM_SCHEDULERS`; the env var can only lower it) is a separate bug — the header was bumped to 16 for the measurement above and reverted, not changed here. `str_stats_on()` / `obj_alloc_count` and friends are already flag-gated and untouched.
