### PR TITLE
perf(perceus): a field read out of a borrowed scrutinee is not refcounted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,27 @@ git log is authoritative for exact commits.
 
 ### Fixed
 
+- **Reading a field of a borrowed value no longer refcounts it.** A field
+  projected out of a scrutinee that is alive for the whole `match` — a
+  borrowed parameter, or any value still needed after the match — and then
+  used only at borrowed positions was bracketed by an `inc_rc`/`dec_rc` pair
+  that nothing needed: the parent already holds the reference, and the
+  projection never escapes the arm. Under the scheduler every refcount
+  operation is atomic, so a one-field wrapper such as `Chunk(NativeU8Arr)`
+  turned a read-only access to data shared between workers into a contended
+  cache line, and the same reads scaled *negatively* with thread count where
+  the unwrapped array scaled 5.8x. A projection that does escape — returned,
+  stored in a constructor, captured by a closure, or passed at an owned
+  argument position — still takes its dup, now emitted at the escaping use
+  rather than at the projection.
+
+- **`NativeArray` reads borrow their array.** `NativeArray.get_*`, `.length`,
+  `.sum` and `.to_list` were absent from the extern borrow table, so every
+  array read looked like an ownership transfer. That flipped the enclosing
+  parameter to owned, which forced a dup at a self-call that the tail-call
+  back-edge never balanced: a loop reading a heap parameter grew its refcount
+  by roughly one per element read and never freed the array.
+
 - A supervisor **nested under another supervisor** now passes its
   capabilities on to its own children, including the fresh children it
   creates each time it is restarted. Previously only a top-level supervisor's

--- a/lib/tir/borrow.ml
+++ b/lib/tir/borrow.ml
@@ -148,6 +148,27 @@ let extern_borrow_table : (string * bool list) list = [
   ("ring_buf_cap",         [true]);
   ("ring_buf_clear",       [true]);
   ("ring_buf_to_list",     [true]);
+  (* ── NativeArray: reads borrow their array, `set` consumes it (in-place) ── *)
+  ("native_u8_arr_get",    [true; false]);
+  ("native_u8_arr_length", [true]);
+  ("native_u8_arr_sum",    [true]);
+  ("native_u8_arr_to_list",[true]);
+  ("native_i32_arr_get",    [true; false]);
+  ("native_i32_arr_length", [true]);
+  ("native_i32_arr_sum",    [true]);
+  ("native_i32_arr_to_list",[true]);
+  ("native_f32_arr_get",    [true; false]);
+  ("native_f32_arr_length", [true]);
+  ("native_f32_arr_sum",    [true]);
+  ("native_f32_arr_to_list",[true]);
+  ("native_int_arr_get",    [true; false]);
+  ("native_int_arr_length", [true]);
+  ("native_int_arr_sum",    [true]);
+  ("native_int_arr_to_list",[true]);
+  ("native_float_arr_get",    [true; false]);
+  ("native_float_arr_length", [true]);
+  ("native_float_arr_sum",    [true]);
+  ("native_float_arr_to_list",[true]);
   (* ── Synthetic C names used directly in lower.ml wrappers ──────────────── *)
   ("march_compare_string", [true; true]);
   ("march_hash_string",    [true]);

--- a/lib/tir/perceus_core.ml
+++ b/lib/tir/perceus_core.ml
@@ -1067,12 +1067,65 @@ let rec insert_rc_expr (env : env) (e : Tir.expr) (live_after : live_set)
          Descending with an updated [env] copy handles shadowing correctly
          (the caller's [env] for sibling branches is untouched, matching the
          old code's save/restore). *)
+      (* A field projected out of a scrutinee that is PROVABLY live across the
+         whole case is a borrowed reference, exactly like [let f = rec.field]
+         on a borrowed record parameter (the ELet [is_borrowed_field] case
+         above, condition 1).  Mark such br_vars as borrowed field vars so the
+         normal borrowed-field discipline applies to them:
+
+           - a use at a BORROWED argument position emits neither a dup nor a
+             post-call EDecRC (the [borrowed_field_vars] exclusions in the
+             EApp/ECallPtr [post_dec_vars] filters, and the alias-binding arm
+             of ELet which skips RC processing of [let a = <br_var>]);
+           - a CONSUMING use (owned argument position, constructor capture,
+             tail return) still gets its EIncRC dup, because the br_vars were
+             re-added to [la] above and are therefore live at every such use.
+
+         Without this, the accessor shape
+
+           fn get(c : Chunk, i : Int) : Int do
+             match c do Chunk(a) -> NativeArray.get_u8(a, i) end
+           end
+
+         emitted [inc_rc]/[dec_rc] around a read that never escapes the arm.
+         Under the scheduler every RC op is atomic, so a read-only projection
+         out of shared data became a contended cache line — measurably
+         negative scaling (see specs/progress for the G73 measurements).
+
+         SAFETY: the premise is "the parent outlives the arm", so this is
+         gated on [live_after] membership ALONE, not on the full
+         [scrutinee_borrowed] disjunction.  [scrutinee_borrowed]'s other two
+         disjuncts are deliberately excluded:
+
+           - [name_free_in v br_body] (the path-insensitive conservatism, §6
+             of specs/perceus-invariants.md) only says the scrutinee is
+             mentioned SOMEWHERE in the arm.  Ownership then transfers into
+             the body, which may consume the scrutinee part-way through and
+             free it while a projected field is still being read.  Today that
+             field holds its own +1 and survives; eliding the dup there would
+             turn a bounded leak into a use-after-free — the wrong direction.
+           - TTuple/TRecord scrutinees are [needs_rc = false]: Perceus never
+             sees the aggregate's lifetime at all, so "the parent outlives the
+             arm" is not a premise it can discharge.
+
+         Missing those cases only leaves an elidable pair on the table, which
+         is the acceptable direction to be wrong in. *)
+      let scrutinee_live_across_case = match a with
+        | Tir.AVar v -> StringSet.mem v.Tir.v_name live_after
+        | _ -> false
+      in
       let env_for_br =
         { env with
           var_ctx =
             List.fold_left (fun ctx (v : Tir.var) ->
               StringMap.add v.Tir.v_name v ctx
-            ) env.var_ctx br.Tir.br_vars }
+            ) env.var_ctx br.Tir.br_vars;
+          borrowed_field_vars =
+            if scrutinee_live_across_case then
+              List.fold_left (fun s (v : Tir.var) ->
+                if needs_rc v.Tir.v_ty then StringSet.add v.Tir.v_name s else s
+              ) env.borrowed_field_vars br.Tir.br_vars
+            else env.borrowed_field_vars }
       in
       let (body', live_before_br) = insert_rc_expr env_for_br br.Tir.br_body la in
       (* Emit EDecRC for br_vars that are heap-typed but dead in this branch body.

--- a/specs/perceus-invariants.md
+++ b/specs/perceus-invariants.md
@@ -408,6 +408,71 @@ neither of which is sort_by:
    elsewhere" set (see below) — without this second, *independent* fix,
    the conservatism above actively causes a double-free, not just a leak.
 
+### 6.1 Branch variables of a live-across-case scrutinee are borrowed
+### field vars (the G73 elision)
+
+**Governing module: `lib/tir/perceus_core.ml`**'s `ECase` case, the
+`scrutinee_live_across_case` computation feeding `env_for_br`'s
+`borrowed_field_vars`.
+
+The `la` re-add described above makes a borrowed scrutinee's branch
+variables *live*, which is enough to stop them being freed and enough to
+make a consuming use dup them. It is **not** enough to stop them being
+dup'd at a use that consumes nothing. A projection bound out of a live
+scrutinee and then handed to a borrowed parameter got the full owned-
+binding treatment:
+
+```
+Box($f) -> let s : String = inc_rc $f; $f in
+             let $rc : Int = string_byte_length(s) in
+             dec_rc s; $rc
+```
+
+`inc_rc` at the projection (because `$f` is live, so the alias binding
+`let s = $f` must mint its own reference) and `dec_rc` after the call (§2's
+borrowed-position rule: the callee will not release what the caller lent
+it). Neither is needed — `b` outlives the whole arm and `s` never escapes
+it. Under the scheduler `march_incrc_local` defers to the atomic
+`march_incrc` on any scheduler thread, so this pair is an atomic
+read-modify-write on a header that other workers are reading concurrently:
+a cache line bouncing between cores for a *read*. Measured on a one-field
+`Cell(NativeU8Arr)` wrapper against the same array read directly, the
+wrapped form was 5.8x slower single-threaded and got **slower** as threads
+were added, while the direct form sped up 5.8x.
+
+**The fix** is not a new mechanism: such a br_var *is* a borrowed field
+var in the sense §7 and the `ELet` `is_borrowed_field` cases already
+define, so the `ECase` branch env now says so. Everything else follows from
+the existing discipline — the alias-binding arm of `ELet` skips RC
+processing of `let a = <br_var>`, the `post_dec_vars` filters in
+`EApp`/`ECallPtr` exclude `borrowed_field_vars`, and a consuming use still
+dups because the br_vars are in the branch's live-at-exit set. The dup for
+an escaping projection is not removed, only **moved** from the projection
+site to the escaping use.
+
+**The safety gate is `live_after` membership ALONE, not `scrutinee_borrowed`.**
+The premise being discharged is "the parent outlives the arm", and only the
+first of `scrutinee_borrowed`'s three disjuncts establishes it:
+
+- `name_free_in v br_body` — the path-insensitive conservatism above — says
+  only that the scrutinee is *mentioned* somewhere in the arm. Ownership
+  then transfers into the body, which may consume and free the scrutinee
+  part-way through while a projected field is still being read. Today that
+  field holds its own `+1` and survives. Eliding it there would convert
+  this section's deliberate leak-not-crash into a use-after-free, which is
+  the one direction that is not allowed to be wrong.
+- `TTuple`/`TRecord` scrutinees are `needs_rc = false` (§1): Perceus never
+  sees the aggregate's lifetime, so it cannot discharge the premise at all.
+
+Excluding those two leaves elidable pairs on the table. That is the
+acceptable direction; §6's asymmetry argument runs the same way here.
+
+**Standing regression artifact:** the golden pair
+`test/snapshots/{lower,perceus}/borrowed_scrutinee_field_read.expected`.
+Its `read_only` function is two projections and two borrowed reads with
+**zero** RC ops; its `escapes` control is the same projection returned from
+the arm, carrying exactly one `inc_rc` at the return.
+
 ### The double-dec fix (`20d1d144`)
 
 `add_cross_decrcs` (the cross-branch dead-variable `EDecRC` pass, §7)

--- a/specs/progress/2026-09-04-borrowed-scrutinee-field-read-rc-elision.md
+++ b/specs/progress/2026-09-04-borrowed-scrutinee-field-read-rc-elision.md
@@ -1,0 +1,147 @@
+# A field read out of a borrowed scrutinee no longer refcounts
+
+**Landed:** 2026-09-04. Found while root-causing a voxel engine's meshing
+throughput; filed there as G73. Carries a cherry-pick of `bfb16dac`
+(`fix(borrow): NativeArray reads borrow their array`, from branch
+`claude/borrow-native-array-reads`) as a prerequisite — without it the
+motivating accessor's parameter is inferred `own`, and the shape this fix
+targets never arises. That commit is unchanged and separately committed.
+
+## The problem
+
+```march
+type Chunk = Chunk(NativeU8Arr)
+fn get(c : Chunk, i : Int) : Int do
+  match c do Chunk(a) -> NativeArray.get_u8(a, i) end
+end
+```
+
+`MARCH_DEBUG_BORROW=1` says `get(c:borrow, i:own)` — borrow inference is
+right. Perceus still emitted, for that single array read:
+
+```
+Chunk($f) -> let a : NativeU8Arr = inc_rc $f; $f in
+               let $rc : Int = native_u8_arr_get(a, i) in
+               dec_rc a; $rc
+```
+
+Two independent mechanisms, each locally correct:
+
+1. The `ECase` **scrutinee-borrowed re-add** (`specs/perceus-invariants.md`
+   §6) puts `$f` in the branch's live-at-exit set. `let a = $f` is then an
+   alias binding whose source is live, so `find_inc_vars` mints `a` its own
+   reference.
+2. `a` is dead after the call and `native_u8_arr_get`'s array parameter is
+   borrowed, so §2's borrowed-position rule schedules the post-call
+   `dec_rc` — the callee will not release what the caller lent it.
+
+Neither is needed: `c` is alive for the whole call and `a` never leaves the
+arm.
+
+It is not cheap overhead. `march_incrc_local` reads a `_Thread_local`
+(`march_sched_in_scheduler()`) and then **always defers to the atomic
+`march_incrc`** on a scheduler thread, so inside `List.pmap_n` there is no
+non-atomic refcounting at all. An atomic read-modify-write on a header that
+other workers are reading concurrently is a cache line bouncing between
+cores in exclusive state — for a *read*. The reporting profile, `sample`
+over a meshing loop at 14 scheduler threads, shows ~27 600 top-of-stack
+samples in refcounting against ~9 000 in the mesher itself.
+
+## What landed
+
+One `env` field, at one site: `lib/tir/perceus_core.ml`'s `ECase` case now
+adds a branch's `needs_rc` `br_vars` to `env_for_br.borrowed_field_vars`
+when the scrutinee is live across the whole case.
+
+No new mechanism. Such a br_var *is* a borrowed field var in exactly the
+sense the `ELet` `is_borrowed_field` cases and §7 already define, and every
+consequence falls out of the existing discipline:
+
+- the alias-binding arm of `ELet` skips RC processing of `let a = <br_var>`
+  (no dup at the projection);
+- the `borrowed_field_vars` exclusion in `EApp`/`ECallPtr`'s
+  `post_dec_vars` filter suppresses the post-call drop;
+- a **consuming** use still dups, because the `la` re-add already made the
+  br_vars live at every such use. The dup for an escaping projection is not
+  removed, only moved from the projection site to the escaping use.
+
+### The safety gate
+
+Gated on `StringSet.mem v.v_name live_after` **alone**, not on the full
+`scrutinee_borrowed` disjunction that drives the `la` re-add. The premise
+is "the parent outlives the arm", and only that disjunct establishes it.
+The other two are deliberately excluded:
+
+- `name_free_in v br_body` — §6's path-insensitive conservatism — says only
+  that the scrutinee is *mentioned* somewhere in the arm. Ownership
+  transfers into the body, which may consume and free it part-way through
+  while a projected field is still being read. Today that field holds its
+  own `+1` and survives; eliding it there would turn §6's deliberate
+  leak-not-crash into a use-after-free.
+- `TTuple`/`TRecord` scrutinees are `needs_rc = false`, so Perceus never
+  sees the aggregate's lifetime and cannot discharge the premise at all.
+
+Both exclusions leave elidable pairs on the table. That is the acceptable
+direction to be wrong in.
+
+`specs/perceus-invariants.md` §6.1 is the governing account.
+
+## Verification
+
+**Machine caveat.** Every measurement below was taken on a box whose 1-minute
+load average was 129-134: four other worktrees were running benchmarks and a
+`cube_forge` test binary concurrently. Absolute wall-clock numbers from this
+box are worthless; only IR-shape facts, exit codes and back-to-back ratios are
+reported.
+
+### IR shape
+
+- `MARCH_DEBUG_BORROW=1` on the motivating accessor reports `get(c:borrow,
+  i:own)` (it reports `c:own` without the `bfb16dac` prerequisite, which is
+  why that commit rides along).
+- `--dump-tir` on the `Chunk` accessor: `Chunk($f) -> let a = $f in
+  NativeArray.get_u8(a, i)` — the `inc_rc`/`dec_rc` pair is gone.
+- `--emit-llvm` on a self-recursive read loop over the wrapper
+  (`burn_cell`, the probe's mode-F shape): **zero** `march_incrc`/
+  `march_decrc` calls in the emitted loop, against one pair per iteration
+  before.
+
+### Escape controls (the elision must not fire when the projection leaves)
+
+Probed base-vs-fix on: the projection **returned** from the arm; **stored in a
+constructor**; passed at an **owned argument position**; **captured by an
+escaping closure**; and read **twice** at borrowed positions. In every
+escaping case exactly one dup survives — **moved** from the projection site to
+the escaping use, not removed. All five programs print identical output under
+the interpreter and both compiled binaries.
+
+### Suites
+
+- **TIR goldens.** All 33 pre-existing goldens are **unchanged** — the corpus
+  had no fixture for this shape at all, which is why the pair stayed invisible.
+  New fixture `test/snapshots/src/borrowed_scrutinee_field_read.march` plus its
+  two goldens; `read_only` is two projections and two borrowed reads with zero
+  RC ops, and the `escapes` control carries exactly one `inc_rc` at the return.
+  37/37 green, and green again on a re-run without `UPDATE_SNAPSHOTS`.
+- **`scripts/run-tests.sh`** — one failure, a stale assertion, fixed here.
+  `test_codegen.ml`'s `test_tco_self_dup_arg_decref_on_live_path` asserted
+  `incs > 0` on a `walk(xs:borrow, acc)` list walk whose forwarded tail is
+  exactly this shape. Measured `@walk` counts: base **1 inc / 1 dec**, fixed
+  **0 / 0**. The balance invariant it guards (an unbalanced dup leaks every
+  cons cell) is untouched; the `incs > 0` clause was a non-vacuousness guard
+  that only made sense while a dup was unavoidable, and is replaced by pinning
+  the exact new count. Checked it is not a leak or a UAF rather than assumed:
+  500-element list, 2000 borrowed walks, interpreter and both compiled binaries
+  print `1000000 / 1 / 500`, the list is intact and re-walkable afterwards, max
+  RSS 2 375 680 (base) vs 2 392 064 (fixed). The group is 10/10 after the
+  update. Everything else in the run passed (1018, 277, 878, 61, 24, 361, 5,
+  36, 10, 7, 693 tests across the suites).
+
+### Deferred to CI
+
+The differential oracle (`test/test_properties.exe`), `dune build @oracle`, the
+RC-sensitive benchmarks and the `pmap_scaling` probe were still running locally
+when this landed — zero failures reported up to that point, but the box's load
+made them unusable as timing evidence and slow as correctness evidence. CI runs
+them on an idle machine; treat that run, not this one, as the verdict on the
+benchmark numbers.

--- a/test/snapshots/lower/borrowed_scrutinee_field_read.expected
+++ b/test/snapshots/lower/borrowed_scrutinee_field_read.expected
@@ -1,0 +1,33 @@
+-- types (1) --
+type Box = Box(String, String)
+-- fns (3) --
+## escapes
+fn escapes(b : Box) : String =
+  let head : String = case b of
+  Box($f9, $f10) -> let $jp_clo12 : () -> '_ = letrec [$jp11] in
+$jp11 in
+let s : String = $f9 in
+s
+  _ -> panic("non-exhaustive pattern match") in
+let $t16 : String = let $t15 : Int = read_only(b) in
+int_to_string($t15) in
+string_concat(head, $t16)
+
+## main
+fn main(_cap_console : Cap(IO.Console)) : () =
+  let b : Box = alloc Box.Box("ab", "cde") in
+let $t17 : String = escapes(b) in
+println($t17)
+
+## read_only
+fn read_only(b : Box) : Int =
+  case b of
+  Box($f3, $f4) -> let $jp_clo6 : () -> '_ = letrec [$jp5] in
+$jp5 in
+let t : String = $f4 in
+let s : String = $f3 in
+let $t1 : Int = string_byte_length(s) in
+let $t2 : Int = string_byte_length(t) in
++($t1, $t2)
+  _ -> panic("non-exhaustive pattern match")
+

--- a/test/snapshots/perceus/borrowed_scrutinee_field_read.expected
+++ b/test/snapshots/perceus/borrowed_scrutinee_field_read.expected
@@ -1,0 +1,51 @@
+-- types (3) --
+type Box = Box(String, String)
+closure $Clo_$jp5$0(Ptr(Unit))
+closure $Clo_$jp11$1(Ptr(Unit))
+-- fns (5) --
+## $jp11$apply$1
+fn $jp11$apply$1($clo : Ptr(Unit)) : '_ =
+  panic("non-exhaustive pattern match")
+
+## $jp5$apply$0
+fn $jp5$apply$0($clo : Ptr(Unit)) : '_ =
+  panic("non-exhaustive pattern match")
+
+## escapes
+fn escapes(b : Box) : String =
+  let head : String = case b of
+  Box($f9, $f10) -> let $jp_clo12 : () -> '_ = alloc $Clo_$jp11$1($jp11$apply$1) in
+dec_rc $jp_clo12;
+let s : String = $f9 in
+inc_rc s;
+s
+  _ -> panic("non-exhaustive pattern match") in
+let $t16 : String = let $t15 : Int = let $rc_2 : Int = read_only(b) in
+dec_rc b;
+$rc_2 in
+int_to_string($t15) in
+let $rc_1 : String = string_concat(head, $t16) in
+dec_rc head;
+dec_rc $t16;
+$rc_1
+
+## main
+fn main(_cap_console : Cap(IO.Console)) : () =
+  let b : Box = alloc Box.Box("ab", "cde") in
+let $t17 : String = escapes(b) in
+let $rc_3 : () = println($t17) in
+dec_rc $t17;
+$rc_3
+
+## read_only
+fn read_only(b : Box) : Int =
+  case b of
+  Box($f3, $f4) -> let $jp_clo6 : () -> '_ = alloc $Clo_$jp5$0($jp5$apply$0) in
+dec_rc $jp_clo6;
+let t : String = $f4 in
+let s : String = $f3 in
+let $t1 : Int = string_byte_length(s) in
+let $t2 : Int = string_byte_length(t) in
++($t1, $t2)
+  _ -> panic("non-exhaustive pattern match")
+

--- a/test/snapshots/src/borrowed_scrutinee_field_read.march
+++ b/test/snapshots/src/borrowed_scrutinee_field_read.march
@@ -1,0 +1,27 @@
+-- A field projected out of a BORROWED scrutinee and used only at borrowed
+-- argument positions must get neither a dup nor a drop: the parent is alive
+-- for the whole call, and the projection never escapes the arm.  Under the
+-- scheduler every RC op is atomic, so this pair turned a read-only projection
+-- out of shared data into a contended cache line (G73).
+--
+-- [read_only] is the elidable shape.  [escapes] is its control: the same
+-- projection, but returned from the arm, so exactly ONE dup must survive --
+-- moved from the projection site to the escaping use.
+mod BorrowedScrutineeFieldRead do
+  needs IO.Console
+  type Box = Box(String, String)
+
+  fn read_only(b : Box) : Int do
+    match b do Box(s, t) -> string_byte_length(s) + string_byte_length(t) end
+  end
+
+  fn escapes(b : Box) : String do
+    let head = match b do Box(s, _) -> s end
+    string_concat(head, int_to_string(read_only(b)))
+  end
+
+  fn main(_cap_console : Cap(IO.Console)) do
+    let b = Box("ab", "cde")
+    println(escapes(b))
+  end
+end

--- a/test/test_codegen.ml
+++ b/test/test_codegen.ml
@@ -1167,7 +1167,17 @@ let test_mutual_tco_borrowed_arg_decref_on_live_path () =
     IncRCs.  Before the fix it dups the tail field once and never releases it
     (1 IncRC / 0 DecRC).  (eafbd71a's own case stays covered by
     test/native/tco_fresh_arg_decrc.march — there the forwarded argument has
-    no IncRC to balance, so it must keep emitting neither op.) *)
+    no IncRC to balance, so it must keep emitting neither op.)
+
+    UPDATED for the G73 elision (specs/perceus-invariants.md §6.1): [xs] is
+    inferred [borrow], so [t] is now a borrowed field of a scrutinee that is
+    live across the whole case and gets NEITHER half of the pair — the
+    balanced 1/1 this test used to observe is now a strictly better 0/0.  The
+    balance assertion is unchanged and still load-bearing; the old
+    non-vacuousness guard ([incs > 0], which only made sense while a dup was
+    unavoidable) is replaced by pinning the exact new count.  Both directions
+    of eafbd71a's bug remain caught: a returning unbalanced dup fails the
+    count AND the balance, and a returning balanced dup fails the count. *)
 let test_tco_self_dup_arg_decref_on_live_path () =
   let ir = emit_tco_opt_ir {|mod Test do
   needs IO.Console
@@ -1203,7 +1213,9 @@ let test_tco_self_dup_arg_decref_on_live_path () =
      — a call to the generated deep drop, which performs that same decrc on
      the box.  Either discharges the dup; neither being present does not. *)
   let decs = count "@march_decrc" + count "@__drop$" in
-  Alcotest.(check bool) "self-tco dup-arg: the tail field is dup'd" true (incs > 0);
+  Alcotest.(check int)
+    "self-tco dup-arg: a borrowed tail forwarded to a borrowed position is not refcounted at all"
+    0 incs;
   Alcotest.(check int)
     "self-tco dup-arg: every IncRC of the forwarded tail has a matching release (else every cons cell leaks)"
     incs decs

--- a/test/test_snapshots.ml
+++ b/test/test_snapshots.ml
@@ -85,6 +85,7 @@ let corpus = [
   "nested_cons_ctor_heap",           "nested_cons_ctor_heap.march";
   "interp_string_operand_rc",        "interp_string_operand_rc.march";
   "unboxed_aggregate",               "unboxed_aggregate.march";
+  "borrowed_scrutinee_field_read",   "borrowed_scrutinee_field_read.march";
 ]
 
 (* ── Path resolution ────────────────────────────────────────────────────


### PR DESCRIPTION
Reading a field out of a *borrowed* variant emitted an `inc_rc`/`decrc` pair even
when the projected value never escaped the arm. Under the scheduler every RC op is
atomic, so this turned read-only access to shared data into cache-line ping-pong and
made it scale **negatively**. Found while root-causing a voxel engine's meshing
throughput; filed there as G73.

```march
type Chunk = Chunk(NativeU8Arr)
fn get(c : Chunk, i : Int) : Int do
  match c do Chunk(a) -> NativeArray.get_u8(a, i) end
end
```

`MARCH_DEBUG_BORROW=1` says `get(c:borrow, i:own)` — borrow inference is right.
Perceus still emitted, for that one array read:

```
Chunk($f) -> let a = inc_rc $f; $f in
               let $rc = native_u8_arr_get(a, i) in
               dec_rc a; $rc
```

## Where it came from

Located with a phase dump before editing — it is Perceus, not `llvm_case`, and it is
two mechanisms stacking, each locally correct:

1. The `ECase` **scrutinee-borrowed re-add** (`specs/perceus-invariants.md` §6) puts
   `$f` in the branch's live-at-exit set. `let a = $f` is then an alias binding whose
   source is live, so `find_inc_vars` mints `a` its own reference.
2. `a` is dead after a call whose parameter is borrowed, so §2's borrowed-position
   rule schedules the post-call drop — the callee will not release what the caller
   lent it.

Neither is needed: `c` is alive for the whole call and `a` never leaves the arm.

`march_incrc_local` reads a `_Thread_local` and then **always defers to the atomic
`march_incrc`** on a scheduler thread, so inside `List.pmap_n` there is no non-atomic
refcounting at all. A one-field `Cell(NativeU8Arr)` wrapper measured 5.8x slower than
the same array read directly at one thread, and got *slower* as threads were added
while the direct form sped up 5.8x. `sample` over the reporting workload's meshing
loop: ~27 600 top-of-stack samples in refcounting against ~9 000 in the mesher.

## The fix

Not a new mechanism. Such a `br_var` **is** a borrowed field var in the sense the
`ELet` `is_borrowed_field` cases already define, so the `ECase` branch env now says
so — one `env` field, at one site. Everything else falls out of the existing
discipline: the alias-binding arm of `ELet` skips RC processing of the projection, the
`borrowed_field_vars` exclusion in `post_dec_vars` suppresses the drop, and a
consuming use still dups because the `br_vars` are already live. The dup for an
escaping projection is not removed, only **moved** from the projection site to the
escaping use.

### Safety gate

Gated on `live_after` membership **alone**, not the full `scrutinee_borrowed`
disjunction. The premise is "the parent outlives the arm" and only that disjunct
establishes it:

- `name_free_in v br_body` — §6's path-insensitive conservatism — says only that the
  scrutinee is *mentioned* somewhere in the arm. Ownership transfers into the body,
  which may free it part-way through while a projected field is still being read.
  Eliding there would turn §6's deliberate leak-not-crash into a use-after-free.
- `TTuple`/`TRecord` scrutinees are `needs_rc = false`, so Perceus never sees the
  aggregate's lifetime and cannot discharge the premise at all.

Both exclusions leave elidable pairs on the table. That is the direction it is
acceptable to be wrong in. `specs/perceus-invariants.md` §6.1 is the governing
account.

## Prerequisite carried along

`bfb16dac` (`fix(borrow): NativeArray reads borrow their array`, from branch
`claude/borrow-native-array-reads`) is **not** an ancestor of `main`. Without it the
motivating accessor infers `c:own` and the shape this PR targets never arises. It is
cherry-picked unchanged as its own commit. The elision does not depend on it — the
standalone repro is `Box(String)` + `string_byte_length`, both already in
`extern_borrow_table`.

## Verification

- **TIR goldens.** All 33 pre-existing goldens **unchanged** — the corpus had no
  fixture for this shape, which is how the pair stayed invisible. New fixture
  `borrowed_scrutinee_field_read`: `read_only` is two projections and two borrowed
  reads with **zero** RC ops; its `escapes` control is the same projection returned
  from the arm, carrying exactly one `inc_rc`. 39/39 after merging `origin/main`
  (whose own new `unboxed_aggregate_branch_join` golden is unaffected).
- **Emitted IR.** A self-recursive read loop over the wrapper emits zero
  `march_incrc`/`march_decrc` calls, against one pair per iteration before.
- **Escape controls**, probed base-vs-fix: projection returned, stored in a
  constructor, passed at an owned position, captured by an escaping closure, read
  twice at borrowed positions. Every escaping case keeps exactly one dup, moved to
  the escaping use; all print identically under the interpreter and both compiled
  binaries.
- **One test updated, not a regression.** `test_tco_self_dup_arg_decref_on_live_path`
  asserted `incs > 0` on a `walk(xs:borrow, acc)` list walk whose forwarded tail is
  exactly this shape. Measured `@walk` counts: **1 inc / 1 dec** before, **0 / 0**
  after. The balance invariant it guards (an unbalanced dup leaks every cons cell) is
  untouched; `incs > 0` was a non-vacuousness guard that only made sense while a dup
  was unavoidable, replaced by pinning the exact new count. Checked it is not a leak
  or a UAF rather than assumed: 500-element list, 2000 borrowed walks, interpreter and
  both compiled binaries print `1000000 / 1 / 500`, the list intact and re-walkable
  afterwards, max RSS 2 375 680 (base) vs 2 392 064 (fixed).
- `scripts/run-tests.sh`: green apart from that one assertion (1018, 277, 878, 61, 24,
  361, 5, 36, 10, 7, 693 tests across the suites); the group is 10/10 after the update.

### Deferred to CI — please read before merging

The differential oracle (`test/test_properties.exe`), `dune build @oracle`, the
RC-sensitive benchmarks (`binary_trees`, `tree_transform`, `list_ops`) and the
`pmap_scaling` probe were still running locally when this was pushed, with **zero
failures reported up to that point**. The box was under load average **129–134** from
four concurrent worktrees, which makes its timings worthless as evidence and its
correctness runs very slow. **CI, on an idle machine, is the verdict on those** — in
particular the benchmark numbers in `specs/benchmarks.md` are not re-validated here.
