### PR TITLE
fix(borrow): NativeArray reads borrow their array

### DIFF
--- a/lib/tir/borrow.ml
+++ b/lib/tir/borrow.ml
@@ -148,6 +148,27 @@ let extern_borrow_table : (string * bool list) list = [
   ("ring_buf_cap",         [true]);
   ("ring_buf_clear",       [true]);
   ("ring_buf_to_list",     [true]);
+  (* ── NativeArray: reads borrow their array, `set` consumes it (in-place) ── *)
+  ("native_u8_arr_get",    [true; false]);
+  ("native_u8_arr_length", [true]);
+  ("native_u8_arr_sum",    [true]);
+  ("native_u8_arr_to_list",[true]);
+  ("native_i32_arr_get",    [true; false]);
+  ("native_i32_arr_length", [true]);
+  ("native_i32_arr_sum",    [true]);
+  ("native_i32_arr_to_list",[true]);
+  ("native_f32_arr_get",    [true; false]);
+  ("native_f32_arr_length", [true]);
+  ("native_f32_arr_sum",    [true]);
+  ("native_f32_arr_to_list",[true]);
+  ("native_int_arr_get",    [true; false]);
+  ("native_int_arr_length", [true]);
+  ("native_int_arr_sum",    [true]);
+  ("native_int_arr_to_list",[true]);
+  ("native_float_arr_get",    [true; false]);
+  ("native_float_arr_length", [true]);
+  ("native_float_arr_sum",    [true]);
+  ("native_float_arr_to_list",[true]);
   (* ── Synthetic C names used directly in lower.ml wrappers ──────────────── *)
   ("march_compare_string", [true; true]);
   ("march_hash_string",    [true]);

--- a/test/snapshots/lower/array_read_tco_loop.expected
+++ b/test/snapshots/lower/array_read_tco_loop.expected
@@ -1,0 +1,255 @@
+-- types (0) --
+-- fns (61) --
+## NativeArray.f32_to_float_arr
+fn NativeArray.f32_to_float_arr(arr : '_) : '_ =
+  native_f32_to_float_arr(arr)
+
+## NativeArray.float_to_f32_arr
+fn NativeArray.float_to_f32_arr(arr : '_) : '_ =
+  native_float_to_f32_arr(arr)
+
+## NativeArray.fold_f32
+fn NativeArray.fold_f32(arr : '_, acc : '_, f : '_) : '_ =
+  native_f32_arr_fold(acc, arr, f)
+
+## NativeArray.fold_float
+fn NativeArray.fold_float(arr : '_, acc : '_, f : '_) : '_ =
+  native_float_arr_fold(acc, arr, f)
+
+## NativeArray.fold_i32
+fn NativeArray.fold_i32(arr : '_, acc : '_, f : '_) : '_ =
+  native_i32_arr_fold(acc, arr, f)
+
+## NativeArray.fold_int
+fn NativeArray.fold_int(arr : '_, acc : '_, f : '_) : '_ =
+  native_int_arr_fold(acc, arr, f)
+
+## NativeArray.fold_u8
+fn NativeArray.fold_u8(arr : '_, acc : '_, f : '_) : '_ =
+  native_u8_arr_fold(acc, arr, f)
+
+## NativeArray.from_list_f32
+fn NativeArray.from_list_f32(lst : '_) : '_ =
+  native_f32_arr_from_list(lst)
+
+## NativeArray.from_list_float
+fn NativeArray.from_list_float(lst : '_) : '_ =
+  native_float_arr_from_list(lst)
+
+## NativeArray.from_list_i32
+fn NativeArray.from_list_i32(lst : '_) : '_ =
+  native_i32_arr_from_list(lst)
+
+## NativeArray.from_list_int
+fn NativeArray.from_list_int(lst : '_) : '_ =
+  native_int_arr_from_list(lst)
+
+## NativeArray.from_list_u8
+fn NativeArray.from_list_u8(lst : '_) : '_ =
+  native_u8_arr_from_list(lst)
+
+## NativeArray.get_f32
+fn NativeArray.get_f32(arr : '_, i : Int) : '_ =
+  native_f32_arr_get(arr, i)
+
+## NativeArray.get_float
+fn NativeArray.get_float(arr : '_, i : Int) : '_ =
+  native_float_arr_get(arr, i)
+
+## NativeArray.get_i32
+fn NativeArray.get_i32(arr : '_, i : Int) : '_ =
+  native_i32_arr_get(arr, i)
+
+## NativeArray.get_int
+fn NativeArray.get_int(arr : '_, i : Int) : '_ =
+  native_int_arr_get(arr, i)
+
+## NativeArray.get_u8
+fn NativeArray.get_u8(arr : '_, i : Int) : '_ =
+  native_u8_arr_get(arr, i)
+
+## NativeArray.i32_to_f32_arr
+fn NativeArray.i32_to_f32_arr(arr : '_) : '_ =
+  native_i32_to_f32_arr(arr)
+
+## NativeArray.i32_to_int_arr
+fn NativeArray.i32_to_int_arr(arr : '_) : '_ =
+  native_i32_to_int_arr(arr)
+
+## NativeArray.int_to_i32_arr
+fn NativeArray.int_to_i32_arr(arr : '_) : '_ =
+  native_int_to_i32_arr(arr)
+
+## NativeArray.int_to_u8_arr
+fn NativeArray.int_to_u8_arr(arr : '_) : '_ =
+  native_int_to_u8_arr(arr)
+
+## NativeArray.length_f32
+fn NativeArray.length_f32(arr : '_) : '_ =
+  native_f32_arr_length(arr)
+
+## NativeArray.length_float
+fn NativeArray.length_float(arr : '_) : '_ =
+  native_float_arr_length(arr)
+
+## NativeArray.length_i32
+fn NativeArray.length_i32(arr : '_) : '_ =
+  native_i32_arr_length(arr)
+
+## NativeArray.length_int
+fn NativeArray.length_int(arr : '_) : '_ =
+  native_int_arr_length(arr)
+
+## NativeArray.length_u8
+fn NativeArray.length_u8(arr : '_) : '_ =
+  native_u8_arr_length(arr)
+
+## NativeArray.make_f32
+fn NativeArray.make_f32(n : Int, fill : Float) : '_ =
+  native_f32_arr_make(n, fill)
+
+## NativeArray.make_float
+fn NativeArray.make_float(n : Int, fill : Float) : '_ =
+  native_float_arr_make(n, fill)
+
+## NativeArray.make_i32
+fn NativeArray.make_i32(n : Int, fill : Int) : '_ =
+  native_i32_arr_make(n, fill)
+
+## NativeArray.make_int
+fn NativeArray.make_int(n : Int, fill : Int) : '_ =
+  native_int_arr_make(n, fill)
+
+## NativeArray.make_u8
+fn NativeArray.make_u8(n : Int, fill : Int) : '_ =
+  native_u8_arr_make(n, fill)
+
+## NativeArray.map2_f32
+fn NativeArray.map2_f32(arr1 : '_, arr2 : '_, f : '_) : '_ =
+  native_f32_arr_map2(arr1, arr2, f)
+
+## NativeArray.map2_float
+fn NativeArray.map2_float(arr1 : '_, arr2 : '_, f : '_) : '_ =
+  native_float_arr_map2(arr1, arr2, f)
+
+## NativeArray.map2_i32
+fn NativeArray.map2_i32(arr1 : '_, arr2 : '_, f : '_) : '_ =
+  native_i32_arr_map2(arr1, arr2, f)
+
+## NativeArray.map2_int
+fn NativeArray.map2_int(arr1 : '_, arr2 : '_, f : '_) : '_ =
+  native_int_arr_map2(arr1, arr2, f)
+
+## NativeArray.map2_u8
+fn NativeArray.map2_u8(arr1 : '_, arr2 : '_, f : '_) : '_ =
+  native_u8_arr_map2(arr1, arr2, f)
+
+## NativeArray.map_f32
+fn NativeArray.map_f32(arr : '_, f : '_) : '_ =
+  native_f32_arr_map(arr, f)
+
+## NativeArray.map_float
+fn NativeArray.map_float(arr : '_, f : '_) : '_ =
+  native_float_arr_map(arr, f)
+
+## NativeArray.map_i32
+fn NativeArray.map_i32(arr : '_, f : '_) : '_ =
+  native_i32_arr_map(arr, f)
+
+## NativeArray.map_int
+fn NativeArray.map_int(arr : '_, f : '_) : '_ =
+  native_int_arr_map(arr, f)
+
+## NativeArray.map_u8
+fn NativeArray.map_u8(arr : '_, f : '_) : '_ =
+  native_u8_arr_map(arr, f)
+
+## NativeArray.set_f32
+fn NativeArray.set_f32(arr : '_, i : Int, v : Float) : '_ =
+  native_f32_arr_set(arr, i, v)
+
+## NativeArray.set_float
+fn NativeArray.set_float(arr : '_, i : Int, v : Float) : '_ =
+  native_float_arr_set(arr, i, v)
+
+## NativeArray.set_i32
+fn NativeArray.set_i32(arr : '_, i : Int, v : Int) : '_ =
+  native_i32_arr_set(arr, i, v)
+
+## NativeArray.set_int
+fn NativeArray.set_int(arr : '_, i : Int, v : Int) : '_ =
+  native_int_arr_set(arr, i, v)
+
+## NativeArray.set_u8
+fn NativeArray.set_u8(arr : '_, i : Int, v : Int) : '_ =
+  native_u8_arr_set(arr, i, v)
+
+## NativeArray.sum_f32
+fn NativeArray.sum_f32(arr : '_) : Float =
+  native_f32_arr_sum(arr)
+
+## NativeArray.sum_float
+fn NativeArray.sum_float(arr : '_) : Float =
+  native_float_arr_sum(arr)
+
+## NativeArray.sum_i32
+fn NativeArray.sum_i32(arr : '_) : Int =
+  native_i32_arr_sum(arr)
+
+## NativeArray.sum_int
+fn NativeArray.sum_int(arr : '_) : Int =
+  native_int_arr_sum(arr)
+
+## NativeArray.sum_u8
+fn NativeArray.sum_u8(arr : '_) : Int =
+  native_u8_arr_sum(arr)
+
+## NativeArray.to_float_arr
+fn NativeArray.to_float_arr(arr : '_) : '_ =
+  native_int_arr_to_float_arr(arr)
+
+## NativeArray.to_list_f32
+fn NativeArray.to_list_f32(arr : '_) : '_ =
+  native_f32_arr_to_list(arr)
+
+## NativeArray.to_list_float
+fn NativeArray.to_list_float(arr : '_) : '_ =
+  native_float_arr_to_list(arr)
+
+## NativeArray.to_list_i32
+fn NativeArray.to_list_i32(arr : '_) : '_ =
+  native_i32_arr_to_list(arr)
+
+## NativeArray.to_list_int
+fn NativeArray.to_list_int(arr : '_) : '_ =
+  native_int_arr_to_list(arr)
+
+## NativeArray.to_list_u8
+fn NativeArray.to_list_u8(arr : '_) : '_ =
+  native_u8_arr_to_list(arr)
+
+## NativeArray.u8_to_f32_arr
+fn NativeArray.u8_to_f32_arr(arr : '_) : '_ =
+  native_u8_to_f32_arr(arr)
+
+## NativeArray.u8_to_int_arr
+fn NativeArray.u8_to_int_arr(arr : '_) : '_ =
+  native_u8_to_int_arr(arr)
+
+## main
+fn main(_cap_console : Cap(IO.Console)) : () =
+  let a : NativeU8Arr = NativeArray.make_u8(4, 7) in
+let $t6 : Int = let $t5 : Int = NativeArray.length_u8(a) in
+sum_bytes(a, 0, $t5, 0) in
+println($t6)
+
+## sum_bytes
+fn sum_bytes(a : NativeU8Arr, i : Int, n : Int, acc : Int) : Int =
+  let $t1 : Bool = >=(i, n) in
+case $t1 of
+  True() -> acc
+  _ -> let $t2 : Int = +(i, 1) in
+let $t4 : Int = let $t3 : Int = NativeArray.get_u8(a, i) in
++(acc, $t3) in
+sum_bytes(a, $t2, n, $t4)
+

--- a/test/snapshots/perceus/array_read_tco_loop.expected
+++ b/test/snapshots/perceus/array_read_tco_loop.expected
@@ -1,0 +1,257 @@
+-- types (0) --
+-- fns (61) --
+## NativeArray.f32_to_float_arr
+fn NativeArray.f32_to_float_arr(arr : '_) : '_ =
+  native_f32_to_float_arr(arr)
+
+## NativeArray.float_to_f32_arr
+fn NativeArray.float_to_f32_arr(arr : '_) : '_ =
+  native_float_to_f32_arr(arr)
+
+## NativeArray.fold_f32
+fn NativeArray.fold_f32(arr : '_, acc : '_, f : '_) : '_ =
+  native_f32_arr_fold(acc, arr, f)
+
+## NativeArray.fold_float
+fn NativeArray.fold_float(arr : '_, acc : '_, f : '_) : '_ =
+  native_float_arr_fold(acc, arr, f)
+
+## NativeArray.fold_i32
+fn NativeArray.fold_i32(arr : '_, acc : '_, f : '_) : '_ =
+  native_i32_arr_fold(acc, arr, f)
+
+## NativeArray.fold_int
+fn NativeArray.fold_int(arr : '_, acc : '_, f : '_) : '_ =
+  native_int_arr_fold(acc, arr, f)
+
+## NativeArray.fold_u8
+fn NativeArray.fold_u8(arr : '_, acc : '_, f : '_) : '_ =
+  native_u8_arr_fold(acc, arr, f)
+
+## NativeArray.from_list_f32
+fn NativeArray.from_list_f32(lst : '_) : '_ =
+  native_f32_arr_from_list(lst)
+
+## NativeArray.from_list_float
+fn NativeArray.from_list_float(lst : '_) : '_ =
+  native_float_arr_from_list(lst)
+
+## NativeArray.from_list_i32
+fn NativeArray.from_list_i32(lst : '_) : '_ =
+  native_i32_arr_from_list(lst)
+
+## NativeArray.from_list_int
+fn NativeArray.from_list_int(lst : '_) : '_ =
+  native_int_arr_from_list(lst)
+
+## NativeArray.from_list_u8
+fn NativeArray.from_list_u8(lst : '_) : '_ =
+  native_u8_arr_from_list(lst)
+
+## NativeArray.get_f32
+fn NativeArray.get_f32(arr : '_, i : Int) : '_ =
+  native_f32_arr_get(arr, i)
+
+## NativeArray.get_float
+fn NativeArray.get_float(arr : '_, i : Int) : '_ =
+  native_float_arr_get(arr, i)
+
+## NativeArray.get_i32
+fn NativeArray.get_i32(arr : '_, i : Int) : '_ =
+  native_i32_arr_get(arr, i)
+
+## NativeArray.get_int
+fn NativeArray.get_int(arr : '_, i : Int) : '_ =
+  native_int_arr_get(arr, i)
+
+## NativeArray.get_u8
+fn NativeArray.get_u8(arr : '_, i : Int) : '_ =
+  native_u8_arr_get(arr, i)
+
+## NativeArray.i32_to_f32_arr
+fn NativeArray.i32_to_f32_arr(arr : '_) : '_ =
+  native_i32_to_f32_arr(arr)
+
+## NativeArray.i32_to_int_arr
+fn NativeArray.i32_to_int_arr(arr : '_) : '_ =
+  native_i32_to_int_arr(arr)
+
+## NativeArray.int_to_i32_arr
+fn NativeArray.int_to_i32_arr(arr : '_) : '_ =
+  native_int_to_i32_arr(arr)
+
+## NativeArray.int_to_u8_arr
+fn NativeArray.int_to_u8_arr(arr : '_) : '_ =
+  native_int_to_u8_arr(arr)
+
+## NativeArray.length_f32
+fn NativeArray.length_f32(arr : '_) : '_ =
+  native_f32_arr_length(arr)
+
+## NativeArray.length_float
+fn NativeArray.length_float(arr : '_) : '_ =
+  native_float_arr_length(arr)
+
+## NativeArray.length_i32
+fn NativeArray.length_i32(arr : '_) : '_ =
+  native_i32_arr_length(arr)
+
+## NativeArray.length_int
+fn NativeArray.length_int(arr : '_) : '_ =
+  native_int_arr_length(arr)
+
+## NativeArray.length_u8
+fn NativeArray.length_u8(arr : '_) : '_ =
+  native_u8_arr_length(arr)
+
+## NativeArray.make_f32
+fn NativeArray.make_f32(n : Int, fill : Float) : '_ =
+  native_f32_arr_make(n, fill)
+
+## NativeArray.make_float
+fn NativeArray.make_float(n : Int, fill : Float) : '_ =
+  native_float_arr_make(n, fill)
+
+## NativeArray.make_i32
+fn NativeArray.make_i32(n : Int, fill : Int) : '_ =
+  native_i32_arr_make(n, fill)
+
+## NativeArray.make_int
+fn NativeArray.make_int(n : Int, fill : Int) : '_ =
+  native_int_arr_make(n, fill)
+
+## NativeArray.make_u8
+fn NativeArray.make_u8(n : Int, fill : Int) : '_ =
+  native_u8_arr_make(n, fill)
+
+## NativeArray.map2_f32
+fn NativeArray.map2_f32(arr1 : '_, arr2 : '_, f : '_) : '_ =
+  native_f32_arr_map2(arr1, arr2, f)
+
+## NativeArray.map2_float
+fn NativeArray.map2_float(arr1 : '_, arr2 : '_, f : '_) : '_ =
+  native_float_arr_map2(arr1, arr2, f)
+
+## NativeArray.map2_i32
+fn NativeArray.map2_i32(arr1 : '_, arr2 : '_, f : '_) : '_ =
+  native_i32_arr_map2(arr1, arr2, f)
+
+## NativeArray.map2_int
+fn NativeArray.map2_int(arr1 : '_, arr2 : '_, f : '_) : '_ =
+  native_int_arr_map2(arr1, arr2, f)
+
+## NativeArray.map2_u8
+fn NativeArray.map2_u8(arr1 : '_, arr2 : '_, f : '_) : '_ =
+  native_u8_arr_map2(arr1, arr2, f)
+
+## NativeArray.map_f32
+fn NativeArray.map_f32(arr : '_, f : '_) : '_ =
+  native_f32_arr_map(arr, f)
+
+## NativeArray.map_float
+fn NativeArray.map_float(arr : '_, f : '_) : '_ =
+  native_float_arr_map(arr, f)
+
+## NativeArray.map_i32
+fn NativeArray.map_i32(arr : '_, f : '_) : '_ =
+  native_i32_arr_map(arr, f)
+
+## NativeArray.map_int
+fn NativeArray.map_int(arr : '_, f : '_) : '_ =
+  native_int_arr_map(arr, f)
+
+## NativeArray.map_u8
+fn NativeArray.map_u8(arr : '_, f : '_) : '_ =
+  native_u8_arr_map(arr, f)
+
+## NativeArray.set_f32
+fn NativeArray.set_f32(arr : '_, i : Int, v : Float) : '_ =
+  native_f32_arr_set(arr, i, v)
+
+## NativeArray.set_float
+fn NativeArray.set_float(arr : '_, i : Int, v : Float) : '_ =
+  native_float_arr_set(arr, i, v)
+
+## NativeArray.set_i32
+fn NativeArray.set_i32(arr : '_, i : Int, v : Int) : '_ =
+  native_i32_arr_set(arr, i, v)
+
+## NativeArray.set_int
+fn NativeArray.set_int(arr : '_, i : Int, v : Int) : '_ =
+  native_int_arr_set(arr, i, v)
+
+## NativeArray.set_u8
+fn NativeArray.set_u8(arr : '_, i : Int, v : Int) : '_ =
+  native_u8_arr_set(arr, i, v)
+
+## NativeArray.sum_f32
+fn NativeArray.sum_f32(arr : '_) : Float =
+  native_f32_arr_sum(arr)
+
+## NativeArray.sum_float
+fn NativeArray.sum_float(arr : '_) : Float =
+  native_float_arr_sum(arr)
+
+## NativeArray.sum_i32
+fn NativeArray.sum_i32(arr : '_) : Int =
+  native_i32_arr_sum(arr)
+
+## NativeArray.sum_int
+fn NativeArray.sum_int(arr : '_) : Int =
+  native_int_arr_sum(arr)
+
+## NativeArray.sum_u8
+fn NativeArray.sum_u8(arr : '_) : Int =
+  native_u8_arr_sum(arr)
+
+## NativeArray.to_float_arr
+fn NativeArray.to_float_arr(arr : '_) : '_ =
+  native_int_arr_to_float_arr(arr)
+
+## NativeArray.to_list_f32
+fn NativeArray.to_list_f32(arr : '_) : '_ =
+  native_f32_arr_to_list(arr)
+
+## NativeArray.to_list_float
+fn NativeArray.to_list_float(arr : '_) : '_ =
+  native_float_arr_to_list(arr)
+
+## NativeArray.to_list_i32
+fn NativeArray.to_list_i32(arr : '_) : '_ =
+  native_i32_arr_to_list(arr)
+
+## NativeArray.to_list_int
+fn NativeArray.to_list_int(arr : '_) : '_ =
+  native_int_arr_to_list(arr)
+
+## NativeArray.to_list_u8
+fn NativeArray.to_list_u8(arr : '_) : '_ =
+  native_u8_arr_to_list(arr)
+
+## NativeArray.u8_to_f32_arr
+fn NativeArray.u8_to_f32_arr(arr : '_) : '_ =
+  native_u8_to_f32_arr(arr)
+
+## NativeArray.u8_to_int_arr
+fn NativeArray.u8_to_int_arr(arr : '_) : '_ =
+  native_u8_to_int_arr(arr)
+
+## main
+fn main(_cap_console : Cap(IO.Console)) : () =
+  let a : NativeU8Arr = NativeArray.make_u8(4, 7) in
+let $t6 : Int = let $t5 : Int = NativeArray.length_u8(a) in
+let $rc_1 : Int = sum_bytes(a, 0, $t5, 0) in
+dec_rc a;
+$rc_1 in
+println($t6)
+
+## sum_bytes
+fn sum_bytes(a : NativeU8Arr, i : Int, n : Int, acc : Int) : Int =
+  let $t1 : Bool = >=(i, n) in
+case $t1 of
+  True() -> acc
+  _ -> let $t2 : Int = +(i, 1) in
+let $t4 : Int = let $t3 : Int = NativeArray.get_u8(a, i) in
++(acc, $t3) in
+sum_bytes(a, $t2, n, $t4)
+

--- a/test/snapshots/src/array_read_tco_loop.march
+++ b/test/snapshots/src/array_read_tco_loop.march
@@ -1,0 +1,25 @@
+-- A self-tail-recursive loop that READS a heap parameter each iteration.
+-- Pins the borrow classification of NativeArray reads: `a` must stay borrowed,
+-- so the loop body carries no inc_rc/dec_rc at all.
+--
+-- Without the NativeArray rows in borrow.ml's extern_borrow_table, the read
+-- looks like an ownership transfer, `a` is inferred owned, and the self-call
+-- dups it once per iteration — a dup the TCO back-edge never balances, so the
+-- refcount grows without bound and the array can never be uniquely owned again.
+-- self_tco_loop.march does not catch this: its loop touches only Ints.
+mod ArrayReadTcoLoop do
+  needs IO.Console
+
+  fn sum_bytes(a : NativeU8Arr, i : Int, n : Int, acc : Int) : Int do
+    if i >= n do
+      acc
+    else
+      sum_bytes(a, i + 1, n, acc + NativeArray.get_u8(a, i))
+    end
+  end
+
+  fn main(_cap_console : Cap(IO.Console)) do
+    let a = NativeArray.make_u8(4, 7)
+    println(sum_bytes(a, 0, NativeArray.length_u8(a), 0))
+  end
+end

--- a/test/test_snapshots.ml
+++ b/test/test_snapshots.ml
@@ -81,6 +81,7 @@ let corpus = [
   "fbip_dead_binding_reuse",         "fbip_dead_binding_reuse.march";
   "record_update",                   "record_update.march";
   "self_tco_loop",                   "self_tco_loop.march";
+  "array_read_tco_loop",             "array_read_tco_loop.march";
   "nested_generic_adt",              "nested_generic_adt.march";
   "nested_cons_ctor_heap",           "nested_cons_ctor_heap.march";
   "interp_string_operand_rc",        "interp_string_operand_rc.march";


### PR DESCRIPTION
`extern_borrow_table` in `lib/tir/borrow.ml` had entries for `ring_buf` and the
whole string family but none for `NativeArray`, so every array read looked like
an ownership transfer.

That flips the enclosing parameter from borrowed to owned, which forces a dup at
a self-call — and the TCO back-edge stores the parameter into its own slot
without dropping the old reference, so the dup is never balanced. March rejects
non-tail self-recursion, so this reaches every loop that reads a heap parameter:

```march
pfn a_go(a : NativeU8Arr, i : Int, n : Int, acc : Int) : Int do
  if i >= n do acc else a_go(a, i + 1, n, acc + NativeArray.get_u8(a, i)) end
end
```

emitted one `march_incrc_local` per iteration and no `decrc` anywhere in the
function. The refcount grows without bound — measured in a voxel-lighting sweep
at 5202 for a 9³ box, 44198 for 17³, 365754 for 33³, roughly one per element
read. The array is then never freed, and can never again be seen as uniquely
owned, which blocks in-place update and FBIP reuse on exactly the buffers that
most want them.

### The change

Adds `_get`, `_length`, `_sum` and `_to_list` for u8/i32/f32/int/float — 21 lines
of table data, no logic. Each was checked against its implementation in
`runtime/march_runtime.c`: all four read through the `NATIVE_ARR_HDR` offset and
never `march_decrc(arr)`.

`_set` is deliberately absent — its copy path *does* decrc the old array, so
borrowing it would double-free. `_map`/`_map2` also only read their array but are
left owned for now.

### Regression test

The second commit adds `test/snapshots/src/array_read_tco_loop.march`. The
existing `self_tco_loop` fixture does not catch this: its loop touches only
`Int`s, so an unbalanced dup on a heap parameter stays invisible.

I verified the fixture actually fails without the fix (by reverting `borrow.ml`
alone), at the perceus stage, with exactly the defect it is meant to pin:

```
expected: let $t5 : Int = NativeArray.length_u8(a) in
actual:   let $t5 : Int = inc_rc a;
```

— the dup appears and the balancing `dec_rc a` disappears. With the fix the loop
body carries no RC ops at all and `main` drops the array once.

### Verification

Run on this branch (main @ c7816766 + these two commits), on macOS/arm64:

- `run_codegen.exe -e` — **602 passed, 0 failed**
- `run_snapshots.exe -e` — **39 passed**, no pre-existing golden changed
- the negative control above

**Not yet run to completion on this branch:** `test_properties.exe` (the
differential oracle). It takes ~80 minutes here and I did not want to hold the PR
on it; it is running now and I will report the result on this PR. CI will cover
it independently. Flagging it rather than implying a green I have not seen.

### Downstream effect

This has been running for a day in a voxel engine that leans on `NativeArray`
loops. Whole-world greedy meshing went **1378 ms → 372 ms** and a block edit
**12.48 ms → 7.11 ms**. The mesher's remaining ceiling is a separate issue
(projecting a field out of a borrowed variant still emits an inc/dec pair, which
makes shared reads scale negatively) — not addressed here.
