### PR TITLE
test(scheduler): make test_pinned_park_wake's resume count deterministic

### DIFF
--- a/specs/progress/2026-09-04-pinned-park-wake-resume-count-flake.md
+++ b/specs/progress/2026-09-04-pinned-park-wake-resume-count-flake.md
@@ -1,0 +1,93 @@
+# `test_pinned_park_wake` asserted a resume count that was scheduling luck
+
+**Status:** filed and **fixed 2026-09-04.** Pre-existing; the test landed
+2026-09-03 in `specs/progress/2026-09-03-pin-main-green-thread-to-scheduler-0.md`
+and started failing on main's macOS leg almost immediately.
+
+## The flake
+
+`test/test_scheduler_pin.c`'s second case parks a **pinned** green thread and
+has eight worker-thread "wakers" wake it, to prove that a pinned proc resumes
+on the main thread across the cross-thread wake path. It then asserted:
+
+```c
+TEST_ASSERT(atomic_load(&g_wakes) >= N_WAKERS, "sleeper was woken (at least once per waker)");
+```
+
+`march_sched_wake` is a **no-op when the target is not parked**, so `g_wakes`
+counted resumes that happened to be delivered, not resumes the test arranged
+for. The sleeper is pinned to scheduler 0 — which is also the OS thread running
+`march_sched_run` and a share of the wakers — so on a small, busy runner it can
+park once, be woken once, and find `g_wakers_done` already at 8. One resume,
+assertion wants eight, red run.
+
+Observed on main's `test (macos-15)` leg three times in two days, always the
+same line:
+
+| run | commit | date |
+|---|---|---|
+| 33820372950 | `1eb43d39` | 2026-09-04 00:06 |
+| 33877691194 | `7419c689` | 2026-09-04 13:22 |
+| 33892464683 | `eaf7a71c` | 2026-09-04 15:57 |
+
+all reporting `FAIL [test_pinned_park_wake:119]: sleeper was woken (at least
+once per waker)` at `File "test/dune", lines 149-152`. It then failed a fourth
+time on `2ac12751`, which is what prompted this fix.
+
+**Not reproducible by load alone on a 14-core machine:** 100 runs at load 14,
+100 interleaved runs at load 64, and 12 runs each at
+`MARCH_NUM_SCHEDULERS=4/16/32/64` all passed. What reproduces it is making the
+wakers *finish sooner* — building the same test with `WAKES_PER=1` and
+`burn(0)` fails **19 of 20 runs** with the exact CI message. That is the
+mechanism stated directly: the assertion holds only while the wakers are still
+running when the sleeper gets scheduled.
+
+## The fix
+
+Make the resume count a **requirement the test enforces**, not an observation:
+
+- The sleeper loops until `g_wakers_done == N_WAKERS` **and**
+  `g_wakes >= REQUIRED_WAKES`, then sets `g_sleeper_done`.
+- Each waker, after its `WAKES_PER` iterations, keeps calling
+  `march_sched_wake` (with a yield) until `g_sleeper_done` is set, instead of
+  firing one parting wake and hoping it lands. This also closes the
+  lost-wakeup window where the sleeper parked just after that single wake.
+- The spin is bounded by `WAKE_SPIN_LIMIT` so a broken `march_sched_wake` ends
+  the spin rather than burning a CI worker. It still cannot turn that breakage
+  into a clean failure — a sleeper that never resumes stays a live parked proc
+  and `march_sched_run` waits for it — but that was true before this change
+  too, and is recorded in the source comment rather than silently accepted.
+- The per-test counters are reset in `test_pinned_park_wake` (they were file
+  statics relying on being run once).
+- A new assertion, `g_sleeper_done == 1`, states the termination property
+  directly.
+
+**This strengthens the test rather than weakening it.** The assertion that
+carries the feature — `g_wake_off_main == 0`, every resume on the main thread —
+was previously backed by however many resumes the scheduler happened to
+deliver, possibly one. It is now backed by at least eight cross-thread wakes on
+every run.
+
+## Verification
+
+| run | result |
+|---|---|
+| the 19/20-red reproduction (`WAKES_PER=1`, `burn(0)`), rebuilt with the fix | **0 / 40 failed** |
+| the real test, unmodified, after the fix | 0 / 200 and 0 / 400 failed |
+| RED control: `march_sched_spawn` instead of `march_sched_spawn_pinned` for the sleeper | **10 / 10 failed**, on `pinned proc resumed on main thread after every wake` |
+
+The RED control is the one that matters: the fix must not have turned the case
+into something that passes regardless. It still fails, and it fails on the
+pinning assertion rather than on the resume count.
+
+## Not the scheduler-count change
+
+This surfaced in the same CI run as
+`specs/progress/2026-09-04-scheduler-count-env-was-a-silent-ceiling.md`, which
+touches `march_sched_init` and adds a `(setenv MARCH_NUM_SCHEDULERS "")`
+wrapper to this harness's `test/dune` rule. It is not that change's doing: the
+three failures above predate that branch, the `test/dune` line numbers in them
+are the pre-edit ones, and at four schedulers with the variable unset the new
+resolution code produces exactly the old value. An interleaved A/B of the pin
+test built against the pre-change and post-change `march_scheduler.c` came out
+0/100 and 0/100.

--- a/specs/todos/2026-09-04-actor-monitor-down-reason-sigsegv-on-linux.md
+++ b/specs/todos/2026-09-04-actor-monitor-down-reason-sigsegv-on-linux.md
@@ -1,0 +1,76 @@
+# `native_actor_monitor_down_reason` exited 139 (SIGSEGV) on the Linux CI leg
+
+**Filed 2026-09-04.** One observation, not yet reproduced. Recorded rather than
+re-run away, because the symptom is a segfault in the actor monitor/death path,
+which is not a class of failure to lose track of.
+
+## The observation
+
+`test (ubuntu-24.04)`, run
+[33912489505](https://github.com/march-language/march/actions/runs/33912489505/job/101151887101),
+on PR #419 (whose entire diff is `test/test_scheduler_pin.c` — a standalone C
+harness — plus a markdown file, so it cannot reach this fixture).
+
+`test/dune`'s 100-iteration stress rule around `native_actor_monitor_down_reason`
+failed at iteration 34:
+
+```
+native_actor_monitor_down_reason: MARCH_NUM_SCHEDULERS=4 iteration 34: binary exited 139
+offending output:
+down ref=1 target=crashed reason=Crash(bang)
+bounded mailbox=1 down=Killed ref=3
+late down ref=5 target=killed reason=Killed
+down target=nulled reason=Crash(embedded-nul-ok)
+terminal watcher mailbox=0
+```
+
+**All five expected lines were printed** (in a legal interleaving — the rule
+matches each with its own `grep -Eq`, not as an ordered golden). The process
+then died of SIGSEGV. So this is a crash at or after the last handler, not a
+wrong result.
+
+## What it is NOT
+
+`specs/progress/2026-08-21-actor-monitor-bounded-mailbox-race.md` fixed a
+different flake in the same fixture: a `mailbox_size` sample race that produced
+`panic: bounded Down or mailbox count mismatch` in roughly 0.1% of runs. That
+one exits via a panic with a message, not SIGSEGV, and the offending output
+above shows `bounded mailbox=1` — the sample that race got wrong is correct
+here.
+
+## What has been ruled out
+
+- **PR #419's own change.** Its diff is `test/test_scheduler_pin.c` (a
+  standalone C test binary, linked into nothing else) and one markdown file.
+- **The `MARCH_NUM_SCHEDULERS` change**
+  (`specs/progress/2026-09-04-scheduler-count-env-was-a-silent-ceiling.md`),
+  which had landed on main just before. This rule pins the variable to 4
+  explicitly; under both the old and the new resolution code that yields
+  exactly 4 scheduler threads. main's own `test (ubuntu-24.04)` leg passed on
+  `2ac12751`, which contains that change.
+
+## Reproduction status
+
+- **macOS, 300 runs at `MARCH_NUM_SCHEDULERS=4`, load ~16: 0 crashes.** The
+  fixture was built from the same tree.
+- Not yet attempted on Linux. `specs/progress/`'s note on running the aarch64
+  CI leg locally in Docker
+  (`specs/progress/…aarch64-ci-leg-local-docker-repro`, and the memo on
+  `alpine:3.21` running natively on an arm64 Mac) is the cheapest next step,
+  though the failing leg is ubuntu-24.04 on amd64 and the platform difference
+  may matter — a segfault that only shows on one libc/arch usually does.
+
+## What to build
+
+1. Try to reproduce on Linux: the fixture in a loop under `MARCH_NUM_SCHEDULERS=4`,
+   then under ASAN (`ci/Dockerfile.ubuntu`; note its own `dune build` fails for
+   want of `node`, so build only `bin/main.exe`).
+2. If it reproduces, get a backtrace. The suspects are the paths the fixture
+   exercises last: `do_actor_death` → `deliver_monitor_down` →
+   `march_sched_send_control`, and the terminal-watcher teardown after the
+   final `mailbox=0` line — i.e. a use-after-free of a monitor entry or of the
+   dying actor's control mailbox during shutdown, which would explain a crash
+   *after* correct output.
+3. If it does not reproduce in a few thousand Linux iterations, leave this file
+   open with the negative result recorded rather than deleting it; a single
+   SIGSEGV in the death path is worth a second sighting before it is dismissed.

--- a/test/test_scheduler_pin.c
+++ b/test/test_scheduler_pin.c
@@ -83,18 +83,48 @@ static void test_pinned_yield_storm(void) {
 
 static march_proc *g_sleeper = NULL;
 static _Atomic int g_wakes = 0, g_wake_off_main = 0, g_wakers_done = 0;
+static _Atomic int g_sleeper_done = 0;
 #define N_WAKERS 8
 #define WAKES_PER 200
 
+/* How many times the pinned sleeper must park and resume before the run may
+ * finish.  This is a REQUIREMENT the wakers cooperate to meet, not a count of
+ * whatever the interleaving happened to produce.
+ *
+ * It used to be the latter, and that flaked: march_sched_wake is a no-op when
+ * the target is not parked, so a sleeper that is slow to be scheduled -- it is
+ * pinned to scheduler 0, which on a 3-core CI runner is also busy running the
+ * wakers -- could park once, be woken once, and find g_wakers_done already at
+ * N_WAKERS.  One resume, assertion wants eight, red run.  Observed three times
+ * on main's macOS leg within two days of this test landing, and reproduced
+ * here 19/20 by shrinking the wakers' own work (WAKES_PER=1, burn(0)) so they
+ * finish before the sleeper gets going.
+ *
+ * Making the count deterministic strengthens the test rather than weakening
+ * it: the assertion that carries the feature -- every resume happened on the
+ * main thread -- is now backed by at least this many cross-thread wakes on
+ * every run, instead of by however many the scheduler felt like delivering. */
+#define REQUIRED_WAKES  N_WAKERS
+
+/* Bound on the post-quota wake spin, so a genuinely broken march_sched_wake
+ * ends the spin instead of burning a CI worker forever.  (It still cannot turn
+ * that breakage into a clean failure: a sleeper that never resumes stays a
+ * live parked proc and march_sched_run waits for it -- true of this test
+ * before this change too.) */
+#define WAKE_SPIN_LIMIT 2000000L
+
 static void pinned_sleeper(void *arg) {
     (void)arg;
-    /* Park until every waker has finished; each resume must be on main. */
-    while (atomic_load(&g_wakers_done) < N_WAKERS) {
+    /* Park until every waker has finished AND the quota is met; each resume
+     * must be on main. */
+    while (atomic_load(&g_wakers_done) < N_WAKERS
+           || atomic_load(&g_wakes) < REQUIRED_WAKES) {
         march_sched_park_self();
         atomic_fetch_add(&g_wakes, 1);
         if (!pthread_equal(pthread_self(), g_main_thread))
             atomic_fetch_add(&g_wake_off_main, 1);
     }
+    atomic_store(&g_sleeper_done, 1);
 }
 
 static void waker_fn(void *arg) {
@@ -105,18 +135,34 @@ static void waker_fn(void *arg) {
         march_sched_yield();
     }
     atomic_fetch_add(&g_wakers_done, 1);
-    march_sched_wake(g_sleeper);       /* final wake so the sleeper sees done */
+    /* Keep waking until the sleeper actually finishes, rather than firing one
+     * final wake and hoping it lands.  This is what makes REQUIRED_WAKES a
+     * property of the test instead of of the interleaving, and it also closes
+     * the lost-wakeup window where the sleeper parks just after the last
+     * waker's single parting wake. */
+    for (long spins = 0;
+         !atomic_load(&g_sleeper_done) && spins < WAKE_SPIN_LIMIT;
+         spins++) {
+        march_sched_wake(g_sleeper);
+        march_sched_yield();
+    }
 }
 
 static void test_pinned_park_wake(void) {
     march_sched_init();
     g_main_thread = pthread_self();
+    atomic_store(&g_wakes, 0);
+    atomic_store(&g_wake_off_main, 0);
+    atomic_store(&g_wakers_done, 0);
+    atomic_store(&g_sleeper_done, 0);
     g_sleeper = march_sched_spawn_pinned(pinned_sleeper, NULL);
     for (int i = 0; i < N_WAKERS; i++) march_sched_spawn(waker_fn, NULL);
     march_sched_request_shutdown();
     march_sched_run();
     TEST_ASSERT(atomic_load(&g_wakers_done) == N_WAKERS, "all wakers finished");
-    TEST_ASSERT(atomic_load(&g_wakes) >= N_WAKERS, "sleeper was woken (at least once per waker)");
+    TEST_ASSERT(atomic_load(&g_sleeper_done) == 1, "sleeper finished (was not left parked)");
+    TEST_ASSERT(atomic_load(&g_wakes) >= REQUIRED_WAKES,
+                "sleeper was woken at least REQUIRED_WAKES times");
     TEST_ASSERT(atomic_load(&g_wake_off_main) == 0, "pinned proc resumed on main thread after every wake");
     TEST_PASS();
 }


### PR DESCRIPTION
Fixes the `test (macos-15)` failure currently red on main (`2ac12751`), and the three identical failures before it.

## The flake

`test_pinned_park_wake` parks a **pinned** green thread and has eight worker-thread wakers wake it, to prove a pinned proc resumes on the main thread across the cross-thread wake path. It asserted:

```c
TEST_ASSERT(atomic_load(&g_wakes) >= N_WAKERS, "sleeper was woken (at least once per waker)");
```

`march_sched_wake` is a **no-op when the target is not parked**, so `g_wakes` counted resumes that happened to be delivered, not resumes the test arranged for. The sleeper is pinned to scheduler 0 — also the thread running `march_sched_run` and a share of the wakers — so on a small busy runner it can park once, be woken once, and find `g_wakers_done` already at 8. One resume, assertion wants eight, red run.

Three prior failures on main's macOS leg in the two days since the test landed (2026-09-03), all `FAIL [test_pinned_park_wake:119]` at `File "test/dune", lines 149-152`:

| run | commit | date |
|---|---|---|
| 33820372950 | `1eb43d39` | 2026-09-04 00:06 |
| 33877691194 | `7419c689` | 2026-09-04 13:22 |
| 33892464683 | `eaf7a71c` | 2026-09-04 15:57 |

## Reproduction

Load alone does not reproduce it on a 14-core machine — 100 runs at load 14, 100 interleaved at load 64, and 12 runs each at `MARCH_NUM_SCHEDULERS=4/16/32/64` all passed. What reproduces it is making the wakers *finish sooner*: the same test built with `WAKES_PER=1` and `burn(0)` fails **19 of 20** with the exact CI message. That states the mechanism directly — the assertion holds only while the wakers are still running when the sleeper gets scheduled.

## The fix

Make the resume count a requirement the test enforces rather than an observation:

- the sleeper loops until the wakers are done **and** the quota is met, then sets `g_sleeper_done`;
- each waker keeps waking (with a yield) until it sees that flag, instead of firing one parting wake and hoping it lands — this also closes the lost-wakeup window where the sleeper parks just after that single wake;
- the spin is bounded so a broken `march_sched_wake` ends it rather than burning a CI worker. It still cannot turn that breakage into a clean failure — a sleeper that never resumes stays a live parked proc and `march_sched_run` waits for it — but that was already true, and is now written down instead of silently assumed;
- the file-static counters are reset per test, and `g_sleeper_done` is asserted.

**This strengthens the case rather than weakening it.** The assertion that carries the feature — `g_wake_off_main == 0`, every resume on the main thread — was backed by however many resumes arrived, possibly one. It is now backed by at least eight cross-thread wakes on every run.

## Verification

| run | result |
|---|---|
| the 19/20-red reproduction, rebuilt with the fix | **0 / 40 failed** |
| the real test, unmodified, after the fix | 0 / 200 and 0 / 400 failed |
| **RED control**: `march_sched_spawn` instead of `march_sched_spawn_pinned` | **10 / 10 failed**, on `pinned proc resumed on main thread after every wake` |

The RED control is the one that matters — the fix must not have made the case pass regardless. It still fails, and on the pinning assertion rather than the resume count.

All seven C scheduler suites green locally: count 7/7, scheduler 10/10, pin 2/2, timer/mbox/churn all passed, mt 3/3.

## Not caused by #416

This surfaced in the same CI run as #416 (the `MARCH_NUM_SCHEDULERS` fix), which touches `march_sched_init` and adds `(setenv MARCH_NUM_SCHEDULERS "")` to this harness's `test/dune` rule. It is not that change's doing: the three failures above predate that branch, their `test/dune` line numbers are the pre-edit ones, and at four schedulers with the variable unset the new resolution code produces exactly the old value. An interleaved A/B of this test built against the pre- and post-change `march_scheduler.c` came out 0/100 and 0/100.
