### PR TITLE
test(http): wait for the server's banner instead of sampling the log once

### DIFF
--- a/specs/progress/2026-09-04-http-e2e-banner-read-before-it-was-written.md
+++ b/specs/progress/2026-09-04-http-e2e-banner-read-before-it-was-written.md
@@ -1,0 +1,83 @@
+# The compiled HTTP e2e test read the server's banner before it was written
+
+**Status:** filed and **fixed 2026-09-04.** Pre-existing; the window is
+unconditional, not load-dependent.
+
+## The failure
+
+`test (ubuntu-24.04)` on main run
+[33916841033](https://github.com/march-language/march/actions/runs/33916841033)
+(`3cc33fb8`):
+
+```
+[FAIL] http server (compiled, end-to-end)  0  thread-pool s...
+ASSERT [compiled HTTP server: thread pool (default)] asked for the THREAD POOL
+but the server did not announce it — the runtime implementation selector
+(march_http_evloop_enabled) is broken, and both variants of this suite are
+testing one server
+server process: still running
+--- server stdout/stderr (.../srv.log) ---
+```
+
+Note what follows that last line: **nothing.** The server log was empty.
+
+## The race
+
+`test/test_http_native.ml` waits for readiness by *connecting* to the port, and
+then reads the log once to confirm which server announced itself.
+
+A successful connect does not imply the banner exists. On the thread-pool path
+the serve routine binds and `listen()`s, and only afterwards calls
+`march_http_pool_start_max` (`runtime/march_http.c:2314`), which is what prints
+`march: HTTP thread pool started` (`runtime/march_http.c:2188`). A client can
+therefore complete a TCP handshake out of the **listen backlog** strictly
+before the banner is written. The readiness poll returns, the single
+`read_log ()` samples an empty file, and the assertion fails.
+
+The window is unconditional — it does not require an overloaded runner, only
+that the connect land in the gap between `listen` and `pool_start`. A slow
+runner widens it, which is presumably why it surfaced on the Linux leg.
+
+## The trap in the diagnostic
+
+The failure message accuses `march_http_evloop_enabled` of being broken. It was
+not. The distinction is in the log contents and nothing else:
+
+- log **empty** → the banner has not been written yet. Timing.
+- log carries the **other variant's** banner → the selector really did
+  regress, both arms are testing one server, and this suite's whole point has
+  evaporated into vacuous green.
+
+The old code could not tell those apart, and the message it chose was the
+alarming one. That reading is now stated in the source next to the fix.
+
+## The fix
+
+Wait for the expected banner (30s deadline) instead of sampling the log once.
+This does not weaken the assertion:
+
+- a log carrying the wrong banner still fails immediately, since the loop is
+  looking for the *expected* string and the mismatch is checked after;
+- a genuinely broken selector still fails, after the deadline;
+- only "correct banner, not yet flushed" changes outcome, which is the bug.
+
+## Verification
+
+| run | result |
+|---|---|
+| both e2e cases (`thread-pool`, `event-loop`) after the fix | **PASS**, full `run_stdlib` green at 878 tests |
+| **RED control**: force `MARCH_HTTP_EVLOOP=1` for *both* variants, i.e. exactly the selector regression this assertion guards | **FAIL**, `asked for the THREAD POOL but the server did not announce it` — and the event-loop arm still passes, as it should |
+
+The RED control is the one that matters. A "fix" to a flaky assertion that also
+stops catching the real defect is worse than the flake; this one still catches
+it.
+
+## Context
+
+Third distinct failure on main's Linux leg in one afternoon, after
+`test_pinned_park_wake`
+(`specs/progress/2026-09-04-pinned-park-wake-resume-count-flake.md`) and a
+single unreproduced `native_actor_monitor_down_reason` SIGSEGV
+(`specs/todos/2026-09-04-actor-monitor-down-reason-sigsegv-on-linux.md`). All
+three are timing-sensitive tests rather than one common defect, but three in an
+afternoon is itself worth noticing.

--- a/test/test_http_native.ml
+++ b/test/test_http_native.ml
@@ -316,8 +316,34 @@ let run_http_e2e ~variant ~slug ~evloop () =
      runtime selector regressed, both variants would quietly run the same
      server and every assertion below would still pass.  The server announces
      itself on stderr, so check it.  ("(event-loop)" appears only in the
-     event-loop banner; the pool prints "HTTP thread pool started".) *)
-  let banner = read_log () in
+     event-loop banner; the pool prints "HTTP thread pool started".)
+
+     WAIT for the banner rather than sampling the log once.  A successful
+     connect does not imply the banner has been written: the thread-pool path
+     binds and listen()s first, and only then calls march_http_pool_start,
+     which is what prints "HTTP thread pool started"
+     (runtime/march_http.c:2188, reached from the serve path at :2314).  A
+     client can therefore complete a TCP handshake out of the listen backlog
+     strictly before the banner exists, so the poll above can return with an
+     EMPTY log.  That is not load-dependent -- the window is unconditional --
+     and it reddened main's Linux leg on 2026-09-04 (run 33916841033) with
+     "asked for the THREAD POOL but the server did not announce it" over a
+     log containing nothing at all.
+
+     Reading it as a missing banner rather than an unwritten one is the trap
+     this comment exists to stop: the diagnostic accuses the runtime selector,
+     and the selector was fine. An EMPTY log means "not yet"; a log carrying
+     the OTHER variant's banner is the real regression, and still fails
+     below. *)
+  let banner_deadline = Unix.gettimeofday () +. 30.0 in
+  let want = if evloop then "(event-loop)" else "thread pool" in
+  let rec await_banner () =
+    let b = read_log () in
+    if find_from b want 0 <> None then b
+    else if Unix.gettimeofday () >= banner_deadline then b
+    else (Unix.sleepf 0.05; await_banner ())
+  in
+  let banner = await_banner () in
   let saw_evloop = find_from banner "(event-loop)" 0 <> None in
   let saw_pool   = find_from banner "thread pool"  0 <> None in
   if evloop && not saw_evloop then


### PR DESCRIPTION
Fixes the `test (ubuntu-24.04)` failure currently red on main (`3cc33fb8`, run [33916841033](https://github.com/march-language/march/actions/runs/33916841033)).

## The race

`test_http_native` waits for readiness by **connecting** to the port, then reads the server log **once** to confirm which implementation announced itself.

A successful connect does not imply the banner exists. On the thread-pool path the serve routine binds and `listen()`s, and only afterwards calls `march_http_pool_start_max` (`runtime/march_http.c:2314`), which is what prints `march: HTTP thread pool started` (`runtime/march_http.c:2188`). A client can complete a TCP handshake **out of the listen backlog** strictly before the banner is written, so the readiness poll returns and the single `read_log ()` samples an empty file.

The window is unconditional — it needs only that the connect land between `listen` and `pool_start`, not an overloaded runner, though a slow one widens it.

## The tell, and the trap in the diagnostic

The CI failure printed:

```
asked for the THREAD POOL but the server did not announce it — the runtime
implementation selector (march_http_evloop_enabled) is broken, ...
server process: still running
--- server stdout/stderr (.../srv.log) ---
```

and then **nothing**. The log was empty.

That message accuses the runtime selector, and the selector was fine. The distinction is entirely in the log contents:

- log **empty** → the banner is not written yet. Timing.
- log carries the **other variant's** banner → the selector really did regress, both arms are testing one server, and this suite's whole point has evaporated into vacuous green.

The old code could not tell those apart and chose the alarming reading. That reasoning is now in the source next to the fix.

## The fix

Wait for the expected banner with a 30s deadline instead of sampling once. The assertion is not weakened:

- a log carrying the wrong banner still fails;
- a genuinely broken selector still fails, after the deadline;
- only "correct banner, not yet written" changes outcome — which is the bug.

## Verification

| run | result |
|---|---|
| both e2e cases (`thread-pool`, `event-loop`) after the fix | **PASS**; full `run_stdlib` green at 878 tests |
| **RED control** — force `MARCH_HTTP_EVLOOP=1` for *both* variants, i.e. exactly the selector regression this assertion guards | **FAIL**: `asked for the THREAD POOL but the server did not announce it`, with the event-loop arm still passing |

The RED control is the one that matters — a fix to a flaky assertion that also stops catching the real defect would be worse than the flake. This one still catches it.

## Context

Third distinct failure on main's Linux leg in one afternoon, after `test_pinned_park_wake` (#419) and a single unreproduced `native_actor_monitor_down_reason` SIGSEGV (filed as `specs/todos/2026-09-04-actor-monitor-down-reason-sigsegv-on-linux.md`). Three separate timing-sensitive tests rather than one common defect — but three in an afternoon is worth noticing on its own.
