### PR TITLE
fix(runtime): native arrays carry a tag, and the message copier knows them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ git log is authoritative for exact commits.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Native arrays carry a header tag.** `native_arr_alloc` left the tag at `0`,
+  an ordinary ADT constructor index, so every generic walker treated a
+  `NativeU8Arr` as a cell of pointer fields and read its payload as pointers.
+  Arrays now carry `MARCH_NATIVE_ARR_TAG`, and the cross-heap message copier
+  (`copy_value`) copies them by byte length instead of by field count. Latent
+  today, because native arrays are barred from actor messages; a prerequisite
+  for lifting that bar.
+
 ### Added
 
 - **Refinement predicates can name a zero-argument constant function.**

--- a/runtime/march_message.c
+++ b/runtime/march_message.c
@@ -41,6 +41,22 @@ typedef struct { int64_t rc; int32_t tag; int32_t pad; int64_t len; char data[];
  * sync manually (same circular-include avoidance). */
 #define MARCH_SIMD_TAG    (-4)
 #define MARCH_SIMD_BOX_SIZE   32u
+/* Native-array sentinel (must match march_runtime.h MARCH_NATIVE_ARR_TAG). A
+ * native array is [rc][tag][pad][len@16][kind@24][data@32]: a FLAT buffer, not
+ * a cell of pointer fields, so it has to be copied by its byte length. Without
+ * this case it fell to the ADT arm below, which reads n_fields from alloc_meta
+ * and scans the payload for pointers. Kept in sync manually (same
+ * circular-include avoidance as the tags above). */
+#define MARCH_NATIVE_ARR_TAG (-6)
+#define NATIVE_ARR_HDR_SZ    32u
+/* elem_kind at byte 24: 0=i64, 1=f64, 2=f32, 3=i32, 4=u8. */
+static size_t native_elem_size(unsigned kind) {
+    switch (kind) {
+        case 0: case 1: return 8u;
+        case 2: case 3: return 4u;
+        default:        return 1u;
+    }
+}
 
 /* Values below one OS page are unboxed scalars (inttoptr-encoded integers). */
 #define IS_HEAP_PTR(p)  ((uintptr_t)(p) >= 4096u)
@@ -193,6 +209,17 @@ static void *copy_value(march_heap_t *dst_heap, void *value, fwd_table *fwd) {
     if (h->tag == MARCH_SIMD_TAG) {
         void *nv = march_process_alloc(dst_heap, MARCH_SIMD_BOX_SIZE);
         memcpy(nv, value, MARCH_SIMD_BOX_SIZE);
+        ((msg_hdr *)nv)->rc = 1;
+        fwd_insert(fwd, value, nv);
+        return nv;
+    }
+
+    if (h->tag == MARCH_NATIVE_ARR_TAG) {
+        int64_t  len  = *(int64_t *)((char *)value + 16);
+        unsigned kind = *(uint8_t *)((char *)value + 24);
+        size_t   sz   = NATIVE_ARR_HDR_SZ + (size_t)len * native_elem_size(kind);
+        void *nv = march_process_alloc(dst_heap, sz);
+        memcpy(nv, value, sz);
         ((msg_hdr *)nv)->rc = 1;
         fwd_insert(fwd, value, nv);
         return nv;

--- a/runtime/march_runtime.c
+++ b/runtime/march_runtime.c
@@ -7777,6 +7777,7 @@ static void *native_arr_alloc(int64_t len, int64_t elem_size, uint8_t kind) {
     if ((((uintptr_t)arr + NATIVE_ARR_HDR) & 15) != 0) {
         fputs("march: native array: misaligned allocation\n", stderr); exit(1);
     }
+    ((march_hdr *)arr)->tag = MARCH_NATIVE_ARR_TAG;
     *(int64_t *)((char *)arr + 16) = len;
     *(uint8_t *)((char *)arr + 24) = kind;
     return arr;

--- a/runtime/march_runtime.h
+++ b/runtime/march_runtime.h
@@ -182,6 +182,13 @@ typedef struct { int64_t rc; int32_t tag; int32_t pad; int64_t len; char data[];
  * binding returned to the caller — ordinary RC, no leak, no cancel-after-
  * fire UAF (the object only dies once BOTH release it). */
 #define MARCH_TIMER_TOKEN_TAG ((int32_t)-5)
+/* Native arrays (NativeU8Arr and friends) carry their own sentinel so a
+ * generic walker can tell a flat byte/word buffer from an ADT cell. Without
+ * it every walker fell through to the ADT case, read n_fields out of
+ * alloc_meta and scanned the PAYLOAD for pointers -- which is why native
+ * arrays were barred from actor messages (GAPS.md G44) rather than copied.
+ * See native_arr_alloc, which sets it, and march_message.c's copy_value. */
+#define MARCH_NATIVE_ARR_TAG ((int32_t)-6)
 
 /* send_after(pid, msg, delay_ms) : TimerRef — schedule msg for delivery to
  * the actor `actor` after delay_ms milliseconds. RC contract matches

--- a/specs/progress/2026-09-07-native-arrays-carry-a-tag-and-the-copier-knows-them.md
+++ b/specs/progress/2026-09-07-native-arrays-carry-a-tag-and-the-copier-knows-them.md
@@ -1,0 +1,45 @@
+- ✅ **Native arrays carry a header tag, and `copy_value` knows them (2026-09-07)** —
+  `native_arr_alloc` (`runtime/march_runtime.c`) never set the header tag, so
+  every `NativeU8Arr`/`NativeIntArr`/… carried `tag = 0`: an ordinary ADT
+  constructor index, indistinguishable from a two-field cell. Every generic
+  walker therefore fell through to its ADT arm, read `n_fields` out of
+  `alloc_meta`, and treated the array's **payload** as a vector of pointer
+  fields. `march_message.c`'s `copy_value` is the one that would have acted on
+  it — on a cross-heap copy or a migration it would have allocated an
+  ADT-shaped object of the wrong size and then recursed into whatever the
+  bytes happened to look like.
+
+  Native arrays now carry `MARCH_NATIVE_ARR_TAG` (`(int32_t)-6`), the next free
+  sentinel after `MARCH_TIMER_TOKEN_TAG`, and `copy_value` has a case for them
+  that copies by byte length — `len` at offset 16, `elem_kind` at 24, the
+  layout `NATIVE_ARR_HDR = 32` already documents.
+
+  Nothing else reads the tag on this path: `march_decrc` is shallow (it uses
+  the tag only for string stats, the GC trace and the resource destructor), and
+  native arrays are opaque 0-arity constructors that no pattern ever matches.
+  706 tests.
+
+  **Why this was latent.** `NativeIntArr`/`NativeFloatArr`/`NativeF32Arr`/
+  `NativeI32Arr`/`NativeU8Arr` are in `non_sendable_types`
+  (`lib/typecheck/typecheck_exhaustive.ml`), so an array cannot reach a message
+  today and the mangling had nothing to mangle. This is groundwork for GAPS G44
+  ("a chunk never crosses an actor boundary"): both defects have to be fixed
+  before an array may be copied into a payload at all.
+
+  **What G44 still needs, and why it is not here.** Allowing arrays in messages
+  needs a copy, and the copy cannot be generic. `march_send`
+  (`runtime/march_runtime.c`) does not copy — a message is passed by reference
+  within one shared heap — and `copy_value` cannot be reused on that path,
+  because `march_alloc` is a plain `calloc` that prepends no `march_alloc_meta`
+  and so ordinary-heap objects carry no field count. `copy_value`'s ADT arm
+  works only for `march_process_alloc` objects. The runtime therefore has no
+  layout information for an ordinary value, which is the real reason arrays are
+  barred rather than copied.
+
+  The fix has to be compiler-emitted: at the `ECon` site for an actor message
+  the typechecker already knows exactly which arguments are native arrays (it
+  walks them in `check_sendable`), so codegen can emit a clone for those
+  arguments and the payload owns a private buffer from birth. That is
+  `lib/tir/llvm_emit.ml` plus the interpreter path, a `march_native_arr_clone`
+  runtime helper, dropping the five names from `non_sendable_types`, and
+  inverting reject tests `t164`/`t165`.


### PR DESCRIPTION
Groundwork for GAPS G44 (*a chunk never crosses an actor boundary*). Two defects, both latent, both of which have to be fixed before a native array may be copied into a message at all.

## The defects

**`native_arr_alloc` never set the header tag.** Every `NativeU8Arr`/`NativeIntArr`/… carried `tag = 0` — an ordinary ADT constructor index, indistinguishable from a two-field cell. So every generic walker fell through to its ADT arm, read `n_fields` out of `alloc_meta`, and treated the array's **payload** as a vector of pointer fields.

**`copy_value` had no case for them.** It is the walker that would have acted on this: on a cross-heap copy or a migration it would have allocated an ADT-shaped object of the wrong size and then recursed into whatever the bytes happened to look like.

## The fix

Native arrays carry `MARCH_NATIVE_ARR_TAG` (`(int32_t)-6`), the next free sentinel after `MARCH_TIMER_TOKEN_TAG`, and `copy_value` copies them by byte length — `len` at offset 16, `elem_kind` at 24, the layout `NATIVE_ARR_HDR = 32` already documents.

Nothing else reads the tag on this path: `march_decrc` is shallow (it uses the tag only for string stats, the GC trace and the resource destructor), and native arrays are opaque 0-arity constructors that no pattern ever matches.

## Why it was latent

The five native array constructors are in `non_sendable_types`, so an array cannot reach a message today and the mangling had nothing to mangle.

## What G44 still needs, and why it is not here

Allowing arrays in messages needs a copy, and the copy cannot be generic:

- `march_send` does not copy — a message is passed by reference within one shared heap.
- `copy_value` cannot be reused on that path, because `march_alloc` is a plain `calloc` that prepends no `march_alloc_meta`, so ordinary-heap objects carry no field count. `copy_value`'s ADT arm works only for `march_process_alloc` objects.

The runtime therefore has no layout information for an ordinary value, which is the real reason arrays are barred rather than copied. The fix has to be **compiler-emitted**: at the `ECon` site for an actor message the typechecker already knows exactly which arguments are native arrays (it walks them in `check_sendable`), so codegen can emit a clone for those arguments and the payload owns a private buffer from birth. That is `lib/tir/llvm_emit.ml` plus the interpreter path, a `march_native_arr_clone` helper, dropping the five names from `non_sendable_types`, and inverting reject tests `t164`/`t165`.

## Testing

`dune runtest`: **706 tests, exit 0.**

Found while working on a voxel project where the G44 workaround costs real time — each water actor regenerated its own chunk (and its four neighbours) from the seed on every load. That project now shares chunks through an FFI-side store keyed by coordinate, so only integers cross the message and the rule is respected; this PR is the groundwork for doing it properly instead.